### PR TITLE
Prefer billing country for removed-form Klarna

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -126,7 +126,8 @@ private object KlarnaRemovedFormUiDefinitionFactory : UiDefinitionFactory.Simple
                 )
                 .requireCountry(
                     allowedCountryCodes = arguments.billingDetailsCollectionConfiguration.allowedBillingCountries,
-                    initialValue = metadata.stripeIntent.countryCode,
+                    initialValue = arguments.initialValues[IdentifierSpec.Country]
+                        ?: metadata.stripeIntent.countryCode,
                 )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionNoFormTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionNoFormTest.kt
@@ -93,7 +93,7 @@ class KlarnaDefinitionNoFormTest {
     }
 
     @Test
-    fun `createFormElements uses setup intent country before default billing country`() {
+    fun `createFormElements uses default billing country before setup intent country`() {
         val formElements = KlarnaDefinition.formElements(
             PaymentMethodMetadataFactory.create(
                 stripeIntent = SetupIntentFactory.create(
@@ -102,6 +102,23 @@ class KlarnaDefinitionNoFormTest {
                 ),
                 defaultBillingDetails = PaymentSheet.BillingDetails(
                     address = PaymentSheet.Address(country = "CA"),
+                ),
+            )
+        )
+
+        assertThat(formElements).hasSize(3)
+        assertThat(formElements[1].identifier.v1).isEqualTo("billing_details[address][country]_section")
+        val countryElement = (formElements[1] as SectionElement).fields.single() as CountryElement
+        assertThat(countryElement.controller.rawFieldValue.value).isEqualTo("CA")
+    }
+
+    @Test
+    fun `createFormElements uses setup intent country when default billing country is absent`() {
+        val formElements = KlarnaDefinition.formElements(
+            PaymentMethodMetadataFactory.create(
+                stripeIntent = SetupIntentFactory.create(
+                    paymentMethodTypes = listOf("card", "klarna"),
+                    countryCode = "US",
                 ),
             )
         )


### PR DESCRIPTION
# Summary

Restores default billing-country precedence for removed-form Klarna SetupIntent country collection.

# Motivation

When a removed-form Klarna SetupIntent has both a restored/default billing country and an Elements Session country, the billing country should win. The Elements Session country remains the fallback when billing country is absent.

The change is standalone on `master` after PR #14136 merged. It updates only `KlarnaDefinition.kt` and `KlarnaDefinitionNoFormTest.kt`.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.lpmfoundations.paymentmethod.definitions.KlarnaDefinitionNoFormTest' --tests 'com.stripe.android.lpmfoundations.luxe.FormElementsBuilderTest' :paymentsheet:detekt :paymentsheet:apiCheck`
- Path-aware pre-push checks: `./gradlew :paymentsheet:apiCheck :paymentsheet:detekt`
- `git diff --check origin/master..HEAD`

# Screenshots

Not applicable. This is a non-visual behavior and test change.

# Changelog

Not applicable. This is a narrow fix with no changelog entry.

Committed and created by Codex.
