### PR TITLE
Add lazy API configuration foundation

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.VisibleForTesting
 import com.google.android.instantapps.InstantApps
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -66,9 +67,15 @@ constructor(
         analyticsRequestExecutor,
         paymentAnalyticsRequestFactory,
     )
+    private val apiConfigProvider: () -> ApiConfiguration.State = {
+        ApiConfiguration.State(
+            publishableKey = publishableKeyProvider(),
+            stripeAccountId = null,
+        )
+    }
     private val paymentIntentFlowResultProcessor = PaymentIntentFlowResultProcessor(
         context,
-        publishableKeyProvider,
+        apiConfigProvider,
         stripeRepository,
         Logger.getInstance(enableLogging),
         workContext,
@@ -77,7 +84,7 @@ constructor(
     )
     private val setupIntentFlowResultProcessor = SetupIntentFlowResultProcessor(
         context,
-        publishableKeyProvider,
+        apiConfigProvider,
         stripeRepository,
         Logger.getInstance(enableLogging),
         workContext,
@@ -107,7 +114,7 @@ constructor(
             enableLogging = enableLogging,
             workContext = workContext,
             uiContext = uiContext,
-            publishableKeyProvider = publishableKeyProvider,
+            publishableKeyProvider = { apiConfigProvider().publishableKey },
             productUsage = paymentAnalyticsRequestFactory.defaultProductUsageTokens,
             isInstantApp = isInstantApp,
             includePaymentSheetNextActionHandlers = false, // StripePaymentController is not used in PaymentSheet.

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -40,6 +40,7 @@ import com.stripe.android.view.AuthActivityStarterHost
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.util.concurrent.TimeUnit
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -67,7 +68,7 @@ constructor(
         analyticsRequestExecutor,
         paymentAnalyticsRequestFactory,
     )
-    private val apiConfigProvider: () -> ApiConfiguration.State = {
+    private val apiConfigProvider: Provider<ApiConfiguration.State> = Provider {
         ApiConfiguration.State(
             publishableKey = publishableKeyProvider(),
             stripeAccountId = null,
@@ -114,7 +115,7 @@ constructor(
             enableLogging = enableLogging,
             workContext = workContext,
             uiContext = uiContext,
-            publishableKeyProvider = { apiConfigProvider().publishableKey },
+            publishableKeyProvider = { apiConfigProvider.get().publishableKey },
             productUsage = paymentAnalyticsRequestFactory.defaultProductUsageTokens,
             isInstantApp = isInstantApp,
             includePaymentSheetNextActionHandlers = false, // StripePaymentController is not used in PaymentSheet.

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -30,7 +31,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : StripeIntentResult<T>>(
     context: Context,
-    private val apiConfigProvider: () -> ApiConfiguration.State,
+    private val apiConfigProvider: Provider<ApiConfiguration.State>,
     protected val stripeRepository: StripeRepository,
     private val logger: Logger,
     private val workContext: CoroutineContext,
@@ -47,7 +48,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         }
 
         val requestOptions = ApiRequest.Options(
-            apiKey = apiConfigProvider().publishableKey,
+            apiKey = apiConfigProvider.get().publishableKey,
             stripeAccount = result.stripeAccountId
         )
 
@@ -336,7 +337,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
 @Singleton
 internal class PaymentIntentFlowResultProcessor @Inject constructor(
     context: Context,
-    apiConfigProvider: () -> ApiConfiguration.State,
+    apiConfigProvider: Provider<ApiConfiguration.State>,
     stripeRepository: StripeRepository,
     logger: Logger,
     @IOContext workContext: CoroutineContext,
@@ -404,7 +405,7 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
 @Singleton
 internal class SetupIntentFlowResultProcessor @Inject constructor(
     context: Context,
-    apiConfigProvider: () -> ApiConfiguration.State,
+    apiConfigProvider: Provider<ApiConfiguration.State>,
     stripeRepository: StripeRepository,
     logger: Logger,
     @IOContext workContext: CoroutineContext,

--- a/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/PaymentFlowResultProcessor.kt
@@ -7,9 +7,9 @@ import com.stripe.android.SetupIntentResult
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.StripeIntentResult.Outcome.Companion.CANCELED
 import com.stripe.android.StripeIntentResult.Outcome.Companion.SUCCEEDED
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
@@ -22,8 +22,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
-import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -32,7 +30,7 @@ import kotlin.coroutines.CoroutineContext
  */
 internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : StripeIntentResult<T>>(
     context: Context,
-    private val publishableKeyProvider: Provider<String>,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     protected val stripeRepository: StripeRepository,
     private val logger: Logger,
     private val workContext: CoroutineContext,
@@ -49,7 +47,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
         }
 
         val requestOptions = ApiRequest.Options(
-            apiKey = publishableKeyProvider.get(),
+            apiKey = apiConfigProvider().publishableKey,
             stripeAccount = result.stripeAccountId
         )
 
@@ -338,7 +336,7 @@ internal sealed class PaymentFlowResultProcessor<T : StripeIntent, out S : Strip
 @Singleton
 internal class PaymentIntentFlowResultProcessor @Inject constructor(
     context: Context,
-    @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+    apiConfigProvider: () -> ApiConfiguration.State,
     stripeRepository: StripeRepository,
     logger: Logger,
     @IOContext workContext: CoroutineContext,
@@ -346,7 +344,7 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
     clock: Clock,
 ) : PaymentFlowResultProcessor<PaymentIntent, PaymentIntentResult>(
     context,
-    publishableKeyProvider,
+    apiConfigProvider,
     stripeRepository,
     logger,
     workContext,
@@ -406,7 +404,7 @@ internal class PaymentIntentFlowResultProcessor @Inject constructor(
 @Singleton
 internal class SetupIntentFlowResultProcessor @Inject constructor(
     context: Context,
-    @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+    apiConfigProvider: () -> ApiConfiguration.State,
     stripeRepository: StripeRepository,
     logger: Logger,
     @IOContext workContext: CoroutineContext,
@@ -414,7 +412,7 @@ internal class SetupIntentFlowResultProcessor @Inject constructor(
     clock: Clock,
 ) : PaymentFlowResultProcessor<SetupIntent, SetupIntentResult>(
     context,
-    publishableKeyProvider,
+    apiConfigProvider,
     stripeRepository,
     logger,
     workContext,

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
@@ -21,7 +21,7 @@ import javax.inject.Singleton
         CollectBankAccountModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
-        CoreCommonModule::class,
+        CoreCommonModule::class
     ]
 )
 internal interface CollectBankAccountComponent {

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountComponent.kt
@@ -21,7 +21,7 @@ import javax.inject.Singleton
         CollectBankAccountModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
-        CoreCommonModule::class
+        CoreCommonModule::class,
     ]
 )
 internal interface CollectBankAccountComponent {

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.payments.bankaccount.di
 import android.app.Application
 import android.content.Context
 import com.stripe.android.BuildConfig
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
@@ -16,6 +17,16 @@ internal object CollectBankAccountModule {
 
     @Provides
     fun providesAppContext(application: Application): Context = application
+
+    @Provides
+    fun provideApiConfigurationProvider(
+        args: CollectBankAccountContract.Args
+    ): () -> ApiConfiguration.State = {
+        ApiConfiguration.State(
+            publishableKey = args.publishableKey,
+            stripeAccountId = args.stripeAccountId,
+        )
+    }
 
     @Provides
     @Named(PUBLISHABLE_KEY)

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/di/CollectBankAccountModule.kt
@@ -19,14 +19,12 @@ internal object CollectBankAccountModule {
     fun providesAppContext(application: Application): Context = application
 
     @Provides
-    fun provideApiConfigurationProvider(
+    fun provideApiConfiguration(
         args: CollectBankAccountContract.Args
-    ): () -> ApiConfiguration.State = {
-        ApiConfiguration.State(
-            publishableKey = args.publishableKey,
-            stripeAccountId = args.stripeAccountId,
-        )
-    }
+    ): ApiConfiguration.State = ApiConfiguration.State(
+        publishableKey = args.publishableKey,
+        stripeAccountId = args.stripeAccountId,
+    )
 
     @Provides
     @Named(PUBLISHABLE_KEY)

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
@@ -1,0 +1,48 @@
+package com.stripe.android.payments.core.injection
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.core.networking.ApiRequest
+import dagger.Module
+import dagger.Provides
+import javax.inject.Provider
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module(includes = [PaymentConfigurationModule::class])
+class ApiConfigurationFromPaymentConfigurationModule {
+    @Provides
+    fun provideApiConfigurationStateProvider(
+        paymentConfiguration: Provider<PaymentConfiguration>
+    ): () -> ApiConfiguration.State {
+        return {
+            val config = paymentConfiguration.get()
+            ApiConfiguration.State(
+                publishableKey = config.publishableKey,
+                stripeAccountId = config.stripeAccountId,
+            )
+        }
+    }
+}
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+class ApiRequestOptionsModule {
+    @Provides
+    fun provideApiRequestOptionsProvider(
+        apiConfigurationProvider: () -> ApiConfiguration.State
+    ): () -> ApiRequest.Options {
+        return {
+            val state = apiConfigurationProvider()
+            ApiRequest.Options(
+                apiKey = state.publishableKey,
+                stripeAccount = state.stripeAccountId,
+            )
+        }
+    }
+
+    @Provides
+    fun provideApiRequestOptions(
+        apiRequestOptionsProvider: () -> ApiRequest.Options
+    ): ApiRequest.Options = apiRequestOptionsProvider()
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
@@ -15,10 +15,9 @@ class ApiConfigurationFromPaymentConfigurationModule {
     fun provideApiConfiguration(
         paymentConfiguration: Provider<PaymentConfiguration>
     ): ApiConfiguration.State {
-        val config = paymentConfiguration.get()
         return ApiConfiguration.State(
-            publishableKey = config.publishableKey,
-            stripeAccountId = config.stripeAccountId,
+            publishableKey = paymentConfiguration.get().publishableKey,
+            stripeAccountId = paymentConfiguration.get().stripeAccountId,
         )
     }
 }
@@ -30,10 +29,9 @@ class ApiRequestOptionsModule {
     fun provideApiRequestOptions(
         apiConfigurationProvider: Provider<ApiConfiguration.State>
     ): ApiRequest.Options {
-        val state = apiConfigurationProvider.get()
         return ApiRequest.Options(
-            apiKey = state.publishableKey,
-            stripeAccount = state.stripeAccountId,
+            apiKey = apiConfigurationProvider.get().publishableKey,
+            stripeAccount = apiConfigurationProvider.get().stripeAccountId,
         )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
@@ -12,16 +12,14 @@ import javax.inject.Provider
 @Module(includes = [PaymentConfigurationModule::class])
 class ApiConfigurationFromPaymentConfigurationModule {
     @Provides
-    fun provideApiConfigurationStateProvider(
+    fun provideApiConfiguration(
         paymentConfiguration: Provider<PaymentConfiguration>
-    ): () -> ApiConfiguration.State {
-        return {
-            val config = paymentConfiguration.get()
-            ApiConfiguration.State(
-                publishableKey = config.publishableKey,
-                stripeAccountId = config.stripeAccountId,
-            )
-        }
+    ): ApiConfiguration.State {
+        val config = paymentConfiguration.get()
+        return ApiConfiguration.State(
+            publishableKey = config.publishableKey,
+            stripeAccountId = config.stripeAccountId,
+        )
     }
 }
 
@@ -29,20 +27,13 @@ class ApiConfigurationFromPaymentConfigurationModule {
 @Module
 class ApiRequestOptionsModule {
     @Provides
-    fun provideApiRequestOptionsProvider(
-        apiConfigurationProvider: () -> ApiConfiguration.State
-    ): () -> ApiRequest.Options {
-        return {
-            val state = apiConfigurationProvider()
-            ApiRequest.Options(
-                apiKey = state.publishableKey,
-                stripeAccount = state.stripeAccountId,
-            )
-        }
-    }
-
-    @Provides
     fun provideApiRequestOptions(
-        apiRequestOptionsProvider: () -> ApiRequest.Options
-    ): ApiRequest.Options = apiRequestOptionsProvider()
+        apiConfigurationProvider: Provider<ApiConfiguration.State>
+    ): ApiRequest.Options {
+        val state = apiConfigurationProvider.get()
+        return ApiRequest.Options(
+            apiKey = state.publishableKey,
+            stripeAccount = state.stripeAccountId,
+        )
+    }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -19,6 +19,7 @@ import com.stripe.android.payments.core.authentication.PaymentNextActionHandlerR
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -29,14 +30,14 @@ internal class PaymentLauncherModule {
     @Provides
     @Named(PUBLISHABLE_KEY)
     fun providePublishableKey(
-        apiConfigurationProvider: () -> ApiConfiguration.State,
-    ): () -> String = { apiConfigurationProvider().publishableKey }
+        apiConfigurationProvider: Provider<ApiConfiguration.State>,
+    ): () -> String = { apiConfigurationProvider.get().publishableKey }
 
     @Provides
     @Named(STRIPE_ACCOUNT_ID)
     fun provideStripeAccountId(
-        apiConfigurationProvider: () -> ApiConfiguration.State,
-    ): () -> String? = { apiConfigurationProvider().stripeAccountId }
+        apiConfigurationProvider: Provider<ApiConfiguration.State>,
+    ): () -> String? = { apiConfigurationProvider.get().stripeAccountId }
 
     @Provides
     @Singleton
@@ -54,7 +55,7 @@ internal class PaymentLauncherModule {
         @IOContext workContext: CoroutineContext,
         @UIContext uiContext: CoroutineContext,
         paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
-        apiConfigurationProvider: () -> ApiConfiguration.State,
+        apiConfigurationProvider: Provider<ApiConfiguration.State>,
         @Named(PRODUCT_USAGE) productUsage: Set<String>,
         @Named(IS_INSTANT_APP) isInstantApp: Boolean,
         @Named(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) includePaymentSheetNextHandlers: Boolean,
@@ -64,7 +65,7 @@ internal class PaymentLauncherModule {
         enableLogging = enableLogging,
         workContext = workContext,
         uiContext = uiContext,
-        publishableKeyProvider = { apiConfigurationProvider().publishableKey },
+        publishableKeyProvider = { apiConfigurationProvider.get().publishableKey },
         productUsage = productUsage,
         isInstantApp = isInstantApp,
         includePaymentSheetNextActionHandlers = includePaymentSheetNextHandlers,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherModule.kt
@@ -2,9 +2,11 @@ package com.stripe.android.payments.core.injection
 
 import android.content.Context
 import com.google.android.instantapps.InstantApps
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
@@ -25,6 +27,18 @@ import kotlin.coroutines.CoroutineContext
 )
 internal class PaymentLauncherModule {
     @Provides
+    @Named(PUBLISHABLE_KEY)
+    fun providePublishableKey(
+        apiConfigurationProvider: () -> ApiConfiguration.State,
+    ): () -> String = { apiConfigurationProvider().publishableKey }
+
+    @Provides
+    @Named(STRIPE_ACCOUNT_ID)
+    fun provideStripeAccountId(
+        apiConfigurationProvider: () -> ApiConfiguration.State,
+    ): () -> String? = { apiConfigurationProvider().stripeAccountId }
+
+    @Provides
     @Singleton
     fun provideThreeDs1IntentReturnUrlMap() = mutableMapOf<String, String>()
 
@@ -40,7 +54,7 @@ internal class PaymentLauncherModule {
         @IOContext workContext: CoroutineContext,
         @UIContext uiContext: CoroutineContext,
         paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        apiConfigurationProvider: () -> ApiConfiguration.State,
         @Named(PRODUCT_USAGE) productUsage: Set<String>,
         @Named(IS_INSTANT_APP) isInstantApp: Boolean,
         @Named(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) includePaymentSheetNextHandlers: Boolean,
@@ -50,7 +64,7 @@ internal class PaymentLauncherModule {
         enableLogging = enableLogging,
         workContext = workContext,
         uiContext = uiContext,
-        publishableKeyProvider = publishableKeyProvider,
+        publishableKeyProvider = { apiConfigurationProvider().publishableKey },
         productUsage = productUsage,
         isInstantApp = isInstantApp,
         includePaymentSheetNextActionHandlers = includePaymentSheetNextHandlers,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
@@ -37,7 +37,7 @@ internal interface PaymentLauncherViewModelFactoryComponent {
             @Named(ENABLE_LOGGING)
             enableLogging: Boolean,
             @BindsInstance
-            apiConfigurationProvider: () -> ApiConfiguration.State,
+            apiConfiguration: ApiConfiguration.State,
             @BindsInstance
             @Named(PRODUCT_USAGE)
             productUsage: Set<String>,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/PaymentLauncherViewModelFactoryComponent.kt
@@ -1,11 +1,10 @@
 package com.stripe.android.payments.core.injection
 
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.polling.PollingAnalyticsModule
 import dagger.BindsInstance
@@ -17,6 +16,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         PaymentLauncherModule::class,
+        ApiRequestOptionsModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
@@ -37,11 +37,7 @@ internal interface PaymentLauncherViewModelFactoryComponent {
             @Named(ENABLE_LOGGING)
             enableLogging: Boolean,
             @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
-            @BindsInstance
-            @Named(STRIPE_ACCOUNT_ID)
-            stripeAccountIdProvider: () -> String?,
+            apiConfigurationProvider: () -> ApiConfiguration.State,
             @BindsInstance
             @Named(PRODUCT_USAGE)
             productUsage: Set<String>,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.BuildConfig
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.reactnative.ReactNativeSdkInternal
 import com.stripe.android.core.reactnative.UnregisterSignal
 import com.stripe.android.core.reactnative.registerForReactNativeActivityResult
@@ -95,26 +96,35 @@ class PaymentLauncherFactory(
     ): PaymentLauncher {
         val productUsage = setOf("PaymentLauncher")
         return StripePaymentLauncher(
-            publishableKeyProvider = { publishableKey },
-            stripeAccountIdProvider = { stripeAccountId },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = publishableKey,
+                    stripeAccountId = stripeAccountId,
+                )
+            },
             hostActivityLauncher = hostActivityLauncher,
             statusBarColor = statusBarColor,
+            includePaymentSheetNextHandlers = false,
             enableLogging = BuildConfig.DEBUG,
             productUsage = productUsage,
-            includePaymentSheetNextHandlers = false,
         )
     }
 
     fun create(applicationContext: Context): PaymentLauncher {
         val productUsage = setOf("PaymentLauncher")
         return StripePaymentLauncher(
-            publishableKeyProvider = { PaymentConfiguration.getInstance(applicationContext).publishableKey },
-            stripeAccountIdProvider = { PaymentConfiguration.getInstance(applicationContext).stripeAccountId },
+            apiConfigurationProvider = {
+                val config = PaymentConfiguration.getInstance(applicationContext)
+                ApiConfiguration.State(
+                    publishableKey = config.publishableKey,
+                    stripeAccountId = config.stripeAccountId,
+                )
+            },
             hostActivityLauncher = hostActivityLauncher,
             statusBarColor = statusBarColor,
+            includePaymentSheetNextHandlers = false,
             enableLogging = BuildConfig.DEBUG,
             productUsage = productUsage,
-            includePaymentSheetNextHandlers = false,
         )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -420,12 +420,10 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 .create(
                     context = application,
                     enableLogging = arg.enableLogging,
-                    apiConfigurationProvider = {
-                        ApiConfiguration.State(
-                            publishableKey = arg.publishableKey,
-                            stripeAccountId = arg.stripeAccountId,
-                        )
-                    },
+                    apiConfiguration = ApiConfiguration.State(
+                        publishableKey = arg.publishableKey,
+                        stripeAccountId = arg.stripeAccountId,
+                    ),
                     productUsage = arg.productUsage,
                     includePaymentSheetNextHandlers = arg.includePaymentSheetNextHandlers,
                 ).viewModelSubcomponentFactory

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.UIContext
@@ -419,8 +420,12 @@ internal class PaymentLauncherViewModel @Inject constructor(
                 .create(
                     context = application,
                     enableLogging = arg.enableLogging,
-                    publishableKeyProvider = { arg.publishableKey },
-                    stripeAccountIdProvider = { arg.stripeAccountId },
+                    apiConfigurationProvider = {
+                        ApiConfiguration.State(
+                            publishableKey = arg.publishableKey,
+                            stripeAccountId = arg.stripeAccountId,
+                        )
+                    },
                     productUsage = arg.productUsage,
                     includePaymentSheetNextHandlers = arg.includePaymentSheetNextHandlers,
                 ).viewModelSubcomponentFactory

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -3,9 +3,8 @@ package com.stripe.android.payments.paymentlauncher
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.ConfirmSetupIntentParams
 import com.stripe.android.model.StripeIntent
@@ -22,8 +21,7 @@ import javax.inject.Named
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class StripePaymentLauncher @AssistedInject internal constructor(
-    @Assisted(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
-    @Assisted(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
+    @Assisted private val apiConfigurationProvider: () -> ApiConfiguration.State,
     @Assisted private val hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>,
     @Assisted(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @Assisted(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) private val includePaymentSheetNextHandlers: Boolean,
@@ -33,8 +31,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun confirm(params: ConfirmPaymentIntentParams) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 confirmStripeIntentParams = params,
@@ -47,8 +45,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun confirm(params: ConfirmSetupIntentParams) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -61,8 +59,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForPaymentIntent(clientSecret: String) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -75,8 +73,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForSetupIntent(clientSecret: String) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.SetupIntentNextActionArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -89,8 +87,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForStripeIntent(intent: StripeIntent) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.StripeIntentNextActionWithIntentArgs(
-                publishableKey = publishableKeyProvider(),
-                stripeAccountId = stripeAccountIdProvider(),
+                publishableKey = apiConfigurationProvider().publishableKey,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -105,7 +103,7 @@ class StripePaymentLauncher @AssistedInject internal constructor(
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.HashedPaymentIntentNextActionArgs(
                 hashedValue = hashedValue,
-                stripeAccountId = stripeAccountIdProvider(),
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncher.kt
@@ -14,6 +14,7 @@ import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import javax.inject.Named
+import javax.inject.Provider
 
 /**
  * Implementation of [PaymentLauncher], start an [PaymentLauncherConfirmationActivity] to confirm and
@@ -21,7 +22,7 @@ import javax.inject.Named
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class StripePaymentLauncher @AssistedInject internal constructor(
-    @Assisted private val apiConfigurationProvider: () -> ApiConfiguration.State,
+    @Assisted private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
     @Assisted private val hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>,
     @Assisted(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @Assisted(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) private val includePaymentSheetNextHandlers: Boolean,
@@ -31,8 +32,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun confirm(params: ConfirmPaymentIntentParams) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
-                publishableKey = apiConfigurationProvider().publishableKey,
-                stripeAccountId = apiConfigurationProvider().stripeAccountId,
+                publishableKey = apiConfigurationProvider.get().publishableKey,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 confirmStripeIntentParams = params,
@@ -45,8 +46,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun confirm(params: ConfirmSetupIntentParams) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.IntentConfirmationArgs(
-                publishableKey = apiConfigurationProvider().publishableKey,
-                stripeAccountId = apiConfigurationProvider().stripeAccountId,
+                publishableKey = apiConfigurationProvider.get().publishableKey,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -59,8 +60,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForPaymentIntent(clientSecret: String) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.PaymentIntentNextActionArgs(
-                publishableKey = apiConfigurationProvider().publishableKey,
-                stripeAccountId = apiConfigurationProvider().stripeAccountId,
+                publishableKey = apiConfigurationProvider.get().publishableKey,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -73,8 +74,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForSetupIntent(clientSecret: String) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.SetupIntentNextActionArgs(
-                publishableKey = apiConfigurationProvider().publishableKey,
-                stripeAccountId = apiConfigurationProvider().stripeAccountId,
+                publishableKey = apiConfigurationProvider.get().publishableKey,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -87,8 +88,8 @@ class StripePaymentLauncher @AssistedInject internal constructor(
     override fun handleNextActionForStripeIntent(intent: StripeIntent) {
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.StripeIntentNextActionWithIntentArgs(
-                publishableKey = apiConfigurationProvider().publishableKey,
-                stripeAccountId = apiConfigurationProvider().stripeAccountId,
+                publishableKey = apiConfigurationProvider.get().publishableKey,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,
@@ -103,7 +104,7 @@ class StripePaymentLauncher @AssistedInject internal constructor(
         hostActivityLauncher.launch(
             PaymentLauncherContract.Args.HashedPaymentIntentNextActionArgs(
                 hashedValue = hashedValue,
-                stripeAccountId = apiConfigurationProvider().stripeAccountId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 enableLogging = enableLogging,
                 productUsage = productUsage,
                 includePaymentSheetNextHandlers = includePaymentSheetNextHandlers,

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory.kt
@@ -7,6 +7,7 @@ import com.stripe.android.payments.core.injection.INCLUDE_PAYMENT_SHEET_NEXT_ACT
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
+import javax.inject.Provider
 
 /**
  * [AssistedFactory] to create a [StripePaymentLauncher] with shared dependencies already created
@@ -19,7 +20,7 @@ import dagger.assisted.AssistedFactory
 @AssistedFactory
 interface StripePaymentLauncherAssistedFactory {
     fun create(
-        @Assisted apiConfigurationProvider: () -> ApiConfiguration.State,
+        @Assisted apiConfigurationProvider: Provider<ApiConfiguration.State>,
         @Assisted(STATUS_BAR_COLOR) statusBarColor: Int?,
         @Assisted(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) includePaymentSheetNextHandlers: Boolean,
         hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherAssistedFactory.kt
@@ -2,8 +2,7 @@ package com.stripe.android.payments.paymentlauncher
 
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.payments.core.injection.INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import dagger.assisted.Assisted
@@ -20,8 +19,7 @@ import dagger.assisted.AssistedFactory
 @AssistedFactory
 interface StripePaymentLauncherAssistedFactory {
     fun create(
-        @Assisted(PUBLISHABLE_KEY) publishableKey: () -> String,
-        @Assisted(STRIPE_ACCOUNT_ID) stripeAccountId: () -> String?,
+        @Assisted apiConfigurationProvider: () -> ApiConfiguration.State,
         @Assisted(STATUS_BAR_COLOR) statusBarColor: Int?,
         @Assisted(INCLUDE_PAYMENT_SHEET_NEXT_ACTION_HANDLERS) includePaymentSheetNextHandlers: Boolean,
         hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -56,8 +56,8 @@ internal class StripePaymentControllerTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val analyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        context,
-        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+        context = context,
+        publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
     )
     private val testDispatcher = StandardTestDispatcher()
 

--- a/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/PaymentIntentFlowResultProcessorTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentIntentResult
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.networking.ApiRequest
@@ -1229,7 +1230,9 @@ internal class PaymentIntentFlowResultProcessorTest {
         pollingAnalyticsEventReporter: FakePollingAnalyticsEventReporter = FakePollingAnalyticsEventReporter(),
     ): PaymentIntentFlowResultProcessor = PaymentIntentFlowResultProcessor(
         ApplicationProvider.getApplicationContext(),
-        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+        {
+            ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+        },
         stripeRepository,
         Logger.noop(),
         testDispatcher,

--- a/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/SetupIntentFlowResultProcessorTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.SetupIntentResult
 import com.stripe.android.StripeIntentResult
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethod
@@ -38,7 +39,9 @@ internal class SetupIntentFlowResultProcessorTest {
 
     private val processor = SetupIntentFlowResultProcessor(
         ApplicationProvider.getApplicationContext(),
-        { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
+        {
+            ApiConfiguration.State(publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, stripeAccountId = null)
+        },
         mockStripeRepository,
         Logger.noop(),
         testDispatcher,

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/StripePaymentLauncherTest.kt
@@ -4,6 +4,7 @@ import android.graphics.Color
 import android.util.Base64
 import androidx.activity.result.ActivityResultLauncher
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,8 +18,12 @@ class StripePaymentLauncherTest {
     private val mockHostActivityLauncher =
         mock<ActivityResultLauncher<PaymentLauncherContract.Args>>()
     private val paymentLauncher = StripePaymentLauncher(
-        publishableKeyProvider = { PUBLISHABLE_KEY },
-        stripeAccountIdProvider = { STRIPE_ACCOUNT_ID },
+        apiConfigurationProvider = {
+            ApiConfiguration.State(
+                publishableKey = PUBLISHABLE_KEY,
+                stripeAccountId = STRIPE_ACCOUNT_ID,
+            )
+        },
         hostActivityLauncher = mockHostActivityLauncher,
         enableLogging = false,
         productUsage = mock(),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/IntentConfirmationModule.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.intent
 
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.paymentelement.CreateIntentWithConfirmationTokenCallback
 import com.stripe.android.paymentelement.PreparePaymentMethodHandler
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -51,8 +52,13 @@ internal class IntentConfirmationModule {
             intentConfirmationInterceptorFactory = interceptorFactory,
             paymentLauncherFactory = { hostActivityLauncher, statusBarColor ->
                 stripePaymentLauncherAssistedFactory.create(
-                    publishableKey = { paymentConfigurationProvider.get().publishableKey },
-                    stripeAccountId = { paymentConfigurationProvider.get().stripeAccountId },
+                    apiConfigurationProvider = {
+                        val configuration = paymentConfigurationProvider.get()
+                        ApiConfiguration.State(
+                            publishableKey = configuration.publishableKey,
+                            stripeAccountId = configuration.stripeAccountId,
+                        )
+                    },
                     hostActivityLauncher = hostActivityLauncher,
                     statusBarColor = statusBarColor,
                     includePaymentSheetNextHandlers = true,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -52,6 +52,7 @@ import com.stripe.android.utils.CompletableSingle
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
+import javax.inject.Provider
 import org.mockito.kotlin.mock
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
@@ -141,7 +142,7 @@ internal interface CustomerSheetTestHelper {
                     },
                     stripePaymentLauncherAssistedFactory = object : StripePaymentLauncherAssistedFactory {
                         override fun create(
-                            apiConfigurationProvider: () -> ApiConfiguration.State,
+                            apiConfigurationProvider: Provider<ApiConfiguration.State>,
                             statusBarColor: Int?,
                             includePaymentSheetNextHandlers: Boolean,
                             hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.nfcscan.NoOpIsNfcScanningAvailable
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
@@ -140,8 +141,7 @@ internal interface CustomerSheetTestHelper {
                     },
                     stripePaymentLauncherAssistedFactory = object : StripePaymentLauncherAssistedFactory {
                         override fun create(
-                            publishableKey: () -> String,
-                            stripeAccountId: () -> String?,
+                            apiConfigurationProvider: () -> ApiConfiguration.State,
                             statusBarColor: Int?,
                             includePaymentSheetNextHandlers: Boolean,
                             hostActivityLauncher: ActivityResultLauncher<PaymentLauncherContract.Args>

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -52,8 +52,8 @@ import com.stripe.android.utils.CompletableSingle
 import com.stripe.android.utils.FakeIntentConfirmationInterceptor
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.RecordingLinkPaymentLauncher
-import javax.inject.Provider
 import org.mockito.kotlin.mock
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
@@ -203,8 +204,12 @@ internal fun createTestConfirmationHandlerFactory(
                     intentConfirmationInterceptorFactory = intentConfirmationInterceptorFactory,
                     paymentLauncherFactory = { launcher, _ ->
                         stripePaymentLauncherAssistedFactory.create(
-                            publishableKey = { paymentConfiguration.publishableKey },
-                            stripeAccountId = { paymentConfiguration.stripeAccountId },
+                            apiConfigurationProvider = {
+                                ApiConfiguration.State(
+                                    publishableKey = paymentConfiguration.publishableKey,
+                                    stripeAccountId = paymentConfiguration.stripeAccountId,
+                                )
+                            },
                             hostActivityLauncher = launcher,
                             statusBarColor = statusBarColor,
                             includePaymentSheetNextHandlers = true,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -182,7 +182,7 @@ internal class PaymentSheetActivityTest {
     }
 
     private val stripePaymentLauncherAssistedFactory = mock<StripePaymentLauncherAssistedFactory> {
-        on { create(any(), any(), any(), any(), any()) } doReturn paymentLauncher
+        on { create(any(), any(), any(), any()) } doReturn paymentLauncher
     }
 
     private val fakeIntentConfirmationInterceptor = FakeIntentConfirmationInterceptor()


### PR DESCRIPTION
# Summary
Add the lazy compatibility foundation for representing the publishable key and optional Stripe account ID as one `ApiConfiguration.State` snapshot.

`ApiConfigurationFromPaymentConfigurationModule` converts the existing `Provider<PaymentConfiguration>` into lazy state and request-options functions without reading global configuration while Dagger constructs a component.

Changed classes and entry points:

- `StripePaymentController`: consume publishableKeyProvider to create ApiConfiguration.State to pass to IntentFlowResultProcessors
- `PaymentFlowResultProcessor`: inject ApiConfiguration.State
- `CollectBankAccountModule`: provide ApiConfiguration.State from args
- `ApiConfigurationFromPaymentConfigurationModule`: compatibility bridge to create ApiConfiguration.State from PaymentConfiguration
- `PaymentLauncherModule`: Add temporary compatibility bridge named providers, still required by downstream consumers e.g. PaymentAnalyticsRequestFactory, removed in next PR
- `PaymentLauncherViewModelFactoryComponent`: Binds ApiConfiguration.State
- `PaymentLauncherFactory`: Creates ApiConfiguration.State from passed pk/stripe account ID or creates by fetching PaymentConfiguration for constructor with only context
- `PaymentLauncherViewModel`: creates ApiConfiguration.State from args
- `StripePaymentLauncher`: updates to consume ApiConfiguration.State
- `StripePaymentLauncherAssistedFactory`: updates to consume ApiConfiguration.State
- `IntentConfirmationModule`: creates ApiConfiguration from PaymentConfiguration, migrated later

Committed and created by Codex.

# Motivation
The module is a compatibility bridge for integrations whose public API still initializes `PaymentConfiguration`. It deliberately preserves lazy failure semantics and remains the supported fallback at standalone entry points; obsolete named-key bindings built on top of it are removed in the cleanup layer.

# Testing
- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — dependency wiring only.

# Changelog
Not applicable — no public API or intended user-visible behavior change.
