### PR TITLE
Add validation to embedded forms

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -1,18 +1,24 @@
 package com.stripe.android.paymentelement
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isNotEnabled
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
+import androidx.compose.ui.test.performTouchInput
 import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
 import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.ui.core.elements.MANDATE_TEST_TAG
 import kotlin.time.Duration.Companion.seconds
 
@@ -94,6 +100,38 @@ internal class EmbeddedFormPage(
         }
 
         composeTestRule.waitForIdle()
+    }
+
+    fun clickDisabledPrimaryButton() {
+        waitUntilVisible()
+
+        composeTestRule.waitUntil(
+            conditionDescription = "embedded form primary button to become disabled",
+            timeoutMillis = 5.seconds.inWholeMilliseconds,
+        ) {
+            composeTestRule.onAllNodes(
+                hasTestTag(PRIMARY_BUTTON_TEST_TAG).and(isNotEnabled())
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+            .performScrollTo()
+            .performTouchInput { click() }
+
+        composeTestRule.waitForIdle()
+    }
+
+    fun assertCardNumberError(errorMessage: String) {
+        composeTestRule.waitUntil(
+            conditionDescription = "card number field to show error '$errorMessage'",
+            timeoutMillis = 5.seconds.inWholeMilliseconds,
+        ) {
+            composeTestRule.onAllNodes(
+                hasText("Card number").and(
+                    SemanticsMatcher.expectValue(SemanticsProperties.Error, errorMessage)
+                )
+            ).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 
     fun assertMandateIsShown() {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -113,6 +113,33 @@ internal class EmbeddedPaymentElementTest {
     }
 
     @Test
+    fun testCardFormValidation() = runEmbeddedPaymentElementTest(
+        networkRule = networkRule,
+        createIntentCallback = { _, shouldSavePaymentMethod ->
+            assertThat(shouldSavePaymentMethod).isFalse()
+            CreateIntentResult.Success("pi_example_secret_12345")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        testContext.configure {
+            formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+        }
+
+        embeddedContentPage.clickOnLpm("card")
+        formPage.clickDisabledPrimaryButton()
+        formPage.assertCardNumberError("This field cannot be blank.")
+
+        formPage.fillOutCardDetails()
+        enqueueDeferredIntentConfirmationRequests()
+        formPage.clickPrimaryButton()
+        formPage.waitUntilMissing()
+    }
+
+    @Test
     fun testRemoveCard() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
         createIntentCallback = { _, shouldSavePaymentMethod ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -20,7 +20,6 @@ import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveIntera
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject
 
 internal class EmbeddedFormInteractorFactory @Inject constructor(
@@ -88,8 +87,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             paymentMethodIncentive = PaymentMethodIncentiveInteractor(
                 paymentMethodMetadata.paymentMethodIncentive
             ).displayedIncentive,
-            // Embedded does not support validation at the moment. Should update here once it does.
-            validationRequested = MutableSharedFlow(),
+            validationRequested = sheetActivityStateHolder.validationRequested,
             coroutineScope = coroutineScope,
             uiContext = Dispatchers.Main,
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentelement.embedded.form
 
 import androidx.annotation.RestrictTo
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -9,6 +10,7 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
@@ -33,6 +35,7 @@ internal fun FormScreenContent(
     onClick: () -> Unit,
     onProcessingCompleted: () -> Unit,
     state: SheetActivityStateHolder.State,
+    onPrimaryButtonDisabledClick: () -> Unit,
 ) {
     val interactorState by interactor.state.collectAsState()
 
@@ -46,6 +49,7 @@ internal fun FormScreenContent(
         FormActivityPrimaryButton(
             state = state,
             onClick = onClick,
+            onDisabledClick = onPrimaryButtonDisabledClick,
             onProcessingCompleted = onProcessingCompleted,
         )
         PaymentSheetContentPadding()
@@ -83,8 +87,9 @@ internal fun FormActivityError(
 @Composable
 internal fun FormActivityPrimaryButton(
     state: SheetActivityStateHolder.State,
-    onProcessingCompleted: () -> Unit = {},
+    onDisabledClick: () -> Unit,
     onClick: () -> Unit,
+    onProcessingCompleted: () -> Unit = {},
 ) {
     Box(
         modifier = Modifier.padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
@@ -98,6 +103,15 @@ internal fun FormActivityPrimaryButton(
             onProcessingCompleted = onProcessingCompleted,
             processingState = state.processingState
         )
+        if (!state.isEnabled && !state.isProcessing) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .pointerInput(Unit) {
+                        detectTapGestures { onDisabledClick() }
+                    }
+            )
+        }
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactory.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveIntera
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableSharedFlow
 import javax.inject.Inject
 
 internal class EmbeddedAddPaymentMethodInteractorFactory @Inject constructor(
@@ -62,7 +61,7 @@ internal class EmbeddedAddPaymentMethodInteractorFactory @Inject constructor(
             initiallySelectedPaymentMethodType = initialCode,
             selection = embeddedSelectionHolder.selection,
             processing = sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing },
-            validationRequested = MutableSharedFlow(),
+            validationRequested = sheetActivityStateHolder.validationRequested,
             incentive = PaymentMethodIncentiveInteractor(
                 paymentMethodMetadata.paymentMethodIncentive
             ).displayedIncentive,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -249,6 +249,7 @@ internal class EmbeddedNavigator private constructor(
                         )
                     },
                     state = state,
+                    onPrimaryButtonDisabledClick = sheetActivityStateHolder::onPrimaryButtonDisabledClick,
                 )
             }
 
@@ -326,6 +327,7 @@ internal class EmbeddedNavigator private constructor(
                                 )
                             },
                             onClick = confirmationHelper::confirm,
+                            onDisabledClick = sheetActivityStateHolder::onPrimaryButtonDisabledClick,
                         )
                         PaymentSheetContentPadding()
                     }
@@ -340,6 +342,7 @@ internal class EmbeddedNavigator private constructor(
             private val isLiveMode: Boolean,
             private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,
             private val onContinueClick: () -> Unit,
+            private val onPrimaryButtonDisabledClick: () -> Unit,
         ) : Screen(), Closeable {
             override fun topBarState(): StateFlow<PaymentSheetTopBarState?> = stateFlowOf(
                 PaymentSheetTopBarStateFactory.create(
@@ -368,6 +371,7 @@ internal class EmbeddedNavigator private constructor(
                 FormActivityPrimaryButton(
                     state = state,
                     onClick = onContinueClick,
+                    onDisabledClick = onPrimaryButtonDisabledClick,
                 )
                 PaymentSheetContentPadding()
             }
@@ -382,6 +386,7 @@ internal class EmbeddedNavigator private constructor(
             private val eventReporter: EventReporter,
             private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,
             private val onContinueClick: () -> Unit,
+            private val onPrimaryButtonDisabledClick: () -> Unit,
         ) : Screen(), Closeable {
             override fun topBarState(): StateFlow<PaymentSheetTopBarState?> = stateFlowOf(
                 PaymentSheetTopBarStateFactory.create(
@@ -413,6 +418,7 @@ internal class EmbeddedNavigator private constructor(
                     FormActivityPrimaryButton(
                         state = state,
                         onClick = onContinueClick,
+                        onDisabledClick = onPrimaryButtonDisabledClick,
                     )
                     PaymentSheetContentPadding()
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -71,6 +71,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             sheetActivityState = sheetActivityStateHolder.state,
             onContinueClick = ::onContinueClick,
+            onPrimaryButtonDisabledClick = sheetActivityStateHolder::onPrimaryButtonDisabledClick,
         )
         return buildList {
             add(paymentOptionsScreen)
@@ -91,6 +92,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
             eventReporter = eventReporter,
             sheetActivityState = sheetActivityStateHolder.state,
             onContinueClick = ::onContinueClick,
+            onPrimaryButtonDisabledClick = sheetActivityStateHolder::onPrimaryButtonDisabledClick,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
@@ -38,10 +38,12 @@ import javax.inject.Singleton
 internal interface SheetActivityStateHolder {
     val state: StateFlow<State>
     val result: SharedFlow<EmbeddedActivityResult>
+    val validationRequested: SharedFlow<Unit>
     fun updateMandate(mandateText: ResolvableString?)
     fun updatePrimaryButton(callback: (PrimaryButton.UIState?) -> PrimaryButton.UIState?)
     fun updateError(error: ResolvableString?)
     fun updateProcessing(isProcessing: Boolean)
+    fun onPrimaryButtonDisabledClick()
 
     fun setResult(result: EmbeddedActivityResult)
 
@@ -85,6 +87,9 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
 
     private val _result = MutableSharedFlow<EmbeddedActivityResult>()
     override val result: SharedFlow<EmbeddedActivityResult> = _result
+
+    private val _validationRequested = MutableSharedFlow<Unit>()
+    override val validationRequested: SharedFlow<Unit> = _validationRequested
 
     private var usBankAccountFormPrimaryButtonUiState: PrimaryButton.UIState? = null
 
@@ -190,6 +195,19 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
                     processingState = PrimaryButtonProcessingState.Idle(null),
                     isEnabled = selectionHolder.selection.value != null,
                 )
+            }
+        }
+    }
+
+    override fun onPrimaryButtonDisabledClick() {
+        val primaryButtonUiState = usBankAccountFormPrimaryButtonUiState
+        if (primaryButtonUiState != null) {
+            if (primaryButtonUiState.canClickWhileDisabled) {
+                primaryButtonUiState.onDisabledClick()
+            }
+        } else if (!_state.value.isProcessing) {
+            coroutineScope.launch {
+                _validationRequested.emit(Unit)
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -262,6 +262,7 @@ internal class FormActivityScreenShotTest {
                     onClick = {},
                     onProcessingCompleted = {},
                     state = state.copy(isEnabled = enabled),
+                    onPrimaryButtonDisabledClick = {},
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -495,6 +495,7 @@ internal class EmbeddedNavigatorTest {
                 )
             ),
             onContinueClick = {},
+            onPrimaryButtonDisabledClick = {},
         )
         val (formScreen, formInteractor) = createFormScreen()
 
@@ -840,6 +841,7 @@ internal class EmbeddedNavigatorTest {
                 )
             ),
             onContinueClick = {},
+            onPrimaryButtonDisabledClick = {},
         )
     }
 
@@ -861,6 +863,7 @@ internal class EmbeddedNavigatorTest {
                 )
             ),
             onContinueClick = {},
+            onPrimaryButtonDisabledClick = {},
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -313,6 +313,34 @@ internal class DefaultSheetActivityStateHolderTest {
     }
 
     @Test
+    fun `disabled primary button click requests form validation`() = testScenario {
+        stateHolder.validationRequested.test {
+            stateHolder.onPrimaryButtonDisabledClick()
+
+            assertThat(awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    @Test
+    fun `disabled primary button click invokes US bank validation`() = testScenario {
+        var validationRequested = false
+        stateHolder.updatePrimaryButton {
+            PrimaryButton.UIState(
+                label = "Continue".resolvableString,
+                canClickWhileDisabled = true,
+                onClick = {},
+                onDisabledClick = { validationRequested = true },
+                enabled = false,
+                lockVisible = false,
+            )
+        }
+
+        stateHolder.onPrimaryButtonDisabledClick()
+
+        assertThat(validationRequested).isTrue()
+    }
+
+    @Test
     fun `updatePrimaryButton updates primary button state`() = testScenario {
         stateHolder.state.test {
             awaitAndVerifyInitialState()
@@ -718,6 +746,7 @@ internal class DefaultSheetActivityStateHolderTest {
                 )
             ),
             onContinueClick = {},
+            onPrimaryButtonDisabledClick = {},
         )
     }
 
@@ -735,6 +764,7 @@ internal class DefaultSheetActivityStateHolderTest {
                 )
             ),
             onContinueClick = {},
+            onPrimaryButtonDisabledClick = {},
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
@@ -34,6 +34,7 @@ internal class FakeSheetActivityStateHolder(
     val updateProcessingTurbine = Turbine<Boolean>()
 
     override val result: SharedFlow<EmbeddedActivityResult> = MutableSharedFlow<EmbeddedActivityResult>()
+    override val validationRequested: SharedFlow<Unit> = MutableSharedFlow<Unit>()
 
     override fun updateMandate(mandateText: ResolvableString?) {
         error("This should never be called!")
@@ -50,6 +51,8 @@ internal class FakeSheetActivityStateHolder(
     override fun updateProcessing(isProcessing: Boolean) {
         updateProcessingTurbine.add(isProcessing)
     }
+
+    override fun onPrimaryButtonDisabledClick() = Unit
 
     override fun setResult(result: EmbeddedActivityResult) {
         resultTurbine.add(result)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -225,6 +225,7 @@ internal class InitialPaymentOptionsScreenFactoryTest {
             isLiveMode = true,
             sheetActivityState = sheetActivityStateHolder.state,
             onContinueClick = {},
+            onPrimaryButtonDisabledClick = {},
         )
         val navigator = EmbeddedNavigator(
             coroutineScope = testScope,


### PR DESCRIPTION
# Summary

- Request field validation when a customer taps a disabled Embedded Payment Element form button.
- Share the validation request with both vertical and horizontal embedded form interactors.
- Preserve US bank account forms' specialized disabled-button validation callback.

This is a single-layer PR targeting `master`.

# Motivation

Embedded form interactors previously received an unattached `MutableSharedFlow`, so there was no way for the form CTA to request validation. Customers tapping the disabled button therefore received no field-level validation feedback.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolderTest' --tests 'com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractorTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.EmbeddedAddPaymentMethodInteractorFactoryTest' --tests 'com.stripe.android.paymentelement.embedded.manage.EmbeddedNavigatorTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.InitialPaymentOptionsScreenFactoryTest'`
- `./gradlew :paymentsheet:detekt`

No tests were newly ignored.

# Screenshots

Not applicable: this change activates existing validation UI and does not change visual styling.

| Before | After |
| --- | --- |
| Not applicable | Not applicable |

# Changelog

Not applicable: this is a behavioral fix to existing embedded form validation with no public API change.

Committed and created by Codex.
