### PR TITLE
Add lazy API configuration foundation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/PaymentAnalyticsRequestFactory.kt
@@ -7,7 +7,7 @@ import androidx.annotation.Keep
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.Stripe
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsFields
 import com.stripe.android.core.networking.AnalyticsRequest
@@ -45,35 +45,36 @@ class PaymentAnalyticsRequestFactory @VisibleForTesting internal constructor(
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     constructor(
         context: Context,
-        publishableKey: String,
+        publishableKeyProvider: () -> String,
         defaultProductUsageTokens: Set<String> = emptySet()
-    ) : this(
-        context,
-        { publishableKey },
-        defaultProductUsageTokens
-    )
-
-    internal constructor(
-        context: Context,
-        publishableKeyProvider: Provider<String>
     ) : this(
         packageManager = context.applicationContext.packageManager,
         packageInfo = context.applicationContext.packageInfo,
         packageName = context.applicationContext.packageName.orEmpty(),
         publishableKeyProvider = publishableKeyProvider,
         networkTypeProvider = NetworkTypeDetector(context)::invoke,
+        defaultProductUsageTokens = defaultProductUsageTokens,
+    )
+
+    internal constructor(
+        context: Context,
+        publishableKeyProvider: () -> String
+    ) : this(
+        context = context,
+        publishableKeyProvider = publishableKeyProvider,
+        defaultProductUsageTokens = emptySet(),
     )
 
     @Inject
     internal constructor(
         context: Context,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        apiConfigurationProvider: Provider<() -> ApiConfiguration.State>,
         @Named(PRODUCT_USAGE) defaultProductUsageTokens: Set<String>
     ) : this(
         packageManager = context.applicationContext.packageManager,
         packageInfo = context.applicationContext.packageInfo,
         packageName = context.applicationContext.packageName.orEmpty(),
-        publishableKeyProvider = publishableKeyProvider,
+        publishableKeyProvider = Provider { apiConfigurationProvider.get()().publishableKey },
         networkTypeProvider = NetworkTypeDetector(context)::invoke,
         defaultProductUsageTokens = defaultProductUsageTokens,
     )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.payments.core.injection
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.core.networking.ApiRequest
+import dagger.Module
+import dagger.Provides
+import javax.inject.Provider
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module(includes = [PaymentConfigurationModule::class])
+class ApiConfigurationFromPaymentConfigurationModule {
+    @Provides
+    fun provideApiConfigurationStateProvider(
+        paymentConfiguration: Provider<PaymentConfiguration>
+    ): () -> ApiConfiguration.State {
+        return {
+            val config = paymentConfiguration.get()
+            ApiConfiguration.State(
+                publishableKey = config.publishableKey,
+                stripeAccountId = config.stripeAccountId,
+            )
+        }
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+class ApiRequestOptionsModule {
+    @Provides
+    fun provideApiRequestOptionsProvider(
+        apiConfigurationProvider: () -> ApiConfiguration.State
+    ): () -> ApiRequest.Options {
+        return {
+            val state = apiConfigurationProvider()
+            ApiRequest.Options(
+                apiKey = state.publishableKey,
+                stripeAccount = state.stripeAccountId,
+            )
+        }
+    }
+
+    @Provides
+    fun provideApiRequestOptions(
+        apiRequestOptionsProvider: () -> ApiRequest.Options
+    ): ApiRequest.Options = apiRequestOptionsProvider()
+}

--- a/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentAnalyticsRequestFactoryTest.kt
@@ -32,8 +32,8 @@ class PaymentAnalyticsRequestFactoryTest {
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        context,
-        API_KEY
+        context = context,
+        publishableKeyProvider = { API_KEY },
     )
 
     @Test
@@ -413,8 +413,8 @@ class PaymentAnalyticsRequestFactoryTest {
     @Test
     fun `product_usage param should include defaultProductUsageTokens and method argument`() {
         val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-            context,
-            API_KEY,
+            context = context,
+            publishableKeyProvider = { API_KEY },
             defaultProductUsageTokens = setOf("Hello")
         )
 
@@ -431,8 +431,8 @@ class PaymentAnalyticsRequestFactoryTest {
     @Test
     fun `product_usage param should de-dupe defaultProductUsageTokens and method argument`() {
         val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-            context,
-            API_KEY,
+            context = context,
+            publishableKeyProvider = { API_KEY },
             defaultProductUsageTokens = setOf("Hello")
         )
 
@@ -448,8 +448,8 @@ class PaymentAnalyticsRequestFactoryTest {
     @Test
     fun `product_usage param should use defaultProductUsageTokens`() {
         val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-            context,
-            API_KEY,
+            context = context,
+            publishableKeyProvider = { API_KEY },
             defaultProductUsageTokens = setOf("Hello")
         )
 
@@ -471,8 +471,8 @@ class PaymentAnalyticsRequestFactoryTest {
 
         try {
             val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                context,
-                API_KEY
+                context = context,
+                publishableKeyProvider = { API_KEY }
             )
 
             val params = analyticsRequestFactory.createSourceCreation(


### PR DESCRIPTION
## Summary
- add a lazy bridge from `PaymentConfiguration` to `ApiConfiguration.State`
- make payment analytics resolve its publishable key through a provider
- establish compatibility infrastructure for the credential migration stack

Stack: 1/15. The next PR targets `tyler/payment-config-stack-01-foundation`.

Committed and created by Codex.