### PR TITLE
Migrate Payments Core launcher credential propagation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -7,9 +7,9 @@ import com.stripe.android.SetupIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.StripeIntentResult.Outcome.Companion.CANCELED
 import com.stripe.android.StripeIntentResult.Outcome.Companion.SUCCEEDED
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -22,8 +22,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -32,7 +30,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : StripeIntentResult<T>>(
     context: Context,
-    private val publishableKeyProvider: Provider<String>,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     protected val stripeRepository: StripeRepository,
     private val logger: Logger,
     private val workContext: CoroutineContext,
@@ -49,7 +47,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         }
 
         val requestOptions = ApiRequest.Options(
-            apiKey = publishableKeyProvider.get(),
+            apiKey = apiConfigProvider().publishableKey,
             stripeAccount = result.stripeAccountId
         )
 
@@ -338,7 +336,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
 @Singleton
 internal class PaymentIntentFlowResultProcessor @Inject constructor(
     context: Context,
-    @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+    apiConfigProvider: () -> ApiConfiguration.State,
     stripeRepository: StripeRepository,
     logger: Logger,
     @IOContext workContext: CoroutineContext,
@@ -346,7 +344,7 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
     clock: Clock,
 ) : PaymentFlowResultProcessor<PaymentIntent, PaymentIntentResult>(
     context,
-    publishableKeyProvider,
+    apiConfigProvider,
     stripeRepository,
     logger,
     workContext,
@@ -406,7 +404,7 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
 @Singleton
 internal class SetupIntentFlowResultProcessor @Inject constructor(
     context: Context,
-    @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+    apiConfigProvider: () -> ApiConfiguration.State,
     stripeRepository: StripeRepository,
     logger: Logger,
     @IOContext workContext: CoroutineContext,
@@ -414,7 +412,7 @@ internal class SetupIntentFlowResultProcessor @Inject constructor(
     clock: Clock,
 ) : PaymentFlowResultProcessor<SetupIntent, SetupIntentResult>(
     context,
-    publishableKeyProvider,
+    apiConfigProvider,
     stripeRepository,
     logger,
     workContext,

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
@@ -21,7 +21,7 @@ import javax.inject.Singleton
         CollectBankAccountModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
-        CoreCommonModule::class
+        CoreCommonModule::class,
     ]
 )
 internal interface CollectBankAccountComponent {

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountModule.kt
@@ -3,8 +3,8 @@ package com.stripe.android.payments.bankaccount.di
 import android.app.Application
 import android.content.Context
 import com.stripe.android.BuildConfig
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import dagger.Module
@@ -18,10 +18,14 @@ internal object CollectBankAccountModule {
     fun providesAppContext(application: Application): Context = application
 
     @Provides
-    @Named(PUBLISHABLE_KEY)
-    fun providePublishableKey(
+    fun provideApiConfigurationProvider(
         args: CollectBankAccountContract.Args
-    ): () -> String = { args.publishableKey }
+    ): () -> ApiConfiguration.State = {
+        ApiConfiguration.State(
+            publishableKey = args.publishableKey,
+            stripeAccountId = args.stripeAccountId,
+        )
+    }
 
     @Provides
     @Named(PRODUCT_USAGE)

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -45,18 +46,20 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
             }
         }.getOrElse {
             finishWithResult(InternalPaymentResult.Failed(it))
-            ErrorReporter.createFallbackInstance(applicationContext)
-                .report(
-                    errorEvent = ErrorReporter.ExpectedErrorEvent.PAYMENT_LAUNCHER_CONFIRMATION_NULL_ARGS,
-                    stripeException = StripeException.create(it),
-                )
+            ErrorReporter.createFallbackInstance(
+                applicationContext,
+                publishableKeyProvider = { PaymentConfiguration.getInstance(applicationContext).publishableKey },
+            ).report(
+                errorEvent = ErrorReporter.ExpectedErrorEvent.PAYMENT_LAUNCHER_CONFIRMATION_NULL_ARGS,
+                stripeException = StripeException.create(it),
+            )
             return
         }
 
         args.validate().onFailure {
             finishWithResult(InternalPaymentResult.Failed(it))
 
-            ErrorReporter.createFallbackInstance(applicationContext)
+            ErrorReporter.createFallbackInstance(applicationContext, publishableKeyProvider = { args.publishableKey })
                 .report(
                     errorEvent = ErrorReporter.ExpectedErrorEvent.PAYMENT_LAUNCHER_CONFIRMATION_INVALID_ARGS,
                     stripeException = StripeException.create(it),

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.BuildConfig
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.reactnative.ReactNativeSdkInternal
 import com.stripe.android.core.reactnative.UnregisterSignal
 import com.stripe.android.core.reactnative.registerForReactNativeActivityResult
@@ -95,26 +96,35 @@ class PaymentLauncherFactory(
     ): PaymentLauncher {
         val productUsage = setOf("PaymentLauncher")
         return StripePaymentLauncher(
-            publishableKeyProvider = { publishableKey },
-            stripeAccountIdProvider = { stripeAccountId },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = publishableKey,
+                    stripeAccountId = stripeAccountId,
+                )
+            },
             hostActivityLauncher = hostActivityLauncher,
             statusBarColor = statusBarColor,
+            includePaymentSheetNextHandlers = false,
             enableLogging = BuildConfig.DEBUG,
             productUsage = productUsage,
-            includePaymentSheetNextHandlers = false,
         )
     }
 
     fun create(applicationContext: Context): PaymentLauncher {
         val productUsage = setOf("PaymentLauncher")
         return StripePaymentLauncher(
-            publishableKeyProvider = { PaymentConfiguration.getInstance(applicationContext).publishableKey },
-            stripeAccountIdProvider = { PaymentConfiguration.getInstance(applicationContext).stripeAccountId },
+            apiConfigurationProvider = {
+                val config = PaymentConfiguration.getInstance(applicationContext)
+                ApiConfiguration.State(
+                    publishableKey = config.publishableKey,
+                    stripeAccountId = config.stripeAccountId,
+                )
+            },
             hostActivityLauncher = hostActivityLauncher,
             statusBarColor = statusBarColor,
+            includePaymentSheetNextHandlers = false,
             enableLogging = BuildConfig.DEBUG,
             productUsage = productUsage,
-            includePaymentSheetNextHandlers = false,
         )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.UIContext
@@ -419,8 +420,12 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 .create(
                     context = application,
                     enableLogging = arg.enableLogging,
-                    publishableKeyProvider = { arg.publishableKey },
-                    stripeAccountIdProvider = { arg.stripeAccountId },
+                    apiConfigurationProvider = {
+                        ApiConfiguration.State(
+                            publishableKey = arg.publishableKey,
+                            stripeAccountId = arg.stripeAccountId,
+                        )
+                    },
                     productUsage = arg.productUsage,
                     includePaymentSheetNextHandlers = arg.includePaymentSheetNextHandlers,
                 ).viewModelSubcomponentFactory

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -3,9 +3,8 @@ package com.stripe.android.payments.paymentlauncher
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.StripeIntent
@@ -22,8 +21,7 @@ import javax.inject.Named
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class StripePaymentLauncher @AssistedInject internal constructor(
-    @Assisted(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
-    @Assisted(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
+    @Assisted private val apiConfigurationProvider: () -> ApiConfiguration.State,
     @Assisted private val hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>,
     @Assisted(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @Assisted(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) private val includePaymentSheetNextHandlers: Boolean,
@@ -33,8 +31,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun confirm(params: ConfirmPaymentIntentParams) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 confirmStripeIntentParams = params,
@@ -47,8 +45,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun confirm(params: ConfirmSetupIntentParams) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -61,8 +59,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForPaymentIntent(clientSecret: String) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -75,8 +73,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForSetupIntent(clientSecret: String) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.SetupIntentNextActionArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -89,8 +87,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForStripeIntent(intent: StripeIntent) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.StripeIntentNextActionWithIntentArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -105,7 +103,7 @@ class StripePaymentLauncher @AssistedInject internal constructor(
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.HashedPaymentIntentNextActionArgs(
                 hashedValue = hashedValue,
-                stripeAccountId = stripeAccountIdProvider(),
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory.kt
@@ -2,8 +2,7 @@ package com.stripe.android.payments.paymentlauncher
 
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.payments.core.injection.INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import dagger.assisted.Assisted
@@ -20,8 +19,7 @@ import dagger.assisted.AssistedFactory
 @AssistedFactory
 interface StripePaymentLauncherAssistedFactory {
     fun create(
-        @Assisted(PUBLISHABLE_KEY) publishableKey: () -> String,
-        @Assisted(STRIPE_ACCOUNT_ID) stripeAccountId: () -> String?,
+        @Assisted apiConfigurationProvider: () -> ApiConfiguration.State,
         @Assisted(STATUS_BAR_COLOR) statusBarColor: Int?,
         @Assisted(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) includePaymentSheetNextHandlers: Boolean,
         hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>

--- a/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.polling
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
@@ -13,13 +13,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.time.Duration.Companion.seconds
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultIntentStatusPoller @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val paymentConfigProvider: Provider<PaymentConfiguration>,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     private val config: IntentStatusPoller.Config,
     private val dispatcher: CoroutineDispatcher,
 ) : IntentStatusPoller {
@@ -56,12 +55,12 @@ class DefaultIntentStatusPoller @Inject constructor(
     }
 
     private suspend fun fetchIntentStatus(): StripeIntent.Status? {
-        val paymentConfig = paymentConfigProvider.get()
+        val apiConfig = apiConfigProvider()
         val paymentIntent = stripeRepository.retrievePaymentIntent(
             clientSecret = config.clientSecret,
             options = ApiRequest.Options(
-                publishableKeyProvider = { paymentConfig.publishableKey },
-                stripeAccountIdProvider = { paymentConfig.stripeAccountId },
+                apiKey = apiConfig.publishableKey,
+                stripeAccount = apiConfig.stripeAccountId,
             ),
         )
         return paymentIntent.getOrNull()?.status

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import android.util.Base64
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,8 +18,12 @@ class StripePaymentLauncherTest {
     private val mockHostActivityLauncher =
         mock<ActivityResultLauncher<PaymentLauncherContract.Args>>()
     private val paymentLauncher = StripePaymentLauncher(
-        publishableKeyProvider = { PUBLISHABLE_KEY },
-        stripeAccountIdProvider = { STRIPE_ACCOUNT_ID },
+        apiConfigurationProvider = {
+            ApiConfiguration.State(
+                publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
+            )
+        },
         hostActivityLauncher = mockHostActivityLauncher,
         enableLogging = false,
         productUsage = mock(),

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.polling
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
@@ -14,8 +14,8 @@ internal fun createIntentStatusPoller(
 ): DefaultIntentStatusPoller {
     return DefaultIntentStatusPoller(
         stripeRepository = FakeStripeRepository(enqueuedStatuses),
-        paymentConfigProvider = {
-            PaymentConfiguration(
+        apiConfigProvider = {
+            ApiConfiguration.State(
                 publishableKey = "key",
                 stripeAccountId = "account_id",
             )


### PR DESCRIPTION
## Summary
- migrate PaymentLauncher, flow-result processing, polling, and bank-account collection to paired API credential state
- keep this review below 500 changed lines

Stack: 2/15. The next PR targets tyler/payment-config-stack-03-core-authentication.

Committed and created by Codex.