### PR TITLE
Store API configuration in Link sessions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -571,8 +571,6 @@ internal class LinkActivityViewModel @Inject constructor(
                     .create(
                         configuration = args.configuration,
                         paymentMethodMetadata = args.paymentMethodMetadata,
-                        publishableKeyProvider = { args.publishableKey },
-                        stripeAccountIdProvider = { args.stripeAccountId },
                         paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
                         context = app,
                         savedStateHandle = handle,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -3,6 +3,8 @@ package com.stripe.android.link
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.ClientAttributionMetadata
@@ -15,7 +17,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class LinkConfiguration(
+internal data class LinkConfiguration constructor(
     val stripeIntent: StripeIntent,
     val merchantName: String,
     val sellerBusinessName: String?,
@@ -51,7 +53,14 @@ internal data class LinkConfiguration(
     val linkSupportedPaymentMethodsOnboardingEnabled: List<String>,
     val clientAttributionMetadata: ClientAttributionMetadata,
     val linkBrand: LinkBrand,
+    val apiConfiguration: ApiConfiguration.State,
 ) : Parcelable {
+
+    val requestOptions: ApiRequest.Options
+        get() = ApiRequest.Options(
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
+        )
 
     val customerIdForEceDefaultValues: String?
         get() = if (enableDisplayableDefaultValuesInEce) customerId else null

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -7,7 +7,6 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.ResolvableString
@@ -70,7 +69,8 @@ internal class LinkControllerInteractor @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) {
 
-    private var configuration: LinkController.Configuration.State? = null
+    internal var configuration: LinkController.Configuration.State? = null
+        private set
 
     private val tag = "LinkControllerViewInteractor"
 
@@ -175,11 +175,6 @@ internal class LinkControllerInteractor @Inject constructor(
         val config = configuration.build()
         this.configuration = config
         updateState { State() }
-        PaymentConfiguration.init(
-            context = application,
-            publishableKey = config.publishableKey,
-            stripeAccountId = config.stripeAccountId,
-        )
         return linkConfigurationLoader.load(config)
             .flatMapCatching { linkMetadata ->
                 val component = linkComponentFactoryProvider.get()

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import javax.inject.Inject
@@ -16,18 +16,19 @@ import javax.inject.Inject
 internal class NativeLinkActivityContract @Inject constructor(
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val requestSurface: RequestSurface,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
 ) :
     ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>() {
     override fun createIntent(context: Context, input: LinkActivityContract.Args): Intent {
-        val paymentConfiguration = PaymentConfiguration.getInstance(context)
+        val apiConfiguration = apiConfigurationProvider()
         return LinkActivity.createIntent(
             context = context,
             args = NativeLinkArgs(
                 configuration = input.configuration,
                 paymentMethodMetadata = input.paymentMethodMetadata,
                 requestSurface = requestSurface,
-                stripeAccountId = paymentConfiguration.stripeAccountId,
-                publishableKey = paymentConfiguration.publishableKey,
+                stripeAccountId = apiConfiguration.stripeAccountId,
+                publishableKey = apiConfiguration.publishableKey,
                 linkExpressMode = input.linkExpressMode,
                 launchMode = input.launchMode,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,

--- a/paymentsheet/src/main/java/com/stripe/android/link/WebLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/WebLinkActivityContract.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.util.Base64
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.link.serialization.PopupPayload
 import com.stripe.android.model.PaymentMethod
@@ -21,16 +21,17 @@ import javax.inject.Inject
  */
 internal class WebLinkActivityContract @Inject internal constructor(
     private val stripeRepository: StripeRepository,
-    private val errorReporter: ErrorReporter
+    private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
 ) : ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>() {
 
     override fun createIntent(context: Context, input: LinkActivityContract.Args): Intent {
-        val paymentConfiguration = PaymentConfiguration.getInstance(context)
+        val apiConfiguration = apiConfigurationProvider()
         val payload = PopupPayload.create(
             configuration = input.configuration,
             context = context,
-            publishableKey = paymentConfiguration.publishableKey,
-            stripeAccount = paymentConfiguration.stripeAccountId,
+            publishableKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
             paymentUserAgent = stripeRepository.buildPaymentUserAgent(),
         )
         return LinkForegroundActivity.createIntent(context, payload.toUrl())

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -87,6 +87,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return runCatching {
             val linkAccount = requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
             linkRepository.createLinkAccountSession(
+                requestOptions = config.requestOptions,
                 consumerSessionClientSecret = linkAccount.clientSecret,
                 intentToken = config.stripeIntent.clientSecret ?: config.elementsSessionId,
                 linkMode = config.linkMode,
@@ -122,6 +123,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         }.mapCatching { account ->
             runCatching {
                 linkRepository.logOut(
+                    requestOptions = config.requestOptions,
                     consumerSessionClientSecret = account.clientSecret,
                     consumerAccountPublishableKey = account.consumerPublishableKey,
                 ).getOrThrow()
@@ -197,6 +199,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
         }.mapCatching { account ->
             linkRepository.createPaymentMethod(
+                requestOptions = config.requestOptions,
                 consumerSessionClientSecret = account.clientSecret,
                 paymentMethod = linkPaymentMethod,
                 clientAttributionMetadata = config.clientAttributionMetadata,
@@ -211,6 +214,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return if (linkAccountValue != null) {
             linkAccountValue.let { account ->
                 linkRepository.createCardPaymentDetails(
+                    requestOptions = config.requestOptions,
                     paymentMethodCreateParams = paymentMethodCreateParams,
                     userEmail = account.email,
                     stripeIntent = config.stripeIntent,
@@ -235,6 +239,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccountValue = linkAccountHolder.linkAccountInfo.value.account
         return linkAccountValue?.let { account ->
             linkRepository.createPaymentDetailsFromPaymentMethod(
+                requestOptions = config.requestOptions,
                 paymentMethod = paymentMethod,
                 userEmail = account.email,
                 stripeIntent = config.stripeIntent,
@@ -261,6 +266,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             val paymentDetails = cardPaymentDetails.paymentDetails
             val paymentMethodCreateParams = cardPaymentDetails.originalParams
             linkRepository.shareCardPaymentDetails(
+                requestOptions = config.requestOptions,
                 id = paymentDetails.id,
                 consumerSessionClientSecret = account.clientSecret,
                 paymentMethodCreateParams = paymentMethodCreateParams,
@@ -275,6 +281,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
         return if (linkAccount != null) {
             linkRepository.createBankAccountPaymentDetails(
+                requestOptions = config.requestOptions,
                 bankAccountId = bankAccountId,
                 userEmail = linkAccount.email,
                 consumerSessionClientSecret = linkAccount.clientSecret,
@@ -300,6 +307,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
         }.mapCatching { account ->
             linkRepository.sharePaymentDetails(
+                requestOptions = config.requestOptions,
                 paymentDetailsId = paymentDetailsId,
                 consumerSessionClientSecret = account.clientSecret,
                 expectedPaymentMethodType = expectedPaymentMethodType,
@@ -376,6 +384,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             ?: return Result.failure(NoLinkAccountFoundException())
         linkEventsReporter.on2FAStart()
         return linkRepository.startVerification(
+            requestOptions = config.requestOptions,
             consumerSessionClientSecret = linkAccount.clientSecret,
             isResendSmsCode = isResendSmsCode
         )
@@ -393,6 +402,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.confirmVerification(
+            requestOptions = config.requestOptions,
             verificationCode = code,
             consumerSessionClientSecret = linkAccount.clientSecret,
             consentGranted = consentGranted,
@@ -411,6 +421,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             ?: return Result.failure(NoLinkAccountFoundException())
 
         return linkRepository.postConsentUpdate(
+            requestOptions = config.requestOptions,
             consumerSessionClientSecret = linkAccount.clientSecret,
             consentGranted = consentGranted,
         )
@@ -420,6 +431,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.listPaymentDetails(
+            requestOptions = config.requestOptions,
             paymentMethodTypes = paymentMethodTypes,
             consumerSessionClientSecret = linkAccount.clientSecret,
         ).onSuccess { paymentDetailsList ->
@@ -433,6 +445,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.listShippingAddresses(
+            requestOptions = config.requestOptions,
             consumerSessionClientSecret = linkAccount.clientSecret,
         )
     }
@@ -441,6 +454,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.deletePaymentDetails(
+            requestOptions = config.requestOptions,
             paymentDetailsId = paymentDetailsId,
             consumerSessionClientSecret = linkAccount.clientSecret,
         )
@@ -453,6 +467,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.updatePaymentDetails(
+            requestOptions = config.requestOptions,
             updateParams = updateParams,
             consumerSessionClientSecret = linkAccount.clientSecret,
         ).map { updatedPaymentDetails ->
@@ -469,6 +484,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.updatePhoneNumber(
+            requestOptions = config.requestOptions,
             consumerSessionClientSecret = linkAccount.clientSecret,
             phoneNumber = phoneNumber,
         ).map { consumerSession ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
@@ -62,6 +62,7 @@ internal class DefaultLinkAuth @Inject constructor(
             )
         } else {
             linkRepository.lookupConsumer(
+                requestOptions = config.requestOptions,
                 email = email,
                 linkAuthIntentId = linkAuthIntentId,
                 sessionId = sessionId,
@@ -90,6 +91,7 @@ internal class DefaultLinkAuth @Inject constructor(
             )
         } else {
             linkRepository.consumerSignUp(
+                requestOptions = config.requestOptions,
                 email = email,
                 phone = phoneNumber,
                 country = country,
@@ -105,6 +107,7 @@ internal class DefaultLinkAuth @Inject constructor(
         supportedVerificationTypes: List<String>?
     ): Result<ConsumerSessionRefresh> {
         return linkRepository.refreshConsumer(
+            requestOptions = config.requestOptions,
             appId = applicationId,
             consumerSessionClientSecret = consumerSessionClientSecret,
             supportedVerificationTypes = supportedVerificationTypes
@@ -123,6 +126,7 @@ internal class DefaultLinkAuth @Inject constructor(
         return runCatching {
             val verificationToken = integrityRequestManager.requestToken().getOrThrow()
             linkRepository.mobileLookupConsumer(
+                requestOptions = config.requestOptions,
                 verificationToken = verificationToken,
                 appId = applicationId,
                 email = email,
@@ -150,6 +154,7 @@ internal class DefaultLinkAuth @Inject constructor(
         return runCatching {
             val verificationToken = integrityRequestManager.requestToken().getOrThrow()
             linkRepository.mobileSignUp(
+                requestOptions = config.requestOptions,
                 name = name,
                 email = email,
                 phoneNumber = phoneNumber,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import dagger.BindsInstance
 import dagger.Component
@@ -15,6 +16,7 @@ import javax.inject.Singleton
     modules = [
         LinkControllerModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
+        ApiRequestOptionsModule::class,
     ]
 )
 internal interface LinkControllerComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.injection
 import android.app.Application
 import android.content.Context
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
@@ -29,6 +30,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module(
@@ -65,6 +67,19 @@ internal interface LinkControllerModule {
         @Singleton
         fun providePaymentMethodMetadata(interactor: LinkControllerInteractor): PaymentMethodMetadata? {
             return interactor.paymentMethodMetadata
+        }
+
+        @Provides
+        fun provideApiConfigurationStateProvider(
+            interactor: Provider<LinkControllerInteractor>
+        ): () -> ApiConfiguration.State {
+            return {
+                val config = requireNotNull(interactor.get().configuration)
+                ApiConfiguration.State(
+                    publishableKey = config.publishableKey,
+                    stripeAccountId = config.stripeAccountId,
+                )
+            }
         }
 
         // TODO

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -6,8 +6,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.Logger
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
@@ -29,6 +27,7 @@ import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmat
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -50,6 +49,7 @@ internal annotation class NativeLinkScope
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
         LinkPassthroughConfirmationModule::class,
+        ApiRequestOptionsModule::class,
     ]
 )
 internal interface NativeLinkComponent {
@@ -81,12 +81,6 @@ internal interface NativeLinkComponent {
             configuration: LinkConfiguration,
             @BindsInstance
             paymentMethodMetadata: PaymentMethodMetadata,
-            @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
-            @BindsInstance
-            @Named(STRIPE_ACCOUNT_ID)
-            stripeAccountIdProvider: () -> String?,
             @BindsInstance
             @PaymentElementCallbackIdentifier
             paymentElementCallbackIdentifier: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -4,10 +4,10 @@ import android.content.Context
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -37,6 +37,7 @@ import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.repositories.LinkApiRepository
 import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.oauth.OAuthConsentViewModelComponent
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
@@ -206,9 +207,10 @@ internal interface NativeLinkModule {
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
 
         @Provides
-        @NativeLinkScope
-        fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(appContext)
+        fun provideApiConfigurationProvider(
+            paymentMethodMetadata: PaymentMethodMetadata
+        ): () -> ApiConfiguration.State {
+            return { paymentMethodMetadata.apiConfiguration }
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -205,6 +205,9 @@ internal class PaymentMethodViewModel @Inject constructor(
                             autocompleteAddressInteractorFactory =
                                 PaymentElementAutocompleteAddressInteractor.Factory(
                                     launcher = parentComponent.autocompleteLauncher,
+                                    publishableKeyProvider = {
+                                        parentComponent.paymentMethodMetadata.apiConfiguration.publishableKey
+                                    },
                                     autocompleteConfig = AutocompleteAddressInteractor.Config(
                                         googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
                                         autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.testing.CoroutineTestRule
@@ -13,6 +14,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -54,6 +56,11 @@ internal class LinkControllerCoordinatorTest {
     private val confirmSetupIntentResults = mutableListOf<LinkController.ConfirmSetupIntentResult>()
 
     private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.INITIALIZED)
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(), "pk_test_123")
+    }
 
     private fun createCoordinator(
         activityResult: LinkActivityResult? = null

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -71,6 +72,11 @@ class LinkControllerInteractorTest {
     // them so the scopes don't outlive the test.
     @get:Rule
     val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(application, "pk_test_123")
+    }
 
     @Test
     fun `Initial state is correct`() = runTest {
@@ -146,6 +152,7 @@ class LinkControllerInteractorTest {
                 publishableKey = "pk_123",
                 stripeAccountId = "acct_123"
             )
+        PaymentConfiguration.init(application, "pk_123", "acct_123")
         assertThat(interactor.configure(controllerConfig).isSuccess).isTrue()
         assertThat(linkComponent.configuration).isEqualTo(loadedConfiguration)
         val paymentConfiguration = PaymentConfiguration.getInstance(application)

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -6,12 +6,10 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.RequestSurface
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -19,24 +17,17 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class NativeLinkActivityContractTest {
 
-    @Before
-    fun before() {
-        PaymentConfiguration.init(
-            context = ApplicationProvider.getApplicationContext(),
-            publishableKey = "pk_test_abcdefg",
-        )
-    }
-
-    @After
-    fun after() {
-        PaymentConfiguration.clearInstance()
-    }
+    private val testApiConfiguration = ApiConfiguration.State(
+        publishableKey = "pk_test_abcdefg",
+        stripeAccountId = null,
+    )
 
     @Test
     fun `intent is created correctly`() {
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
         val args = LinkActivityContract.Args(
             configuration = TestFactory.LINK_CONFIGURATION,
@@ -78,7 +69,8 @@ class NativeLinkActivityContractTest {
 
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
 
         val result = contract.parseResult(
@@ -93,7 +85,8 @@ class NativeLinkActivityContractTest {
     fun `complete with canceled result when result not found`() {
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
 
         val result = contract.parseResult(
@@ -113,7 +106,8 @@ class NativeLinkActivityContractTest {
     fun `unknown result code results in canceled`() {
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
 
         val result = contract.parseResult(42, Intent())
@@ -130,7 +124,8 @@ class NativeLinkActivityContractTest {
     fun `canceled result code is handled correctly`() {
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
 
         val result = contract.parseResult(Activity.RESULT_CANCELED, Intent())

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link
 
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
@@ -306,6 +307,7 @@ internal object TestFactory {
         ),
         cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
         linkBrand = LinkBrand.Link,
+        apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
     )
 
     val LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING = LINK_CONFIGURATION.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
@@ -5,15 +5,13 @@ import android.content.Intent
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.FakeErrorReporter
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -21,18 +19,10 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class WebLinkActivityContractTest {
 
-    @Before
-    fun before() {
-        PaymentConfiguration.init(
-            context = ApplicationProvider.getApplicationContext(),
-            publishableKey = "pk_test_abcdefg",
-        )
-    }
-
-    @After
-    fun after() {
-        PaymentConfiguration.clearInstance()
-    }
+    private val testApiConfiguration = ApiConfiguration.State(
+        publishableKey = "pk_test_abcdefg",
+        stripeAccountId = null,
+    )
 
     @Test
     fun `intent is created correctly`() {
@@ -185,6 +175,6 @@ class WebLinkActivityContractTest {
         stripeRepository: StripeRepository = FakeStripeRepository(),
         errorReporter: FakeErrorReporter = FakeErrorReporter()
     ): WebLinkActivityContract {
-        return WebLinkActivityContract(stripeRepository, errorReporter)
+        return WebLinkActivityContract(stripeRepository, errorReporter, { testApiConfiguration })
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.AuthenticationException
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentDetails
@@ -432,6 +433,7 @@ class DefaultLinkAccountManagerTest {
             )
             var callCount = 0
             override suspend fun createCardPaymentDetails(
+                requestOptions: ApiRequest.Options,
                 paymentMethodCreateParams: PaymentMethodCreateParams,
                 userEmail: String,
                 stripeIntent: StripeIntent,
@@ -446,6 +448,7 @@ class DefaultLinkAccountManagerTest {
             }
 
             override suspend fun lookupConsumer(
+                requestOptions: ApiRequest.Options,
                 email: String?,
                 linkAuthIntentId: String?,
                 sessionId: String,
@@ -454,6 +457,7 @@ class DefaultLinkAccountManagerTest {
             ): Result<ConsumerSessionLookup> {
                 callCount += 1
                 return super.lookupConsumer(
+                    requestOptions = requestOptions,
                     email = email,
                     linkAuthIntentId = linkAuthIntentId,
                     sessionId = sessionId,
@@ -482,6 +486,7 @@ class DefaultLinkAccountManagerTest {
             var createPaymentDetailsFromPaymentMethodCallCount = 0
             var capturedCustomerEphemeralKey = "not_called"
             override suspend fun createPaymentDetailsFromPaymentMethod(
+                requestOptions: ApiRequest.Options,
                 paymentMethod: PaymentMethod,
                 userEmail: String,
                 stripeIntent: StripeIntent,
@@ -546,6 +551,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var shareCardPaymentDetailsCallCount = 0
             override suspend fun shareCardPaymentDetails(
+                requestOptions: ApiRequest.Options,
                 paymentMethodCreateParams: PaymentMethodCreateParams,
                 id: String,
                 consumerSessionClientSecret: String,
@@ -557,6 +563,7 @@ class DefaultLinkAccountManagerTest {
                     shareCardPaymentDetailsCallCount += 1
                 }
                 return super.shareCardPaymentDetails(
+                    requestOptions = requestOptions,
                     paymentMethodCreateParams = paymentMethodCreateParams,
                     id = id,
                     consumerSessionClientSecret = consumerSessionClientSecret,
@@ -588,11 +595,12 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var callCount = 0
             override suspend fun startVerification(
+                requestOptions: ApiRequest.Options,
                 consumerSessionClientSecret: String,
                 isResendSmsCode: Boolean
             ): Result<ConsumerSession> {
                 callCount += 1
-                return super.startVerification(consumerSessionClientSecret, isResendSmsCode)
+                return super.startVerification(requestOptions, consumerSessionClientSecret, isResendSmsCode)
             }
         }
         val accountManager = accountManager(linkRepository = linkRepository)
@@ -663,12 +671,14 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var callCount = 0
             override suspend fun confirmVerification(
+                requestOptions: ApiRequest.Options,
                 verificationCode: String,
                 consumerSessionClientSecret: String,
                 consentGranted: Boolean?
             ): Result<ConsumerSession> {
                 callCount += 1
                 return super.confirmVerification(
+                    requestOptions = requestOptions,
                     verificationCode = verificationCode,
                     consumerSessionClientSecret = consumerSessionClientSecret,
                     consentGranted = consentGranted
@@ -699,6 +709,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var callCount = 0
             override suspend fun confirmVerification(
+                requestOptions: ApiRequest.Options,
                 verificationCode: String,
                 consumerSessionClientSecret: String,
                 consentGranted: Boolean?
@@ -729,6 +740,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var paymentMethodTypes: Set<String>? = null
             override suspend fun listPaymentDetails(
+                requestOptions: ApiRequest.Options,
                 paymentMethodTypes: Set<String>,
                 consumerSessionClientSecret: String,
             ): Result<ConsumerPaymentDetails> {
@@ -751,6 +763,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var paymentMethodTypes: Set<String>? = null
             override suspend fun listPaymentDetails(
+                requestOptions: ApiRequest.Options,
                 paymentMethodTypes: Set<String>,
                 consumerSessionClientSecret: String,
             ): Result<ConsumerPaymentDetails> {
@@ -960,6 +973,7 @@ class DefaultLinkAccountManagerTest {
     fun `createLinkAccountSession returns repository result on success`() = runSuspendTest {
         val linkRepository = object : FakeLinkRepository() {
             override suspend fun createLinkAccountSession(
+                requestOptions: ApiRequest.Options,
                 consumerSessionClientSecret: String,
                 intentToken: String?,
                 linkMode: LinkMode?,
@@ -1003,6 +1017,7 @@ class DefaultLinkAccountManagerTest {
         var capturedIntentToken: String? = null
         val linkRepository = object : FakeLinkRepository() {
             override suspend fun createLinkAccountSession(
+                requestOptions: ApiRequest.Options,
                 consumerSessionClientSecret: String,
                 intentToken: String?,
                 linkMode: LinkMode?,
@@ -1032,6 +1047,7 @@ class DefaultLinkAccountManagerTest {
         var capturedIntentToken: String? = null
         val linkRepository = object : FakeLinkRepository() {
             override suspend fun createLinkAccountSession(
+                requestOptions: ApiRequest.Options,
                 consumerSessionClientSecret: String,
                 intentToken: String?,
                 linkMode: LinkMode?,

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
@@ -68,7 +68,7 @@ class DefaultLinkEventsReporterTest {
             analyticsRequestExecutor = analyticsRequestExecutor,
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = application,
-                publishableKey = "pk_1234"
+                publishableKeyProvider = { "pk_1234" },
             ),
             errorReporter = FakeErrorReporter(),
             workContext = testScope.coroutineContext,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.ui.signup
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -118,6 +119,7 @@ class SignUpScreenStateTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -185,6 +186,7 @@ class LinkFormElementTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
     }
 


### PR DESCRIPTION
## Summary
- retain API configuration in Link configuration, contracts, account management, and session state
- keep this review below 500 changed lines

Stack: 10/15. The next PR targets tyler/payment-config-stack-11-link-repository.

Committed and created by Codex.