### PR TITLE
Migrate authentication credential propagation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
 import com.google.android.instantapps.InstantApps
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -66,9 +67,15 @@ constructor(
         analyticsRequestExecutor,
         paymentAnalyticsRequestFactory,
     )
+    private val apiConfigProvider: () -> ApiConfiguration.State = {
+        ApiConfiguration.State(
+            publishableKey = publishableKeyProvider(),
+            stripeAccountId = null,
+        )
+    }
     private val paymentIntentFlowResultProcessor = PaymentIntentFlowResultProcessor(
         context,
-        publishableKeyProvider,
+        apiConfigProvider,
         stripeRepository,
         Logger.getInstance(enableLogging),
         workContext,
@@ -77,7 +84,7 @@ constructor(
     )
     private val setupIntentFlowResultProcessor = SetupIntentFlowResultProcessor(
         context,
-        publishableKeyProvider,
+        apiConfigProvider,
         stripeRepository,
         Logger.getInstance(enableLogging),
         workContext,
@@ -107,7 +114,7 @@ constructor(
             enableLogging = enableLogging,
             workContext = workContext,
             uiContext = uiContext,
-            publishableKeyProvider = publishableKeyProvider,
+            apiConfigurationState = apiConfigProvider(),
             productUsage = paymentAnalyticsRequestFactory.defaultProductUsageTokens,
             isInstantApp = isInstantApp,
             includePaymentSheetNextActionHandlers = false, // StripePaymentController is not used in PaymentSheet.

--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeNextActionHandler.kt
@@ -4,8 +4,8 @@ import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
@@ -23,7 +23,7 @@ import kotlin.coroutines.CoroutineContext
  * through a JavaScript-based WebView implementation.
  */
 internal class IntentConfirmationChallengeNextActionHandler @Inject constructor(
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @Named(PRODUCT_USAGE) private val productUsageTokens: Set<String>,
     @UIContext private val uiContext: CoroutineContext
 ) : PaymentNextActionHandler<StripeIntent>() {
@@ -75,7 +75,7 @@ internal class IntentConfirmationChallengeNextActionHandler @Inject constructor(
         val intentConfirmationChallengeNextActionStarter = intentConfirmationChallengeNextActionStarterFactory(host)
         intentConfirmationChallengeNextActionStarter.start(
             IntentConfirmationChallengeActivityContract.Args(
-                publishableKey = publishableKeyProvider(),
+                publishableKey = apiConfigProvider().publishableKey,
                 intent = actionable,
                 productUsage = productUsageTokens
             )

--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/di/IntentConfirmationChallengeComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/di/IntentConfirmationChallengeComponent.kt
@@ -3,24 +3,28 @@ package com.stripe.android.challenge.confirmation.di
 import android.content.Context
 import com.stripe.android.challenge.confirmation.IntentConfirmationChallengeArgs
 import com.stripe.android.challenge.confirmation.IntentConfirmationChallengeViewModel
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
+import dagger.Module
+import dagger.Provides
 import javax.inject.Singleton
 
 @Singleton
 @Component(
     modules = [
         IntentConfirmationChallengeModule::class,
+        IntentConfirmationChallengeConfigModule::class,
         CoreCommonModule::class,
         CoroutineContextModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
-        PaymentConfigurationModule::class
+        ApiRequestOptionsModule::class,
     ]
 )
 internal interface IntentConfirmationChallengeComponent {
@@ -34,5 +38,18 @@ internal interface IntentConfirmationChallengeComponent {
             @BindsInstance
             args: IntentConfirmationChallengeArgs,
         ): IntentConfirmationChallengeComponent
+    }
+}
+
+@Module
+internal object IntentConfirmationChallengeConfigModule {
+    @Provides
+    fun provideApiConfigurationProvider(
+        args: IntentConfirmationChallengeArgs
+    ): () -> ApiConfiguration.State = {
+        ApiConfiguration.State(
+            publishableKey = args.publishableKey,
+            stripeAccountId = null,
+        )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/challenge/passive/PassiveChallengeComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/passive/PassiveChallengeComponent.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.challenge.passive
 
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.hcaptcha.HCaptchaModule
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -20,7 +20,7 @@ import javax.inject.Singleton
         PassiveChallengeModule::class,
         StripeRepositoryModule::class,
         CoreCommonModule::class,
-        CoroutineContextModule::class
+        CoroutineContextModule::class,
     ]
 )
 internal interface PassiveChallengeComponent {
@@ -32,8 +32,7 @@ internal interface PassiveChallengeComponent {
             @BindsInstance
             context: Context,
             @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
+            apiConfigurationProvider: () -> ApiConfiguration.State,
             @BindsInstance
             @Named(PRODUCT_USAGE)
             productUsage: Set<String>,

--- a/payments-core/src/main/java/com/stripe/android/challenge/passive/PassiveChallengeViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/passive/PassiveChallengeViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.challenge.passive.PassiveChallengeActivity.Companion.getArgs
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.hcaptcha.HCaptchaService
 import com.stripe.android.model.PassiveCaptchaParams
 import kotlinx.coroutines.flow.Flow
@@ -53,7 +54,12 @@ internal class PassiveChallengeViewModel @Inject constructor(
                 DaggerPassiveChallengeComponent.factory()
                     .create(
                         context = app,
-                        publishableKeyProvider = { args.publishableKey },
+                        apiConfigurationProvider = {
+                            ApiConfiguration.State(
+                                publishableKey = args.publishableKey,
+                                stripeAccountId = null,
+                            )
+                        },
                         productUsage = args.productUsage.toSet(),
                         passiveCaptchaParams = args.passiveCaptchaParams,
                     )

--- a/payments-core/src/main/java/com/stripe/android/challenge/passive/warmer/activity/PassiveChallengeWarmerActivityComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/passive/warmer/activity/PassiveChallengeWarmerActivityComponent.kt
@@ -2,9 +2,9 @@ package com.stripe.android.challenge.passive.warmer.activity
 
 import android.content.Context
 import com.stripe.android.challenge.passive.PassiveChallengeModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.hcaptcha.HCaptchaModule
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
@@ -21,7 +21,7 @@ import javax.inject.Singleton
         PassiveChallengeModule::class,
         StripeRepositoryModule::class,
         CoreCommonModule::class,
-        CoroutineContextModule::class
+        CoroutineContextModule::class,
     ]
 )
 internal interface PassiveChallengeWarmerActivityComponent {
@@ -33,8 +33,7 @@ internal interface PassiveChallengeWarmerActivityComponent {
             @BindsInstance
             context: Context,
             @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
+            apiConfigurationProvider: () -> ApiConfiguration.State,
             @BindsInstance
             @Named(PRODUCT_USAGE)
             productUsage: Set<String>,

--- a/payments-core/src/main/java/com/stripe/android/challenge/passive/warmer/activity/PassiveChallengeWarmerViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/passive/warmer/activity/PassiveChallengeWarmerViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.challenge.passive.warmer.activity.PassiveChallengeWarmerActivity.Companion.getArgs
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.hcaptcha.HCaptchaService
 import com.stripe.android.model.PassiveCaptchaParams
 import kotlinx.coroutines.flow.Flow
@@ -41,7 +42,12 @@ internal class PassiveChallengeWarmerViewModel @Inject constructor(
                 DaggerPassiveChallengeWarmerActivityComponent.factory()
                     .create(
                         context = app,
-                        publishableKeyProvider = { args.publishableKey },
+                        apiConfigurationProvider = {
+                            ApiConfiguration.State(
+                                publishableKey = args.publishableKey,
+                                stripeAccountId = null,
+                            )
+                        },
                         productUsage = args.productUsage.toSet(),
                         passiveCaptchaParams = args.passiveCaptchaParams,
                     )

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherActivity.kt
@@ -38,7 +38,7 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
         val args = PaymentBrowserAuthContract.parseArgs(intent)
         if (args == null) {
             finish()
-            ErrorReporter.createFallbackInstance(applicationContext)
+            ErrorReporter.createFallbackInstance(applicationContext, publishableKeyProvider = { "" })
                 .report(
                     errorEvent = ErrorReporter.ExpectedErrorEvent.BROWSER_LAUNCHER_NULL_ARGS,
                 )
@@ -70,14 +70,14 @@ internal class StripeBrowserLauncherActivity : AppCompatActivity() {
             launcher.launch(intent)
             viewModel.hasLaunched = true
         } catch (e: ActivityNotFoundException) {
-            ErrorReporter.createFallbackInstance(applicationContext)
+            ErrorReporter.createFallbackInstance(applicationContext, publishableKeyProvider = { args.publishableKey })
                 .report(
                     errorEvent = ErrorReporter.ExpectedErrorEvent.BROWSER_LAUNCHER_ACTIVITY_NOT_FOUND,
                     stripeException = StripeException.create(e),
                 )
             finishWithFailure(args)
         } catch (e: SecurityException) {
-            ErrorReporter.createFallbackInstance(applicationContext)
+            ErrorReporter.createFallbackInstance(applicationContext, publishableKeyProvider = { args.publishableKey })
                 .report(
                     errorEvent = ErrorReporter.ExpectedErrorEvent.BROWSER_LAUNCHER_ACTIVITY_NOT_FOUND,
                     stripeException = StripeException.create(e),

--- a/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/StripeBrowserLauncherViewModel.kt
@@ -136,7 +136,7 @@ internal class StripeBrowserLauncherViewModel(
                 analyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
                 paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                     context = application,
-                    publishableKey = config.publishableKey,
+                    publishableKeyProvider = { config.publishableKey },
                 ),
                 browserCapabilities = browserCapabilitiesSupplier.get(),
                 customTabsPackage = CustomTabsClient.getPackageName(application, null),

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentNextActionHandlerRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/DefaultPaymentNextActionHandlerRegistry.kt
@@ -8,6 +8,7 @@ import androidx.annotation.VisibleForTesting
 import com.stripe.android.PaymentRelayContract
 import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.StripeIntent
@@ -35,10 +36,15 @@ internal class DefaultPaymentNextActionHandlerRegistry @Inject internal construc
     @IntentAuthenticatorMap private val paymentNextActionHandlers: Map<NextActionHandlerKey, NextActionHandler>,
     @Named(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) private val includePaymentSheetNextActionHandlers: Boolean,
     applicationContext: Context,
+    apiConfigurationProvider: () -> ApiConfiguration.State,
 ) : PaymentNextActionHandlerRegistry {
 
     private val paymentSheetNextActionHandlers: Map<NextActionHandlerKey, NextActionHandler> by lazy {
-        paymentSheetNextActionHandlers(includePaymentSheetNextActionHandlers, applicationContext)
+        paymentSheetNextActionHandlers(
+            includePaymentSheetNextActionHandlers,
+            applicationContext,
+            apiConfigurationProvider().publishableKey,
+        )
     }
 
     @VisibleForTesting
@@ -118,7 +124,7 @@ internal class DefaultPaymentNextActionHandlerRegistry @Inject internal construc
             enableLogging: Boolean,
             workContext: CoroutineContext,
             uiContext: CoroutineContext,
-            publishableKeyProvider: () -> String,
+            apiConfigurationState: ApiConfiguration.State,
             productUsage: Set<String>,
             isInstantApp: Boolean,
             includePaymentSheetNextActionHandlers: Boolean,
@@ -130,7 +136,7 @@ internal class DefaultPaymentNextActionHandlerRegistry @Inject internal construc
                     enableLogging = enableLogging,
                     workContext = workContext,
                     uiContext = uiContext,
-                    publishableKeyProvider = publishableKeyProvider,
+                    apiConfigurationProvider = { apiConfigurationState },
                     productUsage = productUsage,
                     isInstantApp = isInstantApp,
                     includePaymentSheetNextActionHandlers = includePaymentSheetNextActionHandlers,
@@ -143,7 +149,8 @@ internal class DefaultPaymentNextActionHandlerRegistry @Inject internal construc
 @Suppress("TooGenericExceptionCaught")
 private fun paymentSheetNextActionHandlers(
     includePaymentSheetNextActionHandlers: Boolean,
-    applicationContext: Context
+    applicationContext: Context,
+    publishableKey: String,
 ): Map<NextActionHandlerKey, NextActionHandler> {
     return try {
         if (includePaymentSheetNextActionHandlers) {
@@ -156,7 +163,7 @@ private fun paymentSheetNextActionHandlers(
             emptyMap()
         }
     } catch (e: Exception) {
-        ErrorReporter.createFallbackInstance(applicationContext)
+        ErrorReporter.createFallbackInstance(applicationContext, publishableKeyProvider = { publishableKey })
             .report(
                 // [PAYMENT_SHEET_AUTHENTICATORS_NOT_FOUND] will not be changed to avoid skewed metrics
                 errorEvent = ErrorReporter.UnexpectedErrorEvent.PAYMENT_SHEET_AUTHENTICATORS_NOT_FOUND,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/VoucherNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/VoucherNextActionHandler.kt
@@ -27,7 +27,7 @@ internal class VoucherNextActionHandler @Inject constructor(
     ) {
         val detailsData = actionable.nextActionData as NextActionData.DisplayVoucherDetails
         if (detailsData.hostedVoucherUrl == null) {
-            ErrorReporter.createFallbackInstance(context).report(
+            ErrorReporter.createFallbackInstance(context, publishableKeyProvider = { requestOptions.apiKey }).report(
                 ErrorReporter.UnexpectedErrorEvent.MISSING_HOSTED_VOUCHER_URL,
                 additionalNonPiiParams = mapOf("next_action_type" to (actionable.nextActionType?.code ?: ""))
             )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandler.kt
@@ -3,8 +3,8 @@ package com.stripe.android.payments.core.authentication
 import com.stripe.android.PaymentBrowserAuthStarter
 import com.stripe.android.StripePaymentController
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
@@ -32,7 +32,7 @@ internal class WebIntentNextActionHandler @Inject constructor(
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
     @UIContext private val uiContext: CoroutineContext,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @Named(IS_INSTANT_APP) private val isInstantApp: Boolean,
     private val defaultReturnUrl: DefaultReturnUrl,
     private val redirectResolver: RedirectResolver,
@@ -106,7 +106,7 @@ internal class WebIntentNextActionHandler @Inject constructor(
                 shouldCancelSource = shouldCancelSource,
                 shouldCancelIntentOnUserNavigation = shouldCancelIntentOnUserNavigation,
                 statusBarColor = host.statusBarColor,
-                publishableKey = publishableKeyProvider(),
+                publishableKey = apiConfigProvider().publishableKey,
                 isInstantApp = isInstantApp,
                 referrer = referrer,
                 forceInAppWebView = forceInAppWebView,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2NextActionHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3DS2NextActionHandler.kt
@@ -5,8 +5,8 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.PaymentFlowResult
@@ -25,7 +25,7 @@ import javax.inject.Singleton
 internal class Stripe3DS2NextActionHandler @Inject constructor(
     private val config: PaymentAuthConfig,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>
 ) : PaymentNextActionHandler<StripeIntent>() {
 
@@ -72,7 +72,7 @@ internal class Stripe3DS2NextActionHandler @Inject constructor(
                 requestOptions,
                 enableLogging = enableLogging,
                 host.statusBarColor,
-                publishableKeyProvider(),
+                apiConfigProvider().publishableKey,
                 productUsage
             )
         )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/authentication/threeds2/Stripe3ds2TransactionViewModel.kt
@@ -11,6 +11,7 @@ import com.google.android.instantapps.InstantApps
 import com.stripe.android.R
 import com.stripe.android.StripePaymentController
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -318,7 +319,12 @@ internal class Stripe3ds2TransactionViewModelFactory(
             .create(
                 context = application,
                 enableLogging = args.enableLogging,
-                publishableKeyProvider = { args.publishableKey },
+                apiConfigurationProvider = {
+                    ApiConfiguration.State(
+                        publishableKey = args.publishableKey,
+                        stripeAccountId = args.requestOptions.stripeAccount,
+                    )
+                },
                 productUsage = args.productUsage,
                 isInstantApp = InstantApps.isInstantApp(application),
             )

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/NextActionHandlerComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/NextActionHandlerComponent.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.payments.core.injection
 
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.authentication.DefaultPaymentNextActionHandlerRegistry
@@ -51,8 +51,7 @@ internal interface NextActionHandlerComponent {
             @UIContext
             uiContext: CoroutineContext,
             @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
+            apiConfigurationProvider: () -> ApiConfiguration.State,
             @BindsInstance
             @Named(PRODUCT_USAGE)
             productUsage: Set<String>,

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -17,6 +17,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isGone
 import androidx.core.view.updatePaddingRelative
 import androidx.lifecycle.lifecycleScope
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentBrowserAuthContract
@@ -65,7 +66,10 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         if (args == null) {
             setResult(Activity.RESULT_CANCELED)
             finish()
-            ErrorReporter.createFallbackInstance(applicationContext)
+            ErrorReporter.createFallbackInstance(
+                context = applicationContext,
+                publishableKeyProvider = { PaymentConfiguration.getInstance(applicationContext).publishableKey }
+            )
                 .report(
                     errorEvent = ErrorReporter.ExpectedErrorEvent.AUTH_WEB_VIEW_NULL_ARGS,
                 )
@@ -94,7 +98,7 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         if (clientSecret.isBlank()) {
             logger.debug("PaymentAuthWebViewActivity#onCreate() - clientSecret is blank")
             finish()
-            ErrorReporter.createFallbackInstance(applicationContext)
+            ErrorReporter.createFallbackInstance(applicationContext, publishableKeyProvider = { args.publishableKey })
                 .report(
                     errorEvent = ErrorReporter.UnexpectedErrorEvent.AUTH_WEB_VIEW_BLANK_CLIENT_SECRET,
                 )
@@ -138,7 +142,9 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         error: Throwable?
     ) {
         if (error != null) {
-            ErrorReporter.createFallbackInstance(applicationContext)
+            ErrorReporter.createFallbackInstance(applicationContext, publishableKeyProvider = {
+                requireNotNull(_args).publishableKey
+            })
                 .report(
                     errorEvent = ErrorReporter.ExpectedErrorEvent.AUTH_WEB_VIEW_FAILURE,
                     stripeException = StripeException.create(error),

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModel.kt
@@ -133,8 +133,8 @@ internal class PaymentAuthWebViewActivityViewModel(
                 args,
                 DefaultAnalyticsRequestExecutor(logger, Dispatchers.IO),
                 PaymentAnalyticsRequestFactory(
-                    application,
-                    args.publishableKey,
+                    context = application,
+                    publishableKeyProvider = { args.publishableKey },
                     defaultProductUsageTokens = setOf("PaymentAuthWebViewActivity")
                 )
             ) as T

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -56,8 +56,8 @@ internal class StripePaymentControllerTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        context,
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        context = context,
+        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
     )
     private val testDispatcher = StandardTestDispatcher()
 

--- a/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeNextActionHandlerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeNextActionHandlerTest.kt
@@ -9,6 +9,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntent
@@ -32,7 +33,9 @@ internal class IntentConfirmationChallengeNextActionHandlerTest {
     fun `performNextActionOnResumed uses Modern starter when launcher is set`() = runTest {
         DummyActivityResultCaller.test {
             val handler = IntentConfirmationChallengeNextActionHandler(
-                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                apiConfigProvider = {
+                    ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+                },
                 uiContext = testDispatcher,
                 productUsageTokens = PRODUCT_USAGE
             )
@@ -64,7 +67,9 @@ internal class IntentConfirmationChallengeNextActionHandlerTest {
     @Test
     fun `performNextActionOnResumed uses Legacy starter when launcher is null`() = runTest {
         val handler = IntentConfirmationChallengeNextActionHandler(
-            publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+            apiConfigProvider = {
+                ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+            },
             uiContext = testDispatcher,
             productUsageTokens = PRODUCT_USAGE
         )
@@ -87,7 +92,9 @@ internal class IntentConfirmationChallengeNextActionHandlerTest {
     fun `onNewActivityResultCaller registers for activity result and handles Success`() = runTest {
         DummyActivityResultCaller.test {
             val handler = IntentConfirmationChallengeNextActionHandler(
-                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                apiConfigProvider = {
+                    ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+                },
                 uiContext = testDispatcher,
                 productUsageTokens = PRODUCT_USAGE
             )
@@ -121,7 +128,9 @@ internal class IntentConfirmationChallengeNextActionHandlerTest {
     fun `onNewActivityResultCaller registers for activity result and handles Failed`() = runTest {
         DummyActivityResultCaller.test {
             val handler = IntentConfirmationChallengeNextActionHandler(
-                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                apiConfigProvider = {
+                    ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+                },
                 uiContext = testDispatcher,
                 productUsageTokens = PRODUCT_USAGE
             )
@@ -157,7 +166,9 @@ internal class IntentConfirmationChallengeNextActionHandlerTest {
     fun `onNewActivityResultCaller registers for activity result and handles Canceled`() = runTest {
         DummyActivityResultCaller.test {
             val handler = IntentConfirmationChallengeNextActionHandler(
-                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                apiConfigProvider = {
+                    ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+                },
                 uiContext = testDispatcher,
                 productUsageTokens = PRODUCT_USAGE
             )
@@ -189,7 +200,9 @@ internal class IntentConfirmationChallengeNextActionHandlerTest {
     fun `onNewActivityResultCaller sets the launcher on handler`() = runTest {
         DummyActivityResultCaller.test {
             val handler = IntentConfirmationChallengeNextActionHandler(
-                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+                apiConfigProvider = {
+                    ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+                },
                 uiContext = testDispatcher,
                 productUsageTokens = PRODUCT_USAGE
             )

--- a/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/StripeBrowserLauncherViewModelTest.kt
@@ -30,8 +30,8 @@ class StripeBrowserLauncherViewModelTest {
         analyticsRequests.add(it)
     }
     private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        application,
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        context = application,
+        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
     )
 
     private val savedStateHandle = SavedStateHandle()

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/DefaultPaymentNextActionHandlerRegistryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/DefaultPaymentNextActionHandlerRegistryTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentRelayContract
 import com.stripe.android.PaymentRelayStarter
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.model.StripeIntent.NextActionData
@@ -41,6 +42,7 @@ class DefaultPaymentNextActionHandlerRegistryTest {
         ),
         includePaymentSheetNextActionHandlers = false,
         applicationContext = ApplicationProvider.getApplicationContext(),
+        apiConfigurationProvider = { ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null) },
     )
 
     private val allAuthenticators = setOf(

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/Stripe3DS2AuthenticatorTest.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleRegistry
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentAuthConfig
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.payments.core.authentication.threeds2.Stripe3DS2NextActionHandler
@@ -40,7 +41,9 @@ class Stripe3DS2AuthenticatorTest {
     private val authenticator = Stripe3DS2NextActionHandler(
         paymentAuthConfig,
         enableLogging = false,
-        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+        apiConfigProvider = {
+            ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+        },
         productUsage = setOf()
     )
 

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandlerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/WebIntentNextActionHandlerTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.PaymentBrowserAuthStarter
 import com.stripe.android.StripePaymentController.Companion.PAYMENT_REQUEST_CODE
 import com.stripe.android.StripePaymentController.Companion.SETUP_REQUEST_CODE
 import com.stripe.android.auth.PaymentBrowserAuthContract
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsFields
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -43,8 +44,8 @@ class WebIntentNextActionHandlerTest {
         mock<(AuthActivityStarterHost) -> PaymentBrowserAuthStarter>()
     private val analyticsRequestExecutor = mock<AnalyticsRequestExecutor>()
     private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        context,
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        context = context,
+        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
     )
 
     private val testDispatcher = UnconfinedTestDispatcher()
@@ -182,7 +183,9 @@ class WebIntentNextActionHandlerTest {
             paymentAnalyticsRequestFactory = analyticsRequestFactory,
             enableLogging = false,
             uiContext = testDispatcher,
-            publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+            apiConfigProvider = {
+                ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+            },
             isInstantApp = false,
             defaultReturnUrl = DefaultReturnUrl("some_package_name"),
             redirectResolver = redirectResolver,

--- a/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/authentication/threeds2/DefaultStripe3ds2ChallengeResultProcessorTest.kt
@@ -40,8 +40,8 @@ class DefaultStripe3ds2ChallengeResultProcessorTest {
         analyticsRequests.add(it)
     }
     private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        application,
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        context = application,
+        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
     )
 
     private val stripeRepository = FakeStripeRepository()

--- a/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/PaymentAuthWebViewActivityViewModelTest.kt
@@ -25,8 +25,8 @@ class PaymentAuthWebViewActivityViewModelTest {
     private val analyticsRequests = mutableListOf<AnalyticsRequest>()
     private val analyticsRequestExecutor = AnalyticsRequestExecutor { analyticsRequests.add(it) }
     private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        ApplicationProvider.getApplicationContext(),
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        context = ApplicationProvider.getApplicationContext(),
+        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
     )
 
     @Test


### PR DESCRIPTION
## Summary
- migrate next-action, browser-authentication, challenge, and 3DS2 paths to paired API credential state
- keep this review below 500 changed lines

Stack: 3/15. The next PR targets tyler/payment-config-stack-04-core-standalone.

Committed and created by Codex.