### PR TITLE
Propagate embedded sheet processing state

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -297,16 +297,19 @@ internal class EmbeddedNavigator private constructor(
                 R.string.stripe_paymentsheet_select_your_payment_method.resolvableString
             )
 
-            override fun isPerformingNetworkOperation(): StateFlow<Boolean> = stateFlowOf(false)
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> {
+                return sheetActivityState.mapAsStateFlow { it.isProcessing }
+            }
 
             @Composable
             override fun Content() {
+                val state by sheetActivityState.collectAsState()
                 PaymentMethodVerticalLayoutUI(
                     interactor = interactor,
                     modifier = Modifier.padding(MaterialTheme.stripeFormInsets.getOuterFormInsets()),
                 )
+                FormActivityError(state)
                 Spacer(Modifier.height(40.dp))
-                val state by sheetActivityState.collectAsState()
                 FormActivityPrimaryButton(
                     state = state,
                     onClick = onContinueClick,
@@ -340,7 +343,9 @@ internal class EmbeddedNavigator private constructor(
                 }
             }
 
-            override fun isPerformingNetworkOperation(): StateFlow<Boolean> = stateFlowOf(false)
+            override fun isPerformingNetworkOperation(): StateFlow<Boolean> {
+                return sheetActivityState.mapAsStateFlow { it.isProcessing }
+            }
 
             @Composable
             override fun Content() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -25,6 +25,7 @@ import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.verticalmode.DefaultPaymentMethodVerticalLayoutInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutInteractor
+import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -115,7 +116,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     ): PaymentMethodVerticalLayoutInteractor {
         return DefaultPaymentMethodVerticalLayoutInteractor(
             paymentMethodMetadata = paymentMethodMetadata,
-            processing = stateFlowOf(false),
+            processing = sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing },
             temporarySelection = stateFlowOf(null),
             selection = selectionHolder.selection,
             paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityStateHolder.kt
@@ -41,6 +41,7 @@ internal interface SheetActivityStateHolder {
     fun updateMandate(mandateText: ResolvableString?)
     fun updatePrimaryButton(callback: (PrimaryButton.UIState?) -> PrimaryButton.UIState?)
     fun updateError(error: ResolvableString?)
+    fun updateProcessing(isProcessing: Boolean)
 
     fun setResult(result: EmbeddedActivityResult)
 
@@ -176,6 +177,25 @@ internal class DefaultSheetActivityStateHolder @Inject constructor(
             it.copy(
                 error = error
             )
+        }
+    }
+
+    override fun updateProcessing(isProcessing: Boolean) {
+        _state.update {
+            if (isProcessing) {
+                it.copy(
+                    isProcessing = true,
+                    processingState = PrimaryButtonProcessingState.Processing,
+                    isEnabled = false,
+                    error = null,
+                )
+            } else {
+                it.copy(
+                    isProcessing = false,
+                    processingState = PrimaryButtonProcessingState.Idle(null),
+                    isEnabled = selectionHolder.selection.value != null,
+                )
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -431,6 +431,13 @@ internal class EmbeddedNavigatorTest {
     }
 
     @Test
+    fun `HorizontalPaymentOptions isPerformingNetworkOperation returns processing state`() {
+        val screen = createHorizontalPaymentOptionsScreen(isProcessing = true)
+
+        assertThat(screen.isPerformingNetworkOperation().value).isTrue()
+    }
+
+    @Test
     fun `initial back stack with a form on top starts on the form and can go back`() = runTest {
         val scope = coroutineScopeCleanupRule.track(CoroutineScope(Job() + UnconfinedTestDispatcher(testScheduler)))
         val eventReporter = FakeEventReporter()
@@ -501,6 +508,13 @@ internal class EmbeddedNavigatorTest {
     fun `PaymentOptions isPerformingNetworkOperation returns false`() {
         val screen = createPaymentOptionsScreen()
         assertThat(screen.isPerformingNetworkOperation().value).isFalse()
+    }
+
+    @Test
+    fun `PaymentOptions isPerformingNetworkOperation returns processing state`() {
+        val screen = createPaymentOptionsScreen(isProcessing = true)
+
+        assertThat(screen.isPerformingNetworkOperation().value).isTrue()
     }
 
     @Test
@@ -710,6 +724,7 @@ internal class EmbeddedNavigatorTest {
 
     private fun createPaymentOptionsScreen(
         isLiveMode: Boolean = true,
+        isProcessing: Boolean = false,
     ): EmbeddedNavigator.Screen.VerticalPaymentOptions {
         return EmbeddedNavigator.Screen.VerticalPaymentOptions(
             interactor = FakePaymentMethodVerticalLayoutInteractor.create(),
@@ -719,7 +734,7 @@ internal class EmbeddedNavigatorTest {
                     primaryButtonLabel = "".resolvableString,
                     isEnabled = false,
                     processingState = PrimaryButtonProcessingState.Idle(null),
-                    isProcessing = false,
+                    isProcessing = isProcessing,
                     shouldDisplayLockIcon = true,
                     savedPaymentSelectionToConfirm = null,
                 )
@@ -731,6 +746,7 @@ internal class EmbeddedNavigatorTest {
     private fun createHorizontalPaymentOptionsScreen(
         interactor: AddPaymentMethodInteractor =
             FakeAddPaymentMethodInteractor(FakeAddPaymentMethodInteractor.createState()),
+        isProcessing: Boolean = false,
     ): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
         return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
             interactor = interactor,
@@ -740,7 +756,7 @@ internal class EmbeddedNavigatorTest {
                     primaryButtonLabel = "".resolvableString,
                     isEnabled = false,
                     processingState = PrimaryButtonProcessingState.Idle(null),
-                    isProcessing = false,
+                    isProcessing = isProcessing,
                     shouldDisplayLockIcon = true,
                     savedPaymentSelectionToConfirm = null,
                 )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -233,6 +233,56 @@ class DefaultSheetActivityStateHolderTest {
     }
 
     @Test
+    fun `updateProcessing starts processing and clears error`() = testScenario {
+        stateHolder.updateError("Something went wrong".resolvableString)
+
+        stateHolder.state.test {
+            assertThat(awaitItem().error).isEqualTo("Something went wrong".resolvableString)
+
+            stateHolder.updateProcessing(true)
+
+            val state = awaitItem()
+            assertThat(state.isProcessing).isTrue()
+            assertThat(state.processingState).isEqualTo(PrimaryButtonProcessingState.Processing)
+            assertThat(state.isEnabled).isFalse()
+            assertThat(state.error).isNull()
+        }
+    }
+
+    @Test
+    fun `updateProcessing stops processing and re-enables for selection`() = testScenario {
+        val error = "Something went wrong".resolvableString
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        stateHolder.updateProcessing(true)
+        stateHolder.updateError(error)
+
+        stateHolder.state.test {
+            assertThat(awaitItem().isProcessing).isTrue()
+
+            stateHolder.updateProcessing(false)
+
+            val state = awaitItem()
+            assertThat(state.isProcessing).isFalse()
+            assertThat(state.processingState).isEqualTo(PrimaryButtonProcessingState.Idle(null))
+            assertThat(state.isEnabled).isTrue()
+            assertThat(state.error).isEqualTo(error)
+        }
+    }
+
+    @Test
+    fun `updateProcessing stops processing and stays disabled without selection`() = testScenario {
+        stateHolder.updateProcessing(true)
+
+        stateHolder.state.test {
+            assertThat(awaitItem().isProcessing).isTrue()
+
+            stateHolder.updateProcessing(false)
+
+            assertThat(awaitItem().isEnabled).isFalse()
+        }
+    }
+
+    @Test
     fun `updateMandate updates mandateText`() = testScenario {
         stateHolder.state.test {
             awaitAndVerifyInitialState()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/FakeSheetActivityStateHolder.kt
@@ -7,28 +7,27 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
-import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 
 internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
     val selectionTurbine = Turbine<PaymentSelection.Saved?>()
 
-    override val state: StateFlow<SheetActivityStateHolder.State>
-        get() = stateFlowOf(
-            SheetActivityStateHolder.State(
-                primaryButtonLabel = "".resolvableString,
-                isEnabled = false,
-                processingState = PrimaryButtonProcessingState.Idle(null),
-                isProcessing = false,
-                shouldDisplayLockIcon = true,
-                savedPaymentSelectionToConfirm = null,
-            )
+    override val state = MutableStateFlow(
+        SheetActivityStateHolder.State(
+            primaryButtonLabel = "".resolvableString,
+            isEnabled = false,
+            processingState = PrimaryButtonProcessingState.Idle(null),
+            isProcessing = false,
+            shouldDisplayLockIcon = true,
+            savedPaymentSelectionToConfirm = null,
         )
+    )
 
     val resultTurbine = Turbine<EmbeddedActivityResult>()
     val updateErrorTurbine = Turbine<ResolvableString?>()
+    val updateProcessingTurbine = Turbine<Boolean>()
 
     override val result: SharedFlow<EmbeddedActivityResult> = MutableSharedFlow<EmbeddedActivityResult>()
 
@@ -44,6 +43,10 @@ internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
         updateErrorTurbine.add(error)
     }
 
+    override fun updateProcessing(isProcessing: Boolean) {
+        updateProcessingTurbine.add(isProcessing)
+    }
+
     override fun setResult(result: EmbeddedActivityResult) {
         resultTurbine.add(result)
     }
@@ -55,5 +58,6 @@ internal class FakeSheetActivityStateHolder : SheetActivityStateHolder {
     fun validate() {
         resultTurbine.ensureAllEventsConsumed()
         updateErrorTurbine.ensureAllEventsConsumed()
+        updateProcessingTurbine.ensureAllEventsConsumed()
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -3,12 +3,18 @@ package com.stripe.android.paymentelement.embedded.sheet
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onIdle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
@@ -19,7 +25,9 @@ import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -137,6 +145,40 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         val result = EmbeddedSheetContract.parseResult(scenario.result.resultCode, scenario.result.resultData)
         val cancelled = result as EmbeddedActivityResult.Cancelled
         assertThat(cancelled.customerState).isNotNull()
+    }
+
+    @Test
+    fun `processing blocks back and disables vertical payment method rows`() = launch { scenario ->
+        val cardRow = composeTestRule.onNodeWithTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_card")
+        cardRow.assertIsEnabled()
+
+        scenario.onActivity { activity ->
+            activity.sheetActivityStateHolder.updateProcessing(true)
+        }
+        composeTestRule.waitForIdle()
+
+        cardRow.assertIsNotEnabled()
+        composeTestRule.onNodeWithText(
+            applicationContext.getString(R.string.stripe_paymentsheet_primary_button_processing)
+        ).assertIsDisplayed()
+        Espresso.pressBack()
+        onIdle()
+        scenario.onActivity { activity ->
+            assertThat(activity.embeddedNavigator.screen.value)
+                .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
+        }
+    }
+
+    @Test
+    fun `vertical payment options displays activity error`() = launch { scenario ->
+        val errorMessage = "Unable to update the tax region."
+
+        scenario.onActivity { activity ->
+            activity.sheetActivityStateHolder.updateError(errorMessage.resolvableString)
+        }
+        composeTestRule.waitForIdle()
+
+        composeTestRule.onNodeWithText(errorMessage).assertIsDisplayed()
     }
 
     private fun launch(


### PR DESCRIPTION
# Summary

Propagate the embedded sheet's processing and error state through its payment-options screens.

This change:

- adds an explicit state-holder transition for sheet-scoped asynchronous work;
- reports processing as a network operation from horizontal and vertical payment-options screens;
- disables vertical payment-method interactions while processing; and
- displays activity errors in vertical payment options, matching the horizontal layout.

# Motivation

Embedded sheet screens should consistently block dismissal and payment-method interactions while an asynchronous operation is running. They should also surface failures regardless of which payment-method layout is active. Previously, payment-options screens hard-coded their network-operation state to `false`, and the vertical layout did not render the activity error.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityStateHolderTest' --tests 'com.stripe.android.paymentelement.embedded.manage.EmbeddedNavigatorTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.PaymentOptionsEmbeddedSheetActivityTest'`
- `./gradlew detekt`
- `./gradlew :paymentsheet:lintRelease`
- `./gradlew :paymentsheet:apiCheck`

No tests were ignored.

# Screenshots

Not applicable — this uses the existing processing and error UI without introducing new visual design.

# Changelog

Not applicable — this changes internal embedded-sheet behavior without changing the public API.

Committed and created by Codex.
