### PR TITLE
Consolidate form validation integration tests

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -1,7 +1,5 @@
 package com.stripe.android.paymentelement
 
-import androidx.compose.ui.semantics.SemanticsProperties
-import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.click
 import androidx.compose.ui.test.hasContentDescription
@@ -119,19 +117,6 @@ internal class EmbeddedFormPage(
             .performTouchInput { click() }
 
         composeTestRule.waitForIdle()
-    }
-
-    fun assertCardNumberError(errorMessage: String) {
-        composeTestRule.waitUntil(
-            conditionDescription = "card number field to show error '$errorMessage'",
-            timeoutMillis = 5.seconds.inWholeMilliseconds,
-        ) {
-            composeTestRule.onAllNodes(
-                hasText("Card number").and(
-                    SemanticsMatcher.expectValue(SemanticsProperties.Error, errorMessage)
-                )
-            ).fetchSemanticsNodes().isNotEmpty()
-        }
     }
 
     fun assertMandateIsShown() {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -113,33 +113,6 @@ internal class EmbeddedPaymentElementTest {
     }
 
     @Test
-    fun testCardFormValidation() = runEmbeddedPaymentElementTest(
-        networkRule = networkRule,
-        createIntentCallback = { _, shouldSavePaymentMethod ->
-            assertThat(shouldSavePaymentMethod).isFalse()
-            CreateIntentResult.Success("pi_example_secret_12345")
-        },
-        resultCallback = ::assertCompleted,
-    ) { testContext ->
-        networkRule.elementsSession { response ->
-            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
-        }
-
-        testContext.configure {
-            formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
-        }
-
-        embeddedContentPage.clickOnLpm("card")
-        formPage.clickDisabledPrimaryButton()
-        formPage.assertCardNumberError("This field cannot be blank.")
-
-        formPage.fillOutCardDetails()
-        enqueueDeferredIntentConfirmationRequests()
-        formPage.clickPrimaryButton()
-        formPage.waitUntilMissing()
-    }
-
-    @Test
     fun testRemoveCard() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
         createIntentCallback = { _, shouldSavePaymentMethod ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FormValidationIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FormValidationIntegrationTestRunner.kt
@@ -1,0 +1,171 @@
+package com.stripe.android.paymentsheet
+
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.isNotEnabled
+import androidx.compose.ui.test.junit4.ComposeTestRule
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.paymentelement.EmbeddedContentPage
+import com.stripe.android.paymentelement.EmbeddedFormPage
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.EmbeddedPaymentElementTestRunnerContext
+import com.stripe.android.paymentelement.runEmbeddedPaymentElementTest
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG
+import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.utils.ProductIntegrationTestRunnerContext
+import com.stripe.android.paymentsheet.utils.ProductIntegrationType
+import com.stripe.android.paymentsheet.utils.expectNoResult
+import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
+
+internal enum class FormValidationIntegrationType(
+    val productIntegrationType: ProductIntegrationType?,
+) {
+    PaymentSheet(ProductIntegrationType.PaymentSheet),
+    FlowController(ProductIntegrationType.FlowController),
+    Embedded(null);
+
+    internal object Provider : TestParameterValuesProvider() {
+        override fun provideValues(context: Context?): List<FormValidationIntegrationType> {
+            return entries
+        }
+    }
+}
+
+internal fun runFormValidationIntegrationTest(
+    networkRule: NetworkRule,
+    composeTestRule: ComposeTestRule,
+    integrationType: FormValidationIntegrationType,
+    block: suspend FormValidationIntegrationTestRunnerContext.() -> Unit,
+) {
+    val productIntegrationType = integrationType.productIntegrationType
+    if (productIntegrationType != null) {
+        runProductIntegrationTest(
+            networkRule = networkRule,
+            integrationType = productIntegrationType,
+            resultCallback = ::expectNoResult,
+        ) { context ->
+            FormValidationIntegrationTestRunnerContext.Sheet(
+                composeTestRule = composeTestRule,
+                context = context,
+            ).block()
+        }
+    } else {
+        runEmbeddedPaymentElementTest(
+            networkRule = networkRule,
+            createIntentCallback = { _, _ ->
+                error("CreateIntentCallback should not be called for an invalid form.")
+            },
+            resultCallback = {
+                error("ResultCallback should not be called for an invalid form.")
+            },
+        ) { context ->
+            FormValidationIntegrationTestRunnerContext.Embedded(
+                composeTestRule = composeTestRule,
+                context = context,
+            ).block()
+        }
+    }
+}
+
+internal sealed class FormValidationIntegrationTestRunnerContext(
+    protected val composeTestRule: ComposeTestRule,
+) {
+    abstract suspend fun launch()
+
+    abstract fun navigateToFormFor(paymentMethodCode: String)
+
+    abstract fun clickDisabledPrimaryButton()
+
+    abstract fun markTestSucceeded()
+
+    class Sheet(
+        composeTestRule: ComposeTestRule,
+        private val context: ProductIntegrationTestRunnerContext,
+    ) : FormValidationIntegrationTestRunnerContext(composeTestRule) {
+        private val page = PaymentSheetPage(composeTestRule)
+
+        override suspend fun launch() {
+            context.launch(
+                PaymentSheet.Configuration.Builder("Example, Inc.")
+                    .billingDetailsCollectionConfiguration(requiredBillingDetailsCollectionConfiguration())
+                    .allowsDelayedPaymentMethods(true)
+                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
+                    .build()
+            )
+        }
+
+        override fun navigateToFormFor(paymentMethodCode: String) {
+            page.clickOnLpm(paymentMethodCode, forVerticalMode = true)
+        }
+
+        override fun clickDisabledPrimaryButton() {
+            composeTestRule.waitUntil(5_000) {
+                composeTestRule
+                    .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).and(isNotEnabled()))
+                    .fetchSemanticsNodes().isNotEmpty()
+            }
+
+            composeTestRule.waitUntil(5_000) {
+                composeTestRule
+                    .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG))
+                    .fetchSemanticsNodes().isNotEmpty()
+            }
+
+            composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG))
+                .performScrollTo()
+                .performClick()
+
+            composeTestRule.waitForIdle()
+        }
+
+        override fun markTestSucceeded() {
+            context.markTestSucceeded()
+        }
+    }
+
+    class Embedded(
+        composeTestRule: ComposeTestRule,
+        private val context: EmbeddedPaymentElementTestRunnerContext,
+    ) : FormValidationIntegrationTestRunnerContext(composeTestRule) {
+        private val contentPage = EmbeddedContentPage(composeTestRule)
+        private val formPage = EmbeddedFormPage(composeTestRule)
+
+        override suspend fun launch() {
+            context.configure(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Payment(
+                        amount = 5099,
+                        currency = "usd",
+                    )
+                ),
+                configurationMutator = {
+                    billingDetailsCollectionConfiguration(requiredBillingDetailsCollectionConfiguration())
+                    allowsDelayedPaymentMethods(true)
+                    formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+                }
+            )
+        }
+
+        override fun navigateToFormFor(paymentMethodCode: String) {
+            contentPage.clickOnLpm(paymentMethodCode)
+        }
+
+        override fun clickDisabledPrimaryButton() {
+            formPage.clickDisabledPrimaryButton()
+        }
+
+        override fun markTestSucceeded() {
+            context.markTestSucceeded()
+        }
+    }
+}
+
+private fun requiredBillingDetailsCollectionConfiguration() =
+    PaymentSheet.BillingDetailsCollectionConfiguration(
+        name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+        email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+        phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
+        address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
+    )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FormValidationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FormValidationTest.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.paymentsheet
 
-import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.hasText
-import androidx.compose.ui.test.isNotEnabled
-import androidx.compose.ui.test.performClick
-import androidx.compose.ui.test.performScrollTo
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.Intents.times
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
@@ -15,13 +13,7 @@ import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountActivity
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
-import com.stripe.android.paymentsheet.utils.ProductIntegrationType
-import com.stripe.android.paymentsheet.utils.ProductIntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
-import com.stripe.android.paymentsheet.utils.expectNoResult
-import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -36,65 +28,50 @@ internal class FormValidationTest {
     private val composeTestRule = testRules.compose
     private val networkRule = testRules.networkRule
 
-    private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
-
     @Test
     fun testCard(
-        @TestParameter(valuesProvider = ProductIntegrationTypeProvider::class)
-        integrationType: ProductIntegrationType,
-    ) = runProductIntegrationTest(
+        @TestParameter(valuesProvider = FormValidationIntegrationType.Provider::class)
+        integrationType: FormValidationIntegrationType,
+    ) = runFormValidationIntegrationTest(
         networkRule = networkRule,
+        composeTestRule = composeTestRule,
         integrationType = integrationType,
-        resultCallback = ::expectNoResult
-    ) { testContext ->
+    ) {
         enqueueElementsSession()
 
-        testContext.launch(configuration())
+        launch()
 
         navigateToFormFor(paymentMethodCode = "card")
 
-        clickPrimaryButton()
+        clickDisabledPrimaryButton()
 
         assertFieldErrorsAreShown()
 
-        testContext.markTestSucceeded()
+        markTestSucceeded()
     }
 
     @Test
     fun testUsBankAccount(
-        @TestParameter(valuesProvider = ProductIntegrationTypeProvider::class)
-        integrationType: ProductIntegrationType,
-    ) = runProductIntegrationTest(
+        @TestParameter(valuesProvider = FormValidationIntegrationType.Provider::class)
+        integrationType: FormValidationIntegrationType,
+    ) = runFormValidationIntegrationTest(
         networkRule = networkRule,
+        composeTestRule = composeTestRule,
         integrationType = integrationType,
-        resultCallback = ::expectNoResult
-    ) { testContext ->
+    ) {
         enqueueElementsSession()
 
-        testContext.launch(configuration())
+        launch()
 
         navigateToFormFor(paymentMethodCode = "us_bank_account")
 
-        clickPrimaryButton()
+        clickDisabledPrimaryButton()
 
         assertDoesNotLaunchBankAccountFlow()
         assertFieldErrorsAreShown()
 
-        testContext.markTestSucceeded()
+        markTestSucceeded()
     }
-
-    private fun configuration() = PaymentSheet.Configuration.Builder("Example, Inc.")
-        .billingDetailsCollectionConfiguration(
-            PaymentSheet.BillingDetailsCollectionConfiguration(
-                name = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                email = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                phone = PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always,
-                address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic,
-            )
-        )
-        .allowsDelayedPaymentMethods(true)
-        .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-        .build()
 
     private fun enqueueElementsSession() {
         networkRule.elementsSession { response ->
@@ -114,10 +91,6 @@ internal class FormValidationTest {
         }
     }
 
-    private fun navigateToFormFor(
-        paymentMethodCode: String
-    ) = page.clickOnLpm(paymentMethodCode, forVerticalMode = true)
-
     private fun assertDoesNotLaunchBankAccountFlow() {
         intended(
             hasComponent(
@@ -127,32 +100,20 @@ internal class FormValidationTest {
         )
     }
 
-    private fun clickPrimaryButton() {
-        composeTestRule.waitUntil(5_000) {
-            composeTestRule
-                .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).and(isNotEnabled()))
-                .fetchSemanticsNodes().isNotEmpty()
-        }
-
-        composeTestRule.waitUntil(5_000) {
-            composeTestRule
-                .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG))
-                .fetchSemanticsNodes().isNotEmpty()
-        }
-
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG))
-            .performScrollTo()
-            .performClick()
-
-        composeTestRule.waitForIdle()
-    }
-
     private fun assertFieldErrorsAreShown() {
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule
-                .onAllNodes(hasText("This field cannot be blank."))
+                .onAllNodes(
+                    hasText(BLANK_FIELD_ERROR).or(
+                        SemanticsMatcher.expectValue(SemanticsProperties.Error, BLANK_FIELD_ERROR)
+                    )
+                )
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
+    }
+
+    private companion object {
+        const val BLANK_FIELD_ERROR = "This field cannot be blank."
     }
 }


### PR DESCRIPTION
# Summary

- Consolidate PaymentSheet, FlowController, and Embedded Payment Element form-validation coverage in `FormValidationTest`.
- Add a test-only integration runner that adapts the shared validation flow to all three integrations.
- Remove the duplicate Embedded-only card validation test and its unused page assertion.

This is a single-layer PR targeting `master`.

# Motivation

Form validation coverage was split between the shared PaymentSheet/FlowController test and a separate Embedded card test. The split duplicated behavior and left Embedded US bank account validation uncovered. A form-validation-specific runner keeps the same card and US bank account assertions consistent across all three integrations without broadening the generic product integration runner.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :paymentsheet:compileDebugAndroidTestKotlin`
- `./gradlew :paymentsheet:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.paymentsheet.FormValidationTest` — 6 tests passed on `emulator-5554`
- `./gradlew :paymentsheet:detekt`
- `git diff --check`

No tests were newly ignored.

# Screenshots

Not applicable: this is a test-only refactor with no UI changes.

| Before | After |
| --- | --- |
| Not applicable | Not applicable |

# Changelog

Not applicable: this changes test organization and coverage only, with no user-facing behavior or public API changes.

Committed and created by Codex.
