### PR TITLE
Propagate API configuration to Tap to Add and Card Scan

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncher.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncher.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.asStateFlow
 internal class CardScanStripeLauncher(
     context: Context,
     private val eventsReporter: CardScanEventsReporter,
+    private val publishableKey: String,
     private val enableMlKitCardScan: Boolean,
     private val elementsSessionId: String?,
     private val disableSsdOcrCardScan: Boolean,
@@ -53,6 +54,7 @@ internal class CardScanStripeLauncher(
             CardScanSheetParams(
                 CardScanConfiguration(
                     elementsSessionId = elementsSessionId,
+                    publishableKey = publishableKey,
                     enableMlKitTextRecognition = enableMlKitCardScan,
                     disableSsdOcr = disableSsdOcrCardScan,
                 )
@@ -113,6 +115,7 @@ internal class CardScanStripeLauncher(
         @Composable
         internal fun rememberCardScanStripeLauncher(
             eventsReporter: CardScanEventsReporter,
+            publishableKey: String,
             enableMlKitCardScan: Boolean = false,
             elementsSessionId: String? = null,
             disableSsdOcrCardScan: Boolean = false,
@@ -121,11 +124,12 @@ internal class CardScanStripeLauncher(
             val context = LocalContext.current.applicationContext
             val isLaunchingState = rememberSaveable { mutableStateOf(false) }
             val launcher = remember(
-                eventsReporter, context, enableMlKitCardScan, elementsSessionId, disableSsdOcrCardScan,
+                eventsReporter, context, publishableKey, enableMlKitCardScan, elementsSessionId, disableSsdOcrCardScan,
             ) {
                 CardScanStripeLauncher(
                     context = context,
                     eventsReporter = eventsReporter,
+                    publishableKey = publishableKey,
                     enableMlKitCardScan = enableMlKitCardScan,
                     elementsSessionId = elementsSessionId,
                     disableSsdOcrCardScan = disableSsdOcrCardScan,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/RememberCardScanLauncher.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/RememberCardScanLauncher.kt
@@ -14,6 +14,7 @@ internal fun rememberCardScanLauncher(
     isStripeCardScanAllowed: Boolean = false,
     enableMlKitCardScan: Boolean = false,
     disableSsdOcrCardScan: Boolean = false,
+    publishableKey: String,
     onResult: (CardScanResult) -> Unit,
     isStripeCardScanAvailable: IsStripeCardScanAvailable = DefaultIsStripeCardScanAvailable(),
 ): CardScanLauncher? {
@@ -27,6 +28,7 @@ internal fun rememberCardScanLauncher(
     return if (isStripeCardScanAllowed && isStripeCardScanAvailable() && hasActiveStripeScanner) {
         rememberCardScanStripeLauncher(
             eventsReporter = eventsReporter,
+            publishableKey = publishableKey,
             enableMlKitCardScan = enableMlKitCardScan,
             elementsSessionId = elementsSessionId,
             disableSsdOcrCardScan = disableSsdOcrCardScan,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardScanAction.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardScanAction.kt
@@ -12,6 +12,7 @@ class CardScanAction(
     private val isStripeCardScanAllowed: Boolean,
     private val enableMlKitCardScan: Boolean,
     private val disableSsdOcrCardScan: Boolean,
+    private val publishableKey: String,
     val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
 ) : CardDetailsAction {
     @Composable
@@ -21,6 +22,7 @@ class CardScanAction(
             isStripeCardScanAllowed = isStripeCardScanAllowed,
             enableMlKitCardScan = enableMlKitCardScan,
             disableSsdOcrCardScan = disableSsdOcrCardScan,
+            publishableKey = publishableKey,
             onResult = { result ->
                 (result as? CardScanResult.Completed)?.scannedCard?.let { scannedCard ->
                     onScannedCard(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncherTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncherTest.kt
@@ -106,6 +106,7 @@ class CardScanStripeLauncherTest {
         val launcher = CardScanStripeLauncher(
             context = ApplicationProvider.getApplicationContext(),
             eventsReporter = fakeEventsReporter,
+            publishableKey = "pk_test_123",
             enableMlKitCardScan = false,
             elementsSessionId = null,
             disableSsdOcrCardScan = false,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
@@ -136,6 +136,7 @@ internal class CardScanActionTest {
             isStripeCardScanAllowed = false,
             enableMlKitCardScan = false,
             disableSsdOcrCardScan = false,
+            publishableKey = "pk_test_123",
             automaticallyLaunchedCardScanFormDataHelper = helper,
         )
         val scenario = Scenario(onScannedCardCalls = onScannedCardCalls)

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
@@ -9,6 +9,7 @@ import com.stripe.android.common.nfcscan.tapzone.TapZoneModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -40,6 +41,7 @@ internal interface NfcScanningViewModelComponent {
         NfcCardScannerModule::class,
         NfcScanningEventReporterModule::class,
         TapZoneModule::class,
+        ApiConfigurationModule::class,
     ]
 )
 internal interface NfcScanningViewModelModule {

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporterModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporterModule.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.common.nfcscan.analytics
 
-import android.content.Context
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
@@ -48,10 +46,9 @@ internal interface NfcScanningEventReporterModule {
         }
 
         @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(context: Context): () -> String = {
-            PaymentConfiguration.getInstance(context).publishableKey
-        }
+        fun provideApiConfigurationState(
+            paymentMethodMetadata: PaymentMethodMetadata
+        ): ApiConfiguration.State = paymentMethodMetadata.apiConfiguration
 
         @Provides
         fun provideDurationProvider(): DurationProvider {

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/CreateCardPresentSetupIntentCallbackRetriever.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/CreateCardPresentSetupIntentCallbackRetriever.kt
@@ -20,7 +20,7 @@ internal interface CreateCardPresentSetupIntentCallbackRetriever {
 @OptIn(TapToAddPreview::class)
 internal class DefaultCreateCardPresentSetupIntentCallbackRetriever @Inject constructor(
     errorReporter: ErrorReporter,
-    requestOptionsProvider: Provider<ApiRequest.Options>,
+    requestOptionsProvider: () -> ApiRequest.Options,
     private val createCardPresentSetupIntentCallbackProvider: Provider<CreateCardPresentSetupIntentCallback?>
 ) : CallbackRetriever(errorReporter, requestOptionsProvider), CreateCardPresentSetupIntentCallbackRetriever {
     override fun hasCallback(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.common.taptoadd
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.networking.ApiRequest
@@ -59,7 +59,7 @@ internal interface TapToAddCollectionHandler {
             isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
             terminalWrapper: TerminalWrapper,
             stripeRepository: StripeRepository,
-            paymentConfiguration: PaymentConfiguration,
+            apiConfigurationProvider: () -> ApiConfiguration.State,
             connectionManager: TapToAddConnectionManager,
             tapToPayUxConfiguration: TapToPayUxConfiguration,
             userFacingLogger: UserFacingLogger,
@@ -71,7 +71,6 @@ internal interface TapToAddCollectionHandler {
                     terminalWrapper = terminalWrapper,
                     connectionManager = connectionManager,
                     stripeRepository = stripeRepository,
-                    paymentConfiguration = paymentConfiguration,
                     tapToPayUxConfiguration = tapToPayUxConfiguration,
                     userFacingLogger = userFacingLogger,
                     errorReporter = errorReporter,
@@ -88,7 +87,6 @@ internal interface TapToAddCollectionHandler {
 internal class DefaultTapToAddCollectionHandler(
     private val terminalWrapper: TerminalWrapper,
     private val stripeRepository: StripeRepository,
-    private val paymentConfiguration: PaymentConfiguration,
     private val connectionManager: TapToAddConnectionManager,
     private val errorReporter: ErrorReporter,
     private val userFacingLogger: UserFacingLogger,
@@ -116,6 +114,8 @@ internal class DefaultTapToAddCollectionHandler(
         connectionManager.connect(
             config = TapToAddConnectionManager.ConnectionConfig(
                 merchantDisplayName = metadata.merchantName,
+                publishableKey = metadata.apiConfiguration.publishableKey,
+                isLiveMode = metadata.apiConfiguration.isLiveMode(),
             ),
         )
 
@@ -165,7 +165,7 @@ internal class DefaultTapToAddCollectionHandler(
         val setupIntent = retrieveSetupIntent(clientSecret)
         val setupIntentWithAttachedPaymentMethod = collectPaymentMethod(setupIntent)
         val confirmedIntent = confirmSetupIntent(setupIntentWithAttachedPaymentMethod)
-        val paymentMethod = fetchPaymentMethod(confirmedIntent, customerMetadata)
+        val paymentMethod = fetchPaymentMethod(confirmedIntent, customerMetadata, metadata)
         val updatedPaymentMethod = updatePaymentMethod(paymentMethod, customerMetadata, metadata)
 
         return validatePaymentMethod(updatedPaymentMethod, metadata)
@@ -216,7 +216,7 @@ internal class DefaultTapToAddCollectionHandler(
                         address = billingDetails.address?.asAddressModel()
                     )
                 ),
-                options = getApiOptions(customerMetadata),
+                options = getApiOptions(customerMetadata, metadata),
             ).getOrThrow()
         } ?: paymentMethod
     }
@@ -292,6 +292,7 @@ internal class DefaultTapToAddCollectionHandler(
     private suspend fun fetchPaymentMethod(
         intent: SetupIntent,
         customerMetadata: CustomerMetadata,
+        paymentMethodMetadata: PaymentMethodMetadata
     ): PaymentMethod {
         val paymentMethodId = intent.paymentMethodId
             ?: run {
@@ -317,7 +318,7 @@ internal class DefaultTapToAddCollectionHandler(
         return stripeRepository.retrieveSavedPaymentMethodFromCardPresentPaymentMethod(
             cardPresentPaymentMethodId = paymentMethodId,
             customerId = customerId,
-            options = getApiOptions(customerMetadata)
+            options = getApiOptions(customerMetadata, paymentMethodMetadata)
         ).getOrThrow()
     }
 
@@ -345,7 +346,10 @@ internal class DefaultTapToAddCollectionHandler(
         }
     }
 
-    private fun getApiOptions(customerMetadata: CustomerMetadata): ApiRequest.Options {
+    private fun getApiOptions(
+        customerMetadata: CustomerMetadata,
+        paymentMethodMetadata: PaymentMethodMetadata
+    ): ApiRequest.Options {
         val ephemeralKeySecret = when (customerMetadata) {
             is CustomerMetadata.CustomerSession -> customerMetadata.ephemeralKeySecret
             is CustomerMetadata.LegacyEphemeralKey -> customerMetadata.ephemeralKeySecret
@@ -356,7 +360,7 @@ internal class DefaultTapToAddCollectionHandler(
 
         return ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = paymentConfiguration.stripeAccountId,
+            stripeAccount = paymentMethodMetadata.apiConfiguration.stripeAccountId,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
@@ -2,7 +2,6 @@ package com.stripe.android.common.taptoadd
 
 import android.annotation.SuppressLint
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.ExponentialBackoffRetryDelaySupplier
@@ -30,14 +29,13 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal interface TapToAddConnectionManager {
     /**
      * Indicates if the device has the support required to use the on-device NFC reader
      */
-    val isSupported: Boolean
+    fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean
 
     /**
      * Connects to the NFC reader. Successful completion of this function indicates a successful connection while
@@ -48,7 +46,9 @@ internal interface TapToAddConnectionManager {
     suspend fun connect(config: ConnectionConfig)
 
     data class ConnectionConfig(
-        val merchantDisplayName: String?
+        val merchantDisplayName: String?,
+        val publishableKey: String,
+        val isLiveMode: Boolean,
     )
 
     companion object {
@@ -58,7 +58,6 @@ internal interface TapToAddConnectionManager {
             errorReporter: ErrorReporter,
             applicationContext: Context,
             logger: Logger,
-            paymentConfiguration: Provider<PaymentConfiguration>,
             workContext: CoroutineContext,
             callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
             isSimulatedProvider: TapToAddIsSimulatedProvider,
@@ -68,7 +67,6 @@ internal interface TapToAddConnectionManager {
                     tapToAddConnectionManager = DefaultTapToAddConnectionManager(
                         applicationContext = applicationContext,
                         workContext = workContext,
-                        paymentConfiguration = paymentConfiguration,
                         errorReporter = errorReporter,
                         terminalWrapper = terminalWrapper,
                         logger = logger,
@@ -89,45 +87,43 @@ internal interface TapToAddConnectionManager {
 internal class DefaultTapToAddConnectionManager(
     private val applicationContext: Context,
     private val workContext: CoroutineContext,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val errorReporter: ErrorReporter,
     private val terminalWrapper: TerminalWrapper,
     private val logger: Logger,
     private val callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
-    isSimulatedProvider: TapToAddIsSimulatedProvider,
+    private val isSimulatedProvider: TapToAddIsSimulatedProvider,
 ) : TapToAddConnectionManager, TerminalListener, TapToPayReaderListener {
     private var connectionTask: CompletableDeferred<Unit>? = null
 
-    private val discoveryConfiguration by lazy {
-        DiscoveryConfiguration.TapToPayDiscoveryConfiguration(isSimulatedProvider.get())
-    }
-
     private val connectionTaskLock = Mutex()
 
-    override val isSupported: Boolean
-        get() {
-            if (!callbackRetriever.hasCallback()) {
-                return false
-            }
+    private fun discoveryConfiguration(isLiveMode: Boolean): DiscoveryConfiguration.TapToPayDiscoveryConfiguration {
+        return DiscoveryConfiguration.TapToPayDiscoveryConfiguration(isSimulatedProvider.get(isLiveMode))
+    }
 
-            initializeIfNeeded()
-
-            return terminal().supportsReadersOfType(
-                deviceType = DeviceType.TAP_TO_PAY_DEVICE,
-                discoveryConfiguration = discoveryConfiguration,
-            ).isSupported
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean {
+        if (!callbackRetriever.hasCallback()) {
+            return false
         }
+
+        initializeIfNeeded(publishableKey)
+
+        return terminal().supportsReadersOfType(
+            deviceType = DeviceType.TAP_TO_PAY_DEVICE,
+            discoveryConfiguration = discoveryConfiguration(isLiveMode),
+        ).isSupported
+    }
 
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) = withContext(workContext) {
         runCatching {
-            when (val connectSetupResult = setup()) {
+            when (val connectSetupResult = setup(config.publishableKey, config.isLiveMode)) {
                 is ConnectSetupResult.AlreadyConnected -> Unit
                 is ConnectSetupResult.ExistingTask -> connectSetupResult.task.await()
                 is ConnectSetupResult.NotSupported -> {
                     throw IllegalStateException("Tap to Add is not supported by this device!")
                 }
                 is ConnectSetupResult.CanStart -> {
-                    val discoverReadersResult = discoverReaders()
+                    val discoverReadersResult = discoverReaders(config.isLiveMode)
 
                     if (discoverReadersResult is DiscoverCallResult.CollectedReaders) {
                         connectReader(discoverReadersResult.readers, config)
@@ -152,13 +148,13 @@ internal class DefaultTapToAddConnectionManager(
         )
     }
 
-    private suspend fun setup(): ConnectSetupResult {
+    private suspend fun setup(publishableKey: String, isLiveMode: Boolean): ConnectSetupResult {
         return connectionTaskLock.withLock {
             connectionTask?.let {
                 return@withLock ConnectSetupResult.ExistingTask(it)
             }
 
-            if (!isSupported) {
+            if (!isSupported(publishableKey, isLiveMode)) {
                 return@withLock ConnectSetupResult.NotSupported
             }
 
@@ -173,10 +169,10 @@ internal class DefaultTapToAddConnectionManager(
     }
 
     @SuppressLint("MissingPermission")
-    private suspend fun discoverReaders() = suspendCancellableCoroutine { continuation ->
+    private suspend fun discoverReaders(isLiveMode: Boolean) = suspendCancellableCoroutine { continuation ->
         try {
             val cancellable = terminal().discoverReaders(
-                config = discoveryConfiguration,
+                config = discoveryConfiguration(isLiveMode),
                 discoveryListener = object : DiscoveryListener {
                     override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
                         continuation.resumeWith(Result.success(DiscoverCallResult.CollectedReaders(readers)))
@@ -290,13 +286,13 @@ internal class DefaultTapToAddConnectionManager(
         )
     }
 
-    private fun initializeIfNeeded() {
+    private fun initializeIfNeeded(publishableKey: String) {
         if (!terminalWrapper.isInitialized()) {
             terminalWrapper.initTerminal(
                 context = applicationContext,
                 tokenProvider = object : ConnectionTokenProvider {
                     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
-                        callback.onSuccess(paymentConfiguration.get().publishableKey)
+                        callback.onSuccess(publishableKey)
                     }
                 },
                 listener = this,
@@ -344,7 +340,7 @@ internal class DefaultTapToAddConnectionManager(
 }
 
 internal class UnsupportedTapToAddConnectionManager : TapToAddConnectionManager {
-    override val isSupported: Boolean = false
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = false
 
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
         // No-op
@@ -355,7 +351,11 @@ internal class TapToAddRetriableConnectionManager(
     private val tapToAddConnectionManager: TapToAddConnectionManager,
     private val fatalErrorChecker: TapToAddFatalErrorChecker,
     private val retryDelaySupplier: RetryDelaySupplier,
-) : TapToAddConnectionManager by tapToAddConnectionManager {
+) : TapToAddConnectionManager {
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean {
+        return tapToAddConnectionManager.isSupported(publishableKey, isLiveMode)
+    }
+
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
         var retriesRemaining = MAX_RETRIES
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.common.taptoadd
 
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
@@ -12,7 +11,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 @Module
@@ -69,7 +67,6 @@ internal interface TapToAddConnectionModule {
             errorReporter: ErrorReporter,
             logger: Logger,
             applicationContext: Context,
-            paymentConfiguration: Provider<PaymentConfiguration>,
             @IOContext workContext: CoroutineContext,
             callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
             isSimulatedProvider: TapToAddIsSimulatedProvider,
@@ -79,7 +76,6 @@ internal interface TapToAddConnectionModule {
                 isStripeTerminalSdkAvailable = isStripeTerminalSdkAvailable,
                 terminalWrapper = terminalWrapper,
                 errorReporter = errorReporter,
-                paymentConfiguration = paymentConfiguration,
                 isSimulatedProvider = isSimulatedProvider,
                 logger = logger,
                 callbackRetriever = callbackRetriever,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddIsSimulatedProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddIsSimulatedProvider.kt
@@ -2,20 +2,16 @@ package com.stripe.android.common.taptoadd
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
-import com.stripe.android.PaymentConfiguration
 import javax.inject.Inject
-import javax.inject.Provider
 
 internal interface TapToAddIsSimulatedProvider {
-    fun get(): Boolean
+    fun get(isLiveMode: Boolean): Boolean
 }
 
 internal class DefaultTapToAddIsSimulatedProvider @Inject constructor(
     private val applicationContext: Context,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
 ) : TapToAddIsSimulatedProvider {
-    override fun get(): Boolean {
-        val isLiveMode = paymentConfiguration.get().isLiveMode()
+    override fun get(isLiveMode: Boolean): Boolean {
         val isDebuggable = (applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
 
         return !isLiveMode && isDebuggable

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.common.taptoadd
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.TapToAddPreview
@@ -21,7 +21,7 @@ internal class TapToAddModule {
         isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
         connectionManager: TapToAddConnectionManager,
         stripeRepository: StripeRepository,
-        paymentConfiguration: PaymentConfiguration,
+        apiConfigurationProvider: () -> ApiConfiguration.State,
         terminalWrapper: TerminalWrapper,
         tapToPayUxConfiguration: TapToPayUxConfiguration,
         userFacingLogger: UserFacingLogger,
@@ -33,7 +33,7 @@ internal class TapToAddModule {
             connectionManager = connectionManager,
             terminalWrapper = terminalWrapper,
             stripeRepository = stripeRepository,
-            paymentConfiguration = paymentConfiguration,
+            apiConfigurationProvider = apiConfigurationProvider,
             tapToPayUxConfiguration = tapToPayUxConfiguration,
             errorReporter = errorReporter,
             userFacingLogger = userFacingLogger,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -58,14 +58,15 @@ import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfir
 import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignupConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -93,7 +94,8 @@ import javax.inject.Singleton
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
         LinkInlineSignupConfirmationModule::class,
-        PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,
         TapToAddModule::class,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
 import com.stripe.android.paymentelement.TapToAddPreview
@@ -54,7 +53,11 @@ class DefaultTapToAddConnectionManagerTest {
     private val lifecycleOwner = TestLifecycleOwner()
 
     private val testConnectionConfig =
-        TapToAddConnectionManager.ConnectionConfig(merchantDisplayName = "Test Merchant")
+        TapToAddConnectionManager.ConnectionConfig(
+            merchantDisplayName = "Test Merchant",
+            publishableKey = "pk_test_123",
+            isLiveMode = false,
+        )
 
     @Test
     fun `isSupported returns true when terminal supports tap to add`() = test(
@@ -62,7 +65,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
         }
     ) {
-        assertThat(manager.isSupported).isTrue()
+        assertThat(manager.isSupported("pk_test_123", false)).isTrue()
     }
 
     @Test
@@ -72,7 +75,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
         }
     ) {
-        assertThat(manager.isSupported).isTrue()
+        assertThat(manager.isSupported("pk_test_123", false)).isTrue()
 
         verify(terminalInstance).supportsReadersOfType(
             deviceType = DeviceType.TAP_TO_PAY_DEVICE,
@@ -87,7 +90,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
         }
     ) {
-        assertThat(manager.isSupported).isTrue()
+        assertThat(manager.isSupported("pk_test_123", false)).isTrue()
 
         verify(terminalInstance).supportsReadersOfType(
             deviceType = DeviceType.TAP_TO_PAY_DEVICE,
@@ -101,7 +104,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.NotSupported(IllegalStateException("Not supported!")))
         }
     ) {
-        assertThat(manager.isSupported).isFalse()
+        assertThat(manager.isSupported("pk_test_123", false)).isFalse()
     }
 
     @Test
@@ -112,7 +115,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
         }
     ) {
-        assertThat(manager.isSupported).isFalse()
+        assertThat(manager.isSupported("pk_test_123", false)).isFalse()
 
         wrapperScenario.isInitializedCalls.expectNoEvents()
     }
@@ -706,9 +709,8 @@ class DefaultTapToAddConnectionManagerTest {
                         errorReporter = errorReporter,
                         logger = logger,
                         isSimulatedProvider = object : TapToAddIsSimulatedProvider {
-                            override fun get(): Boolean = isSimulated
+                            override fun get(isLiveMode: Boolean): Boolean = isSimulated
                         },
-                        paymentConfiguration = { PaymentConfiguration(publishableKey = "pk_test") },
                         callbackRetriever = callbackRetriever,
                     ),
                     terminalInstance = terminalInstance,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddIsSimulatedProviderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddIsSimulatedProviderTest.kt
@@ -3,11 +3,9 @@ package com.stripe.android.common.taptoadd
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import javax.inject.Provider
 
 class DefaultTapToAddIsSimulatedProviderTest {
 
@@ -15,40 +13,36 @@ class DefaultTapToAddIsSimulatedProviderTest {
     fun `get returns true when test mode and application is debuggable`() {
         val provider = DefaultTapToAddIsSimulatedProvider(
             applicationContext = context(debuggable = true),
-            paymentConfiguration = provider { PaymentConfiguration(publishableKey = "pk_test_123") },
         )
 
-        assertThat(provider.get()).isTrue()
+        assertThat(provider.get(isLiveMode = false)).isTrue()
     }
 
     @Test
     fun `get returns false when live mode even if debuggable`() {
         val provider = DefaultTapToAddIsSimulatedProvider(
             applicationContext = context(debuggable = true),
-            paymentConfiguration = provider { PaymentConfiguration(publishableKey = "pk_live_123") },
         )
 
-        assertThat(provider.get()).isFalse()
+        assertThat(provider.get(isLiveMode = true)).isFalse()
     }
 
     @Test
     fun `get returns false when test mode but application is not debuggable`() {
         val provider = DefaultTapToAddIsSimulatedProvider(
             applicationContext = context(debuggable = false),
-            paymentConfiguration = provider { PaymentConfiguration(publishableKey = "pk_test_123") },
         )
 
-        assertThat(provider.get()).isFalse()
+        assertThat(provider.get(isLiveMode = false)).isFalse()
     }
 
     @Test
     fun `get returns false when live mode and not debuggable`() {
         val provider = DefaultTapToAddIsSimulatedProvider(
             applicationContext = context(debuggable = false),
-            paymentConfiguration = provider { PaymentConfiguration(publishableKey = "pk_live_123") },
         )
 
-        assertThat(provider.get()).isFalse()
+        assertThat(provider.get(isLiveMode = true)).isFalse()
     }
 
     private fun context(debuggable: Boolean): Context {
@@ -62,9 +56,5 @@ class DefaultTapToAddIsSimulatedProviderTest {
         whenever(context.applicationInfo).thenReturn(appInfo)
 
         return context
-    }
-
-    private fun provider(block: () -> PaymentConfiguration): Provider<PaymentConfiguration> {
-        return Provider { block() }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddConnectionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddConnectionManager.kt
@@ -4,12 +4,14 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 
 internal class FakeTapToAddConnectionManager private constructor(
-    override val isSupported: Boolean,
+    private val isSupported: Boolean,
     connectResults: List<Result<Unit>>,
 ) : TapToAddConnectionManager {
     private val queuedConnectResults = connectResults.toMutableList()
 
     val connectCalls = Turbine<ConnectCall>()
+
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = isSupported
 
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
         connectCalls.add(ConnectCall(config))

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
@@ -4,9 +4,9 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.taptoadd.ui.createTapToAddUxConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
@@ -71,7 +71,7 @@ class TapToAddCollectionHandlerTest {
             isStripeTerminalSdkAvailable = { false },
             terminalWrapper = TestTerminalWrapper.noOp(),
             stripeRepository = FakeTapToAddStripeRepository(Result.failure(NotImplementedError())),
-            paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
+            apiConfigurationProvider = { TEST_API_CONFIGURATION },
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
             tapToPayUxConfiguration = tapToPayUxConfiguration,
             userFacingLogger = FakeUserFacingLogger(),
@@ -90,7 +90,7 @@ class TapToAddCollectionHandlerTest {
             isStripeTerminalSdkAvailable = { true },
             terminalWrapper = TestTerminalWrapper.noOp(),
             stripeRepository = FakeTapToAddStripeRepository(),
-            paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
+            apiConfigurationProvider = { TEST_API_CONFIGURATION },
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
             tapToPayUxConfiguration = tapToPayUxConfiguration,
             userFacingLogger = FakeUserFacingLogger(),
@@ -312,7 +312,7 @@ class TapToAddCollectionHandlerTest {
             assertThat(updateCall.options).isEqualTo(
                 ApiRequest.Options(
                     apiKey = "ek_123",
-                    stripeAccount = TEST_PAYMENT_CONFIGURATION.stripeAccountId,
+                    stripeAccount = TEST_API_CONFIGURATION.stripeAccountId,
                 )
             )
 
@@ -914,7 +914,6 @@ class TapToAddCollectionHandlerTest {
                         handler = DefaultTapToAddCollectionHandler(
                             terminalWrapper = terminalWrapper,
                             stripeRepository = stripeRepository,
-                            paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
                             connectionManager = managerScenario.tapToAddConnectionManager,
                             errorReporter = errorReporter,
                             userFacingLogger = FakeUserFacingLogger(),
@@ -1222,7 +1221,7 @@ class TapToAddCollectionHandlerTest {
         val DEFAULT_CALLBACK = CreateCardPresentSetupIntentCallback {
             CreateIntentResult.Success("si_123_secret")
         }
-        val TEST_PAYMENT_CONFIGURATION = PaymentConfiguration(publishableKey = "pk_test")
+        val TEST_API_CONFIGURATION = ApiConfiguration.State(publishableKey = "pk_test", stripeAccountId = null)
         val DEFAULT_BILLING_DETAILS = PaymentSheet.BillingDetails(
             name = "Jane Doe",
             email = "jane@example.com",

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddRetriableConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddRetriableConnectionManagerTest.kt
@@ -11,16 +11,20 @@ import kotlin.time.Duration
 
 internal class TapToAddRetriableConnectionManagerTest {
     private val testConnectionConfig =
-        TapToAddConnectionManager.ConnectionConfig(merchantDisplayName = "Test Merchant")
+        TapToAddConnectionManager.ConnectionConfig(
+            merchantDisplayName = "Test Merchant",
+            publishableKey = "pk_test_123",
+            isLiveMode = false,
+        )
 
     @Test
     fun `isSupported is true when inner manager's isSupported is true`() = runScenario(isSupported = true) {
-        assertThat(retryConnectionManager.isSupported).isTrue()
+        assertThat(retryConnectionManager.isSupported("pk_test_123", false)).isTrue()
     }
 
     @Test
     fun `isSupported is false when inner manager's isSupported is false`() = runScenario(isSupported = false) {
-        assertThat(retryConnectionManager.isSupported).isFalse()
+        assertThat(retryConnectionManager.isSupported("pk_test_123", false)).isFalse()
     }
 
     @Test

--- a/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanDemoActivity.kt
+++ b/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanDemoActivity.kt
@@ -24,6 +24,7 @@ class CardScanDemoActivity : AppCompatActivity() {
                     elementsSessionId = null,
                     enableMlKitTextRecognition = viewBinding.enableMlKitCheckbox.isChecked,
                     disableSsdOcr = viewBinding.disableSsdOcrCheckbox.isChecked,
+                    publishableKey = "pk_123"
                 )
             )
         }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -221,7 +221,7 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
             BundleCompat.getParcelable(it, INTENT_PARAM_REQUEST, CardScanSheetParams::class.java)
         }
         val cardScanConfiguration = cardScanSheetParams?.cardScanConfiguration
-            ?: CardScanConfiguration(elementsSessionId = null)
+            ?: CardScanConfiguration(elementsSessionId = null, publishableKey = "")
 
         scanFlow = createScanFlow(
             enableMlKitTextRecognition = cardScanConfiguration.enableMlKitTextRecognition,

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanConfiguration.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanConfiguration.kt
@@ -8,6 +8,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class CardScanConfiguration(
     val elementsSessionId: String?,
+    val publishableKey: String,
     val enableMlKitTextRecognition: Boolean = false,
     val disableSsdOcr: Boolean = false,
 ) : Parcelable

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -148,7 +148,7 @@ class CardScanSheet private constructor() {
      * https://paper.dropbox.com/doc/Bouncer-Web-API-Review--BTOclListnApWjHdpv4DoaOuAg-Wy0HGlL0XfwAOz9hHuzS1#:h2=Creating-a-CardImageVerificati
      */
     fun present() {
-        present(CardScanConfiguration(elementsSessionId = null))
+        present(CardScanConfiguration(elementsSessionId = null, publishableKey = ""))
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/di/CardScanModule.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/di/CardScanModule.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.stripecardscan.di
 
 import android.app.Application
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
@@ -13,6 +11,7 @@ import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.stripecardscan.BuildConfig
+import com.stripe.android.stripecardscan.cardscan.CardScanConfiguration
 import com.stripe.android.stripecardscan.cardscan.CardScanEventsReporter
 import com.stripe.android.stripecardscan.cardscan.DefaultCardScanEventsReporter
 import dagger.Binds
@@ -39,12 +38,12 @@ internal interface CardScanModule {
         @Singleton
         internal fun provideAnalyticsRequestFactory(
             application: Application,
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String
+            configuration: CardScanConfiguration,
         ): AnalyticsRequestFactory = AnalyticsRequestFactory(
             packageManager = application.packageManager,
             packageName = application.packageName.orEmpty(),
             packageInfo = application.packageInfo,
-            publishableKeyProvider = publishableKeyProvider,
+            publishableKeyProvider = { configuration.publishableKey },
             networkTypeProvider = NetworkTypeDetector(application)::invoke,
         )
 
@@ -56,12 +55,6 @@ internal interface CardScanModule {
         @Provides
         @Named(ENABLE_LOGGING)
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            application: Application
-        ): () -> String = { PaymentConfiguration.getInstance(application.applicationContext).publishableKey }
 
         @Provides
         @Singleton

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
@@ -213,7 +213,7 @@ internal class DefaultCardScanEventsReporterTest {
                 pluginTypeProvider = { null }
             ),
             durationProvider = durationProvider,
-            cardScanConfiguration = CardScanConfiguration(ELEMENTS_SESSION_ID)
+            cardScanConfiguration = CardScanConfiguration(ELEMENTS_SESSION_ID, publishableKey = "pk_test_123")
         )
 
         testBlock(eventsReporter, analyticsRequestExecutor)


### PR DESCRIPTION
## Summary
- supply loaded credentials to Tap to Add, NFC analytics, and Card Scan without global lookup
- keep this review below 500 changed lines

Stack: 12/15. The next PR targets tyler/payment-config-stack-13-peripheral-modules.

Committed and created by Codex.