### PR TITLE
Remove legacy API credential bindings

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/PaymentConfiguration.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentConfiguration.kt
@@ -107,7 +107,7 @@ constructor(
                     stripeAccountId = stripeAccountId
                 )
 
-            DefaultFraudDetectionDataRepository(context).refresh()
+            DefaultFraudDetectionDataRepository(context, { publishableKey }).refresh()
         }
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/PaymentsFraudDetectionDataRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentsFraudDetectionDataRepositoryFactory.kt
@@ -16,13 +16,18 @@ import kotlin.coroutines.CoroutineContext
 @JvmOverloads
 fun DefaultFraudDetectionDataRepository(
     context: Context,
+    publishableKeyProvider: () -> String,
     workContext: CoroutineContext = Dispatchers.IO,
 ): DefaultFraudDetectionDataRepository {
     return DefaultFraudDetectionDataRepository(
         localStore = DefaultFraudDetectionDataStore(context, workContext),
         fraudDetectionDataRequestFactory = DefaultFraudDetectionDataRequestFactory(context),
         stripeNetworkClient = DefaultStripeNetworkClient(workContext = workContext),
-        errorReporter = ErrorReporter.createFallbackInstance(context, emptySet()),
+        errorReporter = ErrorReporter.createFallbackInstance(
+            context,
+            publishableKeyProvider = publishableKeyProvider,
+            productUsage = emptySet(),
+        ),
         workContext = workContext,
         fraudDetectionEnabledProvider = { Stripe.advancedFraudSignalsEnabled },
     )

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -59,7 +59,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
 
     @Before
     fun before() {
-        validateAnalyticsRequest(eventName = "mc_embedded_init")
+         validateAnalyticsRequest(eventName = "mc_embedded_init")
     }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/attestation/AttestationComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/attestation/AttestationComponent.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.attestation
 
 import android.app.Application
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.link.injection.PaymentsIntegrityModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
@@ -31,8 +31,7 @@ internal interface AttestationComponent {
         fun build(
             @BindsInstance application: Application,
             @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
+            apiConfigurationProvider: () -> ApiConfiguration.State,
             @BindsInstance
             @Named(PRODUCT_USAGE)
             productUsage: Set<String>,

--- a/paymentsheet/src/main/java/com/stripe/android/attestation/AttestationViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/attestation/AttestationViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.attestation.AttestationActivity.Companion.getArgs
 import com.stripe.android.attestation.analytics.AttestationAnalyticsEventsReporter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -62,7 +63,12 @@ internal class AttestationViewModel @Inject constructor(
                 DaggerAttestationComponent.factory()
                     .build(
                         application = app,
-                        publishableKeyProvider = { args.publishableKey },
+                        apiConfigurationProvider = {
+                            ApiConfiguration.State(
+                                publishableKey = args.publishableKey,
+                                stripeAccountId = null,
+                            )
+                        },
                         productUsage = args.productUsage.toSet()
                     )
                     .attestationViewModel

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -50,6 +50,7 @@ import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelecti
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
@@ -117,6 +118,7 @@ import javax.inject.Singleton
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
         NfcScanningAvailabilityModule::class,
         PaymentOptionCardArtModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
     ],
 )
 internal interface CheckoutControllerComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutModule.kt
@@ -2,8 +2,8 @@ package com.stripe.android.checkout.injection
 
 import android.app.Application
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.DisplayDensity
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.core.networking.ApiRequest
@@ -15,7 +15,6 @@ import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Provider
 
 @Module(includes = [PaymentConfigurationModule::class, StripeNetworkClientModule::class])
 internal object CheckoutModule {
@@ -31,12 +30,19 @@ internal object CheckoutModule {
     fun provideProductUsageTokens(): Set<String> = setOf("Checkout")
 
     @Provides
+    fun provideApiRequestOptionsProvider(
+        apiConfigProvider: () -> ApiConfiguration.State
+    ): () -> ApiRequest.Options = {
+        ApiRequest.Options(
+            apiKey = apiConfigProvider().publishableKey,
+            stripeAccount = apiConfigProvider().stripeAccountId,
+        )
+    }
+
+    @Provides
     fun provideApiRequestOptions(
-        paymentConfiguration: Provider<PaymentConfiguration>
-    ): ApiRequest.Options = ApiRequest.Options(
-        apiKey = paymentConfiguration.get().publishableKey,
-        stripeAccount = paymentConfiguration.get().stripeAccountId,
-    )
+        apiRequestOptionsProvider: () -> ApiRequest.Options
+    ): ApiRequest.Options = apiRequestOptionsProvider()
 
     @Provides
     fun provideStripeImageLoader(context: Context): StripeImageLoader = DefaultStripeImageLoader(context)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -219,6 +219,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                 isStripeCardScanAllowed = metadata.isStripeCardScanAllowed,
                 enableMlKitCardScan = metadata.enableMlKitCardScan,
                 disableSsdOcrCardScan = metadata.disableSsdOcrCardScan,
+                publishableKey = metadata.apiConfiguration.publishableKey,
                 automaticallyLaunchedCardScanFormDataHelper =
                     arguments.automaticallyLaunchedCardScanFormDataHelper,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -54,6 +55,7 @@ import kotlin.coroutines.CoroutineContext
         PaymentsIntegrityModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
         NfcScanningAvailabilityModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.requireApplication
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import javax.inject.Inject
@@ -17,11 +16,7 @@ import kotlin.reflect.KClass
 internal class EmbeddedPaymentElementViewModel @Inject constructor(
     val embeddedPaymentElementSubcomponentFactory: EmbeddedPaymentElementSubcomponent.Factory,
     @ViewModelScope private val customViewModelScope: CoroutineScope,
-    eventReporter: EventReporter,
 ) : ViewModel() {
-    init {
-        eventReporter.onInit()
-    }
 
     override fun onCleared() {
         customViewModelScope.cancel()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -76,6 +77,7 @@ import javax.inject.Singleton
         LinkHoldbackExposureModule::class,
         PaymentMethodMessagePromotionsHelperModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
+        ApiRequestOptionsModule::class,
     ],
 )
 internal interface EmbeddedPaymentElementViewModelComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
@@ -33,6 +34,7 @@ import javax.inject.Singleton
         GooglePayLauncherModule::class,
         EmbeddedLinkExtrasModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
+        ApiRequestOptionsModule::class,
     ],
 )
 @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelFactoryComponent.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressElementViewModel
@@ -16,6 +18,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         PaymentSheetCommonModule::class,
+        ApiRequestOptionsModule::class,
         PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
         StripeRepositoryModule::class,
@@ -32,6 +35,7 @@ internal interface AddressElementViewModelFactoryComponent {
         fun create(
             @BindsInstance context: Context,
             @BindsInstance starterArgs: AddressElementActivityContract.Args,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): AddressElementViewModelFactoryComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModule.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.content.Context
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -44,13 +43,6 @@ internal class AddressElementViewModelModule {
     fun providesProductUsage() = setOf("PaymentSheet.AddressController")
 
     @Provides
-    @Named(PUBLISHABLE_KEY)
-    @Singleton
-    fun providesPublishableKey(
-        args: AddressElementActivityContract.Args
-    ): String = args.publishableKey
-
-    @Provides
     @Singleton
     fun provideStripeAutocompleteRepository(
         stripeNetworkClient: StripeNetworkClient,
@@ -58,7 +50,7 @@ internal class AddressElementViewModelModule {
     ): StripeAutocompleteRepository = DefaultStripeAutocompleteRepository(
         stripeNetworkClient = stripeNetworkClient,
         apiRequestFactory = ApiRequest.Factory(),
-        publishableKeyProvider = { args.publishableKey },
+        requestOptionsProvider = { ApiRequest.Options(apiKey = args.publishableKey) },
     )
 
     @Provides
@@ -92,7 +84,10 @@ internal class AddressElementViewModelModule {
             PlacesClientProxy.create(
                 context,
                 it,
-                errorReporter = ErrorReporter.createFallbackInstance(context),
+                errorReporter = ErrorReporter.createFallbackInstance(
+                    context = context,
+                    publishableKeyProvider = { args.publishableKey }
+                ),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelFactoryComponent.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.paymentsheet.injection
 
 import android.app.Application
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
 import com.stripe.android.paymentsheet.addresselement.AutocompleteViewModel
@@ -16,6 +18,7 @@ import javax.inject.Singleton
         CoreCommonModule::class,
         CoroutineContextModule::class,
         StripeRepositoryModule::class,
+        ApiRequestOptionsModule::class,
         AutocompleteViewModelModule::class,
     ]
 )
@@ -27,6 +30,7 @@ internal interface AutocompleteViewModelFactoryComponent {
         fun build(
             @BindsInstance application: Application,
             @BindsInstance args: AutocompleteContract.Args,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): AutocompleteViewModelFactoryComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/AutocompleteViewModelModule.kt
@@ -10,7 +10,6 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
 import com.stripe.android.paymentsheet.addresselement.AutocompleteViewModel
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
@@ -23,7 +22,7 @@ import dagger.Provides
 import javax.inject.Named
 import javax.inject.Singleton
 
-@Module(includes = [PaymentConfigurationModule::class])
+@Module
 internal interface AutocompleteViewModelModule {
     @Binds
     fun bindsAnalyticsRequestFactory(
@@ -62,8 +61,11 @@ internal interface AutocompleteViewModelModule {
         ): PlacesClientProxy = PlacesClientProxy.create(
             context = context,
             googlePlacesApiKey = args.googlePlacesApiKey,
-            errorReporter = ErrorReporter.createFallbackInstance(context),
-        )
+            errorReporter = ErrorReporter.createFallbackInstance(
+                context = context,
+                publishableKeyProvider = { args.publishableKey }
+            ),
+                )
 
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -6,10 +6,9 @@ import com.stripe.android.common.analytics.experiment.DefaultLogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.DefaultLogLinkHoldbackExperiment
 import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.repositories.LinkApiRepository
@@ -21,7 +20,6 @@ import com.stripe.android.repository.ConsumersApiServiceImpl
 import dagger.Module
 import dagger.Provides
 import java.util.Locale
-import javax.inject.Named
 import javax.inject.Qualifier
 import kotlin.coroutines.CoroutineContext
 
@@ -61,8 +59,7 @@ internal class LinkHoldbackExposureModule {
     @LinkDisabledApiRepository
     fun providesLinkRepository(
         application: Application,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+        apiConfigProvider: () -> ApiConfiguration.State,
         requestSurface: RequestSurface,
         stripeRepository: StripeRepository,
         @IOContext workContext: CoroutineContext,
@@ -82,8 +79,7 @@ internal class LinkHoldbackExposureModule {
         return LinkApiRepository(
             application = application,
             requestSurface = requestSurface,
-            publishableKeyProvider = publishableKeyProvider,
-            stripeAccountIdProvider = stripeAccountIdProvider,
+            apiConfigProvider = apiConfigProvider,
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = workContext,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
@@ -19,6 +20,8 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentOptionsViewModelModule::class,
         PaymentSheetAutocompleteModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetAutocompleteModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetAutocompleteModule.kt
@@ -1,13 +1,12 @@
 package com.stripe.android.paymentsheet.injection
 
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.paymentsheet.addresselement.DefaultStripeAutocompleteRepository
 import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
 import dagger.Module
 import dagger.Provides
-import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -16,10 +15,12 @@ internal class PaymentSheetAutocompleteModule {
     @Singleton
     fun provideStripeAutocompleteRepository(
         stripeNetworkClient: StripeNetworkClient,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        apiConfigProvider: () -> ApiConfiguration.State,
     ): StripeAutocompleteRepository = DefaultStripeAutocompleteRepository(
         stripeNetworkClient = stripeNetworkClient,
         apiRequestFactory = ApiRequest.Factory(),
-        publishableKeyProvider = publishableKeyProvider,
+        requestOptionsProvider = {
+            ApiRequest.Options(apiKey = apiConfigProvider().publishableKey)
+        },
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -9,6 +9,7 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
@@ -24,6 +25,8 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
@@ -44,8 +44,18 @@ internal abstract class PaymentSheetLauncherModule {
         }
 
         @Provides
-        fun providePaymentMethodMetadata(viewModel: PaymentSheetViewModel): PaymentMethodMetadata? {
-            return viewModel.paymentMethodMetadata.value
+        @Singleton
+        fun providePaymentMethodMetadataFlow(
+            viewModel: PaymentSheetViewModel
+        ): kotlinx.coroutines.flow.StateFlow<PaymentMethodMetadata?> {
+            return viewModel.paymentMethodMetadata
+        }
+
+        @Provides
+        fun providePaymentMethodMetadata(
+            flow: kotlinx.coroutines.flow.StateFlow<PaymentMethodMetadata?>
+        ): PaymentMethodMetadata? {
+            return flow.value
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddAvailabilityFactory.kt
@@ -10,6 +10,8 @@ internal interface TapToAddAvailabilityFactory {
     fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ): Boolean
 }
 
@@ -20,8 +22,12 @@ internal class DefaultTapToAddAvailabilityFactory @Inject constructor(
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ): Boolean {
-        return connectionManager.isSupported && elementsSession.isTapToAddEnabled && customerMetadata != null
+        return connectionManager.isSupported(publishableKey, isLiveMode) &&
+            elementsSession.isTapToAddEnabled &&
+            customerMetadata != null
     }
 }
 
@@ -29,5 +35,7 @@ internal class TapToAddAvailabilityFactoryForCustomerSheet @Inject constructor()
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ) = false
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarter.kt
@@ -12,9 +12,9 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 internal interface TapToAddConnectionStarter {
-    val isSupported: Boolean
+    fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean
 
-    fun start(config: CommonConfiguration)
+    fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean)
 }
 
 internal class DefaultTapToAddConnectionStarter @Inject constructor(
@@ -22,15 +22,18 @@ internal class DefaultTapToAddConnectionStarter @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
     @IOContext private val coroutineContext: CoroutineContext,
 ) : TapToAddConnectionStarter {
-    override val isSupported: Boolean
-        get() = tapToAddConnectionManager.isSupported
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean {
+        return tapToAddConnectionManager.isSupported(publishableKey, isLiveMode)
+    }
 
-    override fun start(config: CommonConfiguration) {
+    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
         viewModelScope.launch(coroutineContext) {
             runCatching {
                 tapToAddConnectionManager.connect(
                     config = TapToAddConnectionManager.ConnectionConfig(
                         merchantDisplayName = config.merchantDisplayName,
+                        publishableKey = publishableKey,
+                        isLiveMode = isLiveMode,
                     )
                 )
             }
@@ -39,10 +42,9 @@ internal class DefaultTapToAddConnectionStarter @Inject constructor(
 }
 
 internal class NoOpTapToAddConnectionStarter @Inject constructor() : TapToAddConnectionStarter {
-    override val isSupported: Boolean = false
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = false
 
-    @Suppress("UNUSED_PARAMETER")
-    override fun start(config: CommonConfiguration) {
+    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
         // No-op
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/viewmodels/BaseSheetViewModel.kt
@@ -102,6 +102,7 @@ internal abstract class BaseSheetViewModel(
             _paymentMethodMetadata.value?.shouldUseAutocompleteProxyEndpoints ?: false
         },
         eventReporter = addressLauncherEventReporter,
+        publishableKeyProvider = { _paymentMethodMetadata.value?.apiConfiguration?.publishableKey ?: "" }
     )
 
     val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory =

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutController.Address
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networktesting.NetworkRule
@@ -103,10 +104,14 @@ internal class CheckoutSessionTaxRegionUpdaterTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         val updater = CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -416,7 +416,7 @@ internal class CheckoutStateLoaderTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = application,
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
         )
         val savedStateHandle = SavedStateHandle()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CurrencySelectorViewModelTest.kt
@@ -146,7 +146,7 @@ internal class CurrencySelectorViewModelTest {
             analyticsRequestExecutor = fakeAnalyticsRequestExecutor,
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = application,
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
             savedStateHandle = savedStateHandle,
         ).also { viewModelStoreRule.track(it) }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FlagImageResolverTest.kt
@@ -175,7 +175,7 @@ internal class FlagImageResolverTest {
             analyticsRequestExecutor = analyticsRequestExecutor,
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = application,
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.ui.inline.LinkSignupMode
@@ -946,6 +947,7 @@ class DefaultAnalyticsMetadataFactoryTest {
                 clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                 cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
                 linkBrand = LinkBrand.Link,
+                apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             ),
             loginState = LinkState.LoginState.LoggedOut,
             signupModeResult = signupModeResult,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet.state
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -27,7 +27,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `fetchPromotionsAsync calls repository`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val request = fakeRepository.calls.awaitItem()
         assertThat(request.amount).isEqualTo(1099)
@@ -38,7 +41,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode returns promotion if available and in treatment`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -52,7 +58,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode returns null if not available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val metadata = getMetadata("treatment")
         val result = helper.getPromotionIfAvailableForCode(
@@ -65,7 +74,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed fires event with true when promotion available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -76,7 +88,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed fires event with false when promotion not available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val metadata = getMetadata("treatment")
         helper.reportPromotionDisplayed("afterpay_clearpay", metadata)
@@ -86,7 +101,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed does not fire event when not in treatment`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -96,7 +114,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed does not fire event for unsupported PM`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -106,7 +127,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode does not return promotion if variant is control`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -115,7 +139,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionProvider returns null for control`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -124,7 +151,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionProvider returns null for unsupported PMs`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -133,7 +163,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `returns promotion provider for treatment group supported pm`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -159,9 +192,6 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
         val helper = DefaultPaymentMethodMessagePromotionsHelper(
             stripeRepository = fakeRepository,
-            lazyPaymentConfig = {
-                PaymentConfiguration("pk_123")
-            },
             viewModelScope = this,
             workContext = testDispatcher,
             eventReporter = eventReporter

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
@@ -29,6 +29,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isTrue()
     }
@@ -47,6 +49,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -65,6 +69,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -83,6 +89,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = null,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.utils
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodMessageLearnMore
@@ -19,7 +20,7 @@ internal class FakePaymentMethodMessagePromotionsHelper(
     val reportPromotionDisplayedCalls: ReceiveTurbine<Pair<PaymentMethodCode, Boolean>> =
         _reportPromotionDisplayedCalls
 
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         _calls.add(Unit)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
@@ -9,5 +9,7 @@ internal class FakeTapToAddAvailabilityFactory(
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ): Boolean = isAvailableResult
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
@@ -5,12 +5,14 @@ import app.cash.turbine.Turbine
 import com.stripe.android.common.model.CommonConfiguration
 
 internal class FakeTapToAddConnectionStarter private constructor(
-    override val isSupported: Boolean = false,
+    private val isSupportedValue: Boolean = false,
 ) : TapToAddConnectionStarter {
     private val startCalls: Turbine<StartCall> = Turbine()
 
-    override fun start(config: CommonConfiguration) {
-        startCalls.add(StartCall(config))
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = isSupportedValue
+
+    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
+        startCalls.add(StartCall(config, publishableKey))
     }
 
     fun ensureAllEventsConsumed() {
@@ -18,7 +20,8 @@ internal class FakeTapToAddConnectionStarter private constructor(
     }
 
     data class StartCall(
-        val config: CommonConfiguration
+        val config: CommonConfiguration,
+        val publishableKey: String,
     )
 
     class Scenario(
@@ -45,6 +48,6 @@ internal class FakeTapToAddConnectionStarter private constructor(
 
         fun create(
             isSupported: Boolean = false,
-        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupported = isSupported)
+        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupportedValue = isSupported)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
@@ -22,7 +22,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported).isTrue()
+        assertThat(starter.isSupported("pk_test_123", false)).isTrue()
     }
 
     @Test
@@ -34,7 +34,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported).isFalse()
+        assertThat(starter.isSupported("pk_test_123", false)).isFalse()
     }
 
     @Test
@@ -50,13 +50,15 @@ internal class TapToAddConnectionStarterTest {
             merchantDisplayName = "Books & Things",
         )
 
-        starter.start(commonConfiguration)
+        starter.start(commonConfiguration, "pk_test_123", false)
         advanceUntilIdle()
 
         assertThat(manager.connectCalls.awaitItem()).isEqualTo(
             FakeTapToAddConnectionManager.ConnectCall(
                 config = TapToAddConnectionManager.ConnectionConfig(
                     merchantDisplayName = "Books & Things",
+                    publishableKey = "pk_test_123",
+                    isLiveMode = false,
                 ),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.utils
 
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
@@ -118,6 +119,10 @@ internal object LinkTestUtils {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = linkBrand,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -60,6 +60,7 @@ internal open class FakeCustomerRepository(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer? {
         _retrieveCustomerRequests.add(
             RetrieveCustomerRequest(
@@ -76,6 +77,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>> {
         _getPaymentMethodsRequests.add(
             GetPaymentMethodsRequest(
@@ -93,6 +95,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -110,6 +113,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -127,6 +131,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = onAttachPaymentMethod()
 
     override suspend fun updatePaymentMethod(
@@ -134,6 +139,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _updateRequests.add(
             UpdateRequest(
@@ -151,6 +157,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer> {
         _setDefaultPaymentMethodRequests.add(
             SetDefaultRequest(
@@ -167,6 +174,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = onRetrievePaymentMethod(paymentMethodId)
 
     data class RetrieveCustomerRequest(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.StripeIntent
@@ -43,6 +44,7 @@ internal class FakeElementsSessionRepository(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
         lastParams = Params(

--- a/stripe-core/src/main/java/com/stripe/android/core/injection/NamedConstants.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/injection/NamedConstants.kt
@@ -9,18 +9,6 @@ import androidx.annotation.RestrictTo
 const val ENABLE_LOGGING = "enableLogging"
 
 /**
- * Name for user's publishable key
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val PUBLISHABLE_KEY = "publishableKey"
-
-/**
- * Name for user's account id
- */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val STRIPE_ACCOUNT_ID = "stripeAccountId"
-
-/**
  * Name for form initial values
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
@@ -6,15 +6,10 @@ import com.stripe.android.core.ApiKeyValidator
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.AppInfo
 import com.stripe.android.core.exception.InvalidRequestException
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.version.StripeSdkVersion
 import kotlinx.parcelize.Parcelize
 import java.io.OutputStream
 import java.io.UnsupportedEncodingException
-import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Provider
 
 /**
  * A class representing a Stripe API or Analytics request.
@@ -114,22 +109,6 @@ data class ApiRequest internal constructor(
 
         val apiKeyIsLiveMode: Boolean
             get() = !apiKey.contains("test")
-
-        /**
-         * Dedicated constructor for injection.
-         *
-         * Because [PUBLISHABLE_KEY] and [STRIPE_ACCOUNT_ID] might change, whenever required, a new
-         * [ApiRequest.Options] instance is created with the latest values.
-         * Should always be used with [Provider] or [Lazy].
-         */
-        @Inject
-        constructor(
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-            @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?
-        ) : this(
-            apiKey = publishableKeyProvider(),
-            stripeAccount = stripeAccountIdProvider()
-        )
 
         init {
             ApiKeyValidator().requireValid(apiKey)


### PR DESCRIPTION
## Summary
- remove obsolete named credential bindings and finish remaining compatibility cleanup
- keep this review below 500 changed lines

Stack: 14/15. The next PR targets tyler/payment-config-stack-15-documentation.

Committed and created by Codex.