### PR TITLE
Move PaymentElementTheme to stripe-ui-core

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentElementThemeValues.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentElementThemeValues.kt
@@ -6,6 +6,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.sp
 import com.stripe.android.paymentelement.AppearanceAPIAdditionsPreview
 import com.stripe.android.uicore.FormInsets
+import com.stripe.android.uicore.PaymentElementThemeMode
+import com.stripe.android.uicore.PaymentElementThemeValues
 import com.stripe.android.uicore.PrimaryButtonColors
 import com.stripe.android.uicore.PrimaryButtonShape
 import com.stripe.android.uicore.PrimaryButtonStyle
@@ -16,24 +18,12 @@ import com.stripe.android.uicore.StripeThemeDefaults
 import com.stripe.android.uicore.StripeTypography
 import com.stripe.android.uicore.IconStyle as StripeIconStyle
 
-internal data class PaymentElementThemeValues(
-    val colorsLight: StripeColors,
-    val colorsDark: StripeColors,
-    val shapes: StripeShapes,
-    val typography: StripeTypography,
-    val primaryButtonStyle: PrimaryButtonStyle,
-    val formInsets: FormInsets,
-    val sectionSpacing: Float?,
-    val textFieldInsets: FormInsets,
-    val iconStyle: StripeIconStyle,
-    val verticalModeRowPadding: Float,
-)
-
 @OptIn(AppearanceAPIAdditionsPreview::class)
 internal fun PaymentSheet.Appearance.toPaymentElementThemeValues(): PaymentElementThemeValues {
     return PaymentElementThemeValues(
         colorsLight = colorsLight.toStripeColors(isDark = false),
         colorsDark = colorsDark.toStripeColors(isDark = true),
+        themeMode = themeMode.toPaymentElementThemeMode(),
         shapes = shapes.toStripeShapes(),
         typography = typography.toStripeTypography(),
         primaryButtonStyle = primaryButton.toStripePrimaryButtonStyle(
@@ -48,6 +38,14 @@ internal fun PaymentSheet.Appearance.toPaymentElementThemeValues(): PaymentEleme
         iconStyle = iconStyle.toStripeIconStyle(),
         verticalModeRowPadding = verticalModeRowPadding,
     )
+}
+
+internal fun PaymentSheet.ThemeMode.toPaymentElementThemeMode(): PaymentElementThemeMode {
+    return when (this) {
+        PaymentSheet.ThemeMode.Automatic -> PaymentElementThemeMode.Automatic
+        PaymentSheet.ThemeMode.AlwaysLight -> PaymentElementThemeMode.AlwaysLight
+        PaymentSheet.ThemeMode.AlwaysDark -> PaymentElementThemeMode.AlwaysDark
+    }
 }
 
 private fun PaymentSheet.Colors.toStripeColors(isDark: Boolean): StripeColors {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElementTheme.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentElementTheme.kt
@@ -1,97 +1,28 @@
 package com.stripe.android.paymentsheet.ui
 
-import android.content.Context
-import android.content.res.Configuration
-import android.content.res.Resources
-import android.view.ContextThemeWrapper
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalInspectionMode
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.toPaymentElementThemeMode
 import com.stripe.android.paymentsheet.toPaymentElementThemeValues
-import com.stripe.android.uicore.StripeTheme
-import com.stripe.android.uicore.StripeThemeDefaults
+import com.stripe.android.uicore.isDarkTheme
+import com.stripe.android.uicore.PaymentElementTheme as UiCorePaymentElementTheme
 
 @Composable
 internal fun PaymentElementTheme(
     appearance: PaymentSheet.Appearance,
     content: @Composable () -> Unit,
 ) {
-    val isDark = appearance.themeMode.isDarkTheme(isSystemInDarkTheme())
     val themeValues = remember(appearance) {
         appearance.toPaymentElementThemeValues()
     }
-    val baseContext = LocalContext.current
-    val inspectionMode = LocalInspectionMode.current
-    val styleContext = remember(baseContext, isDark, inspectionMode) {
-        baseContext.withUiMode(
-            uiMode = if (isDark) {
-                Configuration.UI_MODE_NIGHT_YES
-            } else {
-                Configuration.UI_MODE_NIGHT_NO
-            },
-            inspectionMode = inspectionMode,
-        )
-    }
 
-    CompositionLocalProvider(
-        LocalContext provides styleContext,
-    ) {
-        StripeTheme(
-            isDark = isDark,
-            colors = if (isDark) themeValues.colorsDark else themeValues.colorsLight,
-            shapes = themeValues.shapes,
-            typography = themeValues.typography,
-            primaryButtonStyle = themeValues.primaryButtonStyle,
-            formInsets = themeValues.formInsets,
-            sectionSpacing = themeValues.sectionSpacing,
-            sectionStyle = StripeThemeDefaults.sectionStyle,
-            textFieldInsets = themeValues.textFieldInsets,
-            iconStyle = themeValues.iconStyle,
-            verticalModeRowPadding = themeValues.verticalModeRowPadding,
-            content = content,
-        )
-    }
+    UiCorePaymentElementTheme(
+        values = themeValues,
+        content = content,
+    )
 }
 
 internal fun PaymentSheet.ThemeMode.isDarkTheme(isSystemDark: Boolean): Boolean {
-    return when (this) {
-        PaymentSheet.ThemeMode.Automatic -> isSystemDark
-        PaymentSheet.ThemeMode.AlwaysLight -> false
-        PaymentSheet.ThemeMode.AlwaysDark -> true
-    }
-}
-
-private fun Context.withUiMode(
-    uiMode: Int,
-    inspectionMode: Boolean,
-): Context {
-    if (uiMode == (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK)) {
-        return this
-    }
-
-    val config = Configuration(resources.configuration).apply {
-        this.uiMode = (this.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or uiMode
-    }
-
-    return object : ContextThemeWrapper(this, theme) {
-        override fun getResources(): Resources {
-            @Suppress("DEPRECATION")
-            if (inspectionMode) {
-                val baseResources = this@withUiMode.resources
-                return Resources(
-                    baseResources.assets,
-                    baseResources.displayMetrics,
-                    config,
-                )
-            }
-
-            return super.getResources()
-        }
-    }.apply {
-        applyOverrideConfiguration(config)
-    }
+    return toPaymentElementThemeMode().isDarkTheme(isSystemDark)
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/PaymentElementTheme.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/PaymentElementTheme.kt
@@ -1,0 +1,84 @@
+package com.stripe.android.uicore
+
+import android.content.Context
+import android.content.res.Configuration
+import android.content.res.Resources
+import android.view.ContextThemeWrapper
+import androidx.annotation.RestrictTo
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+
+@Composable
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PaymentElementTheme(
+    values: PaymentElementThemeValues,
+    content: @Composable () -> Unit,
+) {
+    val isDark = values.themeMode.isDarkTheme(isSystemInDarkTheme())
+    val baseContext = LocalContext.current
+    val inspectionMode = LocalInspectionMode.current
+    val styleContext = remember(baseContext, isDark, inspectionMode) {
+        baseContext.withUiMode(
+            uiMode = if (isDark) {
+                Configuration.UI_MODE_NIGHT_YES
+            } else {
+                Configuration.UI_MODE_NIGHT_NO
+            },
+            inspectionMode = inspectionMode,
+        )
+    }
+
+    CompositionLocalProvider(
+        LocalContext provides styleContext,
+    ) {
+        StripeTheme(
+            isDark = isDark,
+            colors = if (isDark) values.colorsDark else values.colorsLight,
+            shapes = values.shapes,
+            typography = values.typography,
+            primaryButtonStyle = values.primaryButtonStyle,
+            formInsets = values.formInsets,
+            sectionSpacing = values.sectionSpacing,
+            sectionStyle = StripeThemeDefaults.sectionStyle,
+            textFieldInsets = values.textFieldInsets,
+            iconStyle = values.iconStyle,
+            verticalModeRowPadding = values.verticalModeRowPadding,
+            content = content,
+        )
+    }
+}
+
+private fun Context.withUiMode(
+    uiMode: Int,
+    inspectionMode: Boolean,
+): Context {
+    if (uiMode == (resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK)) {
+        return this
+    }
+
+    val config = Configuration(resources.configuration).apply {
+        this.uiMode = (this.uiMode and Configuration.UI_MODE_NIGHT_MASK.inv()) or uiMode
+    }
+
+    return object : ContextThemeWrapper(this, theme) {
+        override fun getResources(): Resources {
+            @Suppress("DEPRECATION")
+            if (inspectionMode) {
+                val baseResources = this@withUiMode.resources
+                return Resources(
+                    baseResources.assets,
+                    baseResources.displayMetrics,
+                    config,
+                )
+            }
+
+            return super.getResources()
+        }
+    }.apply {
+        applyOverrideConfiguration(config)
+    }
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/PaymentElementThemeMode.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/PaymentElementThemeMode.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.uicore
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+enum class PaymentElementThemeMode {
+    Automatic,
+    AlwaysLight,
+    AlwaysDark,
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun PaymentElementThemeMode.isDarkTheme(isSystemDark: Boolean): Boolean {
+    return when (this) {
+        PaymentElementThemeMode.Automatic -> isSystemDark
+        PaymentElementThemeMode.AlwaysLight -> false
+        PaymentElementThemeMode.AlwaysDark -> true
+    }
+}

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/PaymentElementThemeValues.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/PaymentElementThemeValues.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.uicore
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class PaymentElementThemeValues(
+    val colorsLight: StripeColors,
+    val colorsDark: StripeColors,
+    val themeMode: PaymentElementThemeMode,
+    val shapes: StripeShapes,
+    val typography: StripeTypography,
+    val primaryButtonStyle: PrimaryButtonStyle,
+    val formInsets: FormInsets,
+    val sectionSpacing: Float?,
+    val textFieldInsets: FormInsets,
+    val iconStyle: IconStyle,
+    val verticalModeRowPadding: Float,
+)

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/PaymentElementThemeTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/PaymentElementThemeTest.kt
@@ -1,0 +1,143 @@
+package com.stripe.android.uicore
+
+import android.os.Build
+import androidx.compose.material.MaterialTheme
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.createComposeCleanupRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+internal class PaymentElementThemeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @Test
+    @Config(qualifiers = "notnight")
+    fun `always dark overrides system light theme`() = runScenario(
+        themeMode = PaymentElementThemeMode.AlwaysDark,
+    ) {
+        assertThat(isDark).isTrue()
+        assertThat(contextIsDark).isTrue()
+        assertThat(colors.materialColors.primary).isEqualTo(DARK_PRIMARY)
+        assertThat(shapes.cornerRadius).isEqualTo(12f)
+        assertThat(typography.fontSizeMultiplier).isEqualTo(1.5f)
+        assertThat(primaryButtonStyle.colorsDark.background).isEqualTo(DARK_BUTTON)
+        assertThat(formInsets).isEqualTo(FormInsets(start = 1f, top = 2f, end = 3f, bottom = 4f))
+        assertThat(sectionSpacing).isEqualTo(10f)
+        assertThat(textFieldInsets).isEqualTo(FormInsets(start = 5f, top = 6f, end = 7f, bottom = 8f))
+        assertThat(iconStyle).isEqualTo(IconStyle.Outlined)
+        assertThat(verticalModeRowPadding).isEqualTo(9f)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `always light overrides system dark theme`() = runScenario(
+        themeMode = PaymentElementThemeMode.AlwaysLight,
+    ) {
+        assertThat(isDark).isFalse()
+        assertThat(contextIsDark).isFalse()
+        assertThat(colors.materialColors.primary).isEqualTo(LIGHT_PRIMARY)
+        assertThat(primaryButtonStyle.colorsLight.background).isEqualTo(LIGHT_BUTTON)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `automatic follows system dark theme`() = runScenario(
+        themeMode = PaymentElementThemeMode.Automatic,
+    ) {
+        assertThat(isDark).isTrue()
+        assertThat(contextIsDark).isTrue()
+        assertThat(colors.materialColors.primary).isEqualTo(DARK_PRIMARY)
+    }
+
+    @Test
+    @Config(qualifiers = "notnight")
+    fun `automatic follows system light theme`() = runScenario(
+        themeMode = PaymentElementThemeMode.Automatic,
+    ) {
+        assertThat(isDark).isFalse()
+        assertThat(contextIsDark).isFalse()
+        assertThat(colors.materialColors.primary).isEqualTo(LIGHT_PRIMARY)
+    }
+
+    private fun runScenario(
+        themeMode: PaymentElementThemeMode,
+        block: ThemeSnapshot.() -> Unit,
+    ) {
+        var snapshot: ThemeSnapshot? = null
+
+        composeRule.setContent {
+            PaymentElementTheme(
+                values = THEME_VALUES.copy(themeMode = themeMode),
+            ) {
+                snapshot = ThemeSnapshot(
+                    isDark = MaterialTheme.stripeThemeIsDark,
+                    contextIsDark = androidx.compose.ui.platform.LocalContext.current.isSystemDarkTheme(),
+                    colors = MaterialTheme.stripeColors,
+                    shapes = MaterialTheme.stripeShapes,
+                    typography = MaterialTheme.stripeTypography,
+                    primaryButtonStyle = MaterialTheme.stripePrimaryButtonStyle,
+                    formInsets = MaterialTheme.stripeFormInsets,
+                    sectionSpacing = LocalSectionSpacing.current,
+                    textFieldInsets = LocalTextFieldInsets.current,
+                    iconStyle = LocalIconStyle.current,
+                    verticalModeRowPadding = MaterialTheme.stripeVerticalModeRowPadding,
+                )
+            }
+        }
+        composeRule.waitForIdle()
+
+        requireNotNull(snapshot).apply(block)
+    }
+
+    private data class ThemeSnapshot(
+        val isDark: Boolean,
+        val contextIsDark: Boolean,
+        val colors: StripeColors,
+        val shapes: StripeShapes,
+        val typography: StripeTypography,
+        val primaryButtonStyle: PrimaryButtonStyle,
+        val formInsets: FormInsets,
+        val sectionSpacing: Float?,
+        val textFieldInsets: FormInsets,
+        val iconStyle: IconStyle,
+        val verticalModeRowPadding: Float,
+    )
+
+    private companion object {
+        val LIGHT_PRIMARY = Color(0xFF123456)
+        val DARK_PRIMARY = Color(0xFF654321)
+        val LIGHT_BUTTON = Color(0xFFABCDEF)
+        val DARK_BUTTON = Color(0xFFFEDCBA)
+        val THEME_VALUES = PaymentElementThemeValues(
+            colorsLight = StripeThemeDefaults.colorsLight.copy(
+                materialColors = StripeThemeDefaults.colorsLight.materialColors.copy(primary = LIGHT_PRIMARY),
+            ),
+            colorsDark = StripeThemeDefaults.colorsDark.copy(
+                materialColors = StripeThemeDefaults.colorsDark.materialColors.copy(primary = DARK_PRIMARY),
+            ),
+            themeMode = PaymentElementThemeMode.Automatic,
+            shapes = StripeThemeDefaults.shapes.copy(cornerRadius = 12f),
+            typography = StripeThemeDefaults.typography.copy(fontSizeMultiplier = 1.5f),
+            primaryButtonStyle = StripeThemeDefaults.primaryButtonStyle.copy(
+                colorsLight = StripeThemeDefaults.primaryButtonStyle.colorsLight.copy(background = LIGHT_BUTTON),
+                colorsDark = StripeThemeDefaults.primaryButtonStyle.colorsDark.copy(background = DARK_BUTTON),
+            ),
+            formInsets = FormInsets(start = 1f, top = 2f, end = 3f, bottom = 4f),
+            sectionSpacing = 10f,
+            textFieldInsets = FormInsets(start = 5f, top = 6f, end = 7f, bottom = 8f),
+            iconStyle = IconStyle.Outlined,
+            verticalModeRowPadding = 9f,
+        )
+    }
+}


### PR DESCRIPTION
# Summary

- Move `PaymentElementThemeValues` and the scoped `PaymentElementTheme` implementation into `stripe-ui-core`.
- Add a UI-core `PaymentElementThemeMode` and resolve automatic, light, and dark modes inside the scoped theme.
- Keep the PaymentSheet wrapper responsible only for converting `PaymentSheet.Appearance` into UI-core values.

# Motivation

`payments-core` cannot depend on `PaymentSheet.Appearance`. This establishes a module-neutral scoped theme API that a follow-up PaymentLauncher change can consume without reading mutable global `StripeTheme` values. This PR only moves ownership and preserves existing PaymentSheet behavior.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

- `./gradlew :stripe-ui-core:testDebugUnitTest --tests 'com.stripe.android.uicore.PaymentElementThemeTest'`
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.ui.PaymentElementThemeTest'`
- `./gradlew :stripe-ui-core:detekt :paymentsheet:detekt :stripe-ui-core:apiCheck`

# Screenshots

No visual changes.

# Changelog

No user-facing API change.
