### PR TITLE
Remove PaymentElement email configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -902,17 +902,11 @@ class PaymentElement @Inject internal constructor(
         class BillingDetailsCollectionConfiguration {
 
             private var name: CollectionMode = CollectionMode.Automatic
-            private var email: CollectionMode = CollectionMode.Automatic
             private var address: AddressCollectionMode = AddressCollectionMode.Automatic
 
             /** How to collect the name field. */
             fun name(name: CollectionMode): BillingDetailsCollectionConfiguration = apply {
                 this.name = name
-            }
-
-            /** How to collect the email field. */
-            fun email(email: CollectionMode): BillingDetailsCollectionConfiguration = apply {
-                this.email = email
             }
 
             /** How to collect the billing address. */
@@ -931,7 +925,7 @@ class PaymentElement @Inject internal constructor(
             internal fun build(): State = State(
                 name = name,
                 phone = CollectionMode.Automatic,
-                email = email,
+                email = CollectionMode.Automatic,
                 address = address,
             )
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/BillingDetailsCollectionConfigurationMapperTest.kt
@@ -50,7 +50,6 @@ internal class BillingDetailsCollectionConfigurationMapperTest {
     fun `all CollectionMode fields map 1 to 1`() {
         val mapped = BillingDetailsCollectionConfiguration()
             .name(BillingDetailsCollectionConfiguration.CollectionMode.Always)
-            .email(BillingDetailsCollectionConfiguration.CollectionMode.Always)
             .build()
             .asPaymentSheet()
         assertThat(mapped.name)
@@ -58,7 +57,7 @@ internal class BillingDetailsCollectionConfigurationMapperTest {
         assertThat(mapped.phone)
             .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic)
         assertThat(mapped.email)
-            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic)
     }
 
     @Test


### PR DESCRIPTION
# Summary

Remove the configurable PaymentElement billing-email collection mode. Email collection remains automatic.

# Motivation

PaymentElement does not support configuring billing-email collection; exposing the builder method suggests behavior that is unavailable.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Not run (not requested).

# Screenshots

Not applicable: API and mapper behavior only; no visual UI change.

# Changelog

Not applicable: removes an unsupported configuration option and does not add a user-facing SDK behavior change.

Committed and created by Codex.
