### PR TITLE
Migrate CustomerSheet API configuration propagation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.customersheet
 
 import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.injection.DaggerStripeCustomerAdapterComponent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -124,6 +126,14 @@ interface CustomerAdapter {
                     customerEphemeralKeyProvider = customerEphemeralKeyProvider,
                     setupIntentClientSecretProvider = setupIntentClientSecretProvider,
                     paymentMethodTypes = paymentMethodTypes,
+                    apiConfigurationProvider = {
+                        PaymentConfiguration.getInstance(context).let {
+                            ApiConfiguration.State(
+                                publishableKey = it.publishableKey,
+                                stripeAccountId = it.stripeAccountId,
+                            )
+                        }
+                    },
                 )
             return component.stripeCustomerAdapter
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
@@ -604,6 +605,9 @@ class CustomerSheet internal constructor(
                         imageLoader = DefaultStripeImageLoader(application),
                         errorReporter = ErrorReporter.createFallbackInstance(
                             context = application,
+                            publishableKeyProvider = {
+                                PaymentConfiguration.getInstance(application.applicationContext).publishableKey
+                             },
                             productUsage = setOf("CustomerSheet"),
                         ),
                         context = application,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -26,6 +26,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.validate
@@ -47,6 +48,7 @@ internal class DefaultCustomerSheetLoader(
     private val eventReporter: CustomerSheetEventReporter,
     private val errorReporter: ErrorReporter,
     private val workContext: CoroutineContext,
+    private val apiConfigurationResolver: ApiConfigurationResolver,
 ) : CustomerSheetLoader {
 
     @Inject
@@ -57,6 +59,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter: CustomerSheetEventReporter,
         errorReporter: ErrorReporter,
         @IOContext workContext: CoroutineContext,
+        apiConfigurationResolver: ApiConfigurationResolver,
     ) : this(
         googlePayRepositoryFactory = googlePayRepositoryFactory,
         isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
@@ -66,6 +69,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter = eventReporter,
         errorReporter = errorReporter,
         workContext = workContext,
+        apiConfigurationResolver = apiConfigurationResolver,
     )
 
     override suspend fun load(
@@ -178,6 +182,7 @@ internal class DefaultCustomerSheetLoader(
                     IntegrationMetadata.CustomerSheet.AttachmentStyle.CreateAttach
                 }
             ),
+            apiConfiguration = apiConfigurationResolver.resolve(null),
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -14,6 +14,7 @@ import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
@@ -102,7 +103,7 @@ internal class CustomerSheetViewModel(
     private val logger: Logger,
     private val eventReporter: CustomerSheetEventReporter,
     private val workContext: CoroutineContext = Dispatchers.IO,
-    paymentConfiguration: PaymentConfiguration,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
     private val productUsage: Set<String>,
     confirmationHandlerFactory: ConfirmationHandler.Factory,
     private val customerSheetLoader: CustomerSheetLoader,
@@ -122,7 +123,7 @@ internal class CustomerSheetViewModel(
         logger: Logger,
         eventReporter: CustomerSheetEventReporter,
         @IOContext workContext: CoroutineContext = Dispatchers.IO,
-        paymentConfiguration: PaymentConfiguration,
+        apiConfigurationProvider: () -> ApiConfiguration.State,
         @Named(PRODUCT_USAGE) productUsage: Set<String>,
         confirmationHandlerFactory: ConfirmationHandler.Factory,
         customerSheetLoader: CustomerSheetLoader,
@@ -142,7 +143,7 @@ internal class CustomerSheetViewModel(
         eventReporter = eventReporter,
         workContext = workContext,
         productUsage = productUsage,
-        paymentConfiguration = paymentConfiguration,
+        apiConfigurationProvider = apiConfigurationProvider,
         confirmationHandlerFactory = confirmationHandlerFactory,
         customerSheetLoader = customerSheetLoader,
         isNfcScanningAvailable = isNfcScanningAvailable,
@@ -170,7 +171,7 @@ internal class CustomerSheetViewModel(
         )
     )
 
-    private val isConfiguredLiveMode = paymentConfiguration.isLiveMode()
+    private val isConfiguredLiveMode = apiConfigurationProvider().isLiveMode()
     private val isLiveMode
         get() = customerState.value.metadata?.stripeIntent?.isLiveMode ?: isConfiguredLiveMode
 
@@ -903,6 +904,8 @@ internal class CustomerSheetViewModel(
             sellerBusinessName = null,
             forceSetupFutureUseBehavior = false,
             clientAttributionMetadata = clientAttributionMetadata,
+            publishableKey = apiConfigurationProvider().publishableKey,
+            stripeAccountId = apiConfigurationProvider().stripeAccountId,
         )
     }
 
@@ -1323,13 +1326,22 @@ internal class CustomerSheetViewModel(
 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            val application = extras.requireApplication()
             val component = DaggerCustomerSheetViewModelComponent.factory()
                 .create(
-                    application = extras.requireApplication(),
+                    application = application,
                     configuration = args.configuration,
                     args = args,
                     integrationType = args.integrationType,
                     savedStateHandle = extras.createSavedStateHandle(),
+                    apiConfigurationProvider = {
+                        PaymentConfiguration.getInstance(application).let {
+                            ApiConfiguration.State(
+                                publishableKey = it.publishableKey,
+                                stripeAccountId = it.stripeAccountId,
+                            )
+                        }
+                    },
                 )
 
             return component.viewModel as T

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet
 import android.content.Context
 import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.model.PaymentMethod
@@ -32,6 +33,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     private val timeProvider: () -> Long,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: (CustomerEphemeralKey) -> PrefsRepository,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerAdapter {
 
@@ -71,6 +73,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 types = requestedTypes,
                 silentlyFail = false,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -88,6 +91,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -105,6 +109,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -124,6 +129,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter
@@ -29,6 +30,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
     private val elementsSessionRepository: ElementsSessionRepository,
     private val customerAdapter: CustomerAdapter,
     private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetInitializationDataSource,
     CustomerSheetSavedSelectionDataSource,
@@ -132,6 +134,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
             customPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = apiConfigurationProvider(),
         ).onSuccess {
             errorReporter.report(
                 errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerSheet
@@ -34,6 +35,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
     private val prefsRepositoryFactory: PrefsRepository.Factory,
     private val customerSessionProvider: CustomerSheet.CustomerSessionProvider,
     private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
     private val timeProvider: () -> Long,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSessionElementsSessionManager {
@@ -90,6 +92,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                     customPaymentMethods = listOf(),
                     externalPaymentMethods = listOf(),
                     countryOverride = null,
+                    apiConfiguration = apiConfigurationProvider(),
                 ).onSuccess {
                     reportSuccessfulElementsSessionLoad()
                 }.onFailure {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -15,6 +16,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
     private val errorReporter: ErrorReporter,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetPaymentMethodDataSource {
     override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
@@ -42,6 +44,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     paymentMethodId = paymentMethodId,
                     params = params,
+                    stripeAccountId = apiConfigProvider().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }
@@ -66,6 +69,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
                     paymentMethodId = paymentMethodId,
+                    stripeAccountId = apiConfigProvider().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -17,6 +18,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: PrefsRepository.Factory,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetSavedSelectionDataSource {
     override suspend fun retrieveSavedSelection(
@@ -101,6 +103,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
             customerId = ephemeralKey.customerId,
             ephemeralKeySecret = ephemeralKey.ephemeralKey,
             paymentMethodId = paymentMethodId,
+            stripeAccountId = apiConfigProvider().stripeAccountId,
         ).getOrThrow()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerAdapter
@@ -40,6 +41,7 @@ internal interface CustomerAdapterDataSourceComponent {
         fun create(
             @BindsInstance application: Application,
             @BindsInstance adapter: CustomerAdapter,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): CustomerAdapterDataSourceComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerSheet
@@ -40,6 +41,7 @@ internal interface CustomerSessionDataSourceComponent {
         fun create(
             @BindsInstance application: Application,
             @BindsInstance customerSessionProvider: CustomerSheet.CustomerSessionProvider,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): CustomerSessionDataSourceComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
@@ -2,11 +2,13 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 
 @Module(includes = [StripeNetworkClientModule::class])
 internal interface CustomerSheetDataSourceCommonModule {
@@ -17,4 +19,11 @@ internal interface CustomerSheetDataSourceCommonModule {
 
     @Binds
     fun bindsApplicationContext(application: Application): Context
+
+    companion object {
+        @Provides
+        fun provideApiConfigurationState(
+            apiConfigurationProvider: () -> ApiConfiguration.State
+        ): ApiConfiguration.State = apiConfigurationProvider()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
@@ -7,7 +7,6 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import dagger.Binds
@@ -16,7 +15,7 @@ import dagger.Provides
 import java.util.Calendar
 import javax.inject.Named
 
-@Module(includes = [PaymentConfigurationModule::class])
+@Module
 internal interface CustomerSheetDataCommonModule {
     @Binds
     fun bindsCustomerRepository(repository: CustomerApiRepository): CustomerRepository

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet.injection
 import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetContract
 import com.stripe.android.customersheet.CustomerSheetIntegration
@@ -10,6 +11,7 @@ import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.injection.CustomerSheetConfirmationModule
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import dagger.BindsInstance
@@ -21,6 +23,7 @@ import dagger.Component
         ElementsSessionClientParamsModule::class,
         CustomerSheetConfirmationModule::class,
         CustomerSheetViewModelModule::class,
+        PaymentConfigurationModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
         GooglePayLauncherModule::class,
@@ -43,6 +46,8 @@ internal interface CustomerSheetViewModelComponent {
             integrationType: CustomerSheetIntegration.Type,
             @BindsInstance
             savedStateHandle: SavedStateHandle,
+            @BindsInstance
+            apiConfigurationProvider: () -> ApiConfiguration.State,
         ): CustomerSheetViewModelComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -27,8 +27,8 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnectionsAvailable
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
@@ -49,7 +49,7 @@ import kotlin.coroutines.CoroutineContext
 
 @Module(
     includes = [
-        PaymentConfigurationModule::class,
+        ApiRequestOptionsModule::class,
         StripeNetworkClientModule::class,
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.injection
 
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.IOContext
@@ -40,6 +41,7 @@ internal interface StripeCustomerAdapterComponent {
             @BindsInstance customerEphemeralKeyProvider: CustomerEphemeralKeyProvider,
             @BindsInstance setupIntentClientSecretProvider: SetupIntentClientSecretProvider?,
             @BindsInstance paymentMethodTypes: List<String>?,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): StripeCustomerAdapterComponent
     }
 }
@@ -47,6 +49,11 @@ internal interface StripeCustomerAdapterComponent {
 @Module
 internal interface StripeCustomerAdapterModule {
     companion object {
+        @Provides
+        fun provideApiConfigurationState(
+            apiConfigurationProvider: () -> ApiConfiguration.State
+        ): ApiConfiguration.State = apiConfigurationProvider()
+
         @Provides
         fun providePrefsRepositoryFactory(
             appContext: Context,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -5,8 +5,10 @@ import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.asSingle
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
@@ -49,6 +51,14 @@ internal object CustomerSheetHacks {
                     .create(
                         application = application,
                         adapter = integration.adapter,
+                        apiConfigurationProvider = {
+                            PaymentConfiguration.getInstance(application).let {
+                                ApiConfiguration.State(
+                                    publishableKey = it.publishableKey,
+                                    stripeAccountId = it.stripeAccountId,
+                                )
+                            }
+                        },
                     )
 
                 _initializationDataSource.value = adapterDataSourceComponent.customerSheetInitializationDataSource
@@ -62,6 +72,14 @@ internal object CustomerSheetHacks {
                     .create(
                         application = application,
                         customerSessionProvider = integration.customerSessionProvider,
+                        apiConfigurationProvider = {
+                            PaymentConfiguration.getInstance(application).let {
+                                ApiConfiguration.State(
+                                    publishableKey = it.publishableKey,
+                                    stripeAccountId = it.stripeAccountId,
+                                )
+                            }
+                        },
                     )
 
                 _initializationDataSource.value =

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
@@ -191,7 +192,7 @@ class CustomerAdapterTest {
     fun `retrievePaymentMethods filters with paymentMethodTypes`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
-        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any()))
+        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), any()))
             .thenReturn(Result.success(emptyList()))
 
         val adapter = createAdapter(
@@ -208,6 +209,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
+            stripeAccountId = any()
         )
     }
 
@@ -259,6 +261,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
+            stripeAccountId = any()
         )
     }
 
@@ -777,7 +780,10 @@ class CustomerAdapterTest {
             timeProvider = timeProvider,
             customerRepository = customerRepository,
             prefsRepositoryFactory = prefsRepositoryFactory,
-            workContext = testDispatcher
+            workContext = testDispatcher,
+            apiConfigProvider = {
+                ApiConfiguration.State("pk_123", "acc_123")
+            },
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -118,6 +118,8 @@ internal class CustomerSheetScreenshotTest {
         sellerBusinessName = null,
         forceSetupFutureUseBehavior = false,
         clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+        publishableKey = "pk_test_123",
+        stripeAccountId = null,
     )
 
     private val selectPaymentMethodViewState = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -33,6 +34,7 @@ class CustomerSheetTest {
     @Before
     fun setup() {
         val appContext = ApplicationProvider.getApplicationContext<Application>()
+        PaymentConfiguration.init(appContext, "pk_test_123")
 
         val activityInfo = ActivityInfo().apply {
             name = TestActivity::class.java.name

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet.data
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetFixtures
@@ -721,6 +722,9 @@ class CustomerAdapterDataSourceTest {
             customerAdapter = adapter,
             elementsSessionRepository = elementsSessionRepository,
             errorReporter = errorReporter,
+            apiConfigurationProvider = {
+                ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+            },
             workContext = coroutineContext,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -267,6 +268,9 @@ class CustomerSessionPaymentMethodDataSourceTest {
             customerRepository = customerRepository,
             errorReporter = errorReporter,
             workContext = coroutineContext,
+            apiConfigProvider = {
+                ApiConfiguration.State("pk_123", null)
+            }
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethodFixtures
@@ -241,7 +242,10 @@ class CustomerSessionSavedSelectionDataSourceTest {
             prefsRepositoryFactory = {
                 prefsRepository
             },
-            workContext = coroutineContext
+            workContext = coroutineContext,
+            apiConfigProvider = {
+                ApiConfiguration.State("pk_123", null)
+            }
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.utils.FakeCustomerSessionProvider
 import com.stripe.android.isInstanceOf
@@ -511,6 +512,9 @@ class DefaultCustomerSessionElementsSessionManagerTest {
                 onIntentConfiguration = onIntentConfiguration,
                 onProvidesCustomerSessionClientSecret = onCustomerSessionClientSecret,
             ),
+            apiConfigurationProvider = {
+                ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+            },
             timeProvider = timeProvider,
             workContext = coroutineContext,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -4,8 +4,10 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
@@ -40,6 +42,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.testing.CoroutineTestRule
@@ -63,6 +66,7 @@ import org.junit.Test
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -452,6 +456,9 @@ internal class DefaultCustomerSheetLoaderTest {
                 workContext = coroutineContext,
                 customerAdapter = FakeCustomerAdapter(),
                 errorReporter = FakeErrorReporter(),
+                apiConfigurationProvider = {
+                    ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+                },
             )
         )
 
@@ -849,7 +856,8 @@ internal class DefaultCustomerSheetLoaderTest {
                 override fun invoke(
                     environment: GooglePayEnvironment,
                     cardFundingFilter: CardFundingFilter,
-                    cardBrandFilter: CardBrandFilter
+                    cardBrandFilter: CardBrandFilter,
+                    apiConfiguration: ApiConfiguration.State?
                 ): GooglePayRepository {
                     return if (isGooglePayReady) {
                         readyGooglePayRepository
@@ -864,7 +872,8 @@ internal class DefaultCustomerSheetLoaderTest {
             isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
             eventReporter = eventReporter,
             errorReporter = errorReporter,
-            workContext = workContext
+            workContext = workContext,
+            apiConfigurationResolver = ApiConfigurationResolver(Provider { PaymentConfiguration("pk_test_123") })
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.FakeCustomerAdapter
@@ -18,6 +19,7 @@ import com.stripe.android.isInstanceOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
+import org.junit.Before
 import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
@@ -25,6 +27,11 @@ import kotlin.time.Duration.Companion.seconds
 @RunWith(AndroidJUnit4::class)
 class CustomerSheetHacksTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(application, "pk_test_123")
+    }
 
     @After
     fun teardown() {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.nfcscan.NoOpIsNfcScanningAvailable
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
@@ -82,6 +83,10 @@ internal interface CustomerSheetTestHelper {
             publishableKey = "pk_test_123",
             stripeAccountId = null,
         ),
+        apiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
+            publishableKey = paymentConfiguration.publishableKey,
+            stripeAccountId = paymentConfiguration.stripeAccountId,
+        ),
         configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(
             merchantDisplayName = "Example",
             googlePayEnabled = isGooglePayAvailable,
@@ -127,7 +132,13 @@ internal interface CustomerSheetTestHelper {
             configuration = configuration,
             integrationType = integrationType,
             statusBarColor = null,
-            paymentConfiguration = PaymentConfiguration(if (isLiveMode) "pk_live" else "pk_test"),
+            apiConfigurationProvider = {
+                if (isLiveMode) {
+                    ApiConfiguration.State(publishableKey = "pk_live", stripeAccountId = null)
+                } else {
+                    apiConfiguration
+                }
+            },
             logger = Logger.noop(),
             productUsage = emptySet(),
             confirmationHandlerFactory = confirmationHandler?.let { ConfirmationHandler.Factory { _ -> it } }
@@ -140,8 +151,7 @@ internal interface CustomerSheetTestHelper {
                     },
                     stripePaymentLauncherAssistedFactory = object : StripePaymentLauncherAssistedFactory {
                         override fun create(
-                            publishableKey: () -> String,
-                            stripeAccountId: () -> String?,
+                            apiConfigurationProvider: () -> ApiConfiguration.State,
                             statusBarColor: Int?,
                             includePaymentSheetNextHandlers: Boolean,
                             hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>


### PR DESCRIPTION
## Summary
- bind lazy API configuration providers at CustomerSheet and CustomerAdapter entry points
- keep this review below 500 changed lines

Stack: 9/15. The next PR targets tyler/payment-config-stack-10-link-configuration.

Committed and created by Codex.