### PR TITLE
Pass request options explicitly to Link repositories

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -2,11 +2,10 @@ package com.stripe.android.link.repositories
 
 import android.app.Application
 import com.stripe.android.DefaultFraudDetectionDataRepository
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentMethod
@@ -40,7 +39,6 @@ import com.stripe.android.repository.ConsumersApiService
 import kotlinx.coroutines.withContext
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -50,8 +48,7 @@ import kotlin.coroutines.CoroutineContext
 internal class LinkApiRepository @Inject constructor(
     application: Application,
     private val requestSurface: RequestSurface,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
-    @Named(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     private val stripeRepository: StripeRepository,
     private val consumersApiService: ConsumersApiService,
     @IOContext private val workContext: CoroutineContext,
@@ -60,16 +57,14 @@ internal class LinkApiRepository @Inject constructor(
 ) : LinkRepository {
 
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
-        DefaultFraudDetectionDataRepository(application, workContext)
-
-    private val apiRequestOptions: ApiRequest.Options
-        get() = buildRequestOptions()
+        DefaultFraudDetectionDataRepository(application, { apiConfigProvider().publishableKey }, workContext)
 
     init {
         fraudDetectionDataRepository.refresh()
     }
 
     override suspend fun lookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         linkAuthIntentId: String?,
         sessionId: String,
@@ -84,7 +79,7 @@ internal class LinkApiRepository @Inject constructor(
                     requestSurface = requestSurface.value,
                     sessionId = sessionId,
                     doNotLogConsumerFunnelEvent = false,
-                    requestOptions = apiRequestOptions,
+                    requestOptions = requestOptions,
                     customerId = customerId,
                     supportedVerificationTypes = supportedVerificationTypes
                 )
@@ -93,6 +88,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun lookupConsumerWithoutBackendLoggingForExposure(
+        requestOptions: ApiRequest.Options,
         email: String,
         sessionId: String,
     ): Result<ConsumerSessionLookup> = withContext(workContext) {
@@ -105,7 +101,7 @@ internal class LinkApiRepository @Inject constructor(
                     sessionId = sessionId,
                     doNotLogConsumerFunnelEvent = true,
                     supportedVerificationTypes = null,
-                    requestOptions = apiRequestOptions,
+                    requestOptions = requestOptions,
                     customerId = null
                 )
             )
@@ -113,6 +109,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun mobileLookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         emailSource: EmailSource?,
         linkAuthIntentId: String?,
@@ -131,7 +128,7 @@ internal class LinkApiRepository @Inject constructor(
                 requestSurface = requestSurface.value,
                 verificationToken = verificationToken,
                 appId = appId,
-                requestOptions = apiRequestOptions,
+                requestOptions = requestOptions,
                 sessionId = sessionId,
                 customerId = customerId,
                 supportedVerificationTypes = supportedVerificationTypes,
@@ -141,6 +138,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun refreshConsumer(
+        requestOptions: ApiRequest.Options,
         appId: String,
         consumerSessionClientSecret: String,
         supportedVerificationTypes: List<String>?,
@@ -151,12 +149,13 @@ internal class LinkApiRepository @Inject constructor(
                 consumerSessionClientSecret = consumerSessionClientSecret,
                 supportedVerificationTypes = supportedVerificationTypes,
                 requestSurface = requestSurface.value,
-                requestOptions = apiRequestOptions,
+                requestOptions = requestOptions,
             )
         }
     }
 
     override suspend fun consumerSignUp(
+        requestOptions: ApiRequest.Options,
         email: String,
         phone: String?,
         country: String?,
@@ -178,11 +177,12 @@ internal class LinkApiRepository @Inject constructor(
                 consentAction = consentAction,
                 requestSurface = requestSurface.value
             ),
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun mobileSignUp(
+        requestOptions: ApiRequest.Options,
         name: String?,
         email: String,
         phoneNumber: String?,
@@ -211,11 +211,12 @@ internal class LinkApiRepository @Inject constructor(
                 verificationToken = verificationToken,
                 appId = appId
             ),
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun createCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -229,7 +230,7 @@ internal class LinkApiRepository @Inject constructor(
                 email = userEmail,
             ),
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         ).mapCatching {
             val paymentDetails = it.paymentDetails.first()
             val extraParams = extraConfirmationParams(paymentMethodCreateParams.toParamMap())
@@ -258,6 +259,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun createPaymentDetailsFromPaymentMethod(
+        requestOptions: ApiRequest.Options,
         paymentMethod: PaymentMethod,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -269,7 +271,7 @@ internal class LinkApiRepository @Inject constructor(
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentMethodId = paymentMethod.id,
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
             customerEphemeralKey = customerEphemeralKey,
         ).mapCatching {
             LinkPaymentDetails.Saved(
@@ -280,6 +282,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun createBankAccountPaymentDetails(
+        requestOptions: ApiRequest.Options,
         bankAccountId: String,
         userEmail: String,
         consumerSessionClientSecret: String,
@@ -294,7 +297,7 @@ internal class LinkApiRepository @Inject constructor(
                 clientAttributionMetadata = clientAttributionMetadata.toParams(),
             ),
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         ).mapCatching {
             it.paymentDetails.first()
         }.onFailure {
@@ -306,6 +309,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun shareCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
         consumerSessionClientSecret: String,
@@ -326,7 +330,7 @@ internal class LinkApiRepository @Inject constructor(
             extraParams = mapOf(
                 "payment_method_options" to extraConfirmationParams(paymentMethodCreateParams.toParamMap()),
             ) + allowRedisplay + billingPhone + paymentMethodParams + clientAttributionMetadataParams,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         ).onFailure {
             errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_SHARE_CARD_FAILURE, StripeException.create(it))
         }.map { paymentMethod ->
@@ -344,6 +348,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun sharePaymentDetails(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String?,
@@ -368,15 +373,13 @@ internal class LinkApiRepository @Inject constructor(
             allowRedisplayParams +
             clientAttributionMetadataParams
 
-        // Allow using a custom API key so that payment methods can be created under the
-        // merchant-of-record if necessary.
-        val requestOptions = buildRequestOptions(apiKey)
+        val effectiveOptions = buildRequestOptions(requestOptions, apiKey)
 
         consumersApiService.sharePaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentDetailsId = paymentDetailsId,
             expectedPaymentMethodType = expectedPaymentMethodType,
-            requestOptions = requestOptions,
+            requestOptions = effectiveOptions,
             requestSurface = requestSurface.value,
             extraParams = extraParams,
             billingPhone = billingPhone,
@@ -384,6 +387,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun createPaymentMethod(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentMethod: LinkPaymentMethod,
         clientAttributionMetadata: ClientAttributionMetadata,
@@ -397,22 +401,24 @@ internal class LinkApiRepository @Inject constructor(
         )
         stripeRepository.createPaymentMethod(
             paymentMethodCreateParams = params,
-            options = apiRequestOptions,
+            options = requestOptions,
         )
     }
 
     override suspend fun logOut(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,
     ): Result<ConsumerSession> = withContext(workContext) {
         stripeRepository.logOut(
             consumerSessionClientSecret = consumerSessionClientSecret,
             consumerAccountPublishableKey = consumerAccountPublishableKey,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun startVerification(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         isResendSmsCode: Boolean
     ): Result<ConsumerSession> {
@@ -425,7 +431,7 @@ internal class LinkApiRepository @Inject constructor(
                     type = VerificationType.SMS,
                     customEmailType = null,
                     connectionsMerchantName = null,
-                    requestOptions = apiRequestOptions,
+                    requestOptions = requestOptions,
                     isResendSmsCode = isResendSmsCode
                 )
             )
@@ -433,6 +439,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun confirmVerification(
+        requestOptions: ApiRequest.Options,
         verificationCode: String,
         consumerSessionClientSecret: String,
         consentGranted: Boolean?
@@ -445,13 +452,14 @@ internal class LinkApiRepository @Inject constructor(
                     requestSurface = requestSurface.value,
                     type = VerificationType.SMS,
                     consentGranted = consentGranted,
-                    requestOptions = apiRequestOptions,
+                    requestOptions = requestOptions,
                 )
             )
         }
     }
 
     override suspend fun postConsentUpdate(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consentGranted: Boolean,
     ): Result<Unit> = withContext(workContext) {
@@ -459,53 +467,58 @@ internal class LinkApiRepository @Inject constructor(
             consumerSessionClientSecret = consumerSessionClientSecret,
             consentGranted = consentGranted,
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun listPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodTypes: Set<String>,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails> {
         return stripeRepository.listPaymentDetails(
             clientSecret = consumerSessionClientSecret,
             paymentMethodTypes = paymentMethodTypes,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun listShippingAddresses(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
     ): Result<ConsumerShippingAddresses> {
         return stripeRepository.listShippingAddresses(
             clientSecret = consumerSessionClientSecret,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun deletePaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
     ): Result<Unit> {
         return stripeRepository.deletePaymentDetails(
             clientSecret = consumerSessionClientSecret,
             paymentDetailsId = paymentDetailsId,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun updatePaymentDetails(
+        requestOptions: ApiRequest.Options,
         updateParams: ConsumerPaymentDetailsUpdateParams,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails> {
         return stripeRepository.updatePaymentDetails(
             clientSecret = consumerSessionClientSecret,
             paymentDetailsUpdateParams = updateParams,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun createLinkAccountSession(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         intentToken: String?,
         linkMode: LinkMode?,
@@ -515,11 +528,12 @@ internal class LinkApiRepository @Inject constructor(
             intentToken = intentToken,
             linkMode = linkMode,
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun updatePhoneNumber(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         phoneNumber: String,
     ): Result<ConsumerSession> = withContext(workContext) {
@@ -527,12 +541,13 @@ internal class LinkApiRepository @Inject constructor(
             consumerSessionClientSecret = consumerSessionClientSecret,
             phoneNumber = phoneNumber,
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     private fun buildRequestOptions(
-        customApiKey: String? = null,
+        defaultOptions: ApiRequest.Options,
+        customApiKey: String?,
     ): ApiRequest.Options {
         return if (customApiKey != null) {
             ApiRequest.Options(
@@ -540,10 +555,7 @@ internal class LinkApiRepository @Inject constructor(
                 stripeAccount = null,
             )
         } else {
-            ApiRequest.Options(
-                apiKey = publishableKeyProvider(),
-                stripeAccount = stripeAccountIdProvider(),
-            )
+            defaultOptions
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.repositories
 
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.model.ClientAttributionMetadata
@@ -33,6 +34,7 @@ internal interface LinkRepository {
      *                   retrieval of displayable payment details.
      */
     suspend fun lookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         linkAuthIntentId: String?,
         sessionId: String,
@@ -46,6 +48,7 @@ internal interface LinkRepository {
      * Link global holdback to look up consumers in the event Link is disabled.
      */
     suspend fun lookupConsumerWithoutBackendLoggingForExposure(
+        requestOptions: ApiRequest.Options,
         email: String,
         sessionId: String,
     ): Result<ConsumerSessionLookup>
@@ -57,6 +60,7 @@ internal interface LinkRepository {
      *                   retrieval of displayable payment details.
      */
     suspend fun mobileLookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         emailSource: EmailSource?,
         linkAuthIntentId: String?,
@@ -72,6 +76,7 @@ internal interface LinkRepository {
      * Refresh the mobile consumer session.
      */
     suspend fun refreshConsumer(
+        requestOptions: ApiRequest.Options,
         appId: String,
         consumerSessionClientSecret: String,
         supportedVerificationTypes: List<String>?,
@@ -81,6 +86,7 @@ internal interface LinkRepository {
      * Sign up for a new Link account.
      */
     suspend fun consumerSignUp(
+        requestOptions: ApiRequest.Options,
         email: String,
         phone: String?,
         country: String?,
@@ -90,6 +96,7 @@ internal interface LinkRepository {
     ): Result<ConsumerSessionSignup>
 
     suspend fun mobileSignUp(
+        requestOptions: ApiRequest.Options,
         name: String?,
         email: String,
         phoneNumber: String?,
@@ -107,6 +114,7 @@ internal interface LinkRepository {
      * Create a new card payment method in the consumer account.
      */
     suspend fun createCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -115,6 +123,7 @@ internal interface LinkRepository {
     ): Result<LinkPaymentDetails.New>
 
     suspend fun createPaymentDetailsFromPaymentMethod(
+        requestOptions: ApiRequest.Options,
         paymentMethod: PaymentMethod,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -124,6 +133,7 @@ internal interface LinkRepository {
     ): Result<LinkPaymentDetails.Saved>
 
     suspend fun createBankAccountPaymentDetails(
+        requestOptions: ApiRequest.Options,
         bankAccountId: String,
         userEmail: String,
         consumerSessionClientSecret: String,
@@ -131,6 +141,7 @@ internal interface LinkRepository {
     ): Result<ConsumerPaymentDetails.PaymentDetails>
 
     suspend fun shareCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
         consumerSessionClientSecret: String,
@@ -138,6 +149,7 @@ internal interface LinkRepository {
     ): Result<LinkPaymentDetails.Passthrough>
 
     suspend fun sharePaymentDetails(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String?,
@@ -149,12 +161,14 @@ internal interface LinkRepository {
     ): Result<SharePaymentDetails>
 
     suspend fun createPaymentMethod(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentMethod: LinkPaymentMethod,
         clientAttributionMetadata: ClientAttributionMetadata
     ): Result<PaymentMethod>
 
     suspend fun logOut(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,
     ): Result<ConsumerSession>
@@ -163,6 +177,7 @@ internal interface LinkRepository {
      * Start an SMS verification.
      */
     suspend fun startVerification(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         isResendSmsCode: Boolean = false
     ): Result<ConsumerSession>
@@ -171,6 +186,7 @@ internal interface LinkRepository {
      * Confirm an SMS verification code.
      */
     suspend fun confirmVerification(
+        requestOptions: ApiRequest.Options,
         verificationCode: String,
         consumerSessionClientSecret: String,
         consentGranted: Boolean?,
@@ -180,6 +196,7 @@ internal interface LinkRepository {
      * Update consent status for the signed in consumer.
      */
     suspend fun postConsentUpdate(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consentGranted: Boolean,
     ): Result<Unit>
@@ -188,6 +205,7 @@ internal interface LinkRepository {
      * Fetch all saved payment methods for the signed in consumer.
      */
     suspend fun listPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodTypes: Set<String>,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails>
@@ -196,6 +214,7 @@ internal interface LinkRepository {
      * Fetch all shipping addresses for the signed in consumer.
      */
     suspend fun listShippingAddresses(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
     ): Result<ConsumerShippingAddresses>
 
@@ -203,6 +222,7 @@ internal interface LinkRepository {
      * Delete the payment method from the consumer account.
      */
     suspend fun deletePaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
     ): Result<Unit>
@@ -211,11 +231,13 @@ internal interface LinkRepository {
      * Update an existing payment method in the consumer account.
      */
     suspend fun updatePaymentDetails(
+        requestOptions: ApiRequest.Options,
         updateParams: ConsumerPaymentDetailsUpdateParams,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails>
 
     suspend fun createLinkAccountSession(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         intentToken: String?,
         linkMode: LinkMode?,
@@ -225,6 +247,7 @@ internal interface LinkRepository {
      * Update the phone number for the signed in consumer.
      */
     suspend fun updatePhoneNumber(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         phoneNumber: String,
     ): Result<ConsumerSession>

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link.repositories
 
 import app.cash.turbine.Turbine
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
@@ -63,6 +64,7 @@ internal open class FakeLinkRepository : LinkRepository {
     private val mobileSignUpCalls = Turbine<MobileSignUpCall>()
 
     override suspend fun lookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         linkAuthIntentId: String?,
         sessionId: String,
@@ -79,6 +81,7 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun lookupConsumerWithoutBackendLoggingForExposure(
+        requestOptions: ApiRequest.Options,
         email: String,
         sessionId: String
     ): Result<ConsumerSessionLookup> {
@@ -92,6 +95,7 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun mobileLookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         emailSource: EmailSource?,
         linkAuthIntentId: String?,
@@ -116,12 +120,14 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun refreshConsumer(
+        requestOptions: ApiRequest.Options,
         appId: String,
         consumerSessionClientSecret: String,
         supportedVerificationTypes: List<String>?
     ): Result<ConsumerSessionRefresh> = refreshConsumerResult
 
     override suspend fun consumerSignUp(
+        requestOptions: ApiRequest.Options,
         email: String,
         phone: String?,
         country: String?,
@@ -131,6 +137,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ) = consumerSignUpResult
 
     override suspend fun mobileSignUp(
+        requestOptions: ApiRequest.Options,
         name: String?,
         email: String,
         phoneNumber: String?,
@@ -161,6 +168,7 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun createCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -169,6 +177,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ) = createCardPaymentDetailsResult
 
     override suspend fun createPaymentDetailsFromPaymentMethod(
+        requestOptions: ApiRequest.Options,
         paymentMethod: PaymentMethod,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -178,6 +187,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ): Result<LinkPaymentDetails.Saved> = createPaymentDetailsFromPaymentMethodResult
 
     override suspend fun createBankAccountPaymentDetails(
+        requestOptions: ApiRequest.Options,
         bankAccountId: String,
         userEmail: String,
         consumerSessionClientSecret: String,
@@ -185,6 +195,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ) = createBankAccountPaymentDetailsResult
 
     override suspend fun shareCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
         consumerSessionClientSecret: String,
@@ -192,6 +203,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ): Result<LinkPaymentDetails.Passthrough> = shareCardPaymentDetailsResult
 
     override suspend fun sharePaymentDetails(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String?,
@@ -203,58 +215,69 @@ internal open class FakeLinkRepository : LinkRepository {
     ): Result<SharePaymentDetails> = sharePaymentDetails
 
     override suspend fun createPaymentMethod(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentMethod: LinkPaymentMethod,
         clientAttributionMetadata: ClientAttributionMetadata,
     ) = createPaymentMethod
 
     override suspend fun logOut(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?
     ) = logOutResult
 
     override suspend fun startVerification(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         isResendSmsCode: Boolean
     ) = startVerificationResult
 
     override suspend fun confirmVerification(
+        requestOptions: ApiRequest.Options,
         verificationCode: String,
         consumerSessionClientSecret: String,
         consentGranted: Boolean?
     ): Result<ConsumerSession> = confirmVerificationResult
 
     override suspend fun postConsentUpdate(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consentGranted: Boolean,
     ): Result<Unit> = postConsentUpdateResult
 
     override suspend fun listPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodTypes: Set<String>,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails> = listPaymentDetailsResult
 
     override suspend fun listShippingAddresses(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
     ): Result<ConsumerShippingAddresses> = listShippingAddressesResult
 
     override suspend fun deletePaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
     ): Result<Unit> = deletePaymentDetailsResult
 
     override suspend fun updatePaymentDetails(
+        requestOptions: ApiRequest.Options,
         updateParams: ConsumerPaymentDetailsUpdateParams,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails> = updatePaymentDetailsResult
 
     override suspend fun createLinkAccountSession(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         intentToken: String?,
         linkMode: LinkMode?,
     ): Result<LinkAccountSession> = createLinkAccountSessionResult
 
     override suspend fun updatePhoneNumber(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         phoneNumber: String,
     ): Result<ConsumerSession> = updatePhoneNumberResult

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.repositories
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.FakeConsumersApiService
@@ -74,6 +75,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.lookupConsumer(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             linkAuthIntentId = null,
             sessionId = SESSION_ID,
@@ -111,6 +113,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.lookupConsumer(
+            requestOptions = DEFAULT_OPTIONS,
             email = "email",
             linkAuthIntentId = null,
             sessionId = SESSION_ID,
@@ -127,6 +130,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.mobileLookupConsumer(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             linkAuthIntentId = null,
             verificationToken = TestFactory.VERIFICATION_TOKEN,
@@ -174,6 +178,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.mobileLookupConsumer(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             linkAuthIntentId = null,
             verificationToken = TestFactory.VERIFICATION_TOKEN,
@@ -194,6 +199,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.consumerSignUp(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             phone = TestFactory.CUSTOMER_PHONE,
             country = TestFactory.COUNTRY,
@@ -224,6 +230,7 @@ class LinkApiRepositoryTest {
         consumersApiService.signUpResult = Result.failure(error)
 
         val result = linkRepository.consumerSignUp(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             phone = TestFactory.CUSTOMER_PHONE,
             country = TestFactory.COUNTRY,
@@ -241,6 +248,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.mobileSignUp(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             phoneNumber = TestFactory.CUSTOMER_PHONE,
             country = TestFactory.COUNTRY,
@@ -278,6 +286,7 @@ class LinkApiRepositoryTest {
         consumersApiService.mobileSignUpResult = Result.failure(error)
 
         val result = linkRepository.mobileSignUp(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             phoneNumber = TestFactory.CUSTOMER_PHONE,
             country = TestFactory.COUNTRY,
@@ -300,6 +309,7 @@ class LinkApiRepositoryTest {
         val email = "email@stripe.com"
 
         linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             userEmail = email,
             stripeIntent = paymentIntent,
@@ -342,6 +352,7 @@ class LinkApiRepositoryTest {
         val email = "email@stripe.com"
 
         linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParamsWithoutBillingAddress,
             userEmail = email,
             stripeIntent = paymentIntent,
@@ -381,6 +392,7 @@ class LinkApiRepositoryTest {
             val createParams = cardPaymentMethodCreateParams.copy(allowRedisplay = allowRedisplay)
 
             val linkDetails = linkRepository.createCardPaymentDetails(
+                requestOptions = DEFAULT_OPTIONS,
                 paymentMethodCreateParams = createParams,
                 userEmail = email,
                 stripeIntent = paymentIntent,
@@ -399,6 +411,7 @@ class LinkApiRepositoryTest {
             val email = "email@stripe.com"
 
             linkRepository.createCardPaymentDetails(
+                requestOptions = DEFAULT_OPTIONS,
                 paymentMethodCreateParams = cardPaymentMethodCreateParams,
                 userEmail = email,
                 stripeIntent = paymentIntent,
@@ -438,6 +451,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(fakeConsumersApiService)
 
         val result = linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             userEmail = "jenny@example.com",
             stripeIntent = paymentIntent,
@@ -471,6 +485,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success(paymentDetails))
 
         val result = linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             userEmail = email,
             stripeIntent = paymentIntent,
@@ -538,6 +553,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.failure(RuntimeException("error")))
 
         val result = linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             userEmail = "email@stripe.com",
             stripeIntent = paymentIntent,
@@ -565,6 +581,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.createPaymentDetailsFromPaymentMethod(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethod = paymentMethod,
             userEmail = "email@stripe.com",
             stripeIntent = paymentIntent,
@@ -609,6 +626,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.createPaymentDetailsFromPaymentMethod(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethod = paymentMethod,
             userEmail = "email@stripe.com",
             stripeIntent = paymentIntent,
@@ -633,6 +651,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.failure(RuntimeException("error")))
 
         val result = linkRepository.createBankAccountPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             bankAccountId = "id_123",
             userEmail = "email@stripe.com",
             consumerSessionClientSecret = "secret",
@@ -650,6 +669,7 @@ class LinkApiRepositoryTest {
     fun `createBankAccountPaymentDetails sends client attribution metadata properly`() = runTest {
         val clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA
         linkRepository.createBankAccountPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             bankAccountId = "id_123",
             userEmail = "email@stripe.com",
             consumerSessionClientSecret = "secret",
@@ -686,6 +706,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
 
         val result = linkRepository.shareCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
             id = paymentDetailsId,
@@ -740,6 +761,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
 
         val result = linkRepository.shareCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
             id = paymentDetailsId,
@@ -774,6 +796,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.failure(RuntimeException("error")))
 
         val result = linkRepository.shareCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
             id = "csmrpd*AYq4D_sXdAAAAOQ0",
@@ -805,7 +828,10 @@ class LinkApiRepositoryTest {
     @Test
     fun `startVerification sends correct parameters`() = runTest {
         val secret = "secret"
-        linkRepository.startVerification(secret)
+        linkRepository.startVerification(
+            requestOptions = DEFAULT_OPTIONS,
+            consumerSessionClientSecret = secret,
+        )
 
         verify(consumersApiService).startConsumerVerification(
             consumerSessionClientSecret = secret,
@@ -836,7 +862,10 @@ class LinkApiRepositoryTest {
         )
             .thenReturn(consumerSession)
 
-        val result = linkRepository.startVerification("secret")
+        val result = linkRepository.startVerification(
+            requestOptions = DEFAULT_OPTIONS,
+            consumerSessionClientSecret = "secret",
+        )
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -858,7 +887,10 @@ class LinkApiRepositoryTest {
         )
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.startVerification("secret")
+        val result = linkRepository.startVerification(
+            requestOptions = DEFAULT_OPTIONS,
+            consumerSessionClientSecret = "secret",
+        )
 
         assertThat(result.isFailure).isTrue()
     }
@@ -866,7 +898,11 @@ class LinkApiRepositoryTest {
     @Test
     fun `listPaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
-        linkRepository.listPaymentDetails(setOf("card"), secret)
+        linkRepository.listPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
+            paymentMethodTypes = setOf("card"),
+            consumerSessionClientSecret = secret,
+        )
 
         verify(stripeRepository).listPaymentDetails(
             eq(secret),
@@ -884,6 +920,7 @@ class LinkApiRepositoryTest {
         val paymentDetailsId = "csmrpd*AYq4D_sXdAAAAOQ0"
 
         linkRepository.sharePaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             consumerSessionClientSecret = consumerSessionSecret,
             paymentDetailsId = paymentDetailsId,
             expectedPaymentMethodType = "card",
@@ -905,7 +942,11 @@ class LinkApiRepositoryTest {
     fun `deletePaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
         val id = "payment_details_id"
-        linkRepository.deletePaymentDetails(id, secret)
+        linkRepository.deletePaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
+            paymentDetailsId = id,
+            consumerSessionClientSecret = secret,
+        )
 
         verify(stripeRepository).deletePaymentDetails(
             eq(secret),
@@ -918,7 +959,11 @@ class LinkApiRepositoryTest {
     fun `deletePaymentDetails returns successful result`() = runTest {
         whenever(stripeRepository.deletePaymentDetails(any(), any(), any())).thenReturn(Result.success(Unit))
 
-        val result = linkRepository.deletePaymentDetails("id", "secret")
+        val result = linkRepository.deletePaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
+            paymentDetailsId = "id",
+            consumerSessionClientSecret = "secret",
+        )
 
         assertThat(result.isSuccess).isTrue()
     }
@@ -929,7 +974,11 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.deletePaymentDetails(any(), any(), any()))
             .thenReturn(Result.failure(error))
 
-        val result = linkRepository.deletePaymentDetails("id", "secret")
+        val result = linkRepository.deletePaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
+            paymentDetailsId = "id",
+            consumerSessionClientSecret = "secret",
+        )
 
         assertThat(result.exceptionOrNull()).isEqualTo(error)
     }
@@ -943,8 +992,9 @@ class LinkApiRepositoryTest {
         )
 
         linkRepository.updatePaymentDetails(
-            params,
-            secret,
+            requestOptions = DEFAULT_OPTIONS,
+            updateParams = params,
+            consumerSessionClientSecret = secret,
         )
 
         verify(stripeRepository).updatePaymentDetails(
@@ -960,11 +1010,12 @@ class LinkApiRepositoryTest {
             .thenReturn(Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS))
 
         val result = linkRepository.updatePaymentDetails(
-            ConsumerPaymentDetailsUpdateParams(
+            requestOptions = DEFAULT_OPTIONS,
+            updateParams = ConsumerPaymentDetailsUpdateParams(
                 "id",
                 clientAttributionMetadataParams = mapOf("merchant_integration_source" to "elements"),
             ),
-            "secret",
+            consumerSessionClientSecret = "secret",
         )
 
         assertThat(result.getOrNull()).isEqualTo(TestFactory.CONSUMER_PAYMENT_DETAILS)
@@ -977,11 +1028,12 @@ class LinkApiRepositoryTest {
             .thenReturn(Result.failure(error))
 
         val result = linkRepository.updatePaymentDetails(
-            ConsumerPaymentDetailsUpdateParams(
+            requestOptions = DEFAULT_OPTIONS,
+            updateParams = ConsumerPaymentDetailsUpdateParams(
                 "id",
                 clientAttributionMetadataParams = mapOf("merchant_integration_source" to "elements"),
             ),
-            "secret",
+            consumerSessionClientSecret = "secret",
         )
 
         assertThat(result.exceptionOrNull()).isEqualTo(error)
@@ -1000,6 +1052,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
 
         val result = linkRepository.shareCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams.copy(allowRedisplay = allowRedisplay),
             consumerSessionClientSecret = "consumer_session_secret",
             id = "csmrpd*AYq4D_sXdAAAAOQ0",
@@ -1032,13 +1085,17 @@ class LinkApiRepositoryTest {
         return LinkApiRepository(
             application = ApplicationProvider.getApplicationContext(),
             requestSurface = RequestSurface.PaymentElement,
-            publishableKeyProvider = { PUBLISHABLE_KEY },
-            stripeAccountIdProvider = { STRIPE_ACCOUNT_ID },
+            apiConfigProvider = {
+                ApiConfiguration.State(
+                    publishableKey = PUBLISHABLE_KEY,
+                    stripeAccountId = STRIPE_ACCOUNT_ID,
+                )
+            },
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = Dispatchers.IO,
             locale = Locale.US,
-            errorReporter = errorReporter
+            errorReporter = errorReporter,
         )
     }
 
@@ -1077,5 +1134,9 @@ class LinkApiRepositoryTest {
         const val STRIPE_ACCOUNT_ID = "stripeAccountId"
         const val CONSUMER_SURFACE = "android_payment_element"
         const val SESSION_ID = "sess_123"
+        val DEFAULT_OPTIONS = ApiRequest.Options(
+            apiKey = PUBLISHABLE_KEY,
+            stripeAccount = STRIPE_ACCOUNT_ID,
+        )
     }
 }


### PR DESCRIPTION
## Summary
- make Link callers own request options while preserving consumer and merchant-of-record key overrides
- keep this review below 500 changed lines

Stack: 11/15. The next PR targets tyler/payment-config-stack-12-tap-to-add-card-scan.

Committed and created by Codex.