### PR TITLE
Migrate remaining Payments Core credential consumers

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampPresenterCoordinator.kt
@@ -93,7 +93,7 @@ internal class OnrampPresenterCoordinator @Inject constructor(
             config = it,
             readyCallback = ::handleGooglePayIsReady,
             cardBrandFilter = DefaultCardBrandFilter,
-            cardFundingFilter = DefaultCardFundingFilter
+            cardFundingFilter = DefaultCardFundingFilter,
         )
     }
 
@@ -230,7 +230,7 @@ internal class OnrampPresenterCoordinator @Inject constructor(
                                 clientAttributionMetadata = null,
                                 transactionId = selection.transactionId,
                                 label = selection.label,
-                                publishableKey = it
+                                publishableKey = it,
                             )
                         },
                         onFailure = { error ->

--- a/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/GooglePayJsonFactory.kt
@@ -3,8 +3,7 @@ package com.stripe.android
 import android.content.Context
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.model.CardBrand
@@ -16,7 +15,7 @@ import org.json.JSONObject
 import java.util.Currency
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Named
+import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
@@ -99,13 +98,15 @@ class GooglePayJsonFactory internal constructor(
 
     @Inject
     internal constructor(
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+        apiConfigProvider: Provider<ApiConfiguration.State>,
         googlePayConfig: GooglePayPaymentMethodLauncher.Config,
         cardBrandFilter: CardBrandFilter,
         cardFundingFilter: CardFundingFilter
     ) : this(
-        googlePayConfig = GooglePayConfig(publishableKeyProvider(), stripeAccountIdProvider()),
+        googlePayConfig = GooglePayConfig(
+            apiConfigProvider.get().publishableKey,
+            apiConfigProvider.get().stripeAccountId
+        ),
         isJcbEnabled = googlePayConfig.isJcbEnabled,
         cardBrandFilter = cardBrandFilter,
         cardFundingFilter = cardFundingFilter,

--- a/payments-core/src/main/java/com/stripe/android/IssuingCardPinService.kt
+++ b/payments-core/src/main/java/com/stripe/android/IssuingCardPinService.kt
@@ -373,8 +373,8 @@ class IssuingCardPinService @VisibleForTesting internal constructor(
                     requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
                     appInfo = appInfo,
                     paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                        context,
-                        { publishableKey },
+                        context = context,
+                        publishableKeyProvider = { publishableKey },
                         defaultProductUsageTokens = setOf("IssuingCardPinService")
                     )
                 ),

--- a/payments-core/src/main/java/com/stripe/android/PaymentConfiguration.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentConfiguration.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.os.Parcelable
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.ApiKeyValidator
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
@@ -107,7 +108,10 @@ constructor(
                     stripeAccountId = stripeAccountId
                 )
 
-            DefaultFraudDetectionDataRepository(context).refresh()
+            DefaultFraudDetectionDataRepository(
+                context,
+                { ApiConfiguration.State(publishableKey, stripeAccountId) },
+            ).refresh()
         }
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/payments-core/src/main/java/com/stripe/android/PaymentsFraudDetectionDataRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentsFraudDetectionDataRepositoryFactory.kt
@@ -4,25 +4,45 @@ package com.stripe.android
 
 import android.content.Context
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.frauddetection.DefaultFraudDetectionDataRepository
 import com.stripe.android.core.frauddetection.DefaultFraudDetectionDataRequestFactory
 import com.stripe.android.core.frauddetection.DefaultFraudDetectionDataStore
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.utils.ApiConfigProviderFromPaymentConfig
 import kotlinx.coroutines.Dispatchers
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+fun DefaultFraudDetectionDataRepository(
+    context: Context,
+    workContext: CoroutineContext,
+): DefaultFraudDetectionDataRepository {
+    return DefaultFraudDetectionDataRepository(
+        context = context,
+        apiConfigurationProvider = ApiConfigProviderFromPaymentConfig.get(context),
+        workContext = workContext,
+    )
+}
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @JvmOverloads
 fun DefaultFraudDetectionDataRepository(
     context: Context,
+    apiConfigurationProvider: Provider<ApiConfiguration.State>,
     workContext: CoroutineContext = Dispatchers.IO,
 ): DefaultFraudDetectionDataRepository {
     return DefaultFraudDetectionDataRepository(
         localStore = DefaultFraudDetectionDataStore(context, workContext),
         fraudDetectionDataRequestFactory = DefaultFraudDetectionDataRequestFactory(context),
         stripeNetworkClient = DefaultStripeNetworkClient(workContext = workContext),
-        errorReporter = ErrorReporter.createFallbackInstance(context, emptySet()),
+        errorReporter = ErrorReporter.createFallbackInstance(
+            context,
+            apiConfigurationProvider = apiConfigurationProvider,
+            productUsage = emptySet(),
+        ),
         workContext = workContext,
         fraudDetectionEnabledProvider = { Stripe.advancedFraudSignalsEnabled },
     )

--- a/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactory.kt
@@ -3,6 +3,8 @@ package com.stripe.android.cards
 import android.content.Context
 import androidx.annotation.RestrictTo
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
@@ -14,9 +16,11 @@ import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.ApiConfigProviderFromPaymentConfig
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Provider
 
 /**
  * A [CardAccountRangeRepository.Factory] that returns a [DefaultCardAccountRangeRepositoryFactory].
@@ -24,11 +28,12 @@ import javax.inject.Named
  * Will throw an exception if [PaymentConfiguration] has not been instantiated.
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
+class DefaultCardAccountRangeRepositoryFactory internal constructor(
     context: Context,
     @Named(PRODUCT_USAGE) private val productUsageTokens: Set<String>,
     private val requestSurface: RequestSurface,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
+    private val apiConfigProvider: Provider<ApiConfiguration.State>
 ) : CardAccountRangeRepository.Factory {
     private val appContext = context.applicationContext
     private val cardAccountRangeRepository = lazy {
@@ -41,6 +46,26 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
         )
     }
 
+    @Inject
+    constructor(
+        context: Context,
+        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
+        @Named(PRODUCT_USAGE) productUsageTokens: Set<String>,
+        requestSurface: RequestSurface,
+        analyticsRequestExecutor: AnalyticsRequestExecutor,
+    ) : this(
+        context = context,
+        productUsageTokens = productUsageTokens,
+        requestSurface = requestSurface,
+        analyticsRequestExecutor = analyticsRequestExecutor,
+        apiConfigProvider = Provider {
+            ApiConfiguration.State(
+                publishableKey = publishableKeyProvider(),
+                stripeAccountId = null,
+            )
+        },
+    )
+
     @JvmOverloads
     constructor(
         context: Context,
@@ -50,6 +75,7 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
         productUsageTokens = productUsageTokens,
         requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
         analyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
+        apiConfigProvider = ApiConfigProviderFromPaymentConfig.get(context)
     )
 
     @Throws(IllegalStateException::class)
@@ -71,7 +97,11 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
                 ),
                 store,
                 DefaultAnalyticsRequestExecutor(),
-                PaymentAnalyticsRequestFactory(appContext, publishableKey, productUsageTokens)
+                PaymentAnalyticsRequestFactory(
+                    context = appContext,
+                    publishableKeyProvider = { publishableKey },
+                    defaultProductUsageTokens = productUsageTokens
+                )
             ),
             staticSource = StaticCardAccountRangeSource(),
             store = store
@@ -82,9 +112,7 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
         store: CardAccountRangeStore
     ): CardAccountRangeSource {
         return runCatching {
-            PaymentConfiguration.getInstance(
-                appContext
-            ).publishableKey
+            apiConfigProvider.get().publishableKey
         }.onSuccess { publishableKey ->
             fireAnalyticsEvent(
                 publishableKey,
@@ -108,7 +136,11 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
                     ),
                     store,
                     DefaultAnalyticsRequestExecutor(),
-                    PaymentAnalyticsRequestFactory(appContext, publishableKey, productUsageTokens)
+                    PaymentAnalyticsRequestFactory(
+                        context = appContext,
+                        publishableKeyProvider = { publishableKey },
+                        defaultProductUsageTokens = productUsageTokens
+                    )
                 )
             },
             onFailure = {
@@ -123,9 +155,9 @@ class DefaultCardAccountRangeRepositoryFactory @Inject constructor(
     ) {
         analyticsRequestExecutor.executeAsync(
             PaymentAnalyticsRequestFactory(
-                appContext,
-                publishableKey,
-                productUsageTokens,
+                context = appContext,
+                publishableKeyProvider = { publishableKey },
+                defaultProductUsageTokens = productUsageTokens,
             ).createRequest(event)
         )
     }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncher.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.core.reactnative.ReactNativeSdkInternal
@@ -85,6 +86,7 @@ class GooglePayLauncher internal constructor(
                 billingAddressParameters = config.billingAddressConfig.convert(),
                 existingPaymentMethodRequired = config.existingPaymentMethodRequired,
                 allowCreditCards = config.allowCreditCards,
+                apiConfiguration = PaymentConfiguration.getInstance(context).toApiConfiguration(),
                 errorReporter = ErrorReporter.createFallbackInstance(
                     context = context,
                     productUsage = setOf(PRODUCT_USAGE),
@@ -129,6 +131,7 @@ class GooglePayLauncher internal constructor(
                 billingAddressParameters = config.billingAddressConfig.convert(),
                 existingPaymentMethodRequired = config.existingPaymentMethodRequired,
                 allowCreditCards = config.allowCreditCards,
+                apiConfiguration = PaymentConfiguration.getInstance(context).toApiConfiguration(),
                 errorReporter = ErrorReporter.createFallbackInstance(
                     context = context,
                     productUsage = setOf(PRODUCT_USAGE),
@@ -177,6 +180,7 @@ class GooglePayLauncher internal constructor(
                 billingAddressParameters = config.billingAddressConfig.convert(),
                 existingPaymentMethodRequired = config.existingPaymentMethodRequired,
                 allowCreditCards = config.allowCreditCards,
+                apiConfiguration = PaymentConfiguration.getInstance(context).toApiConfiguration(),
                 errorReporter = ErrorReporter.createFallbackInstance(
                     context = context,
                     productUsage = setOf(PRODUCT_USAGE)
@@ -416,6 +420,7 @@ fun rememberGooglePayLauncher(
                     billingAddressParameters = config.billingAddressConfig.convert(),
                     existingPaymentMethodRequired = config.existingPaymentMethodRequired,
                     allowCreditCards = config.allowCreditCards,
+                    apiConfiguration = PaymentConfiguration.getInstance(context).toApiConfiguration(),
                     errorReporter = ErrorReporter.createFallbackInstance(
                         context = context,
                         productUsage = setOf(GooglePayLauncher.PRODUCT_USAGE)
@@ -432,4 +437,11 @@ fun rememberGooglePayLauncher(
             DefaultAnalyticsRequestExecutor()
         )
     }
+}
+
+private fun PaymentConfiguration.toApiConfiguration(): ApiConfiguration.State {
+    return ApiConfiguration.State(
+        publishableKey = publishableKey,
+        stripeAccountId = stripeAccountId,
+    )
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherViewModel.kt
@@ -19,6 +19,7 @@ import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.PaymentController
 import com.stripe.android.StripePaymentController
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.ApiRequest
@@ -312,6 +313,7 @@ internal class GooglePayLauncherViewModel(
                 billingAddressParameters = args.config.billingAddressConfig.convert(),
                 existingPaymentMethodRequired = args.config.existingPaymentMethodRequired,
                 allowCreditCards = args.config.allowCreditCards,
+                apiConfiguration = ApiConfiguration.State(publishableKey, stripeAccountId),
                 errorReporter = errorReporter,
                 logger = logger,
                 cardFundingFilter = DefaultCardFundingFilter,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -21,6 +21,7 @@ import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.core.reactnative.ReactNativeSdkInternal
@@ -53,14 +54,14 @@ class GooglePayPaymentMethodLauncher internal constructor(
     readyCallback: ReadyCallback,
     activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
     private val skipReadyCheck: Boolean,
-    context: Context,
+    private val context: Context,
     googlePayRepositoryFactory: GooglePayRepositoryFactory,
     private val cardBrandFilter: CardBrandFilter,
     private val cardFundingFilter: CardFundingFilter,
     paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        context,
-        PaymentConfiguration.getInstance(context).publishableKey,
-        setOf(PRODUCT_USAGE_TOKEN)
+        context = context,
+        publishableKeyProvider = { PaymentConfiguration.getInstance(context).publishableKey },
+        defaultProductUsageTokens = setOf(PRODUCT_USAGE_TOKEN)
     ),
     analyticsRequestExecutor: AnalyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
 ) {
@@ -70,7 +71,6 @@ class GooglePayPaymentMethodLauncher internal constructor(
         lifecycleOwner = lifecycleOwner,
         activityResultLauncher = activityResultLauncher,
         onPaymentDataChangedCallback = null,
-        context = context,
         paymentAnalyticsRequestFactory = paymentAnalyticsRequestFactory,
         analyticsRequestExecutor = analyticsRequestExecutor,
     )
@@ -102,7 +102,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
         config,
         readyCallback,
         DefaultCardBrandFilter,
-        DefaultCardFundingFilter
+        DefaultCardFundingFilter,
     )
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -126,7 +126,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
         config,
         readyCallback,
         DefaultCardBrandFilter,
-        DefaultCardFundingFilter
+        DefaultCardFundingFilter,
     )
 
     /**
@@ -156,7 +156,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
         config,
         readyCallback,
         DefaultCardBrandFilter,
-        DefaultCardFundingFilter
+        DefaultCardFundingFilter,
     )
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -167,7 +167,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
         config: Config,
         readyCallback: ReadyCallback,
         cardBrandFilter: CardBrandFilter,
-        cardFundingFilter: CardFundingFilter
+        cardFundingFilter: CardFundingFilter,
     ) : this(
         lifecycleOwner,
         config,
@@ -197,7 +197,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
             }
         },
         cardBrandFilter = cardBrandFilter,
-        cardFundingFilter = cardFundingFilter
+        cardFundingFilter = cardFundingFilter,
     )
 
     init {
@@ -206,7 +206,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
                 val repository = googlePayRepositoryFactory(
                     environment = config.environment,
                     cardFundingFilter = cardFundingFilter,
-                    cardBrandFilter = cardBrandFilter
+                    cardBrandFilter = cardBrandFilter,
                 )
                 readyCallback.onReady(
                     repository.isReady().first().also {
@@ -247,6 +247,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
             label = label,
             clientAttributionMetadata = null,
             isElements = false,
+            publishableKey = null,
         )
     }
 
@@ -266,6 +267,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
             "present() may only be called when Google Pay is available on this device."
         }
 
+        val paymentConfiguration = PaymentConfiguration.getInstance(context)
         internalLauncher.present(
             currencyCode = currencyCode,
             amount = amount,
@@ -276,7 +278,10 @@ class GooglePayPaymentMethodLauncher internal constructor(
             transactionId = transactionId,
             label = label,
             isElements = isElements,
-            publishableKey = publishableKey,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = publishableKey ?: paymentConfiguration.publishableKey,
+                stripeAccountId = paymentConfiguration.stripeAccountId,
+            ),
             displayItems = displayItems,
             billingEmailOverride = billingEmailOverride,
             shippingAddressParameters = null,
@@ -466,7 +471,7 @@ fun rememberGooglePayPaymentMethodLauncher(
                 currentReadyCallback.onReady(it)
             },
             cardBrandFilter = DefaultCardBrandFilter,
-            cardFundingFilter = DefaultCardFundingFilter
+            cardFundingFilter = DefaultCardFundingFilter,
         )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncher.kt
@@ -179,7 +179,8 @@ class GooglePayPaymentMethodLauncher internal constructor(
             override fun invoke(
                 environment: GooglePayEnvironment,
                 cardFundingFilter: CardFundingFilter,
-                cardBrandFilter: CardBrandFilter
+                cardBrandFilter: CardBrandFilter,
+                apiConfiguration: ApiConfiguration.State
             ): GooglePayRepository {
                 return DefaultGooglePayRepository(
                     context = context,
@@ -187,6 +188,7 @@ class GooglePayPaymentMethodLauncher internal constructor(
                     billingAddressParameters = config.billingAddressConfig.convert(),
                     existingPaymentMethodRequired = config.existingPaymentMethodRequired,
                     allowCreditCards = config.allowCreditCards,
+                    apiConfiguration = apiConfiguration,
                     errorReporter = ErrorReporter.createFallbackInstance(
                         context = context,
                         productUsage = setOf(PRODUCT_USAGE_TOKEN),
@@ -207,6 +209,9 @@ class GooglePayPaymentMethodLauncher internal constructor(
                     environment = config.environment,
                     cardFundingFilter = cardFundingFilter,
                     cardBrandFilter = cardBrandFilter,
+                    apiConfiguration = PaymentConfiguration.getInstance(context).let {
+                        ApiConfiguration.State(it.publishableKey, it.stripeAccountId)
+                    },
                 )
                 readyCallback.onReady(
                     repository.isReady().first().also {

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -38,7 +38,10 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
     }
 
     private val errorReporter: ErrorReporter by lazy {
-        ErrorReporter.createFallbackInstance(context = this)
+        ErrorReporter.createFallbackInstance(
+            context = this,
+            apiConfigurationProvider = { args.apiConfiguration },
+        )
     }
 
     private lateinit var args: GooglePayPaymentMethodLauncherContractV2.Args

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -11,6 +11,7 @@ import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentMethod
 import kotlinx.parcelize.Parcelize
@@ -57,7 +58,7 @@ class GooglePayPaymentMethodLauncherContractV2 :
         internal val cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
         internal val clientAttributionMetadata: ClientAttributionMetadata? = null,
         internal val isElements: Boolean = false,
-        internal val publishableKey: String? = null,
+        internal val apiConfiguration: ApiConfiguration.State,
         internal val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
         internal val billingEmailOverride: String? = null,
         internal val shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters?,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -14,7 +14,6 @@ import com.google.android.gms.wallet.PaymentDataRequest
 import com.google.android.gms.wallet.PaymentsClient
 import com.stripe.android.BuildConfig
 import com.stripe.android.GooglePayJsonFactory
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.InvalidRequestException
@@ -203,12 +202,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
                 .create(
                     context = application,
                     enableLogging = BuildConfig.DEBUG,
-                    publishableKeyProvider = {
-                        args.publishableKey ?: PaymentConfiguration.getInstance(application).publishableKey
-                    },
-                    stripeAccountIdProvider = {
-                        PaymentConfiguration.getInstance(application).stripeAccountId
-                    },
+                    apiConfiguration = args.apiConfiguration,
                     productUsage = setOf(GooglePayPaymentMethodLauncher.PRODUCT_USAGE_TOKEN),
                     config = args.config,
                     cardBrandFilter = args.cardBrandFilter,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayRepository.kt
@@ -9,6 +9,7 @@ import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.GooglePayConfig
 import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -17,6 +18,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.seconds
 
@@ -51,12 +53,13 @@ internal class DefaultGooglePayRepository(
     private val billingAddressParameters: GooglePayJsonFactory.BillingAddressParameters,
     private val existingPaymentMethodRequired: Boolean,
     private val allowCreditCards: Boolean,
+    private val apiConfiguration: ApiConfiguration.State,
     private val paymentsClientFactory: PaymentsClientFactory = DefaultPaymentsClientFactory(context),
     private val errorReporter: ErrorReporter,
     private val logger: Logger = Logger.noop(),
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter,
-    private val additionalEnabledNetworks: List<String> = emptyList()
+    private val additionalEnabledNetworks: List<String> = emptyList(),
 ) : GooglePayRepository {
 
     @Inject
@@ -66,13 +69,15 @@ internal class DefaultGooglePayRepository(
         logger: Logger,
         errorReporter: ErrorReporter,
         cardBrandFilter: CardBrandFilter,
-        cardFundingFilter: CardFundingFilter
+        cardFundingFilter: CardFundingFilter,
+        apiConfigurationProvider: Provider<ApiConfiguration.State>,
     ) : this(
         context.applicationContext,
         googlePayConfig.environment,
         googlePayConfig.billingAddressConfig.convert(),
         googlePayConfig.existingPaymentMethodRequired,
         googlePayConfig.allowCreditCards,
+        apiConfigurationProvider.get(),
         DefaultPaymentsClientFactory(context),
         errorReporter,
         logger,
@@ -82,7 +87,7 @@ internal class DefaultGooglePayRepository(
     )
 
     private val googlePayJsonFactory = GooglePayJsonFactory(
-        GooglePayConfig(context),
+        GooglePayConfig(apiConfiguration.publishableKey, apiConfiguration.stripeAccountId),
         cardBrandFilter = cardBrandFilter,
         cardFundingFilter = cardFundingFilter,
         additionalEnabledNetworks = additionalEnabledNetworks

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncher.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.googlepaylauncher
 
-import android.content.Context
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -8,9 +7,8 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.GooglePayJsonFactory
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
-import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -31,13 +29,8 @@ class InternalGooglePayPaymentMethodLauncher @AssistedInject internal constructo
     @Assisted private val lifecycleOwner: LifecycleOwner,
     @Assisted private val activityResultLauncher: ActivityResultLauncher<GooglePayPaymentMethodLauncherContractV2.Args>,
     @Assisted private val onPaymentDataChangedCallback: GooglePayPaymentDataUpdateCallback?,
-    context: Context,
-    paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-        context,
-        PaymentConfiguration.getInstance(context).publishableKey,
-        setOf(GooglePayPaymentMethodLauncher.PRODUCT_USAGE_TOKEN)
-    ),
-    analyticsRequestExecutor: AnalyticsRequestExecutor = DefaultAnalyticsRequestExecutor(),
+    paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
+    analyticsRequestExecutor: AnalyticsRequestExecutor,
 ) {
     init {
         if (!GooglePayPaymentMethodLauncher.HAS_SENT_INIT_ANALYTIC_EVENT) {
@@ -76,7 +69,7 @@ class InternalGooglePayPaymentMethodLauncher @AssistedInject internal constructo
         transactionId: String?,
         label: String?,
         isElements: Boolean,
-        publishableKey: String?,
+        apiConfiguration: ApiConfiguration.State,
         displayItems: List<GooglePayJsonFactory.DisplayItem>,
         billingEmailOverride: String?,
         shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters?,
@@ -93,7 +86,7 @@ class InternalGooglePayPaymentMethodLauncher @AssistedInject internal constructo
                 cardFundingFilter = cardFundingFilter,
                 clientAttributionMetadata = clientAttributionMetadata,
                 isElements = isElements,
-                publishableKey = publishableKey,
+                apiConfiguration = apiConfiguration,
                 displayItems = displayItems,
                 billingEmailOverride = billingEmailOverride,
                 shippingAddressParameters = shippingAddressParameters,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherViewModelFactoryComponent.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayPaymentMethodLauncherViewModelFactoryComponent.kt
@@ -3,16 +3,15 @@ package com.stripe.android.googlepaylauncher.injection
 import android.content.Context
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.Injector
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherViewModel
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
-import com.stripe.android.payments.core.injection.ApiConfigurationFromNamedModule
+import com.stripe.android.payments.core.injection.ApiConfigurationToNamedModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
@@ -28,8 +27,8 @@ import javax.inject.Singleton
 @Singleton
 @Component(
     modules = [
-        ApiConfigurationFromNamedModule::class,
         GooglePayPaymentMethodLauncherModule::class,
+        ApiConfigurationToNamedModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
@@ -48,11 +47,7 @@ internal interface GooglePayPaymentMethodLauncherViewModelFactoryComponent {
             @Named(ENABLE_LOGGING)
             enableLogging: Boolean,
             @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
-            @BindsInstance
-            @Named(STRIPE_ACCOUNT_ID)
-            stripeAccountIdProvider: () -> String?,
+            apiConfiguration: ApiConfiguration.State,
             @BindsInstance
             @Named(PRODUCT_USAGE)
             productUsage: Set<String>,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayRepositoryFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/injection/GooglePayRepositoryFactory.kt
@@ -5,6 +5,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.DefaultGooglePayRepository
@@ -18,7 +19,8 @@ interface GooglePayRepositoryFactory {
     operator fun invoke(
         environment: GooglePayEnvironment,
         cardFundingFilter: CardFundingFilter,
-        cardBrandFilter: CardBrandFilter
+        cardBrandFilter: CardBrandFilter,
+        apiConfiguration: ApiConfiguration.State,
     ): GooglePayRepository
 }
 
@@ -31,7 +33,8 @@ class DefaultGooglePayRepositoryFactory @Inject constructor(
     override fun invoke(
         environment: GooglePayEnvironment,
         cardFundingFilter: CardFundingFilter,
-        cardBrandFilter: CardBrandFilter
+        cardBrandFilter: CardBrandFilter,
+        apiConfiguration: ApiConfiguration.State
     ): GooglePayRepository {
         return DefaultGooglePayRepository(
             appContext,
@@ -43,7 +46,8 @@ class DefaultGooglePayRepositoryFactory @Inject constructor(
             errorReporter = errorReporter,
             logger = logger,
             cardFundingFilter = cardFundingFilter,
-            cardBrandFilter = cardBrandFilter
+            cardBrandFilter = cardBrandFilter,
+            apiConfiguration = apiConfiguration
         )
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
+++ b/payments-core/src/main/java/com/stripe/android/networking/StripeApiRepository.kt
@@ -11,6 +11,7 @@ import com.stripe.android.cards.Bin
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.CardNumber
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.AppInfo
 import com.stripe.android.core.Logger
@@ -136,9 +137,20 @@ class StripeApiRepository @JvmOverloads internal constructor(
     private val analyticsRequestExecutor: AnalyticsRequestExecutor =
         DefaultAnalyticsRequestExecutor(logger, workContext),
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
-        DefaultFraudDetectionDataRepository(context, workContext),
+        DefaultFraudDetectionDataRepository(
+            context,
+            { ApiConfiguration.State(publishableKeyProvider(), null) },
+            workContext,
+        ),
     private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory =
-        DefaultCardAccountRangeRepositoryFactory(context, productUsageTokens, requestSurface, analyticsRequestExecutor),
+        DefaultCardAccountRangeRepositoryFactory(
+            context,
+            productUsageTokens,
+            requestSurface,
+            analyticsRequestExecutor
+        ) {
+            ApiConfiguration.State(publishableKeyProvider(), null)
+        },
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory =
         PaymentAnalyticsRequestFactory(context, publishableKeyProvider, productUsageTokens),
     private val fraudDetectionDataParamsUtils: FraudDetectionDataParamsUtils = FraudDetectionDataParamsUtils(),

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -3,7 +3,6 @@ package com.stripe.android.payments.core.analytics
 import android.content.Context
 import androidx.annotation.RestrictTo
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
@@ -13,9 +12,11 @@ import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.utils.ApiConfigProviderFromPaymentConfig
 import com.stripe.android.utils.filterNotNullValues
 import dagger.Binds
 import dagger.BindsInstance
@@ -45,19 +46,18 @@ interface ErrorReporter : FraudDetectionErrorReporter {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
+        /**
+         * Prefer using an injected version of [ErrorReporter].
+         *
+         * This should only be used if you don't already have access to a dagger component.
+         */
         fun createFallbackInstance(
             context: Context,
             productUsage: Set<String> = emptySet(),
         ): ErrorReporter {
             return createFallbackInstance(
                 context = context,
-                apiConfigurationProvider = {
-                    val paymentConfiguration = PaymentConfiguration.getInstance(context)
-                    ApiConfiguration.State(
-                        publishableKey = paymentConfiguration.publishableKey,
-                        stripeAccountId = paymentConfiguration.stripeAccountId,
-                    )
-                },
+                apiConfigurationProvider = ApiConfigProviderFromPaymentConfig.get(context),
                 productUsage = productUsage,
             )
         }
@@ -82,6 +82,25 @@ interface ErrorReporter : FraudDetectionErrorReporter {
                     productUsage = productUsage,
                 )
                 .errorReporter
+        }
+
+        /**
+         * Prefer using an injected version of [ErrorReporter].
+         *
+         * This should only be used if args are null when launching an activity so we have no way to access
+         * a publishable key.
+         */
+        fun createFallbackInstanceWithoutPublishableKey(
+            context: Context,
+            productUsage: Set<String> = emptySet()
+        ): ErrorReporter {
+            return createFallbackInstance(
+                context = context,
+                apiConfigurationProvider = {
+                    ApiConfiguration.State(ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY, null)
+                },
+                productUsage = productUsage
+            )
         }
 
         fun getAdditionalParamsFromError(error: Throwable): Map<String, String> {

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherConfirmationActivity.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.R
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.uicore.utils.fadeOut
@@ -45,18 +46,22 @@ internal class PaymentLauncherConfirmationActivity : AppCompatActivity() {
             }
         }.getOrElse {
             finishWithResult(InternalPaymentResult.Failed(it))
-            ErrorReporter.createFallbackInstance(applicationContext)
-                .report(
-                    errorEvent = ErrorReporter.ExpectedErrorEvent.PAYMENT_LAUNCHER_CONFIRMATION_NULL_ARGS,
-                    stripeException = StripeException.create(it),
-                )
+            ErrorReporter.createFallbackInstanceWithoutPublishableKey(applicationContext).report(
+                errorEvent = ErrorReporter.ExpectedErrorEvent.PAYMENT_LAUNCHER_CONFIRMATION_NULL_ARGS,
+                stripeException = StripeException.create(it),
+            )
             return
         }
 
         args.validate().onFailure {
             finishWithResult(InternalPaymentResult.Failed(it))
 
-            ErrorReporter.createFallbackInstance(applicationContext)
+            ErrorReporter.createFallbackInstance(
+                applicationContext,
+                apiConfigurationProvider = {
+                    ApiConfiguration.State(args.publishableKey, args.stripeAccountId)
+                },
+            )
                 .report(
                     errorEvent = ErrorReporter.ExpectedErrorEvent.PAYMENT_LAUNCHER_CONFIRMATION_INVALID_ARGS,
                     stripeException = StripeException.create(it),

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherFactory.kt
@@ -10,12 +10,12 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.reactnative.ReactNativeSdkInternal
 import com.stripe.android.core.reactnative.UnregisterSignal
 import com.stripe.android.core.reactnative.registerForReactNativeActivityResult
 import com.stripe.android.core.utils.StatusBarCompat
+import com.stripe.android.utils.ApiConfigProviderFromPaymentConfig
 
 /**
  * Factory to create a [PaymentLauncher], initialize all required dependencies.
@@ -113,13 +113,7 @@ class PaymentLauncherFactory(
     fun create(applicationContext: Context): PaymentLauncher {
         val productUsage = setOf("PaymentLauncher")
         return StripePaymentLauncher(
-            apiConfigurationProvider = {
-                val config = PaymentConfiguration.getInstance(applicationContext)
-                ApiConfiguration.State(
-                    publishableKey = config.publishableKey,
-                    stripeAccountId = config.stripeAccountId,
-                )
-            },
+            apiConfigurationProvider = ApiConfigProviderFromPaymentConfig.get(applicationContext),
             hostActivityLauncher = hostActivityLauncher,
             statusBarColor = statusBarColor,
             includePaymentSheetNextHandlers = false,

--- a/payments-core/src/main/java/com/stripe/android/utils/ApiConfigProviderFromPaymentConfig.kt
+++ b/payments-core/src/main/java/com/stripe/android/utils/ApiConfigProviderFromPaymentConfig.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.utils
+
+import android.content.Context
+import androidx.annotation.RestrictTo
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import javax.inject.Provider
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object ApiConfigProviderFromPaymentConfig {
+    fun get(context: Context): Provider<ApiConfiguration.State> = Provider {
+        val config = PaymentConfiguration.getInstance(context)
+        ApiConfiguration.State(
+            publishableKey = config.publishableKey,
+            stripeAccountId = config.stripeAccountId
+        )
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/CardWidgetViewModel.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.view
 
+import javax.inject.Provider
 import android.content.Context
 import android.view.View
 import androidx.lifecycle.Lifecycle
@@ -13,21 +14,21 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.BuildConfig.DEBUG
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.networking.StripeApiRepository
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.utils.ApiConfigProviderFromPaymentConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import javax.inject.Provider
 
 internal class CardWidgetViewModel(
-    private val paymentConfigProvider: Provider<PaymentConfiguration>,
+    private val apiConfigProvider: Provider<ApiConfiguration.State>,
     private val stripeRepository: StripeRepository,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ViewModel() {
@@ -55,12 +56,12 @@ internal class CardWidgetViewModel(
     }
 
     private suspend fun determineCbcEligibility(): Boolean {
-        val paymentConfig = paymentConfigProvider.get()
+        val apiConfig = apiConfigProvider.get()
 
         val response = stripeRepository.retrieveCardElementConfig(
             requestOptions = ApiRequest.Options(
-                apiKey = paymentConfig.publishableKey,
-                stripeAccount = paymentConfig.stripeAccountId,
+                apiKey = apiConfig.publishableKey,
+                stripeAccount = apiConfig.stripeAccountId,
             ),
             params = onBehalfOf?.let {
                 mapOf("on_behalf_of" to it)
@@ -74,15 +75,16 @@ internal class CardWidgetViewModel(
     class Factory(val context: Context) : ViewModelProvider.Factory {
 
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+            val apiConfigProvider = ApiConfigProviderFromPaymentConfig.get(context)
             val stripeRepository = StripeApiRepository(
                 context = context,
-                publishableKeyProvider = { PaymentConfiguration.getInstance(context).publishableKey },
+                publishableKeyProvider = { apiConfigProvider.get().publishableKey },
                 requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
             )
 
             @Suppress("UNCHECKED_CAST")
             return CardWidgetViewModel(
-                paymentConfigProvider = { PaymentConfiguration.getInstance(context) },
+                apiConfigProvider = apiConfigProvider,
                 stripeRepository = stripeRepository,
             ) as T
         }

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -20,7 +20,6 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.R
 import com.stripe.android.StripeIntentResult
 import com.stripe.android.auth.PaymentBrowserAuthContract
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.databinding.StripePaymentAuthWebViewActivityBinding
@@ -66,10 +65,7 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
         if (args == null) {
             setResult(Activity.RESULT_CANCELED)
             finish()
-            ErrorReporter.createFallbackInstance(
-                context = applicationContext,
-                apiConfigurationProvider = { ApiConfiguration.State("", null) },
-            )
+            ErrorReporter.createFallbackInstanceWithoutPublishableKey(context = applicationContext)
                 .report(
                     errorEvent = ErrorReporter.ExpectedErrorEvent.AUTH_WEB_VIEW_NULL_ARGS,
                 )
@@ -149,10 +145,6 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
                 applicationContext,
                 apiConfigurationProvider = { requireNotNull(_args).apiConfiguration },
             )
-                .report(
-                    errorEvent = ErrorReporter.ExpectedErrorEvent.AUTH_WEB_VIEW_FAILURE,
-                    stripeException = StripeException.create(error),
-                )
             viewModel.logError()
             setResult(
                 Activity.RESULT_OK,

--- a/payments-core/src/test/java/com/stripe/android/StripeTest.java
+++ b/payments-core/src/test/java/com/stripe/android/StripeTest.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory;
+import com.stripe.android.core.ApiConfiguration;
 import com.stripe.android.core.AppInfo;
 import com.stripe.android.core.exception.AuthenticationException;
 import com.stripe.android.core.exception.InvalidRequestException;
@@ -91,7 +92,9 @@ public class StripeTest {
     private final Context context = ApplicationProvider.getApplicationContext();
     @NonNull
     private final FraudDetectionDataRepository defaultFraudDetectionDataRepository =
-            DefaultFraudDetectionDataRepository(context);
+            DefaultFraudDetectionDataRepository(
+                    context,
+                    () -> new ApiConfiguration.State(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, null));
     @NonNull
     private final Stripe defaultStripe = createStripe();
 

--- a/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/CardAccountRangeServiceTest.kt
@@ -392,7 +392,7 @@ class CardAccountRangeServiceTest {
             ApiRequest.Options(publishableKey),
             DefaultCardAccountRangeStore(applicationContext),
             DefaultAnalyticsRequestExecutor(),
-            PaymentAnalyticsRequestFactory(applicationContext, publishableKey)
+            PaymentAnalyticsRequestFactory(context = applicationContext, publishableKeyProvider = { publishableKey })
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryFactoryTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.utils.ApiConfigProviderFromPaymentConfig
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.BeforeTest
@@ -20,7 +21,8 @@ class DefaultCardAccountRangeRepositoryFactoryTest {
         context = context,
         productUsageTokens = setOf("SomeProduct"),
         requestSurface = StripeRepository.DEFAULT_REQUEST_SURFACE,
-        analyticsRequestExecutor = { analyticsRequests.add(it) }
+        analyticsRequestExecutor = { analyticsRequests.add(it) },
+        apiConfigProvider = ApiConfigProviderFromPaymentConfig.get(context)
     )
 
     @BeforeTest

--- a/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -316,7 +316,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
             ApiRequest.Options(publishableKey),
             store,
             { },
-            PaymentAnalyticsRequestFactory(application, publishableKey)
+            PaymentAnalyticsRequestFactory(context = application, publishableKeyProvider = { publishableKey })
         )
     }
 

--- a/payments-core/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/RemoteCardAccountRangeSourceTest.kt
@@ -41,8 +41,8 @@ internal class RemoteCardAccountRangeSourceTest {
             cardAccountRangeStore,
             { },
             PaymentAnalyticsRequestFactory(
-                ApplicationProvider.getApplicationContext(),
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
             )
         )
 
@@ -73,8 +73,8 @@ internal class RemoteCardAccountRangeSourceTest {
                 cardAccountRangeStore,
                 { },
                 PaymentAnalyticsRequestFactory(
-                    ApplicationProvider.getApplicationContext(),
-                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                    context = ApplicationProvider.getApplicationContext(),
+                    publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
                 )
             )
 
@@ -95,8 +95,8 @@ internal class RemoteCardAccountRangeSourceTest {
             cardAccountRangeStore = cardAccountRangeStore,
             analyticsRequestExecutor = {},
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                ApplicationProvider.getApplicationContext(),
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
             )
         )
 
@@ -112,8 +112,8 @@ internal class RemoteCardAccountRangeSourceTest {
             cardAccountRangeStore = cardAccountRangeStore,
             analyticsRequestExecutor = {},
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                ApplicationProvider.getApplicationContext(),
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
             )
         )
 
@@ -129,8 +129,8 @@ internal class RemoteCardAccountRangeSourceTest {
             cardAccountRangeStore = cardAccountRangeStore,
             analyticsRequestExecutor = {},
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                ApplicationProvider.getApplicationContext(),
-                ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
             )
         )
 
@@ -149,8 +149,8 @@ internal class RemoteCardAccountRangeSourceTest {
                 cardAccountRangeStore,
                 { },
                 PaymentAnalyticsRequestFactory(
-                    ApplicationProvider.getApplicationContext(),
-                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                    context = ApplicationProvider.getApplicationContext(),
+                    publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
                 )
             )
 
@@ -195,8 +195,8 @@ internal class RemoteCardAccountRangeSourceTest {
                     analyticsRequests.add(it)
                 },
                 PaymentAnalyticsRequestFactory(
-                    ApplicationProvider.getApplicationContext(),
-                    ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                    context = ApplicationProvider.getApplicationContext(),
+                    publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY }
                 )
             )
 

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherTest.kt
@@ -54,7 +54,7 @@ class GooglePayPaymentMethodLauncherTest {
                 googlePayRepositoryFactory = mock(),
                 paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                     context = activity,
-                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
                 ),
                 analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
                 cardBrandFilter = DefaultCardBrandFilter,
@@ -86,7 +86,7 @@ class GooglePayPaymentMethodLauncherTest {
                 googlePayRepositoryFactory = mock(),
                 paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                     context = activity,
-                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
                 ),
                 analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
                 cardBrandFilter = DefaultCardBrandFilter,
@@ -103,7 +103,7 @@ class GooglePayPaymentMethodLauncherTest {
                 googlePayRepositoryFactory = mock(),
                 paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                     context = activity,
-                    publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    publishableKeyProvider = { ApiKeyFixtures.FAKE_PUBLISHABLE_KEY },
                 ),
                 analyticsRequestExecutor = { firedEvents += it.params["event"].toString() },
                 cardBrandFilter = DefaultCardBrandFilter,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.GooglePayConfig
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
@@ -216,6 +217,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     ),
                     currencyCode = "usd",
                     amount = 0,
+                    apiConfiguration = ApiConfiguration.State("pk_123", "acct_123"),
                     shippingAddressParameters = null,
                 )
             )
@@ -245,6 +247,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     ),
                     currencyCode = "usd",
                     amount = 0,
+                    apiConfiguration = ApiConfiguration.State("pk_123", "acct_123"),
                     shippingAddressParameters = null,
                 )
             )
@@ -346,6 +349,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                     amount = 1099,
                     label = null,
                     transactionId = null,
+                    apiConfiguration = ApiConfiguration.State("pk_123", "acct_123"),
                     shippingAddressParameters = null,
                 )
             )
@@ -417,6 +421,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
                 paymentMethodSelectionFlow = PaymentMethodSelectionFlow.Automatic,
                 checkoutSessionId = null,
             ),
+            apiConfiguration = ApiConfiguration.State("pk_123", "acct_123"),
             shippingAddressParameters = null,
         )
         val REQUEST_OPTIONS = ApiRequest.Options(

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayRepositoryTest.kt
@@ -10,13 +10,12 @@ import com.google.android.gms.tasks.Tasks
 import com.google.android.gms.wallet.PaymentsClient
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.GooglePayJsonFactory
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -30,11 +29,10 @@ import kotlin.time.Duration.Companion.seconds
 @RunWith(AndroidJUnit4::class)
 class GooglePayRepositoryTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
-
-    @Before
-    fun setup() {
-        PaymentConfiguration.init(context, "pk_123")
-    }
+    private val apiConfiguration = ApiConfiguration.State(
+        publishableKey = "pk_123",
+        stripeAccountId = "acct_123",
+    )
 
     @Test
     fun `when google pay is ready, 'isReady' should return true`() = runTest {
@@ -127,6 +125,7 @@ class GooglePayRepositoryTest {
             billingAddressParameters = GooglePayJsonFactory.BillingAddressParameters(),
             existingPaymentMethodRequired = true,
             allowCreditCards = true,
+            apiConfiguration = apiConfiguration,
             paymentsClientFactory = { paymentsClient },
             errorReporter = errorReporter,
             logger = Logger.noop(),

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncherTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.FakeActivityResultLauncher
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import kotlinx.coroutines.test.runTest
@@ -79,7 +80,10 @@ class InternalGooglePayPaymentMethodLauncherTest {
             transactionId = "pi_12345",
             label = null,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                stripeAccountId = ACCOUNT_ID,
+            ),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = null,
@@ -96,7 +100,7 @@ class InternalGooglePayPaymentMethodLauncherTest {
                 cardFundingFilter = DefaultCardFundingFilter,
                 clientAttributionMetadata = null,
                 isElements = true,
-                publishableKey = null,
+                apiConfiguration = ApiConfiguration.State(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, ACCOUNT_ID),
                 displayItems = emptyList(),
                 billingEmailOverride = null,
                 shippingAddressParameters = null,
@@ -127,7 +131,10 @@ class InternalGooglePayPaymentMethodLauncherTest {
             transactionId = null,
             label = null,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                stripeAccountId = ACCOUNT_ID,
+            ),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = null,
@@ -149,7 +156,6 @@ class InternalGooglePayPaymentMethodLauncherTest {
             lifecycleOwner = lifecycleOwner,
             activityResultLauncher = activityResultLauncher,
             onPaymentDataChangedCallback = onPaymentDataChangedCallback,
-            context = context,
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = context,
                 publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
@@ -159,6 +165,7 @@ class InternalGooglePayPaymentMethodLauncherTest {
     }
 
     private companion object {
+        const val ACCOUNT_ID = "acct_123"
         val CONFIG = GooglePayPaymentMethodLauncher.Config(
             environment = GooglePayEnvironment.Test,
             merchantCountryCode = "US",

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/injection/DefaultGooglePayRepositoryFactoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/injection/DefaultGooglePayRepositoryFactoryTest.kt
@@ -9,7 +9,7 @@ import com.google.android.gms.wallet.PaymentsClient
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
@@ -38,7 +38,6 @@ internal class DefaultGooglePayRepositoryFactoryTest {
 
     @Before
     fun setup() {
-        PaymentConfiguration.init(context, "pk_123")
         GooglePayRepository.googlePayAvailabilityClientFactory =
             object : GooglePayAvailabilityClient.Factory {
                 override fun create(paymentsClient: PaymentsClient): GooglePayAvailabilityClient {
@@ -85,6 +84,10 @@ internal class DefaultGooglePayRepositoryFactoryTest {
             environment = GooglePayEnvironment.Test,
             cardFundingFilter = DefaultCardFundingFilter,
             cardBrandFilter = DefaultCardBrandFilter,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_123",
+                stripeAccountId = "acct_123",
+            ),
         )
 
         Scenario(

--- a/payments-core/src/test/java/com/stripe/android/utils/CardElementTestHelper.kt
+++ b/payments-core/src/test/java/com/stripe/android/utils/CardElementTestHelper.kt
@@ -3,7 +3,7 @@ package com.stripe.android.utils
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.MobileCardElementConfig
 import com.stripe.android.testing.AbsFakeStripeRepository
@@ -17,8 +17,8 @@ internal object CardElementTestHelper {
         viewModelStoreTestRule: ViewModelStoreTestRule,
     ): ViewModelStoreOwner {
         val cardWidgetViewModel = CardWidgetViewModel(
-            paymentConfigProvider = {
-                PaymentConfiguration(
+            apiConfigProvider = {
+                ApiConfiguration.State(
                     publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
                     stripeAccountId = null,
                 )

--- a/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardNumberEditTextTest.kt
@@ -45,6 +45,7 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.testharness.ViewTestUtils
 import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.ApiConfigProviderFromPaymentConfig
 import com.stripe.android.utils.FakeCardElementConfigRepository
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.createTestActivityRule
@@ -95,7 +96,10 @@ internal class CardNumberEditTextTest {
 
     private val analyticsRequestExecutor = AnalyticsRequestExecutor {}
     private val analyticsRequestFactory =
-        PaymentAnalyticsRequestFactory(context, ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+        PaymentAnalyticsRequestFactory(
+            context = context,
+            publishableKeyProvider = { ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY }
+        )
 
     private val cardNumberEditText = CardNumberEditText(
         context,
@@ -1076,7 +1080,7 @@ internal class CardNumberEditTextTest {
         val repository = FakeCardElementConfigRepository()
 
         val cardWidgetViewModel = CardWidgetViewModel(
-            paymentConfigProvider = { PaymentConfiguration.getInstance(context) },
+            apiConfigProvider = ApiConfigProviderFromPaymentConfig.get(context),
             stripeRepository = repository,
             dispatcher = dispatcher
         ).also { viewModelStoreRule.track(it) }

--- a/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/view/CardWidgetViewModelTest.kt
@@ -2,7 +2,7 @@ package com.stripe.android.view
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.utils.FakeCardElementConfigRepository
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -10,7 +10,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
-private val paymentConfig = PaymentConfiguration(
+private val apiConfigState = ApiConfiguration.State(
     publishableKey = "pk_test_123",
     stripeAccountId = null,
 )
@@ -28,7 +28,7 @@ class CardWidgetViewModelTest {
             val stripeRepository = FakeCardElementConfigRepository()
 
             val viewModel = CardWidgetViewModel(
-                paymentConfigProvider = { paymentConfig },
+                apiConfigProvider = { apiConfigState },
                 stripeRepository = stripeRepository,
                 dispatcher = testDispatcher
             ).also { viewModelStoreRule.track(it) }
@@ -46,7 +46,7 @@ class CardWidgetViewModelTest {
             val stripeRepository = FakeCardElementConfigRepository()
 
             val viewModel = CardWidgetViewModel(
-                paymentConfigProvider = { paymentConfig },
+                apiConfigProvider = { apiConfigState },
                 stripeRepository = stripeRepository,
                 dispatcher = testDispatcher
             ).also { viewModelStoreRule.track(it) }
@@ -63,7 +63,7 @@ class CardWidgetViewModelTest {
         val stripeRepository = FakeCardElementConfigRepository()
 
         val viewModel = CardWidgetViewModel(
-            paymentConfigProvider = { paymentConfig },
+            apiConfigProvider = { apiConfigState },
             stripeRepository = stripeRepository,
             dispatcher = testDispatcher
         ).also { viewModelStoreRule.track(it) }
@@ -80,7 +80,7 @@ class CardWidgetViewModelTest {
         val stripeRepository = FakeCardElementConfigRepository()
 
         val viewModel = CardWidgetViewModel(
-            paymentConfigProvider = { paymentConfig },
+            apiConfigProvider = { apiConfigState },
             stripeRepository = stripeRepository,
             dispatcher = testDispatcher
         ).also { viewModelStoreRule.track(it) }
@@ -98,7 +98,7 @@ class CardWidgetViewModelTest {
         val stripeRepository = FakeCardElementConfigRepository()
 
         val viewModel = CardWidgetViewModel(
-            paymentConfigProvider = { paymentConfig },
+            apiConfigProvider = { apiConfigState },
             stripeRepository = stripeRepository,
             dispatcher = testDispatcher
         ).also { viewModelStoreRule.track(it) }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.awaitWithTimeout
 import com.stripe.android.common.validation.isSupportedWithBillingConfig
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
@@ -30,6 +32,7 @@ import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.validate
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 
@@ -45,6 +48,7 @@ internal class DefaultCustomerSheetLoader(
     private val eventReporter: CustomerSheetEventReporter,
     private val errorReporter: ErrorReporter,
     private val workContext: CoroutineContext,
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
 ) : CustomerSheetLoader {
 
     @Inject
@@ -54,6 +58,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter: CustomerSheetEventReporter,
         errorReporter: ErrorReporter,
         @IOContext workContext: CoroutineContext,
+        paymentConfiguration: Provider<PaymentConfiguration>,
     ) : this(
         googlePayRepositoryFactory = googlePayRepositoryFactory,
         isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
@@ -62,6 +67,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter = eventReporter,
         errorReporter = errorReporter,
         workContext = workContext,
+        paymentConfiguration = paymentConfiguration,
     )
 
     override suspend fun load(
@@ -144,7 +150,13 @@ internal class DefaultCustomerSheetLoader(
                 GooglePayEnvironment.Test
             },
             cardBrandFilter = cardBrandFilter,
-            cardFundingFilter = cardFundingFilter
+            cardFundingFilter = cardFundingFilter,
+            apiConfiguration = paymentConfiguration.get().let {
+                ApiConfiguration.State(
+                    publishableKey = it.publishableKey,
+                    stripeAccountId = it.stripeAccountId,
+                )
+            },
         ).isReady().first()
         val isGooglePayReadyAndEnabled = configuration.googlePayEnabled && isGooglePaySupportedOnDevice
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinition.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentelement.confirmation.gpay
 import android.content.Context
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
@@ -110,7 +112,12 @@ internal class GooglePayConfirmationDefinition @Inject constructor(
             transactionId = intent.id,
             label = config.customLabel,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = PaymentConfiguration.getInstance(context).let {
+                ApiConfiguration.State(
+                    publishableKey = it.publishableKey,
+                    stripeAccountId = it.stripeAccountId,
+                )
+            },
             displayItems = GooglePayDisplayItemsFactory.create(confirmationArgs.paymentMethodMetadata, context),
             billingEmailOverride = config.billingEmailOverride,
             shippingAddressParameters = config.shippingAddressParameters,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -12,6 +12,7 @@ import com.stripe.android.common.analytics.experiment.PaymentMethodMessagePromot
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.utils.DurationProvider
@@ -692,7 +693,13 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         return googlePayRepositoryFactory(
             environment = environment,
             cardFundingFilter = DefaultCardFundingFilter,
-            cardBrandFilter = DefaultCardBrandFilter
+            cardBrandFilter = DefaultCardBrandFilter,
+            apiConfiguration = paymentConfiguration.get().let {
+                ApiConfiguration.State(
+                    publishableKey = it.publishableKey,
+                    stripeAccountId = it.stripeAccountId,
+                )
+            },
         ).isReady().first()
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -4,8 +4,10 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
@@ -842,7 +844,8 @@ internal class DefaultCustomerSheetLoaderTest {
                 override fun invoke(
                     environment: GooglePayEnvironment,
                     cardFundingFilter: CardFundingFilter,
-                    cardBrandFilter: CardBrandFilter
+                    cardBrandFilter: CardBrandFilter,
+                    apiConfiguration: ApiConfiguration.State,
                 ): GooglePayRepository {
                     return if (isGooglePayReady) {
                         readyGooglePayRepository
@@ -856,7 +859,12 @@ internal class DefaultCustomerSheetLoaderTest {
             isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
             eventReporter = eventReporter,
             errorReporter = errorReporter,
-            workContext = workContext
+            workContext = workContext,
+            paymentConfiguration = {
+                PaymentConfiguration(
+                    publishableKey = "pk_test_123",
+                )
+            },
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationActivityTest.kt
@@ -14,6 +14,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
@@ -37,6 +38,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.createTestActivityRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,6 +48,11 @@ import com.stripe.android.R as PaymentsCoreR
 @RunWith(RobolectricTestRunner::class)
 internal class GooglePayConfirmationActivityTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    @Before
+    fun setUp() {
+        PaymentConfiguration.init(application, "pk_test_123", "acct_123")
+    }
 
     @get:Rule
     val intentsRule = IntentsRule()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationDefinitionTest.kt
@@ -8,7 +8,9 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.GooglePayJsonFactory
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
@@ -54,6 +56,7 @@ import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.SetupIntentFactory
 import kotlinx.coroutines.test.runTest
 import kotlinx.parcelize.Parcelize
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -66,6 +69,11 @@ import com.stripe.android.R as PaymentsCoreR
 @Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 class GooglePayConfirmationDefinitionTest {
+    @Before
+    fun setUp() {
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(), "pk_test_123", "acct_123")
+    }
+
     @get:Rule
     val allowNoExistingPaymentMethodForGooglePayRule = FeatureFlagTestRule(
         featureFlag = FeatureFlags.allowNoExistingPaymentMethodForGooglePay,
@@ -421,7 +429,7 @@ class GooglePayConfirmationDefinitionTest {
             transactionId = "pi_12345",
             label = null,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = null,
@@ -458,7 +466,7 @@ class GooglePayConfirmationDefinitionTest {
             transactionId = "pi_12345",
             label = null,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = null,
@@ -496,7 +504,7 @@ class GooglePayConfirmationDefinitionTest {
             transactionId = "pi_12345",
             label = "Merchant Inc.",
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = null,
@@ -535,7 +543,7 @@ class GooglePayConfirmationDefinitionTest {
             transactionId = "pi_12345",
             label = "Merchant Inc.",
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = null,
@@ -589,7 +597,7 @@ class GooglePayConfirmationDefinitionTest {
             transactionId = "pi_12345",
             label = null,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
             displayItems = listOf(
                 GooglePayJsonFactory.DisplayItem(
                     label = "Widget x2",
@@ -633,7 +641,7 @@ class GooglePayConfirmationDefinitionTest {
             transactionId = "pi_12345",
             label = null,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = shippingAddressParameters,
@@ -710,7 +718,7 @@ class GooglePayConfirmationDefinitionTest {
             transactionId = "pi_12345",
             label = null,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = null,
@@ -743,7 +751,7 @@ class GooglePayConfirmationDefinitionTest {
             transactionId = "pi_12345",
             label = null,
             isElements = true,
-            publishableKey = null,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
             displayItems = emptyList(),
             billingEmailOverride = null,
             shippingAddressParameters = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/gpay/GooglePayConfirmationFlowTest.kt
@@ -6,6 +6,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayEnvironment
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
@@ -24,6 +26,7 @@ import com.stripe.android.paymentsheet.utils.RecordingInternalGooglePayPaymentMe
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.PaymentMethodFactory
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
@@ -33,6 +36,11 @@ import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class GooglePayConfirmationFlowTest {
+    @Before
+    fun setUp() {
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(), "pk_test_123", "acct_123")
+    }
+
     @Test
     fun `on launch, should persist parameters & launch using launcher as expected`() = runTest {
         val internalGooglePayPaymentMethodLauncher = mock<InternalGooglePayPaymentMethodLauncher>()
@@ -91,7 +99,7 @@ class GooglePayConfirmationFlowTest {
                     transactionId = "pi_12345",
                     label = null,
                     isElements = true,
-                    publishableKey = null,
+                    apiConfiguration = ApiConfiguration.State("pk_test_123", "acct_123"),
                     displayItems = emptyList(),
                     billingEmailOverride = null,
                     shippingAddressParameters = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.common.analytics.experiment.PaymentMethodMessagePromot
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.model.CountryCode
@@ -5025,7 +5026,8 @@ internal class DefaultPaymentElementLoaderTest {
                 override fun invoke(
                     environment: GooglePayEnvironment,
                     cardFundingFilter: CardFundingFilter,
-                    cardBrandFilter: CardBrandFilter
+                    cardBrandFilter: CardBrandFilter,
+                    apiConfiguration: ApiConfiguration.State,
                 ): GooglePayRepository {
                     return GooglePayRepository { flowOf(isGooglePayReady) }
                 }


### PR DESCRIPTION
# Summary
Migrate the remaining standalone Payments Core consumers to paired API configuration after the Google Pay readiness migration.

Changed classes and entry points:

- `IssuingCardPinService`: Build API request options from paired configuration.
- `PaymentConfiguration`: Supply paired configuration to fraud detection initialization.
- `PaymentsFraudDetectionDataRepositoryFactory`: Replace independently resolved credentials with an API configuration provider.
- `DefaultCardAccountRangeRepositoryFactory`: Resolve card-range request credentials lazily from paired API configuration while preserving existing entry points.
- `StripeApiRepository`: Supply paired configuration to fraud detection and card-range repositories.
- `ErrorReporter`: Use the shared lazy `PaymentConfiguration` adapter and support fallback reporting when launch arguments contain no key.
- `PaymentLauncherConfirmationActivity`: Report argument errors using credentials carried by launcher arguments.
- `PaymentLauncherFactory`: Use the shared lazy API configuration adapter.
- `ApiConfigProviderFromPaymentConfig`: Lazily adapt standalone consumers configured through `PaymentConfiguration`.
- `CardWidgetViewModel`: Use paired API configuration for card-element requests.
- `PaymentAuthWebViewActivity`: Select the appropriate error reporter from available browser-auth arguments.

Tests and shared test helpers were updated for the constructor and provider changes.

Committed and created by Codex.

# Motivation
Standalone Payments Core entry points need one coherent publishable-key/account snapshot while continuing to support integrations configured through `PaymentConfiguration`. Lazy compatibility adapters avoid eagerly resolving global configuration and allow later stack layers to supply explicit API configuration.

`PaymentsFraudDetectionDataRepositoryFactory` temporarily retains its context-based compatibility overload because later Link and PaymentSheet layers have not yet supplied explicit providers at this point in the stack. Final cleanup removes that adapter after all callers migrate.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- Payments Core, PaymentSheet, and Crypto Onramp debug compilation
- `./gradlew :payments-core:testDebugUnitTest`

# Screenshots
Not applicable — internal request configuration only.

# Changelog
Not applicable — existing public entry points remain compatible.
