### PR TITLE
Find skipped `paymentsheet-example` E2E tests and fail github check if found

### DIFF
--- a/.github/workflows/find_skipped_e2e_tests.yml
+++ b/.github/workflows/find_skipped_e2e_tests.yml
@@ -1,0 +1,76 @@
+name: Find skipped E2E tests
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  find-skipped-e2e-tests:
+    name: Find skipped E2E tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Find skipped E2E tests
+        id: skipped_tests
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          matches=$(git diff \
+            --unified=0 \
+            "$BASE_SHA"..."$HEAD_SHA" \
+            -- paymentsheet-example/src/androidTest \
+            | grep -E '^\+[[:space:]]*@Ignore([[:space:](]|$)' \
+            || true)
+
+          if [[ -n "$matches" ]]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+            {
+              echo 'matches<<EOF'
+              echo "$matches"
+              echo 'EOF'
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
+        id: find_comment
+        if: steps.skipped_tests.outputs.found == 'true' && !contains(github.event.pull_request.labels.*.name, 'accept-skipped-test')
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: '[find-skipped-e2e-tests]'
+
+      - uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
+        if: steps.skipped_tests.outputs.found == 'true' && !contains(github.event.pull_request.labels.*.name, 'accept-skipped-test')
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚨 Skipped end-to-end tests detected in this PR:
+
+            ```text
+            ${{ steps.skipped_tests.outputs.matches }}
+            ```
+
+            Please remove the `@Ignore` annotation before merging. Tests should not be skipped.
+
+            If this is intentional, you can bypass this check by adding the label `accept-skipped-test` to this PR.
+
+            ℹ️ If this comment appears to be left in error, double check that the flagged tests are end-to-end tests and/or make sure your branch is up-to-date with `master`.
+
+            [find-skipped-e2e-tests]
+          edit-mode: replace
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fail if skipped tests are not accepted
+        if: steps.skipped_tests.outputs.found == 'true' && !contains(github.event.pull_request.labels.*.name, 'accept-skipped-test')
+        run: exit 1

--- a/.github/workflows/find_skipped_e2e_tests.yml
+++ b/.github/workflows/find_skipped_e2e_tests.yml
@@ -25,10 +25,30 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           matches=$(git diff \
-            --unified=0 \
+            --unified=10 \
             "$BASE_SHA"..."$HEAD_SHA" \
             -- paymentsheet-example/src/androidTest \
-            | grep -E '^\+[[:space:]]*@Ignore([[:space:](]|$)' \
+            | awk '
+              /^\+\+\+ b\// {
+                file = substr($0, 7)
+              }
+              /^\+[[:space:]]*@Ignore([[:space:](]|$)/ {
+                ignored = 1
+                next
+              }
+              ignored && /^[+ ][[:space:]]*fun[[:space:]]+/ {
+                test_name = substr($0, 2)
+                sub(/^[[:space:]]*fun[[:space:]]+/, "", test_name)
+                sub(/[[:space:](].*$/, "", test_name)
+                print file ": " test_name
+                ignored = 0
+              }
+              /^diff --git / || /^@@ / {
+                if (ignored) {
+                  ignored = 0
+                }
+              }
+            ' \
             || true)
 
           if [[ -n "$matches" ]]; then


### PR DESCRIPTION
# Summary
Find skipped `paymentsheet-example` E2E tests and fail github check if found. This is done by checking the Github diff for `@Ignore` additions in the `paymentsheet-example/src/androidTest` folder. 

# Motivation
[RUN_MOBILESDK-5558](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5558)

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified