### PR TITLE
Remove email collection from Express Checkout configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
@@ -47,7 +47,6 @@ class ExpressCheckoutElement @Inject internal constructor(
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         class BillingDetailsCollectionConfiguration {
             private var name: CollectionMode = CollectionMode.Automatic
-            private var email: CollectionMode = CollectionMode.Automatic
             private var address: AddressCollectionMode = AddressCollectionMode.Automatic
 
             /**
@@ -98,11 +97,6 @@ class ExpressCheckoutElement @Inject internal constructor(
                 this.name = name
             }
 
-            /** How to collect the email field. */
-            fun email(email: CollectionMode): BillingDetailsCollectionConfiguration = apply {
-                this.email = email
-            }
-
             /** How to collect the billing address. */
             fun address(address: AddressCollectionMode): BillingDetailsCollectionConfiguration = apply {
                 this.address = address
@@ -111,13 +105,11 @@ class ExpressCheckoutElement @Inject internal constructor(
             @Parcelize
             internal data class State(
                 val name: CollectionMode,
-                val email: CollectionMode,
                 val address: AddressCollectionMode,
             ) : Parcelable
 
             internal fun build(): State = State(
                 name = name,
-                email = email,
                 address = address,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutBillingDetailsCollectionConfigurationMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutBillingDetailsCollectionConfigurationMapper.kt
@@ -13,7 +13,7 @@ internal fun State.asPaymentSheet(
     PaymentSheetBillingDetails(
         name = name.asPaymentSheet(),
         phone = PaymentSheetBillingDetails.CollectionMode.Automatic,
-        email = email.asPaymentSheet(),
+        email = PaymentSheetBillingDetails.CollectionMode.Automatic,
         address = address.asPaymentSheet(requiresBillingAddress),
         attachDefaultsToPaymentMethod = true,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -195,10 +195,6 @@ internal class CheckoutCommonConfigurationFactoryTest {
                             ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration
                                 .CollectionMode.Always
                         )
-                        .email(
-                            ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration
-                                .CollectionMode.Never
-                        )
                         .address(
                             ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration
                                 .AddressCollectionMode.Full
@@ -216,7 +212,7 @@ internal class CheckoutCommonConfigurationFactoryTest {
         assertThat(result.billingDetailsCollectionConfiguration.name)
             .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
         assertThat(result.billingDetailsCollectionConfiguration.email)
-            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic)
         assertThat(result.billingDetailsCollectionConfiguration.address)
             .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ExpressCheckoutElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ExpressCheckoutElementTest.kt
@@ -33,9 +33,6 @@ internal class ExpressCheckoutElementTest {
         assertThat(state.billingDetailsCollectionConfiguration.name).isEqualTo(
             ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
         )
-        assertThat(state.billingDetailsCollectionConfiguration.email).isEqualTo(
-            ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
-        )
         assertThat(state.billingDetailsCollectionConfiguration.address).isEqualTo(
             ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic
         )
@@ -112,9 +109,6 @@ internal class ExpressCheckoutElementTest {
                     .name(
                         ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.CollectionMode.Always
                     )
-                    .email(
-                        ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.CollectionMode.Never
-                    )
                     .address(
                         ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration
                             .AddressCollectionMode.Full
@@ -124,9 +118,6 @@ internal class ExpressCheckoutElementTest {
 
         assertThat(state.billingDetailsCollectionConfiguration.name).isEqualTo(
             ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.CollectionMode.Always
-        )
-        assertThat(state.billingDetailsCollectionConfiguration.email).isEqualTo(
-            ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.CollectionMode.Never
         )
         assertThat(state.billingDetailsCollectionConfiguration.address).isEqualTo(
             ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -127,9 +127,6 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
                     .name(
                         ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.CollectionMode.Always
                     )
-                    .email(
-                        ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration.CollectionMode.Never
-                    )
                     .address(
                         ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration
                             .AddressCollectionMode.Full
@@ -154,7 +151,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
                 PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
             )
             assertThat(billingDetails.email).isEqualTo(
-                PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Never
+                PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
             )
             assertThat(billingDetails.address).isEqualTo(
                 PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full


### PR DESCRIPTION
## Summary
- remove the email option from ExpressCheckoutElement billing-details collection configuration
- keep downstream email collection in Automatic mode
- update affected unit tests

## Testing
- ./gradlew :paymentsheet:testDebugUnitTest
- ./gradlew :paymentsheet:detekt

Committed and created by Codex.