### PR TITLE
Add replace-current-screen navigation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -109,6 +109,13 @@ internal class EmbeddedNavigator private constructor(
                 navigationHandler.transitionToWithDelay(action.screen)
                 onScreenShown(action.screen)
             }
+            is Action.ReplaceCurrentScreen -> {
+                val replacedScreen = screen.value
+                if (navigationHandler.replaceCurrentScreen(action.screen)) {
+                    onScreenHidden(replacedScreen)
+                    onScreenShown(action.screen)
+                }
+            }
         }
     }
 
@@ -375,5 +382,7 @@ internal class EmbeddedNavigator private constructor(
         data class Close(val shouldInvokeRowSelectionCallback: Boolean = false) : Action()
 
         data class GoToScreen(val screen: Screen) : Action()
+
+        data class ReplaceCurrentScreen(val screen: Screen) : Action()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -132,6 +132,19 @@ internal class NavigationHandler<T : Any>(
         navigateWithDelay { popInternal() }
     }
 
+    fun replaceCurrentScreen(target: T): Boolean {
+        return if (!isTransitioning.get()) {
+            val previousBackStack = backStack.value
+            val replacedScreen = previousBackStack.last()
+            backStack.value = previousBackStack.dropLast(1) + target
+            replacedScreen.onClose()
+            true
+        } else {
+            target.onClose()
+            false
+        }
+    }
+
     private fun popInternal() {
         backStack.update { screens ->
             val modifiableScreens = screens.toMutableList()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -243,6 +243,46 @@ internal class EmbeddedNavigatorTest {
     }
 
     @Test
+    fun `ReplaceCurrentScreen reports replaced screen hidden and replacement shown`() = testScenario {
+        val updateInteractor = FakeUpdatePaymentMethodInteractor()
+        val manageUpdateScreen = EmbeddedNavigator.Screen.ManageUpdate(updateInteractor)
+        val paymentOptionsScreen = createPaymentOptionsScreen()
+        navigator.screen.test {
+            assertThat(awaitItem()).isEqualTo(initialScreen)
+            navigator.performAction(EmbeddedNavigator.Action.GoToScreen(manageUpdateScreen))
+            assertThat(awaitItem()).isEqualTo(manageUpdateScreen)
+            assertThat(eventReporter.showEditablePaymentOptionCalls.awaitItem()).isEqualTo(Unit)
+
+            navigator.performAction(EmbeddedNavigator.Action.ReplaceCurrentScreen(paymentOptionsScreen))
+
+            assertThat(awaitItem()).isEqualTo(paymentOptionsScreen)
+        }
+
+        assertThat(eventReporter.hideEditablePaymentOptionCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(eventReporter.showNewPaymentOptionsCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(updateInteractor.closeCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `ReplaceCurrentScreen does not report dropped replacement shown`() = testScenario {
+        val (formScreen, formInteractor) = createFormScreen()
+        val paymentOptionsInteractor = FakePaymentMethodVerticalLayoutInteractor.create()
+        val paymentOptionsScreen = createPaymentOptionsScreen(interactor = paymentOptionsInteractor)
+        navigator.screen.test {
+            assertThat(awaitItem()).isEqualTo(initialScreen)
+
+            navigator.performAction(EmbeddedNavigator.Action.GoToScreen(formScreen))
+            navigator.performAction(EmbeddedNavigator.Action.ReplaceCurrentScreen(paymentOptionsScreen))
+
+            assertThat(paymentOptionsInteractor.closeCalls.awaitItem()).isEqualTo(Unit)
+            assertThat(awaitItem()).isEqualTo(formScreen)
+        }
+
+        paymentOptionsInteractor.validate()
+        formInteractor.validate()
+    }
+
+    @Test
     fun `initial screen ManageUpdate calls onShowEditablePaymentOption`() = runTest {
         val eventReporter = FakeEventReporter()
         EmbeddedNavigator(
@@ -725,9 +765,11 @@ internal class EmbeddedNavigatorTest {
     private fun createPaymentOptionsScreen(
         isLiveMode: Boolean = true,
         isProcessing: Boolean = false,
+        interactor: FakePaymentMethodVerticalLayoutInteractor =
+            FakePaymentMethodVerticalLayoutInteractor.create(),
     ): EmbeddedNavigator.Screen.VerticalPaymentOptions {
         return EmbeddedNavigator.Screen.VerticalPaymentOptions(
-            interactor = FakePaymentMethodVerticalLayoutInteractor.create(),
+            interactor = interactor,
             isLiveMode = isLiveMode,
             sheetActivityState = stateFlowOf(
                 SheetActivityStateHolder.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -261,6 +261,78 @@ internal class NavigationHandlerTest {
     }
 
     @Test
+    fun `replaceCurrentScreen preserves backstack and closes replaced screen`() = runTest {
+        val initialScreen = mock<PaymentSheetScreen>()
+        val replacedScreen = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+        val replacementScreen = mock<PaymentSheetScreen>()
+        val navigationHandler = NavigationHandler<PaymentSheetScreen>(
+            coroutineScope = this,
+            initialScreen = initialScreen,
+            shouldRemoveInitialScreenOnTransition = false,
+        ) {}
+
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(initialScreen)
+            navigationHandler.transitionTo(replacedScreen)
+            assertThat(awaitItem()).isEqualTo(replacedScreen)
+
+            val replaced = navigationHandler.replaceCurrentScreen(replacementScreen)
+
+            assertThat(replaced).isTrue()
+            assertThat(awaitItem()).isEqualTo(replacementScreen)
+            assertThat(navigationHandler.previousScreen.value).isEqualTo(initialScreen)
+            assertThat(navigationHandler.canGoBack).isTrue()
+            verify(replacedScreen as Closeable).close()
+        }
+    }
+
+    @Test
+    fun `replaceCurrentScreen replaces root without adding to backstack`() = runTest {
+        val initialScreen = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+        val replacementScreen = mock<PaymentSheetScreen>()
+        val navigationHandler = NavigationHandler<PaymentSheetScreen>(
+            coroutineScope = this,
+            initialScreen = initialScreen,
+            shouldRemoveInitialScreenOnTransition = false,
+        ) {}
+
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(initialScreen)
+
+            val replaced = navigationHandler.replaceCurrentScreen(replacementScreen)
+
+            assertThat(replaced).isTrue()
+            assertThat(awaitItem()).isEqualTo(replacementScreen)
+            assertThat(navigationHandler.previousScreen.value).isNull()
+            assertThat(navigationHandler.canGoBack).isFalse()
+            verify(initialScreen as Closeable).close()
+        }
+    }
+
+    @Test
+    fun `replaceCurrentScreen closes replacement while transition is in progress`() = runTest {
+        val testScope = TestScope()
+        val navigationHandler = NavigationHandler<PaymentSheetScreen>(
+            coroutineScope = testScope,
+            initialScreen = PaymentSheetScreen.Loading,
+        ) {}
+
+        navigationHandler.currentScreen.test {
+            assertThat(awaitItem()).isEqualTo(PaymentSheetScreen.Loading)
+            val pendingScreen = mock<PaymentSheetScreen>()
+            navigationHandler.transitionToWithDelay(pendingScreen)
+            val droppedReplacement = mock<PaymentSheetScreen>(extraInterfaces = arrayOf(Closeable::class))
+
+            val replaced = navigationHandler.replaceCurrentScreen(droppedReplacement)
+
+            assertThat(replaced).isFalse()
+            verify(droppedReplacement as Closeable).close()
+            testScope.testScheduler.advanceTimeBy(251.milliseconds)
+            assertThat(awaitItem()).isEqualTo(pendingScreen)
+        }
+    }
+
+    @Test
     fun `pop removes the top screen from the backstack`() = runTest {
         var calledPopHandler = false
         val screenOne = mock<PaymentSheetScreen>()


### PR DESCRIPTION
# Summary

Adds an internal navigation action that replaces the current Embedded screen while preserving the earlier back stack and closing the replaced screen.

# Motivation

Embedded navigation sometimes needs to exchange the active screen without adding another back-stack entry. The replacement operation also needs explicit lifecycle behavior when navigation succeeds or when another transition is already in progress.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

./gradlew :paymentsheet:testDebugUnitTest — passed.

Ignored tests: None.

# Screenshots

Not applicable: this is internal navigation behavior with no visual changes.

# Changelog

Not applicable: this changes an internal navigation API and has no user-visible behavior on its own.

Committed and created by Codex.