### PR TITLE
Extract stateless form definition factory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/NativeLinkFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/NativeLinkFormHelperFactory.kt
@@ -1,0 +1,62 @@
+package com.stripe.android.link.ui.paymentmenthod
+
+import androidx.lifecycle.viewModelScope
+import com.stripe.android.link.injection.NativeLinkComponent
+import com.stripe.android.paymentsheet.DefaultFormDefinitionFactory
+import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.FormHelper
+import com.stripe.android.paymentsheet.LinkInlineHandler
+import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
+import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
+import com.stripe.android.paymentsheet.addresselement.analytics.NoOpAddressLauncherEventReporter
+import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+
+internal class NativeLinkFormHelperFactory(
+    private val parentComponent: NativeLinkComponent,
+) {
+    fun create(): FormHelper {
+        val linkInlineHandler = LinkInlineHandler.create()
+        val paymentMethodMetadata = parentComponent.paymentMethodMetadata
+
+        return DefaultFormHelper(
+            coroutineScope = parentComponent.viewModel.viewModelScope,
+            linkInlineHandler = linkInlineHandler,
+            paymentMethodMetadata = paymentMethodMetadata,
+            selectionUpdater = {},
+            eventReporter = parentComponent.eventReporter,
+            savedStateHandle = parentComponent.viewModel.savedStateHandle,
+            formDefinitionFactory = DefaultFormDefinitionFactory(
+                linkInlineHandler = linkInlineHandler,
+                cardAccountRangeRepositoryFactory = parentComponent.cardAccountRangeRepositoryFactory,
+                paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = { null },
+                linkConfigurationCoordinator = null,
+                setAsDefaultMatchesSaveForFutureUse =
+                    FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+                autocompleteAddressInteractorFactory = createAutocompleteAddressInteractorFactory(),
+                isLinkUI = true,
+                automaticallyLaunchedCardScanFormDataHelper = null,
+                tapToAddHelper = null,
+                paymentMethodMessagePromotionsHelper = null,
+                isNfcScanningAvailable = null,
+            ),
+        )
+    }
+
+    private fun createAutocompleteAddressInteractorFactory(): AutocompleteAddressInteractor.Factory {
+        return PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = parentComponent.autocompleteLauncher,
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
+                autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
+                isInlineAutocompleteEnabled = true,
+            ),
+            placesClient = null,
+            stripeAutocompleteRepository = null,
+            coroutineScope = null,
+            shouldUseAutocompleteProxyEndpointsProvider = { false },
+            eventReporter = NoOpAddressLauncherEventReporter,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -23,13 +23,8 @@ import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.completePaymentButtonLabel
 import com.stripe.android.link.withDismissalDisabled
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
-import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
-import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
-import com.stripe.android.paymentsheet.addresselement.analytics.NoOpAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
-import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -196,28 +191,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                             dismissalCoordinator = parentComponent.dismissalCoordinator,
                             linkLaunchMode = parentComponent.linkLaunchMode
                         ),
-                        formHelper = DefaultFormHelper.create(
-                            coroutineScope = parentComponent.viewModel.viewModelScope,
-                            cardAccountRangeRepositoryFactory = parentComponent.cardAccountRangeRepositoryFactory,
-                            paymentMethodMetadata = parentComponent.paymentMethodMetadata,
-                            eventReporter = parentComponent.eventReporter,
-                            savedStateHandle = parentComponent.viewModel.savedStateHandle,
-                            autocompleteAddressInteractorFactory =
-                                PaymentElementAutocompleteAddressInteractor.Factory(
-                                    launcher = parentComponent.autocompleteLauncher,
-                                    autocompleteConfig = AutocompleteAddressInteractor.Config(
-                                        googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
-                                        autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
-                                        isInlineAutocompleteEnabled = true,
-                                    ),
-                                    placesClient = null,
-                                    stripeAutocompleteRepository = null,
-                                    coroutineScope = null,
-                                    shouldUseAutocompleteProxyEndpointsProvider = { false },
-                                    eventReporter = NoOpAddressLauncherEventReporter,
-                                ),
-                            isLinkUI = true,
-                        ),
+                        formHelper = NativeLinkFormHelperFactory(parentComponent).create(),
                         logger = parentComponent.logger,
                         dismissalCoordinator = parentComponent.dismissalCoordinator,
                         linkLaunchMode = parentComponent.linkLaunchMode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -8,7 +8,9 @@ import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.DefaultFormDefinitionFactory
 import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.FormDefinitionFactory
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
@@ -38,39 +40,60 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
         paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
         selectionUpdater: (PaymentSelection?) -> Unit,
     ): FormHelper {
+        val linkInlineHandler = LinkInlineHandler.create()
         return DefaultFormHelper(
             coroutineScope = coroutineScope,
-            linkInlineHandler = LinkInlineHandler.create(),
-            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+            linkInlineHandler = linkInlineHandler,
             paymentMethodMetadata = paymentMethodMetadata,
-            newPaymentSelectionProvider = { code ->
-                val currentSelection = embeddedSelectionHolder.selection.value
-                    ?.takeIf { it.paymentMethodType == code }
-                    ?: embeddedSelectionHolder.getPreviousNewSelection(code)
-                when (currentSelection) {
-                    is PaymentSelection.ExternalPaymentMethod -> {
-                        NewPaymentOptionSelection.External(currentSelection)
-                    }
-                    is PaymentSelection.CustomPaymentMethod -> {
-                        NewPaymentOptionSelection.Custom(currentSelection)
-                    }
-                    is PaymentSelection.New -> {
-                        NewPaymentOptionSelection.New(currentSelection)
-                    }
-                    else -> null
-                }
-            },
             selectionUpdater = selectionUpdater,
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
-            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
             eventReporter = eventReporter,
             savedStateHandle = savedStateHandle,
+            formDefinitionFactory = createFormDefinitionFactory(
+                setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+                paymentMethodMetadata = paymentMethodMetadata,
+                automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+                tapToAddHelper = tapToAddHelper,
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                linkInlineHandler = linkInlineHandler,
+            ),
+        )
+    }
+
+    fun createFormDefinitionFactory(
+        setAsDefaultMatchesSaveForFutureUse: Boolean,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+        tapToAddHelper: TapToAddHelper?,
+        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+        linkInlineHandler: LinkInlineHandler,
+    ): FormDefinitionFactory {
+        return DefaultFormDefinitionFactory(
+            linkInlineHandler = linkInlineHandler,
+            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+            paymentMethodMetadata = paymentMethodMetadata,
+            newPaymentSelectionProvider = ::newPaymentSelection,
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
+            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
             autocompleteAddressInteractorFactory = null,
+            isLinkUI = false,
             automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
             tapToAddHelper = tapToAddHelper,
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
             isNfcScanningAvailable = isNfcScanningAvailable,
         )
+    }
+
+    private fun newPaymentSelection(code: PaymentMethodCode): NewPaymentOptionSelection? {
+        return when (
+            val currentSelection = embeddedSelectionHolder.selection.value
+                ?.takeIf { it.paymentMethodType == code }
+                ?: embeddedSelectionHolder.getPreviousNewSelection(code)
+        ) {
+            is PaymentSelection.ExternalPaymentMethod -> NewPaymentOptionSelection.External(currentSelection)
+            is PaymentSelection.CustomPaymentMethod -> NewPaymentOptionSelection.Custom(currentSelection)
+            is PaymentSelection.New -> NewPaymentOptionSelection.New(currentSelection)
+            else -> null
+        }
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
@@ -3,18 +3,16 @@ package com.stripe.android.paymentelement.embedded.content
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.containsVolatileDifferences
-import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.FormHelper
-import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -32,8 +30,6 @@ internal fun interface EmbeddedSelectionChooser {
 internal class DefaultEmbeddedSelectionChooser @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val formHelperFactory: EmbeddedFormHelperFactory,
-    private val eventReporter: EventReporter,
-    @ViewModelScope private val coroutineScope: CoroutineScope,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
 ) : EmbeddedSelectionChooser {
     private var previousConfiguration: CommonConfiguration?
@@ -151,35 +147,34 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
         previousSelection: PaymentSelection.New,
         paymentMethodMetadata: PaymentMethodMetadata,
     ): Boolean {
-        val newFormHelper = formHelperFactory.create(
-            coroutineScope = coroutineScope,
+        val newFormDefinitionFactory = formHelperFactory.createFormDefinitionFactory(
             paymentMethodMetadata = paymentMethodMetadata,
-            eventReporter = eventReporter,
             // Card scan auto-launch is only relevant in the form, not when selecting the default.
             automaticallyLaunchedCardScanFormDataHelper = null,
             tapToAddHelper = null,
             // Not important for determining formType so use default value
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
             paymentMethodMessagePromotionsHelper = null,
-        ) {}
-        val newFormType = newFormHelper.formTypeForCode(previousSelection.paymentMethodType)
+            linkInlineHandler = LinkInlineHandler.create(),
+        )
+        val newFormType = newFormDefinitionFactory.formTypeForCode(previousSelection.paymentMethodType)
         if (newFormType != FormHelper.FormType.UserInteractionRequired) {
             return true
         }
         return previousPaymentMethodMetadata?.let { previousPaymentMethodMetadata ->
-            val previousFormHelper = formHelperFactory.create(
-                coroutineScope = coroutineScope,
+            val previousFormDefinitionFactory = formHelperFactory.createFormDefinitionFactory(
                 paymentMethodMetadata = previousPaymentMethodMetadata,
-                eventReporter = eventReporter,
                 // Card scan auto-launch is only relevant in the form, not when selecting the default.
                 automaticallyLaunchedCardScanFormDataHelper = null,
                 tapToAddHelper = null,
                 // Not important for determining formType so use default value
                 setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
-                paymentMethodMessagePromotionsHelper = null
-            ) {}
-            val previousFormElements = previousFormHelper.formElementsForCode(previousSelection.paymentMethodType)
-            val newFormElements = newFormHelper.formElementsForCode(previousSelection.paymentMethodType)
+                paymentMethodMessagePromotionsHelper = null,
+                linkInlineHandler = LinkInlineHandler.create(),
+            )
+            val previousFormElements =
+                previousFormDefinitionFactory.formElementsForCode(previousSelection.paymentMethodType)
+            val newFormElements = newFormDefinitionFactory.formElementsForCode(previousSelection.paymentMethodType)
             previousFormElements.size >= newFormElements.size
         } == true
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
@@ -1,0 +1,79 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
+import kotlinx.coroutines.CoroutineScope
+
+internal class BaseSheetFormHelperFactory(
+    private val viewModel: BaseSheetViewModel,
+) {
+    fun create(
+        coroutineScope: CoroutineScope,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        linkInlineHandler: LinkInlineHandler,
+        shouldCreateAutomaticallyLaunchedCardScanFormDataHelper: Boolean,
+        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+    ): FormHelper {
+        return DefaultFormHelper(
+            coroutineScope = coroutineScope,
+            linkInlineHandler = linkInlineHandler,
+            paymentMethodMetadata = paymentMethodMetadata,
+            selectionUpdater = viewModel::updateSelection,
+            eventReporter = viewModel.eventReporter,
+            savedStateHandle = viewModel.savedStateHandle,
+            formDefinitionFactory = createFormDefinitionFactory(
+                paymentMethodMetadata = paymentMethodMetadata,
+                linkInlineHandler = linkInlineHandler,
+                automaticallyLaunchedCardScanFormDataHelper = createAutomaticallyLaunchedCardScanFormDataHelper(
+                    shouldCreate = shouldCreateAutomaticallyLaunchedCardScanFormDataHelper,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                ),
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+            ),
+        )
+    }
+
+    private fun createFormDefinitionFactory(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        linkInlineHandler: LinkInlineHandler,
+        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+    ): FormDefinitionFactory {
+        return DefaultFormDefinitionFactory(
+            linkInlineHandler = linkInlineHandler,
+            cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
+            paymentMethodMetadata = paymentMethodMetadata,
+            newPaymentSelectionProvider = { viewModel.newPaymentSelection },
+            linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
+            setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
+            autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+            isLinkUI = false,
+            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+            tapToAddHelper = viewModel.tapToAddHelper,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+            isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
+        )
+    }
+
+    private fun createAutomaticallyLaunchedCardScanFormDataHelper(
+        shouldCreate: Boolean,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): AutomaticallyLaunchedCardScanFormDataHelper? {
+        if (!shouldCreate) {
+            return null
+        }
+
+        val hasSeenAutomaticCardScanLaunch =
+            viewModel.newPaymentSelection?.paymentSelection is PaymentSelection.New.Card &&
+                viewModel.newPaymentSelection?.getPaymentMethodCreateParams() != null
+
+        return AutomaticallyLaunchedCardScanFormDataHelper(
+            openCardScanAutomaticallyConfig = paymentMethodMetadata.openCardScanAutomatically,
+            savedStateHandle = viewModel.savedStateHandle,
+            hasAutomaticallyLaunchedCardScanInitialValue = hasSeenAutomaticCardScanLaunch,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -1,131 +1,32 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.cards.CardAccountRangeRepository
-import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
-import com.stripe.android.common.taptoadd.TapToAddHelper
-import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.FormHelper.FormType
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
-import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
-import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
-import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
+private const val PREVIOUSLY_COMPLETED_PAYMENT_FORM = "previously_completed_payment_form"
+
 internal class DefaultFormHelper(
     private val coroutineScope: CoroutineScope,
     private val linkInlineHandler: LinkInlineHandler,
-    private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     private val paymentMethodMetadata: PaymentMethodMetadata,
-    private val newPaymentSelectionProvider: (PaymentMethodCode) -> NewPaymentOptionSelection?,
     private val selectionUpdater: (PaymentSelection?) -> Unit,
-    private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
-    private val setAsDefaultMatchesSaveForFutureUse: Boolean,
     private val eventReporter: EventReporter,
     private val savedStateHandle: SavedStateHandle,
-    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
-    private val isLinkUI: Boolean = false,
-    private val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
-    private val tapToAddHelper: TapToAddHelper?,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
-    private val isNfcScanningAvailable: IsNfcScanningAvailable?,
-) : FormHelper {
-    companion object {
-        internal const val PREVIOUSLY_COMPLETED_PAYMENT_FORM = "previously_completed_payment_form"
-        fun create(
-            viewModel: BaseSheetViewModel,
-            coroutineScope: CoroutineScope,
-            paymentMethodMetadata: PaymentMethodMetadata,
-            linkInlineHandler: LinkInlineHandler = LinkInlineHandler.create(),
-            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper: Boolean = false,
-            paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
-        ): FormHelper {
-            return DefaultFormHelper(
-                coroutineScope = coroutineScope,
-                linkInlineHandler = linkInlineHandler,
-                cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
-                paymentMethodMetadata = paymentMethodMetadata,
-                newPaymentSelectionProvider = {
-                    viewModel.newPaymentSelection
-                },
-                linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
-                selectionUpdater = {
-                    viewModel.updateSelection(it)
-                },
-                setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
-                eventReporter = viewModel.eventReporter,
-                savedStateHandle = viewModel.savedStateHandle,
-                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
-                automaticallyLaunchedCardScanFormDataHelper =
-                if (shouldCreateAutomaticallyLaunchedCardScanFormDataHelper) {
-                    val hasSeenAutomaticCardScanLaunch =
-                        viewModel.newPaymentSelection?.paymentSelection is PaymentSelection.New.Card &&
-                            viewModel.newPaymentSelection?.getPaymentMethodCreateParams() != null
-
-                    AutomaticallyLaunchedCardScanFormDataHelper(
-                        openCardScanAutomaticallyConfig = paymentMethodMetadata.openCardScanAutomatically,
-                        savedStateHandle = viewModel.savedStateHandle,
-                        hasAutomaticallyLaunchedCardScanInitialValue = hasSeenAutomaticCardScanLaunch,
-                    )
-                } else {
-                    null
-                },
-                tapToAddHelper = viewModel.tapToAddHelper,
-                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
-                isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
-            )
-        }
-
-        fun create(
-            coroutineScope: CoroutineScope,
-            cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
-            autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
-            paymentMethodMetadata: PaymentMethodMetadata,
-            eventReporter: EventReporter,
-            savedStateHandle: SavedStateHandle,
-            isLinkUI: Boolean = false,
-        ): FormHelper {
-            return DefaultFormHelper(
-                coroutineScope = coroutineScope,
-                linkInlineHandler = LinkInlineHandler.create(),
-                cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
-                paymentMethodMetadata = paymentMethodMetadata,
-                newPaymentSelectionProvider = { null },
-                linkConfigurationCoordinator = null,
-                selectionUpdater = {},
-                setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
-                eventReporter = eventReporter,
-                savedStateHandle = savedStateHandle,
-                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-                isLinkUI = isLinkUI,
-                automaticallyLaunchedCardScanFormDataHelper = null,
-                tapToAddHelper = null,
-                paymentMethodMessagePromotionsHelper = null,
-                isNfcScanningAvailable = null,
-            )
-        }
-    }
-
+    formDefinitionFactory: FormDefinitionFactory,
+) : FormHelper, FormDefinitionFactory by formDefinitionFactory {
     private val lastFormValues = MutableSharedFlow<Pair<FormFieldValues?, String>>(replay = 1)
 
     private val paymentSelection: Flow<PaymentSelection?> = combine(
@@ -154,56 +55,9 @@ internal class DefaultFormHelper(
         }
     }
 
-    override fun formElementsForCode(code: String): List<FormElement> {
-        return paymentMethodMetadata.formElementsForCode(
-            code = code,
-            uiDefinitionFactoryArgumentsFactory = createArgumentsFactory(code),
-        ) ?: emptyList()
-    }
-
-    override fun createFormArguments(
-        paymentMethodCode: PaymentMethodCode,
-    ): FormArguments {
-        return FormArgumentsFactory.create(
-            paymentMethodCode = paymentMethodCode,
-            metadata = paymentMethodMetadata,
-        )
-    }
-
     override fun onFormFieldValuesChanged(formValues: FormFieldValues?, selectedPaymentMethodCode: String) {
         coroutineScope.launch {
             lastFormValues.emit(formValues to selectedPaymentMethodCode)
-        }
-    }
-
-    override fun getPaymentMethodParams(
-        formValues: FormFieldValues?,
-        selectedPaymentMethodCode: String
-    ): PaymentMethodCreateParams? {
-        return formValues?.transformToPaymentMethodCreateParams(
-            paymentMethodCode = selectedPaymentMethodCode,
-            paymentMethodMetadata = paymentMethodMetadata
-        )
-    }
-
-    private fun requiresFormScreen(paymentMethodCode: String, formElements: List<FormElement>): Boolean {
-        val userInteractionAllowed = formElements.any { it.allowsUserInteraction }
-        return userInteractionAllowed ||
-            paymentMethodCode == PaymentMethod.Type.USBankAccount.code ||
-            paymentMethodCode == PaymentMethod.Type.Link.code
-    }
-
-    override fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormType {
-        val formElements = formElementsForCode(paymentMethodCode)
-        return if (requiresFormScreen(paymentMethodCode, formElements)) {
-            FormType.UserInteractionRequired
-        } else {
-            val mandate = formElements.firstNotNullOfOrNull { it.mandateText }
-            if (mandate == null) {
-                FormType.Empty
-            } else {
-                FormType.MandateOnly(mandate)
-            }
         }
     }
 
@@ -224,35 +78,5 @@ internal class DefaultFormHelper(
             eventReporter.onPaymentMethodFormCompleted(code)
             previouslyCompletedForm = code
         }
-    }
-
-    private fun createArgumentsFactory(code: String): UiDefinitionFactory.Arguments.Factory {
-        val currentSelection = newPaymentSelectionProvider(code)?.takeIf { it.getType() == code }
-
-        return UiDefinitionFactory.Arguments.Factory.Default(
-            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
-            linkInlineHandler = linkInlineHandler,
-            onLinkInlineSignupStateChanged = linkInlineHandler::onStateUpdated,
-            paymentMethodCreateParams = currentSelection?.getPaymentMethodCreateParams(),
-            paymentMethodOptionsParams = currentSelection?.getPaymentMethodOptionParams(),
-            paymentMethodExtraParams = currentSelection?.getPaymentMethodExtraParams(),
-            initialLinkUserInput = when (val selection = currentSelection?.paymentSelection) {
-                is PaymentSelection.New.Card -> selection.linkInput
-                else -> null
-            },
-            previousLinkSignupCheckboxSelection = when (val selection = currentSelection?.paymentSelection) {
-                // User entered a card and may have link input
-                is PaymentSelection.New.Card -> selection.linkInput != null
-                else -> null // Not a card, so no previous choice
-            },
-            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
-            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-            isLinkUI = isLinkUI,
-            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
-            tapToAddHelper = tapToAddHelper,
-            paymentMethodMessagingPromotionsHelper = paymentMethodMessagePromotionsHelper,
-            isNfcScanningAvailable = isNfcScanningAvailable,
-        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
@@ -1,0 +1,145 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
+import com.stripe.android.common.taptoadd.TapToAddHelper
+import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
+import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.FormElement
+
+internal interface FormDefinitionFactory {
+    fun formElementsForCode(code: PaymentMethodCode): List<FormElement>
+
+    fun createFormArguments(paymentMethodCode: PaymentMethodCode): FormArguments
+
+    fun getPaymentMethodParams(
+        formValues: FormFieldValues?,
+        selectedPaymentMethodCode: PaymentMethodCode,
+    ): PaymentMethodCreateParams?
+
+    fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormHelper.FormType
+}
+
+internal class DefaultFormDefinitionFactory(
+    private val linkInlineHandler: LinkInlineHandler,
+    private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+    private val newPaymentSelectionProvider: (PaymentMethodCode) -> NewPaymentOptionSelection?,
+    private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
+    private val setAsDefaultMatchesSaveForFutureUse: Boolean,
+    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    private val isLinkUI: Boolean,
+    private val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+    private val tapToAddHelper: TapToAddHelper?,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+    private val isNfcScanningAvailable: IsNfcScanningAvailable?,
+) : FormDefinitionFactory {
+    override fun formElementsForCode(code: PaymentMethodCode): List<FormElement> {
+        return paymentMethodMetadata.formElementsForCode(
+            code = code,
+            uiDefinitionFactoryArgumentsFactory = createArgumentsFactory(code),
+        ) ?: emptyList()
+    }
+
+    override fun createFormArguments(paymentMethodCode: PaymentMethodCode): FormArguments {
+        return FormArgumentsFactory.create(
+            paymentMethodCode = paymentMethodCode,
+            metadata = paymentMethodMetadata,
+        )
+    }
+
+    override fun getPaymentMethodParams(
+        formValues: FormFieldValues?,
+        selectedPaymentMethodCode: PaymentMethodCode,
+    ): PaymentMethodCreateParams? {
+        return formValues?.transformToPaymentMethodCreateParams(
+            paymentMethodCode = selectedPaymentMethodCode,
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
+    }
+
+    override fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormHelper.FormType {
+        val formElements = formElementsForCode(paymentMethodCode)
+        return if (requiresFormScreen(paymentMethodCode, formElements)) {
+            FormHelper.FormType.UserInteractionRequired
+        } else {
+            val mandate = formElements.firstNotNullOfOrNull { it.mandateText }
+            if (mandate == null) {
+                FormHelper.FormType.Empty
+            } else {
+                FormHelper.FormType.MandateOnly(mandate)
+            }
+        }
+    }
+
+    private fun requiresFormScreen(paymentMethodCode: String, formElements: List<FormElement>): Boolean {
+        val userInteractionAllowed = formElements.any { it.allowsUserInteraction }
+        return userInteractionAllowed ||
+            paymentMethodCode == PaymentMethod.Type.USBankAccount.code ||
+            paymentMethodCode == PaymentMethod.Type.Link.code
+    }
+
+    private fun createArgumentsFactory(code: PaymentMethodCode): UiDefinitionFactory.Arguments.Factory {
+        val currentSelection = newPaymentSelectionProvider(code)?.takeIf { it.getType() == code }
+
+        return UiDefinitionFactory.Arguments.Factory.Default(
+            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
+            linkInlineHandler = linkInlineHandler,
+            onLinkInlineSignupStateChanged = linkInlineHandler::onStateUpdated,
+            paymentMethodCreateParams = currentSelection?.getPaymentMethodCreateParams(),
+            paymentMethodOptionsParams = currentSelection?.getPaymentMethodOptionParams(),
+            paymentMethodExtraParams = currentSelection?.getPaymentMethodExtraParams(),
+            initialLinkUserInput = when (val selection = currentSelection?.paymentSelection) {
+                is PaymentSelection.New.Card -> selection.linkInput
+                else -> null
+            },
+            previousLinkSignupCheckboxSelection = when (val selection = currentSelection?.paymentSelection) {
+                is PaymentSelection.New.Card -> selection.linkInput != null
+                else -> null
+            },
+            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            isLinkUI = isLinkUI,
+            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+            tapToAddHelper = tapToAddHelper,
+            paymentMethodMessagingPromotionsHelper = paymentMethodMessagePromotionsHelper,
+            isNfcScanningAvailable = isNfcScanningAvailable,
+        )
+    }
+
+    companion object {
+        fun create(
+            viewModel: BaseSheetViewModel,
+            paymentMethodMetadata: PaymentMethodMetadata,
+        ): FormDefinitionFactory {
+            return DefaultFormDefinitionFactory(
+                linkInlineHandler = LinkInlineHandler.create(),
+                cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
+                paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = { viewModel.newPaymentSelection },
+                linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
+                setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
+                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+                isLinkUI = false,
+                automaticallyLaunchedCardScanFormDataHelper = null,
+                tapToAddHelper = viewModel.tapToAddHelper,
+                paymentMethodMessagePromotionsHelper = null,
+                isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
@@ -1,28 +1,11 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.forms.FormFieldValues
-import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.uicore.elements.FormElement
 
-internal interface FormHelper {
-
-    fun formElementsForCode(code: String): List<FormElement>
-
-    fun createFormArguments(
-        paymentMethodCode: PaymentMethodCode,
-    ): FormArguments
+internal interface FormHelper : FormDefinitionFactory {
 
     fun onFormFieldValuesChanged(formValues: FormFieldValues?, selectedPaymentMethodCode: String)
-
-    fun getPaymentMethodParams(
-        formValues: FormFieldValues?,
-        selectedPaymentMethodCode: String
-    ): PaymentMethodCreateParams?
-
-    fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormType
 
     sealed interface FormType {
         object Empty : FormType

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -5,7 +5,8 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
-import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.BaseSheetFormHelperFactory
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -94,10 +95,10 @@ internal class DefaultAddPaymentMethodInteractor(
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
         ): AddPaymentMethodInteractor {
             val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Main)
-            val formHelper = DefaultFormHelper.create(
-                viewModel = viewModel,
+            val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                 coroutineScope = coroutineScope,
                 paymentMethodMetadata = paymentMethodMetadata,
+                linkInlineHandler = LinkInlineHandler.create(),
                 shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -11,10 +11,11 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.BaseSheetFormHelperFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.FormHelper.FormType
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.code
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
@@ -136,10 +137,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         ): PaymentMethodVerticalLayoutInteractor {
             val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Default)
             val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
-            val formHelper = DefaultFormHelper.create(
-                viewModel = viewModel,
+            val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                 coroutineScope = formHelperScope,
                 paymentMethodMetadata = paymentMethodMetadata,
+                linkInlineHandler = LinkInlineHandler.create(),
+                shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )
             val isCurrentScreen = viewModel.navigationHandler.currentScreen.mapAsStateFlow {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -4,8 +4,9 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
+import com.stripe.android.paymentsheet.BaseSheetFormHelperFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -125,10 +126,10 @@ internal class DefaultVerticalModeFormInteractor(
         ): VerticalModeFormInteractor {
             val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Default)
             val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
-            val formHelper = DefaultFormHelper.create(
-                viewModel = viewModel,
+            val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                 coroutineScope = formHelperScope,
                 paymentMethodMetadata = paymentMethodMetadata,
+                linkInlineHandler = LinkInlineHandler.create(),
                 shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -1,18 +1,14 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.DefaultFormDefinitionFactory
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 
 internal object VerticalModeInitialScreenFactory {
     fun create(
@@ -60,16 +56,10 @@ internal object VerticalModeInitialScreenFactory {
             (viewModel.selection.value as? PaymentSelection.New?)?.let { newPaymentSelection ->
                 val paymentMethodCode = newPaymentSelection.paymentMethodCreateParams.typeCode
 
-                // This form helper only answers formTypeForCode synchronously and is then discarded, so give it a
-                // scope we cancel immediately rather than leaking its init collector on viewModelScope for the life
-                // of the sheet.
-                val formTypeScope = viewModel.viewModelScope.childScope(Dispatchers.Main)
-                val formType = DefaultFormHelper.create(
+                val formType = DefaultFormDefinitionFactory.create(
                     viewModel = viewModel,
-                    coroutineScope = formTypeScope,
                     paymentMethodMetadata = paymentMethodMetadata
                 ).formTypeForCode(paymentMethodCode)
-                formTypeScope.cancel()
 
                 if (formType == FormHelper.FormType.UserInteractionRequired) {
                     add(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -23,13 +23,11 @@ import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelecti
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
-import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeStripeImageLoader
 import com.stripe.android.uicore.FormInsets
@@ -44,11 +42,7 @@ import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -61,9 +55,6 @@ import kotlin.test.assertFailsWith
 )
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutStateLoaderTest {
-
-    @get:Rule
-    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `loadInitial commits state with payment method metadata`() = runScenario {
@@ -260,8 +251,6 @@ internal class CheckoutStateLoaderTest {
                     savedStateHandle = savedStateHandle,
                     isNfcScanningAvailable = FakeIsNfcScanningAvailable(result = false),
                 ),
-                eventReporter = FakeEventReporter(),
-                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
                 internalRowSelectionCallback = { null },
             )
         },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
@@ -16,17 +16,12 @@ import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser.Companion.PREVIOUS_CONFIGURATION_KEY
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser.Companion.PREVIOUS_PAYMENT_METHOD_METADATA_KEY
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -34,9 +29,6 @@ import org.junit.Test
 internal class DefaultEmbeddedSelectionChooserTest {
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
-
-    @get:Rule
-    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     private val defaultConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
         .build()
@@ -494,8 +486,6 @@ internal class DefaultEmbeddedSelectionChooserTest {
             chooser = DefaultEmbeddedSelectionChooser(
                 savedStateHandle = savedStateHandle,
                 formHelperFactory = formHelperFactory,
-                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
-                eventReporter = FakeEventReporter(),
                 internalRowSelectionCallback = { internalRowSelectionCallback }
             ),
             savedStateHandle = savedStateHandle,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -152,11 +152,12 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
         ),
         block: (List<FormElement>) -> Unit,
     ) {
-        val defaultFormHelper = DefaultFormHelper.create(
-            viewModel = viewModel,
+        val defaultFormHelper = BaseSheetFormHelperFactory(viewModel).create(
             coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = paymentMethodMetadata,
-            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true
+            linkInlineHandler = LinkInlineHandler.create(),
+            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
+            paymentMethodMessagePromotionsHelper = null,
         )
 
         val formElements = defaultFormHelper.formElementsForCode(PaymentMethod.Type.Card.code)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -234,23 +234,30 @@ internal class FormHelperTest {
             val cardBrand = "visa"
             val name = "Joe"
             val receivedSelection = CompletableDeferred<PaymentSelection?>()
+            val linkInlineHandler = LinkInlineHandler.create()
+            val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
 
             val formHelper = DefaultFormHelper(
                 coroutineScope = coroutineScope,
-                linkInlineHandler = LinkInlineHandler.create(),
-                cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-                newPaymentSelectionProvider = { null },
-                linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                linkInlineHandler = linkInlineHandler,
+                paymentMethodMetadata = paymentMethodMetadata,
                 selectionUpdater = { selection -> receivedSelection.complete(selection) },
-                setAsDefaultMatchesSaveForFutureUse = false,
                 eventReporter = FakeEventReporter(),
                 savedStateHandle = SavedStateHandle(),
-                autocompleteAddressInteractorFactory = null,
-                automaticallyLaunchedCardScanFormDataHelper = null,
-                tapToAddHelper = null,
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
-                isNfcScanningAvailable = null,
+                formDefinitionFactory = DefaultFormDefinitionFactory(
+                    linkInlineHandler = linkInlineHandler,
+                    cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    newPaymentSelectionProvider = { null },
+                    linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                    setAsDefaultMatchesSaveForFutureUse = false,
+                    autocompleteAddressInteractorFactory = null,
+                    isLinkUI = false,
+                    automaticallyLaunchedCardScanFormDataHelper = null,
+                    tapToAddHelper = null,
+                    paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                    isNfcScanningAvailable = null,
+                ),
             )
 
             val formFieldValues = FormFieldValues(
@@ -770,20 +777,25 @@ internal class FormHelperTest {
     ): FormHelper {
         return DefaultFormHelper(
             coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
-            cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             paymentMethodMetadata = paymentMethodMetadata,
-            newPaymentSelectionProvider = newPaymentSelectionProvider,
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             linkInlineHandler = linkInlineHandler,
             selectionUpdater = selectionUpdater,
-            setAsDefaultMatchesSaveForFutureUse = false,
             eventReporter = eventReporter,
             savedStateHandle = SavedStateHandle(),
-            autocompleteAddressInteractorFactory = null,
-            automaticallyLaunchedCardScanFormDataHelper = null,
-            tapToAddHelper = tapToAddHelper,
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
-            isNfcScanningAvailable = null,
+            formDefinitionFactory = DefaultFormDefinitionFactory(
+                linkInlineHandler = linkInlineHandler,
+                cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+                paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = newPaymentSelectionProvider,
+                linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                setAsDefaultMatchesSaveForFutureUse = false,
+                autocompleteAddressInteractorFactory = null,
+                isLinkUI = false,
+                automaticallyLaunchedCardScanFormDataHelper = null,
+                tapToAddHelper = tapToAddHelper,
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                isNfcScanningAvailable = null,
+            ),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1375,11 +1375,11 @@ internal class PaymentOptionsViewModelTest {
         val viewModel = createLinkViewModel()
 
         val linkInlineHandler = LinkInlineHandler.create()
-        val formHelper = DefaultFormHelper.create(
-            viewModel = viewModel,
+        val formHelper = BaseSheetFormHelperFactory(viewModel).create(
             coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
             linkInlineHandler = linkInlineHandler,
+            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
             paymentMethodMessagePromotionsHelper = null
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -813,11 +813,12 @@ internal class PaymentSheetViewModelTest {
             )
 
             val linkInlineHandler = LinkInlineHandler.create()
-            val formHelper = DefaultFormHelper.create(
-                viewModel = viewModel,
+            val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                 coroutineScope = viewModel.viewModelScope,
                 paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
                 linkInlineHandler = linkInlineHandler,
+                shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
+                paymentMethodMessagePromotionsHelper = null,
             )
 
             formHelper.onFormFieldValuesChanged(
@@ -1610,10 +1611,12 @@ internal class PaymentSheetViewModelTest {
             stripeIntent = PaymentIntentFixtures.PI_OFF_SESSION,
         )
 
-        val observedArgs = DefaultFormHelper.create(
-            viewModel = viewModel,
+        val observedArgs = BaseSheetFormHelperFactory(viewModel).create(
             coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
+            linkInlineHandler = LinkInlineHandler.create(),
+            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
+            paymentMethodMessagePromotionsHelper = null,
         ).createFormArguments(
             paymentMethodCode = LpmRepositoryTestHelpers.card.code,
         )
@@ -2790,11 +2793,12 @@ internal class PaymentSheetViewModelTest {
                 assertThat(awaitItem()?.enabled).isFalse()
 
                 val linkInlineHandler = LinkInlineHandler.create()
-                val formHelper = DefaultFormHelper.create(
-                    viewModel = viewModel,
+                val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                     coroutineScope = viewModel.viewModelScope,
                     paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
                     linkInlineHandler = linkInlineHandler,
+                    shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
+                    paymentMethodMessagePromotionsHelper = null,
                 )
 
                 formHelper.onFormFieldValuesChanged(


### PR DESCRIPTION
# Summary

Extract the synchronous form-definition operations from `DefaultFormHelper` into a scope-free `FormDefinitionFactory`. `DefaultFormHelper` continues to own form-value collection, payment-selection updates, and completion analytics, and delegates only form construction, argument creation, parameter transformation, and form-type lookup to the new factory.

Synchronous callers in Embedded Payment Element selection restoration and vertical-mode initial-screen creation now use the definition factory directly without creating a coroutine scope.

This is a single-layer PR targeting `master`.

# Motivation

Some callers only need to inspect or construct a form synchronously, but `DefaultFormHelper` requires a coroutine scope because it also coordinates live selection updates. Those callers previously had to provide an unused scope or create and immediately cancel one. Pulling out only the stateless definition operations removes that lifecycle requirement while keeping existing selection coordination encapsulated in `DefaultFormHelper`.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:compileDebugKotlin`
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.FormHelperTest' --tests 'com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactoryTest' --tests 'com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooserTest' --tests 'com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactoryTest' --tests 'com.stripe.android.checkout.CheckoutStateLoaderTest'`
- `./gradlew :paymentsheet:detekt`
- `git diff --check`

No tests were ignored.

# Screenshots

Not applicable — this is an internal refactor with no UI changes.

# Changelog

Not applicable — this internal refactor does not change public API or user-visible behavior.

Committed and created by Codex.
