### PR TITLE
Reduce PaymentSheet E2E managed-device concurrency

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,7 +10,8 @@ trigger_map:
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
-    # Limit concurrent managed devices so each emulator has reliable network connectivity.
+    # Split PaymentSheet E2E across two machines so no host runs more than three emulators.
+    - PAYMENTSHEET_E2E_MACHINE_SHARD_COUNT: 2
     - PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT: 3
 
 pipelines:
@@ -22,7 +23,8 @@ pipelines:
       run-financial-connections-and-crypto-instrumentation-tests: { }
       run-connections-e2e-tests-on-push: { }
       run-cardscan-and-google-pay-tests: { }
-      run-paymentsheet-e2e: { }
+      run-paymentsheet-e2e:
+        parallel: $PAYMENTSHEET_E2E_MACHINE_SHARD_COUNT
       check-dependencies-and-publish-pom: { }
   pipeline-connect-e2e-debug-tests:
     stages:
@@ -498,13 +500,13 @@ workflows:
                 #!/usr/bin/env bash
                 set -euo pipefail
                 # Keep the explicit class list so tests with dedicated workflows stay excluded.
-                CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index 0 --num-shards 1)
+                CLASSES=$(python3 scripts/get_shard_test_classes.py --shard-index "$BITRISE_IO_PARALLEL_INDEX" --num-shards "$PAYMENTSHEET_E2E_MACHINE_SHARD_COUNT")
 
                 ./scripts/retry_with_emulator_cleanup.sh 3 ./gradlew -PSTRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN=$STRIPE_PAYMENTSHEET_EXAMPLE_SENTRY_DSN -Pandroid.experimental.androidTest.numManagedDeviceShards=$PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT -Pandroid.experimental.testOptions.managedDevices.maxConcurrentDevices=$PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT "-Pandroid.testInstrumentationRunnerArguments.class=$CLASSES" :paymentsheet-example:pixel2api33chromeBaseDebugAndroidTest --init-script build-configuration/instrumentation-test-init.gradle
       - bundle::export_instrumentation_test_results:
           title: Export PaymentSheet E2E test results
           inputs:
-            - test_title: PaymentSheet E2E tests
+            - test_title: "PaymentSheet E2E tests (worker $BITRISE_IO_PARALLEL_INDEX)"
     meta:
       bitrise.io:
         stack: ubuntu-resolute-26.04-bitrise-2026-android

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -10,8 +10,8 @@ trigger_map:
 app:
   envs:
     - GRADLE_OPTS: -Dkotlin.incremental=false
-    # Run PaymentSheet E2E tests in parallel on one machine so Bitrise bills a single job.
-    - PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT: 6
+    # Limit concurrent managed devices so each emulator has reliable network connectivity.
+    - PAYMENTSHEET_E2E_DEVICE_SHARD_COUNT: 3
 
 pipelines:
   main-trigger-pipeline:


### PR DESCRIPTION
## Summary
- split PaymentSheet E2E classes across two parallel Bitrise workers
- run three managed devices per worker, preserving six-way device parallelism without placing all six emulators on one host
- retain all 53 E2E classes with disjoint 27/26-class worker partitions

## Diagnosis
The failed run was infrastructure-wide rather than a product/test race: five managed-device shards timed out before their test behavior while waiting for network-backed initial UI state, while shard 0 completed its tests. The failures covered two independent backend hosts (the playground checkout backend and the Address Element publishable-key backend), and a rerun passed. This began after #13921 moved six previously separate E2E workers onto six emulators on one host.

Running only three devices on the draft PR confirmed the host-concurrency mitigation but doubled wall time to 32 minutes. This revision instead uses two hosts with three devices each. It keeps the lower per-host pressure while restoring six-way aggregate parallelism; the tradeoff is two billable Bitrise workers instead of one.

## Testing
- `ruby -e 'require "yaml"; YAML.load_file("bitrise.yml", aliases: true); puts "bitrise.yml: valid YAML"'`\n- verified worker partitions contain 27 and 26 classes, have zero overlap, and exactly cover all 53 classes\n- `git diff --check`\n\nNo ShampooRule change was used: the evidence identifies a multi-emulator CI infrastructure failure, not an individual instrumentation-test synchronization failure.\n\nCommitted and created by Codex.