### PR TITLE
Move event reporter providers to activity roots

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -14,11 +14,9 @@ import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.ui.ErrorMessage
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.utils.DismissKeyboardOnProcessing
-import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormUI
@@ -31,7 +29,6 @@ import com.stripe.android.uicore.utils.collectAsState
 @Composable
 internal fun FormScreenContent(
     interactor: VerticalModeFormInteractor,
-    eventReporter: EventReporter,
     onClick: () -> Unit,
     onProcessingCompleted: () -> Unit,
     state: SheetActivityStateHolder.State,
@@ -41,19 +38,17 @@ internal fun FormScreenContent(
 
     DismissKeyboardOnProcessing(interactorState.isProcessing)
 
-    EventReporterProvider(eventReporter) {
-        VerticalModeFormUI(interactor = interactor, showsWalletHeader = false)
-        USBankAccountMandate(state)
-        FormActivityError(state)
-        Spacer(Modifier.height(40.dp))
-        FormActivityPrimaryButton(
-            state = state,
-            onClick = onClick,
-            onDisabledClick = onPrimaryButtonDisabledClick,
-            onProcessingCompleted = onProcessingCompleted,
-        )
-        PaymentSheetContentPadding()
-    }
+    VerticalModeFormUI(interactor = interactor, showsWalletHeader = false)
+    USBankAccountMandate(state)
+    FormActivityError(state)
+    Spacer(Modifier.height(40.dp))
+    FormActivityPrimaryButton(
+        state = state,
+        onClick = onClick,
+        onDisabledClick = onPrimaryButtonDisabledClick,
+        onProcessingCompleted = onProcessingCompleted,
+    )
+    PaymentSheetContentPadding()
 }
 
 @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedNavigator.kt
@@ -30,7 +30,6 @@ import com.stripe.android.paymentsheet.ui.PaymentSheetTopBarStateFactory
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.UpdatePaymentMethodUI
 import com.stripe.android.paymentsheet.utils.DismissKeyboardOnProcessing
-import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.paymentsheet.utils.addPaymentMethodTitle
 import com.stripe.android.paymentsheet.utils.isOnlyOneNonCardPaymentMethod
@@ -210,7 +209,6 @@ internal class EmbeddedNavigator private constructor(
 
         class Form(
             val formInteractor: VerticalModeFormInteractor,
-            private val eventReporter: EventReporter,
             private val sheetActivityStateHolder: SheetActivityStateHolder,
             private val confirmationHelper: SheetActivityConfirmationHelper,
             private val embeddedSelectionHolder: EmbeddedSelectionHolder,
@@ -235,7 +233,6 @@ internal class EmbeddedNavigator private constructor(
                 val state by sheetActivityStateHolder.state.collectAsState()
                 FormScreenContent(
                     interactor = formInteractor,
-                    eventReporter = eventReporter,
                     onClick = {
                         confirmationHelper.confirm()
                     },
@@ -259,7 +256,6 @@ internal class EmbeddedNavigator private constructor(
 
             class Factory @Inject constructor(
                 private val interactorFactory: EmbeddedFormInteractorFactory,
-                private val eventReporter: EventReporter,
                 private val sheetActivityStateHolder: SheetActivityStateHolder,
                 private val confirmationHelper: SheetActivityConfirmationHelper,
                 private val embeddedSelectionHolder: EmbeddedSelectionHolder,
@@ -274,7 +270,6 @@ internal class EmbeddedNavigator private constructor(
                             paymentMethodCode = launchMode.selectedPaymentMethodCode,
                             hasSavedPaymentMethods = hasSavedPaymentMethods,
                         ),
-                        eventReporter = eventReporter,
                         sheetActivityStateHolder = sheetActivityStateHolder,
                         confirmationHelper = confirmationHelper,
                         embeddedSelectionHolder = embeddedSelectionHolder,
@@ -288,7 +283,6 @@ internal class EmbeddedNavigator private constructor(
         class SavedPaymentMethodConfirm(
             private val interactor: SavedPaymentMethodConfirmInteractor,
             private val isLiveMode: Boolean,
-            private val eventReporter: EventReporter,
             private val sheetActivityStateHolder: SheetActivityStateHolder,
             private val confirmationHelper: SheetActivityConfirmationHelper,
             private val embeddedSelectionHolder: EmbeddedSelectionHolder,
@@ -309,28 +303,26 @@ internal class EmbeddedNavigator private constructor(
                 val state by sheetActivityStateHolder.state.collectAsState()
                 DismissKeyboardOnProcessing(state.isProcessing)
 
-                EventReporterProvider(eventReporter) {
-                    Column {
-                        SavedPaymentMethodConfirmUI(interactor)
-                        USBankAccountMandate(state)
-                        FormActivityError(state)
-                        Spacer(Modifier.height(40.dp))
-                        FormActivityPrimaryButton(
-                            state = state,
-                            onProcessingCompleted = {
-                                sheetActivityStateHolder.setResult(
-                                    successfulConfirmationResult(
-                                        embeddedSelectionHolder = embeddedSelectionHolder,
-                                        customerStateHolder = customerStateHolder,
-                                        launchMode = launchMode,
-                                    )
+                Column {
+                    SavedPaymentMethodConfirmUI(interactor)
+                    USBankAccountMandate(state)
+                    FormActivityError(state)
+                    Spacer(Modifier.height(40.dp))
+                    FormActivityPrimaryButton(
+                        state = state,
+                        onProcessingCompleted = {
+                            sheetActivityStateHolder.setResult(
+                                successfulConfirmationResult(
+                                    embeddedSelectionHolder = embeddedSelectionHolder,
+                                    customerStateHolder = customerStateHolder,
+                                    launchMode = launchMode,
                                 )
-                            },
-                            onClick = confirmationHelper::confirm,
-                            onDisabledClick = sheetActivityStateHolder::onPrimaryButtonDisabledClick,
-                        )
-                        PaymentSheetContentPadding()
-                    }
+                            )
+                        },
+                        onClick = confirmationHelper::confirm,
+                        onDisabledClick = sheetActivityStateHolder::onPrimaryButtonDisabledClick,
+                    )
+                    PaymentSheetContentPadding()
                 }
             }
 
@@ -383,7 +375,6 @@ internal class EmbeddedNavigator private constructor(
 
         class HorizontalPaymentOptions(
             private val interactor: AddPaymentMethodInteractor,
-            private val eventReporter: EventReporter,
             private val sheetActivityState: StateFlow<SheetActivityStateHolder.State>,
             private val onContinueClick: () -> Unit,
             private val onPrimaryButtonDisabledClick: () -> Unit,
@@ -409,19 +400,17 @@ internal class EmbeddedNavigator private constructor(
 
             @Composable
             override fun Content() {
-                EventReporterProvider(eventReporter) {
-                    AddPaymentMethod(interactor = interactor)
-                    val state by sheetActivityState.collectAsState()
-                    USBankAccountMandate(state)
-                    FormActivityError(state)
-                    Spacer(Modifier.height(40.dp))
-                    FormActivityPrimaryButton(
-                        state = state,
-                        onClick = onContinueClick,
-                        onDisabledClick = onPrimaryButtonDisabledClick,
-                    )
-                    PaymentSheetContentPadding()
-                }
+                AddPaymentMethod(interactor = interactor)
+                val state by sheetActivityState.collectAsState()
+                USBankAccountMandate(state)
+                FormActivityError(state)
+                Spacer(Modifier.height(40.dp))
+                FormActivityPrimaryButton(
+                    state = state,
+                    onClick = onContinueClick,
+                    onDisabledClick = onPrimaryButtonDisabledClick,
+                )
+                PaymentSheetContentPadding()
             }
 
             override fun close() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -34,6 +34,7 @@ import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.ui.PaymentElementTheme
 import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
 import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
@@ -105,7 +106,9 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
 
         setContent {
             PaymentElementTheme(appearance = activityArgs.configuration.appearance) {
-                SheetContent()
+                EventReporterProvider(eventReporter) {
+                    SheetContent()
+                }
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -89,7 +89,6 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
     private fun createHorizontalScreen(): EmbeddedNavigator.Screen {
         return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
             interactor = addPaymentMethodInteractorFactory.create(),
-            eventReporter = eventReporter,
             sheetActivityState = sheetActivityStateHolder.state,
             onContinueClick = ::onContinueClick,
             onPrimaryButtonDisabledClick = sheetActivityStateHolder::onPrimaryButtonDisabledClick,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenFactory.kt
@@ -4,7 +4,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
 import javax.inject.Inject
@@ -12,7 +11,6 @@ import javax.inject.Inject
 internal class SavedPaymentMethodConfirmScreenFactory @Inject constructor(
     private val interactorFactory: SavedPaymentMethodConfirmInteractor.Factory,
     private val paymentMethodMetadata: PaymentMethodMetadata,
-    private val eventReporter: EventReporter,
     private val sheetActivityStateHolder: SheetActivityStateHolder,
     private val confirmationHelper: SheetActivityConfirmationHelper,
     private val embeddedSelectionHolder: EmbeddedSelectionHolder,
@@ -22,7 +20,6 @@ internal class SavedPaymentMethodConfirmScreenFactory @Inject constructor(
     fun create(selection: PaymentSelection.Saved) = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
         interactor = interactorFactory.create(selection, embeddedSelectionHolder::setSelection),
         isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
-        eventReporter = eventReporter,
         sheetActivityStateHolder = sheetActivityStateHolder,
         confirmationHelper = confirmationHelper,
         embeddedSelectionHolder = embeddedSelectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/FormActivityScreenShotTest.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.ui.PaymentElementTheme
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.screenshottesting.PaparazziRule
@@ -151,7 +152,6 @@ internal class FormActivityScreenShotTest {
         val screen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
             interactor = FakeSavedPaymentMethodConfirmInteractor(formEnabled = false),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
-            eventReporter = FakeEventReporter(),
             sheetActivityStateHolder = stateHolder,
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
             embeddedSelectionHolder = selectionHolder,
@@ -161,7 +161,9 @@ internal class FormActivityScreenShotTest {
 
         paparazziRule.snapshot {
             ViewModelStoreOwnerContext {
-                screen.Content()
+                EventReporterProvider(FakeEventReporter()) {
+                    screen.Content()
+                }
             }
         }
     }
@@ -255,15 +257,16 @@ internal class FormActivityScreenShotTest {
         val state by stateHolder.state.collectAsState()
 
         ViewModelStoreOwnerContext {
-            Column {
-                FormScreenContent(
-                    interactor = interactor,
-                    eventReporter = eventReporter,
-                    onClick = {},
-                    onProcessingCompleted = {},
-                    state = state.copy(isEnabled = enabled),
-                    onPrimaryButtonDisabledClick = {},
-                )
+            EventReporterProvider(eventReporter) {
+                Column {
+                    FormScreenContent(
+                        interactor = interactor,
+                        onClick = {},
+                        onProcessingCompleted = {},
+                        state = state.copy(isEnabled = enabled),
+                        onPrimaryButtonDisabledClick = {},
+                    )
+                }
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -814,7 +814,6 @@ internal class EmbeddedNavigatorTest {
         )
         return EmbeddedNavigator.Screen.Form.Factory(
             interactorFactory = interactorFactory,
-            eventReporter = FakeEventReporter(),
             sheetActivityStateHolder = FakeSheetActivityStateHolder(),
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
             embeddedSelectionHolder = selectionHolder,
@@ -852,7 +851,6 @@ internal class EmbeddedNavigatorTest {
     ): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
         return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
             interactor = interactor,
-            eventReporter = FakeEventReporter(),
             sheetActivityState = stateFlowOf(
                 SheetActivityStateHolder.State(
                     primaryButtonLabel = "".resolvableString,
@@ -873,7 +871,6 @@ internal class EmbeddedNavigatorTest {
         val formInteractor = TestFormInteractor(isLiveMode = isLiveMode)
         val screen = EmbeddedNavigator.Screen.Form(
             formInteractor = formInteractor,
-            eventReporter = FakeEventReporter(),
             sheetActivityStateHolder = FakeSheetActivityStateHolder(),
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
             embeddedSelectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
@@ -902,7 +899,6 @@ internal class EmbeddedNavigatorTest {
         val screen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
             interactor = interactor,
             isLiveMode = isLiveMode,
-            eventReporter = FakeEventReporter(),
             sheetActivityStateHolder = stateHolder,
             confirmationHelper = confirmationHelper,
             embeddedSelectionHolder = selectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityStateHolderTest.kt
@@ -659,7 +659,6 @@ internal class DefaultSheetActivityStateHolderTest {
         screenFactory = SavedPaymentMethodConfirmScreenFactory(
             interactorFactory = savedPaymentMethodConfirmInteractorFactory,
             paymentMethodMetadata = paymentMethodMetadata,
-            eventReporter = FakeEventReporter(),
             sheetActivityStateHolder = stateHolder,
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
             embeddedSelectionHolder = selectionHolder,
@@ -721,7 +720,6 @@ internal class DefaultSheetActivityStateHolderTest {
     ): EmbeddedNavigator.Screen.Form {
         return EmbeddedNavigator.Screen.Form(
             formInteractor = interactor,
-            eventReporter = FakeEventReporter(),
             sheetActivityStateHolder = FakeSheetActivityStateHolder(),
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
             embeddedSelectionHolder = DefaultEmbeddedSelectionHolder(SavedStateHandle()),
@@ -753,7 +751,6 @@ internal class DefaultSheetActivityStateHolderTest {
     private fun createHorizontalPaymentOptionsScreen(): EmbeddedNavigator.Screen.HorizontalPaymentOptions {
         return EmbeddedNavigator.Screen.HorizontalPaymentOptions(
             interactor = FakeAddPaymentMethodInteractor(FakeAddPaymentMethodInteractor.createState()),
-            eventReporter = FakeEventReporter(),
             sheetActivityState = stateFlowOf(
                 SheetActivityStateHolder.State(
                     primaryButtonLabel = "Continue".resolvableString,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactoryTest.kt
@@ -210,7 +210,6 @@ internal class InitialPaymentOptionsScreenFactoryTest {
                     eventReporter = FakeEventReporter(),
                     paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
                 ),
-                eventReporter = FakeEventReporter(),
                 sheetActivityStateHolder = sheetActivityStateHolder,
                 confirmationHelper = FakeSheetActivityConfirmationHelper(),
                 embeddedSelectionHolder = selectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -145,7 +145,6 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             originalScreen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
                 interactor = interactor,
                 isLiveMode = true,
-                eventReporter = activity.eventReporter,
                 sheetActivityStateHolder = activity.sheetActivityStateHolder,
                 confirmationHelper = FakeSheetActivityConfirmationHelper(),
                 embeddedSelectionHolder = activity.selectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenFactoryTest.kt
@@ -10,7 +10,6 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentsheet.FakeCustomerStateHolder
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.SavedPaymentMethodConfirmInteractor
@@ -76,7 +75,6 @@ internal class SavedPaymentMethodConfirmScreenFactoryTest {
         return SavedPaymentMethodConfirmScreenFactory(
             interactorFactory = interactorFactory,
             paymentMethodMetadata = paymentMethodMetadata,
-            eventReporter = FakeEventReporter(),
             sheetActivityStateHolder = FakeSheetActivityStateHolder(),
             confirmationHelper = FakeSheetActivityConfirmationHelper(),
             embeddedSelectionHolder = selectionHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SavedPaymentMethodConfirmScreenTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.FakeCustomerStateHolder
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PrimaryButtonProcessingState
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
@@ -142,7 +143,6 @@ internal class SavedPaymentMethodConfirmScreenTest {
         val screen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
             interactor = interactor,
             isLiveMode = true,
-            eventReporter = eventReporter,
             sheetActivityStateHolder = stateHolder,
             confirmationHelper = confirmationHelper,
             embeddedSelectionHolder = selectionHolder,
@@ -154,8 +154,10 @@ internal class SavedPaymentMethodConfirmScreenTest {
             CompositionLocalProvider(
                 LocalSoftwareKeyboardController provides keyboardController,
             ) {
-                StripeTheme {
-                    screen.Content()
+                EventReporterProvider(eventReporter) {
+                    StripeTheme {
+                        screen.Content()
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Summary
Move `EventReporterProvider` ownership to the `EmbeddedSheetActivity`, `PaymentSheetActivity`, `PaymentOptionsActivity`, and `LinkActivity` composition roots. Remove redundant event reporter dependencies and provider wrappers from nested screen models and composables.

Committed and created by Codex.

# Motivation
Analytics composition locals belong to activity composition roots rather than individual screen implementations. Centralizing each provider avoids duplicated wrappers, keeps nested models and composables focused on screen-specific behavior, and covers the entire activity content consistently.

PaymentSheet and PaymentOptions continue observing `paymentMethodMetadata` at the composition root so `LocalElementsSessionId` updates after loading.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:compileDebugUnitTestKotlin`.

Ran focused `:paymentsheet:testDebugUnitTest` coverage for the affected navigator, state holder, screen factories, activity, Compose UI, and Paparazzi test classes.

Ran focused `:paymentsheet:testDebugUnitTest` coverage for PaymentSheet, PaymentOptions, and Link activities plus representative PaymentSheet, Link, vertical form, and Paparazzi screen tests.

No tests were ignored.

# Screenshots
Not applicable. This refactor does not change rendered UI, and the affected Paparazzi tests pass without baseline changes.

# Changelog
Not applicable. This is an internal ownership refactor with no public API or user-visible behavior change.
