### PR TITLE
Resolve API configuration for PaymentSheet loading

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
@@ -94,3 +94,18 @@ class ApiRequestOptionsModule {
         apiRequestOptionsProvider: () -> ApiRequest.Options
     ): ApiRequest.Options = apiRequestOptionsProvider()
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+class ApiRequestOptionsOnlyModule {
+    @Provides
+    fun provideApiRequestOptionsProvider(
+        apiConfigurationProvider: () -> ApiConfiguration.State
+    ): () -> ApiRequest.Options = {
+        val state = apiConfigurationProvider()
+        ApiRequest.Options(
+            apiKey = state.publishableKey,
+            stripeAccount = state.stripeAccountId,
+        )
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -141,6 +141,10 @@ internal class CheckoutPaymentElementAnalyticsTest {
         },
         setup = { controller ->
             networkRule.validateAnalyticsRequest(
+                eventName = "mc_embedded_init",
+                productUsage = setOf("Checkout"),
+            )
+            networkRule.validateAnalyticsRequest(
                 eventName = "mc_load_started",
                 productUsage = setOf("Checkout"),
             )
@@ -173,6 +177,10 @@ internal class CheckoutPaymentElementAnalyticsTest {
             analyticsPayloadField("error_code", "checkout_session_total_changed"),
         )
         // The Checkout Session is refreshed after confirmation fails.
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_embedded_init",
+            productUsage = setOf("Checkout"),
+        )
         networkRule.validateAnalyticsRequest(
             eventName = "mc_load_started",
             productUsage = setOf("Checkout"),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -50,6 +50,7 @@ import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelecti
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
@@ -117,6 +118,7 @@ import javax.inject.Singleton
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
         NfcScanningAvailabilityModule::class,
         PaymentOptionCardArtModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
     ],
 )
 internal interface CheckoutControllerComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutModule.kt
@@ -2,8 +2,8 @@ package com.stripe.android.checkout.injection
 
 import android.app.Application
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.DisplayDensity
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.core.networking.ApiRequest
@@ -15,7 +15,6 @@ import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Provider
 
 @Module(includes = [PaymentConfigurationModule::class, StripeNetworkClientModule::class])
 internal object CheckoutModule {
@@ -31,12 +30,19 @@ internal object CheckoutModule {
     fun provideProductUsageTokens(): Set<String> = setOf("Checkout")
 
     @Provides
+    fun provideApiRequestOptionsProvider(
+        apiConfigProvider: () -> ApiConfiguration.State
+    ): () -> ApiRequest.Options = {
+        ApiRequest.Options(
+            apiKey = apiConfigProvider().publishableKey,
+            stripeAccount = apiConfigProvider().stripeAccountId,
+        )
+    }
+
+    @Provides
     fun provideApiRequestOptions(
-        paymentConfiguration: Provider<PaymentConfiguration>
-    ): ApiRequest.Options = ApiRequest.Options(
-        apiKey = paymentConfiguration.get().publishableKey,
-        stripeAccount = paymentConfiguration.get().stripeAccountId,
-    )
+        apiRequestOptionsProvider: () -> ApiRequest.Options
+    ): ApiRequest.Options = apiRequestOptionsProvider()
 
     @Provides
     fun provideStripeImageLoader(context: Context): StripeImageLoader = DefaultStripeImageLoader(context)

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
@@ -185,6 +185,7 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
             configuration = config,
             customerMetadata = paymentMethodMetadata.customerMetadata,
             customerEmail = elementsSessionCustomerEmail,
+            stripeAccountId = paymentMethodMetadata.apiConfiguration.stripeAccountId,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -66,6 +66,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -94,6 +95,7 @@ import javax.inject.Singleton
         DefaultIntentConfirmationModule::class,
         LinkInlineSignupConfirmationModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,
         TapToAddModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.DefaultCardFundingFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.awaitWithTimeout
 import com.stripe.android.common.validation.isSupportedWithBillingConfig
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
@@ -28,12 +26,12 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.validate
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 
@@ -50,7 +48,7 @@ internal class DefaultCustomerSheetLoader(
     private val eventReporter: CustomerSheetEventReporter,
     private val errorReporter: ErrorReporter,
     private val workContext: CoroutineContext,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val apiConfigurationResolver: ApiConfigurationResolver,
 ) : CustomerSheetLoader {
 
     @Inject
@@ -61,7 +59,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter: CustomerSheetEventReporter,
         errorReporter: ErrorReporter,
         @IOContext workContext: CoroutineContext,
-        paymentConfiguration: Provider<PaymentConfiguration>,
+        apiConfigurationResolver: ApiConfigurationResolver,
     ) : this(
         googlePayRepositoryFactory = googlePayRepositoryFactory,
         isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
@@ -71,7 +69,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter = eventReporter,
         errorReporter = errorReporter,
         workContext = workContext,
-        paymentConfiguration = paymentConfiguration,
+        apiConfigurationResolver = apiConfigurationResolver,
     )
 
     override suspend fun load(
@@ -159,12 +157,7 @@ internal class DefaultCustomerSheetLoader(
             },
             cardBrandFilter = cardBrandFilter,
             cardFundingFilter = cardFundingFilter,
-            apiConfiguration = paymentConfiguration.get().let {
-                ApiConfiguration.State(
-                    publishableKey = it.publishableKey,
-                    stripeAccountId = it.stripeAccountId,
-                )
-            },
+            apiConfiguration = apiConfigurationResolver.resolve(null),
         ).isReady().first()
         val isGooglePayReadyAndEnabled = configuration.googlePayEnabled && isGooglePaySupportedOnDevice
 
@@ -190,6 +183,7 @@ internal class DefaultCustomerSheetLoader(
                     IntegrationMetadata.CustomerSheet.AttachmentStyle.CreateAttach
                 }
             ),
+            apiConfiguration = apiConfigurationResolver.resolve(null),
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet
 
 import android.content.Context
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.injection.IOContext
@@ -71,6 +72,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 types = requestedTypes,
                 silentlyFail = false,
+                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -88,6 +90,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -105,6 +108,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -124,6 +128,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter
@@ -29,6 +30,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
     private val elementsSessionRepository: ElementsSessionRepository,
     private val customerAdapter: CustomerAdapter,
     private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetInitializationDataSource,
     CustomerSheetSavedSelectionDataSource,
@@ -132,6 +134,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
             customPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = apiConfigurationProvider(),
         ).onSuccess {
             errorReporter.report(
                 errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerSheet
@@ -34,6 +35,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
     private val prefsRepositoryFactory: PrefsRepository.Factory,
     private val customerSessionProvider: CustomerSheet.CustomerSessionProvider,
     private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
     private val timeProvider: () -> Long,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSessionElementsSessionManager {
@@ -90,6 +92,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                     customPaymentMethods = listOf(),
                     externalPaymentMethods = listOf(),
                     countryOverride = null,
+                    apiConfiguration = apiConfigurationProvider(),
                 ).onSuccess {
                     reportSuccessfulElementsSessionLoad()
                 }.onFailure {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -15,6 +16,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
     private val errorReporter: ErrorReporter,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetPaymentMethodDataSource {
     override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
@@ -42,6 +44,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     paymentMethodId = paymentMethodId,
                     params = params,
+                    stripeAccountId = apiConfigProvider().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }
@@ -66,6 +69,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
                     paymentMethodId = paymentMethodId,
+                    stripeAccountId = apiConfigProvider().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -17,6 +18,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: PrefsRepository.Factory,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetSavedSelectionDataSource {
     override suspend fun retrieveSavedSelection(
@@ -101,6 +103,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
             customerId = ephemeralKey.customerId,
             ephemeralKeySecret = ephemeralKey.ephemeralKey,
             paymentMethodId = paymentMethodId,
+            stripeAccountId = apiConfigProvider().stripeAccountId,
         ).getOrThrow()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerAdapter
@@ -40,6 +41,7 @@ internal interface CustomerAdapterDataSourceComponent {
         fun create(
             @BindsInstance application: Application,
             @BindsInstance adapter: CustomerAdapter,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): CustomerAdapterDataSourceComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerSheet
@@ -40,6 +41,7 @@ internal interface CustomerSessionDataSourceComponent {
         fun create(
             @BindsInstance application: Application,
             @BindsInstance customerSessionProvider: CustomerSheet.CustomerSessionProvider,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): CustomerSessionDataSourceComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
@@ -2,11 +2,13 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 
 @Module(includes = [StripeNetworkClientModule::class])
 internal interface CustomerSheetDataSourceCommonModule {
@@ -17,4 +19,11 @@ internal interface CustomerSheetDataSourceCommonModule {
 
     @Binds
     fun bindsApplicationContext(application: Application): Context
+
+    companion object {
+        @Provides
+        fun provideApiConfigurationState(
+            apiConfigurationProvider: () -> ApiConfiguration.State
+        ): ApiConfiguration.State = apiConfigurationProvider()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
@@ -2,13 +2,11 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import android.content.Context
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
 
 @Module(includes = [StripeNetworkClientModule::class])
 internal interface CustomerSheetDataSourceCommonModule {
@@ -19,11 +17,4 @@ internal interface CustomerSheetDataSourceCommonModule {
 
     @Binds
     fun bindsApplicationContext(application: Application): Context
-
-    companion object {
-        @Provides
-        fun provideApiConfigurationState(
-            apiConfigurationProvider: () -> ApiConfiguration.State
-        ): ApiConfiguration.State = apiConfigurationProvider()
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -5,8 +5,10 @@ import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.asSingle
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
@@ -49,6 +51,14 @@ internal object CustomerSheetHacks {
                     .create(
                         application = application,
                         adapter = integration.adapter,
+                        apiConfigurationProvider = {
+                            PaymentConfiguration.getInstance(application).let {
+                                ApiConfiguration.State(
+                                    publishableKey = it.publishableKey,
+                                    stripeAccountId = it.stripeAccountId,
+                                )
+                            }
+                        },
                     )
 
                 _initializationDataSource.value = adapterDataSourceComponent.customerSheetInitializationDataSource
@@ -62,6 +72,14 @@ internal object CustomerSheetHacks {
                     .create(
                         application = application,
                         customerSessionProvider = integration.customerSessionProvider,
+                        apiConfigurationProvider = {
+                            PaymentConfiguration.getInstance(application).let {
+                                ApiConfiguration.State(
+                                    publishableKey = it.publishableKey,
+                                    stripeAccountId = it.stripeAccountId,
+                                )
+                            }
+                        },
                     )
 
                 _initializationDataSource.value =

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -571,8 +571,6 @@ internal class LinkActivityViewModel @Inject constructor(
                     .create(
                         configuration = args.configuration,
                         paymentMethodMetadata = args.paymentMethodMetadata,
-                        publishableKeyProvider = { args.publishableKey },
-                        stripeAccountIdProvider = { args.stripeAccountId },
                         paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
                         context = app,
                         savedStateHandle = handle,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -3,6 +3,8 @@ package com.stripe.android.link
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.ClientAttributionMetadata
@@ -15,7 +17,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class LinkConfiguration(
+internal data class LinkConfiguration constructor(
     val stripeIntent: StripeIntent,
     val merchantName: String,
     val sellerBusinessName: String?,
@@ -51,7 +53,14 @@ internal data class LinkConfiguration(
     val linkSupportedPaymentMethodsOnboardingEnabled: List<String>,
     val clientAttributionMetadata: ClientAttributionMetadata,
     val linkBrand: LinkBrand,
+    val apiConfiguration: ApiConfiguration.State,
 ) : Parcelable {
+
+    val requestOptions: ApiRequest.Options
+        get() = ApiRequest.Options(
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
+        )
 
     val customerIdForEceDefaultValues: String?
         get() = if (enableDisplayableDefaultValuesInEce) customerId else null

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
@@ -14,6 +15,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         LinkControllerModule::class,
+        ApiRequestOptionsOnlyModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -2,6 +2,8 @@ package com.stripe.android.link.injection
 
 import android.app.Application
 import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
@@ -30,6 +32,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
 import javax.inject.Singleton
+import javax.inject.Provider
 
 @Module(
     includes = [
@@ -57,6 +60,18 @@ internal interface LinkControllerModule {
     fun bindLinkConfigurationLoader(impl: DefaultLinkConfigurationLoader): LinkConfigurationLoader
 
     companion object {
+        @Provides
+        @Singleton
+        fun provideApiConfigurationProvider(
+            paymentConfiguration: Provider<PaymentConfiguration>,
+        ): () -> ApiConfiguration.State = {
+            val configuration = paymentConfiguration.get()
+            ApiConfiguration.State(
+                publishableKey = configuration.publishableKey,
+                stripeAccountId = configuration.stripeAccountId,
+            )
+        }
+
         @Provides
         @Singleton
         fun provideAppContext(application: Application): Context = application.applicationContext

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -3,8 +3,8 @@ package com.stripe.android.link.injection
 import android.app.Application
 import android.content.Context
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
@@ -31,8 +31,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
-import javax.inject.Singleton
 import javax.inject.Provider
+import javax.inject.Singleton
 
 @Module(
     includes = [

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmat
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationToNamedModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
@@ -50,6 +51,7 @@ internal annotation class NativeLinkScope
         DefaultIntentConfirmationModule::class,
         LinkPassthroughConfirmationModule::class,
         ApiRequestOptionsModule::class,
+        ApiConfigurationToNamedModule::class,
     ]
 )
 internal interface NativeLinkComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -6,8 +6,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.Logger
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
@@ -29,6 +27,7 @@ import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmat
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -50,6 +49,7 @@ internal annotation class NativeLinkScope
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
         LinkPassthroughConfirmationModule::class,
+        ApiRequestOptionsModule::class,
     ]
 )
 internal interface NativeLinkComponent {
@@ -81,12 +81,6 @@ internal interface NativeLinkComponent {
             configuration: LinkConfiguration,
             @BindsInstance
             paymentMethodMetadata: PaymentMethodMetadata,
-            @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
-            @BindsInstance
-            @Named(STRIPE_ACCOUNT_ID)
-            stripeAccountIdProvider: () -> String?,
             @BindsInstance
             @PaymentElementCallbackIdentifier
             paymentElementCallbackIdentifier: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -8,6 +8,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -37,6 +38,7 @@ import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.repositories.LinkApiRepository
 import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.oauth.OAuthConsentViewModelComponent
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
@@ -151,6 +153,11 @@ internal interface NativeLinkModule {
     @SuppressWarnings("TooManyFunctions")
     companion object {
         @Provides
+        fun providePaymentConfiguration(context: Context): PaymentConfiguration {
+            return PaymentConfiguration.getInstance(context)
+        }
+
+        @Provides
         @NativeLinkScope
         fun providesLinkAccountHolder(
             savedStateHandle: SavedStateHandle,
@@ -206,9 +213,10 @@ internal interface NativeLinkModule {
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
 
         @Provides
-        @NativeLinkScope
-        fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(appContext)
+        fun provideApiConfigurationProvider(
+            paymentMethodMetadata: PaymentMethodMetadata
+        ): () -> ApiConfiguration.State {
+            return { paymentMethodMetadata.apiConfiguration }
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -5,6 +5,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.utils.FeatureFlags.enableNfcScanning
@@ -99,6 +100,7 @@ internal data class PaymentMethodMetadata(
     val cardArts: List<PaymentMethod.Card.CardArt>,
     val shouldUseAutocompleteProxyEndpoints: Boolean,
     private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+    val apiConfiguration: ApiConfiguration.State,
 ) : Parcelable {
 
     val requiresBillingAddressForAutomaticTax: Boolean
@@ -390,6 +392,7 @@ internal data class PaymentMethodMetadata(
             analyticsMetadata: AnalyticsMetadata,
             isTapToAddAvailable: Boolean,
             paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+            apiConfiguration: ApiConfiguration.State,
         ): PaymentMethodMetadata {
             val linkSettings = elementsSession.linkSettings
             val cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty()
@@ -452,6 +455,7 @@ internal data class PaymentMethodMetadata(
                 cardArts = cardArts,
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 paymentMethodLayout = paymentMethodLayout,
+                apiConfiguration = apiConfiguration,
             )
         }
 
@@ -463,6 +467,7 @@ internal data class PaymentMethodMetadata(
             isGooglePayReady: Boolean,
             customerMetadata: CustomerMetadata,
             integrationMetadata: IntegrationMetadata.CustomerSheet,
+            apiConfiguration: ApiConfiguration.State,
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
@@ -523,6 +528,7 @@ internal data class PaymentMethodMetadata(
                 cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty(),
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+                apiConfiguration = apiConfiguration,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -22,8 +22,8 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.CustomerStateHolder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PaymentConfigurationModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -31,6 +32,7 @@ import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -53,6 +55,8 @@ import kotlin.coroutines.CoroutineContext
         PaymentsIntegrityModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsOnlyModule::class,
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
         NfcScanningAvailabilityModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.requireApplication
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import javax.inject.Inject
@@ -17,11 +16,7 @@ import kotlin.reflect.KClass
 internal class EmbeddedPaymentElementViewModel @Inject constructor(
     val embeddedPaymentElementSubcomponentFactory: EmbeddedPaymentElementSubcomponent.Factory,
     @ViewModelScope private val customViewModelScope: CoroutineScope,
-    eventReporter: EventReporter,
 ) : ViewModel() {
-    init {
-        eventReporter.onInit()
-    }
 
     override fun onCleared() {
         customViewModelScope.cancel()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -264,7 +264,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)
 
-        eventReporter.onInit()
+        // eventReporter.onInit()
 
         viewModelScope.launch(workContext) {
             loadPaymentSheetState()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -264,8 +264,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)
 
-        // eventReporter.onInit()
-
         viewModelScope.launch(workContext) {
             loadPaymentSheetState()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.stripe.android.common.analytics.experiment.LoggableExperiment
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsEvent
+import com.stripe.android.core.networking.AnalyticsFields
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestV2Executor
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory
@@ -52,22 +53,24 @@ internal class DefaultEventReporter @Inject internal constructor(
         origin = ORIGIN,
     )
 
-    override fun onInit() {
+    override fun onInit(publishableKey: String) {
         fireEvent(
             event = PaymentSheetEvent.Init(
                 mode = mode,
             ),
-            paymentMethodMetadata = null, // We won't have a value on init, and using null prevents a stack overflow.
+            paymentMethodMetadata = null,
+            publishableKey = publishableKey,
         )
     }
 
-    override fun onLoadStarted(initializedViaCompose: Boolean) {
+    override fun onLoadStarted(initializedViaCompose: Boolean, publishableKey: String) {
         durationProvider.start(DurationProvider.Key.Loading)
         fireEvent(
             event = PaymentSheetEvent.LoadStarted(
                 initializedViaCompose = initializedViaCompose
             ),
             paymentMethodMetadata = null, // We don't have these details until load is complete.
+            publishableKey = publishableKey,
         )
     }
 
@@ -93,6 +96,7 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onLoadFailed(
         error: Throwable,
+        publishableKey: String,
     ) {
         val duration = durationProvider.end(DurationProvider.Key.Loading)
         fireEvent(
@@ -102,6 +106,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 loadTimings = buildLoadTimings(),
             ),
             paymentMethodMetadata = null, // We don't have these details until load is completed successfully.
+            publishableKey = publishableKey,
         )
     }
 
@@ -631,12 +636,15 @@ internal class DefaultEventReporter @Inject internal constructor(
     private fun fireEvent(
         event: PaymentSheetEvent,
         paymentMethodMetadata: PaymentMethodMetadata? = paymentMethodMetadataProvider.get(),
+        publishableKey: String? = null,
     ) {
         CoroutineScope(workContext).launch {
+            val additionalParams = defaultParams(paymentMethodMetadata) + event.params +
+                (publishableKey?.let { mapOf(AnalyticsFields.PUBLISHABLE_KEY to it) } ?: emptyMap())
             analyticsRequestExecutor.executeAsync(
                 paymentAnalyticsRequestFactory.createRequest(
                     event = event,
-                    additionalParams = defaultParams(paymentMethodMetadata) + event.params,
+                    additionalParams = additionalParams,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -14,9 +14,14 @@ import com.stripe.android.ui.core.cardscan.CardScanEventsReporter
 
 internal interface LoadingEventReporter {
     /**
+     * PaymentSheet or FlowController have been initialized.
+     */
+    fun onInit(publishableKey: String)
+
+    /**
      * PaymentSheet or FlowController have started loading.
      */
-    fun onLoadStarted(initializedViaCompose: Boolean)
+    fun onLoadStarted(initializedViaCompose: Boolean, publishableKey: String)
 
     /**
      * PaymentSheet or FlowController have successfully loaded the information required to be
@@ -30,7 +35,7 @@ internal interface LoadingEventReporter {
     /**
      * PaymentSheet or FlowController have failed to load.
      */
-    fun onLoadFailed(error: Throwable)
+    fun onLoadFailed(error: Throwable, publishableKey: String)
 
     /**
      * PaymentSheet or FlowController have failed to load from the Elements session endpoint.
@@ -45,11 +50,6 @@ internal interface LoadingEventReporter {
 
 @Suppress("TooManyFunctions")
 internal interface EventReporter : CardScanEventsReporter {
-
-    /**
-     * PaymentSheet has been instantiated or FlowController has finished its configuration.
-     */
-    fun onInit()
 
     /**
      * PaymentSheet has been dismissed by pressing the close button.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -17,8 +17,10 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataU
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.injection.PaymentSheetCommonModule
@@ -40,6 +42,8 @@ import javax.inject.Singleton
         ExtendedPaymentElementConfirmationModule::class,
         TapToAddConnectionStarterModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsOnlyModule::class,
         PaymentElementRequestSurfaceModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -16,8 +16,8 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.ApiConfigurationModule

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -69,8 +69,6 @@ internal class FlowControllerViewModel(
     private val restartSession = SessionSavedStateHandler.attachTo(this, handle)
 
     init {
-        flowControllerStateComponent.eventReporter.onInit()
-
         viewModelScope.launch {
             stateFlow.collectLatest { state ->
                 flowControllerStateComponent.linkHandler.setupLink(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import dagger.Module
+import dagger.Provides
+import javax.inject.Provider
+
+@Module
+internal object ApiConfigurationModule {
+    @Provides
+    fun provideApiConfigurationStateProvider(
+        paymentMethodMetadata: Provider<PaymentMethodMetadata?>
+    ): () -> ApiConfiguration.State {
+        return { requireNotNull(paymentMethodMetadata.get()?.apiConfiguration) }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule
@@ -19,6 +20,8 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsOnlyModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentOptionsViewModelModule::class,
         PaymentSheetAutocompleteModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -6,8 +6,8 @@ import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
-import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -9,8 +9,8 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
-import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelperModule

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -10,6 +10,7 @@ import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelperModule
@@ -24,6 +25,8 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsOnlyModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -2,9 +2,8 @@ package com.stripe.android.paymentsheet.repositories
 
 import com.stripe.android.Stripe
 import com.stripe.android.checkout.CheckoutController.Address
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.safeAnalyticsMessage
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
@@ -18,7 +17,6 @@ import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import java.util.TimeZone
 import java.util.UUID
 import javax.inject.Inject
-import javax.inject.Named
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutSessionRepository @Inject constructor(
@@ -26,8 +24,7 @@ internal class CheckoutSessionRepository @Inject constructor(
     private val stripeNetworkClient: StripeNetworkClient,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
-    @Named(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
 ) {
 
     private val apiRequestFactory = ApiRequest.Factory(
@@ -37,16 +34,17 @@ internal class CheckoutSessionRepository @Inject constructor(
     )
     private val stripeErrorJsonParser = StripeErrorJsonParser()
 
-    private fun createOptions(): ApiRequest.Options = ApiRequest.Options(
-        apiKey = publishableKeyProvider(),
-        stripeAccount = stripeAccountIdProvider(),
-    )
+    private val requestOptions: ApiRequest.Options
+        get() = ApiRequest.Options(
+            apiKey = apiConfigurationProvider().publishableKey,
+            stripeAccount = apiConfigurationProvider().stripeAccountId,
+        )
 
     private suspend fun executePost(
         url: String,
         params: Map<String, *>,
     ): Result<CheckoutSessionResponse> {
-        val options = createOptions()
+        val options = requestOptions
         return executeRequestWithResultParser(
             stripeErrorJsonParser = stripeErrorJsonParser,
             stripeNetworkClient = stripeNetworkClient,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.repositories
 
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
@@ -19,7 +18,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -29,7 +27,6 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 internal class CustomerApiRepository @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     private val logger: Logger,
     private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
@@ -39,13 +36,14 @@ internal class CustomerApiRepository @Inject constructor(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer? {
         return stripeRepository.retrieveCustomer(
             customerId,
             productUsageTokens,
             ApiRequest.Options(
                 ephemeralKeySecret,
-                lazyPaymentConfig.get().stripeAccountId
+                stripeAccountId
             )
         ).getOrNull()
     }
@@ -55,6 +53,7 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>> = withContext(workContext) {
         val requests = types.filter { paymentMethodType ->
             paymentMethodType in setOf(
@@ -73,7 +72,7 @@ internal class CustomerApiRepository @Inject constructor(
                     productUsageTokens = productUsageTokens,
                     requestOptions = ApiRequest.Options(
                         apiKey = ephemeralKeySecret,
-                        stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                        stripeAccount = stripeAccountId,
                     ),
                 ).onFailure {
                     logger.error("Failed to retrieve payment methods.", it)
@@ -108,13 +107,14 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         return stripeRepository.detachPaymentMethod(
             productUsageTokens = productUsageTokens,
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             ),
         ).onFailure {
             logger.error("Failed to detach payment method $paymentMethodId.", it)
@@ -133,10 +133,11 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = with(CoroutineScope(workContext)) {
         val requestOptions = ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+            stripeAccount = stripeAccountId,
         )
 
         val detachOne: suspend (String) -> Result<PaymentMethod> = { pmId ->
@@ -154,6 +155,7 @@ internal class CustomerApiRepository @Inject constructor(
             // We only support removing duplicate cards.
             types = listOf(PaymentMethod.Type.Card),
             silentlyFail = false,
+            stripeAccountId = stripeAccountId,
         ).getOrElse {
             return Result.failure(it)
         }
@@ -212,6 +214,7 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.attachPaymentMethod(
             customerId = customerId,
@@ -219,7 +222,7 @@ internal class CustomerApiRepository @Inject constructor(
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             )
         ).onFailure {
             logger.error("Failed to attach payment method $paymentMethodId.", it)
@@ -230,13 +233,14 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.updatePaymentMethod(
             paymentMethodId = paymentMethodId,
             paymentMethodUpdateParams = params,
             options = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             )
         ).onFailure {
             logger.error("Failed to update payment method $paymentMethodId.", it)
@@ -246,12 +250,13 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer> = stripeRepository.setDefaultPaymentMethod(
         paymentMethodId = paymentMethodId,
         customerId = customerId,
         options = ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+            stripeAccount = stripeAccountId,
         )
     )
 
@@ -259,6 +264,7 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.retrieveCustomerPaymentMethod(
             customerId = customerId,
@@ -266,7 +272,7 @@ internal class CustomerApiRepository @Inject constructor(
             productUsageTokens = productUsageTokens,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             ),
         ).onFailure {
             logger.error("Failed to retrieve payment method $paymentMethodId.", it)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -14,6 +14,7 @@ internal interface CustomerRepository {
     suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer?
 
     /**
@@ -26,6 +27,7 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>>
 
     /**
@@ -37,6 +39,7 @@ internal interface CustomerRepository {
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     /**
@@ -48,6 +51,7 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     /**
@@ -57,6 +61,7 @@ internal interface CustomerRepository {
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     suspend fun updatePaymentMethod(
@@ -64,17 +69,20 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     suspend fun setDefaultPaymentMethod(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer>
 
     suspend fun retrievePaymentMethod(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -2,9 +2,9 @@ package com.stripe.android.paymentsheet.repositories
 
 import android.app.Application
 import com.stripe.android.DefaultFraudDetectionDataRepository
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.Stripe
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
@@ -28,7 +28,6 @@ import com.stripe.android.paymentsheet.toDeferredIntentParams
 import kotlinx.coroutines.withContext
 import java.util.Calendar
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal interface ElementsSessionRepository {
@@ -39,21 +38,18 @@ internal interface ElementsSessionRepository {
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String> = emptySet(),
     ): Result<ElementsSession>
 }
 
 internal class RealElementsSessionRepository @Inject constructor(
-    application: Application,
+    private val application: Application,
     private val stripeNetworkClient: StripeNetworkClient,
     private val stripeRepository: StripeRepository,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     @IOContext private val workContext: CoroutineContext,
     private val clientParams: ElementsSessionClientParams,
 ) : ElementsSessionRepository {
-
-    private val fraudDetectionDataRepository =
-        DefaultFraudDetectionDataRepository(application, workContext)
 
     private val apiRequestFactory = ApiRequest.Factory(
         appInfo = Stripe.appInfo,
@@ -62,14 +58,6 @@ internal class RealElementsSessionRepository @Inject constructor(
     )
     private val stripeErrorJsonParser = StripeErrorJsonParser()
 
-    // The PaymentConfiguration can change after initialization, so this needs to get a new
-    // request options each time requested.
-    private val requestOptions: ApiRequest.Options
-        get() = ApiRequest.Options(
-            apiKey = lazyPaymentConfig.get().publishableKey,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
-        )
-
     override suspend fun get(
         initializationMode: PaymentElementLoader.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
@@ -77,8 +65,11 @@ internal class RealElementsSessionRepository @Inject constructor(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
+        val fraudDetectionDataRepository =
+            DefaultFraudDetectionDataRepository(application, { apiConfiguration.publishableKey }, workContext)
         fraudDetectionDataRepository.refresh()
 
         val params = initializationMode.toElementsSessionParams(
@@ -91,12 +82,15 @@ internal class RealElementsSessionRepository @Inject constructor(
             linkDisallowedFundingSourceCreation = linkDisallowedFundingSourceCreation,
         )
 
-        val options = requestOptions
+        val options = ApiRequest.Options(
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
+        )
         val elementsSession = retrieveElementsSession(params, options)
 
         return elementsSession.getResultOrElse { elementsSessionFailure ->
             if (shouldFallback(elementsSession)) {
-                fallback(params, elementsSessionFailure)
+                fallback(params, elementsSessionFailure, options)
             } else {
                 elementsSession
             }
@@ -148,6 +142,7 @@ internal class RealElementsSessionRepository @Inject constructor(
     private suspend fun fallback(
         params: ElementsSessionParams,
         elementsSessionFailure: Throwable,
+        requestOptions: ApiRequest.Options,
     ): Result<ElementsSession> = withContext(workContext) {
         val stripeIntent = when (params) {
             is ElementsSessionParams.PaymentIntentType -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
@@ -37,6 +38,7 @@ internal interface SavedPaymentMethodRepository {
 internal class DefaultSavedPaymentMethodRepository @Inject constructor(
     private val customerRepository: CustomerRepository,
     private val checkoutSessionRepository: CheckoutSessionRepository,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
 ) : SavedPaymentMethodRepository {
 
     override suspend fun detachPaymentMethod(
@@ -57,6 +59,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 customerSessionClientSecret = customerMetadata.customerSessionClientSecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -64,6 +67,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
     }
@@ -89,6 +93,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -97,6 +102,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
     }
@@ -113,6 +119,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -120,6 +127,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
     }
@@ -138,6 +146,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -145,6 +154,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.gate.LinkGate
@@ -36,6 +37,7 @@ internal interface CreateLinkState {
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkStateResult
 }
 
@@ -80,6 +82,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkStateResult {
         val linkDisabledReasons = getLinkDisabledReasons(
             elementsSession = elementsSession,
@@ -98,6 +101,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             initializationMode = initializationMode,
             customerMetadata = customerMetadata,
             clientAttributionMetadata = clientAttributionMetadata,
+            apiConfiguration = apiConfiguration,
         )
         val accountStatus = accountStatusProvider(linkConfiguration)
         val loginState = accountStatus.toLoginState()
@@ -224,6 +228,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkConfiguration {
         val cardBrandFilter = getCardBrandFilter(
             elementsSession = elementsSession,
@@ -236,6 +241,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             configuration,
             customerMetadata,
             customerEmail = elementsSession.customer?.email,
+            stripeAccountId = apiConfiguration.stripeAccountId,
         )
         val customerInfo = LinkConfiguration.CustomerInfo(
             name = configuration.defaultBillingDetails?.name,
@@ -254,6 +260,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             cardBrandChoice = cardBrandChoice,
             shippingDetails = shippingDetails,
             clientAttributionMetadata = clientAttributionMetadata,
+            apiConfiguration = apiConfiguration,
         )
     }
 
@@ -266,6 +273,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         cardBrandChoice: LinkConfiguration.CardBrandChoice?,
         shippingDetails: AddressDetails?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ) = LinkConfiguration(
         stripeIntent = elementsSession.stripeIntent,
         merchantName = configuration.merchantDisplayName,
@@ -309,6 +317,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             elementsSession.linkSettings?.linkSupportedPaymentMethodsOnboardingEnabled.orEmpty(),
         clientAttributionMetadata = clientAttributionMetadata,
         linkBrand = elementsSession.linkBrand,
+        apiConfiguration = apiConfiguration,
     )
 
     private fun getCardBrandChoice(elementsSession: ElementsSession): LinkConfiguration.CardBrandChoice? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -31,6 +32,7 @@ internal class ElementsSessionLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         configuration: CommonConfiguration,
         savedPaymentMethodSelection: SavedSelection.PaymentMethod?,
+        apiConfiguration: ApiConfiguration.State,
     ): ElementsSession {
         return elementsSessionRepository.get(
             initializationMode = initializationMode,
@@ -39,6 +41,7 @@ internal class ElementsSessionLoader @Inject constructor(
             customPaymentMethods = configuration.customPaymentMethods,
             savedPaymentMethodSelectionId = savedPaymentMethodSelection?.id,
             countryOverride = configuration.userOverrideCountry,
+            apiConfiguration = apiConfiguration,
             linkDisallowedFundingSourceCreation = configuration.link.disallowFundingSourceCreation,
         ).getOrThrow()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -306,9 +306,13 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         integrationConfiguration: PaymentElementLoader.Configuration,
         metadata: PaymentElementLoader.Metadata,
-    ): Result<PaymentElementLoader.State> = workContext.runCatching(::reportFailedLoad) {
+    ): Result<PaymentElementLoader.State> {
         val configuration = integrationConfiguration.commonConfiguration
         val apiConfiguration = apiConfigurationResolver.resolve(configuration.apiConfiguration)
+
+        return workContext.runCatching(
+            onFailure = { error -> reportFailedLoad(error, apiConfiguration.publishableKey) }
+        ) {
         eventReporter.onInit(apiConfiguration.publishableKey)
         // Validate configuration before loading
         initializationMode.validate()
@@ -481,7 +485,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             paymentMethodMetadata = state.paymentMethodMetadata,
         )
 
-        return@runCatching state
+            return@runCatching state
+        }
     }
 
     private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(
@@ -883,11 +888,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
     private fun reportFailedLoad(
         error: Throwable,
+        publishableKey: String,
     ) {
         logger.error("Failure loading PaymentSheetState", error)
-        val publishableKey = runCatching {
-            apiConfigurationResolver.resolve(null).publishableKey
-        }.getOrDefault("")
         eventReporter.onLoadFailed(error, publishableKey)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
@@ -43,6 +42,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -62,7 +62,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -275,7 +274,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val userFacingLogger: UserFacingLogger,
     private val integrityRequestManager: IntegrityRequestManager,
     private val tapToAddConnectionStarter: TapToAddConnectionStarter,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val apiConfigurationResolver: ApiConfigurationResolver,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val analyticsMetadataFactory: AnalyticsMetadataFactory,
     private val customerRepository: CustomerRepository,
@@ -309,16 +308,18 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         metadata: PaymentElementLoader.Metadata,
     ): Result<PaymentElementLoader.State> = workContext.runCatching(::reportFailedLoad) {
         val configuration = integrationConfiguration.commonConfiguration
+        val apiConfiguration = apiConfigurationResolver.resolve(configuration.apiConfiguration)
+        eventReporter.onInit(apiConfiguration.publishableKey)
         // Validate configuration before loading
         initializationMode.validate()
         configuration.validate(
             initializationMode = initializationMode,
-            isLiveMode = paymentConfiguration.get().isLiveMode(),
+            isLiveMode = apiConfiguration.isLiveMode(),
             callbackIdentifier = paymentElementCallbackIdentifier,
             isTapToAddSupported = tapToAddConnectionStarter.isSupported,
         )
 
-        eventReporter.onLoadStarted(metadata.initializedViaCompose)
+        eventReporter.onLoadStarted(metadata.initializedViaCompose, apiConfiguration.publishableKey)
         tapToAddConnectionStarter.start(configuration)
 
         // Give immediately available results a chance to complete before later load work checks isCompleted.
@@ -326,24 +327,25 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             durationProvider.measureDuration(
                 DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported
             ) {
-                isGooglePaySupportedOnDevice()
+                isGooglePaySupportedOnDevice(apiConfiguration)
             }
         }
         val isGooglePaySupportedByConfiguration = async {
             durationProvider.measureDuration(
                 DurationProvider.Key.PaymentSheetLoadIsGooglePayReady
             ) {
-                configuration.isGooglePayReady()
+                configuration.isGooglePayReady(apiConfiguration)
             }
         }
 
-        val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration)
+        val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration, apiConfiguration)
 
         val savedPaymentMethodSelection = retrieveSavedPaymentMethodSelection(configuration)
         val elementsSession = loadSession(
             initializationMode = initializationMode,
             configuration = configuration,
             savedPaymentMethodSelection = savedPaymentMethodSelection,
+            apiConfiguration = apiConfiguration,
         )
 
         // Preemptively prepare Integrity asynchronously if needed, as warm up can take
@@ -352,7 +354,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             launch { integrityRequestManager.prepare() }
         }
 
-        fetchPaymentMethodMessaging(elementsSession)
+        fetchPaymentMethodMessaging(elementsSession, apiConfiguration)
 
         val isGooglePayReady = isGooglePayReady(
             configuration = configuration,
@@ -389,6 +391,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }
@@ -410,6 +413,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }
@@ -482,6 +486,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
     private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(
         configuration: CommonConfiguration,
+        apiConfiguration: ApiConfiguration.State,
     ): PrefetchedPaymentMethods? {
         val customer = configuration.customer ?: return null
         val accessType = customer.accessType
@@ -497,7 +502,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                         PaymentMethod.Type.SepaDebit,
                         PaymentMethod.Type.USBankAccount,
                     ), // These are the only payment method types we support as saved payment methods.
-                    silentlyFail = paymentConfiguration.get().isLiveMode(),
+                    silentlyFail = apiConfiguration.isLiveMode(),
+                    stripeAccountId = apiConfiguration.stripeAccountId,
                 )
             }
         }
@@ -507,6 +513,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         configuration: CommonConfiguration,
         savedPaymentMethodSelection: SavedSelection.PaymentMethod?,
+        apiConfiguration: ApiConfiguration.State,
     ): ElementsSession {
         return durationProvider.measureDuration(
             DurationProvider.Key.PaymentSheetLoadSessionLoad
@@ -518,6 +525,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     configuration = configuration,
                     savedPaymentMethodSelection = savedPaymentMethodSelection,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }
@@ -558,6 +566,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): PaymentMethodMetadata {
         val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
             stripeIntent = elementsSession.stripeIntent,
@@ -615,6 +624,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             analyticsMetadata = analyticsMetadata,
             isTapToAddAvailable = isTapToAddAvailable,
             paymentMethodLayout = paymentMethodLayout,
+            apiConfiguration = apiConfiguration,
         )
 
         return paymentMethodMetadata
@@ -696,35 +706,36 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     // Default filters are used here because this only determines the ready state,
     // not what's presented to Google Pay. This check runs async before we fetch the
     // elements session, so using merchant-defined filters would add latency.
-    private suspend fun isGooglePayReadyForEnvironment(environment: GooglePayEnvironment): Boolean {
+    private suspend fun isGooglePayReadyForEnvironment(
+        environment: GooglePayEnvironment,
+        apiConfiguration: ApiConfiguration.State
+    ): Boolean {
         return googlePayRepositoryFactory(
             environment = environment,
             cardFundingFilter = DefaultCardFundingFilter,
             cardBrandFilter = DefaultCardBrandFilter,
-            apiConfiguration = paymentConfiguration.get().let {
-                ApiConfiguration.State(
-                    publishableKey = it.publishableKey,
-                    stripeAccountId = it.stripeAccountId,
-                )
-            },
+            apiConfiguration = apiConfiguration
         ).isReady().first()
     }
 
-    private suspend fun CommonConfiguration.isGooglePayReady(): Boolean {
+    private suspend fun CommonConfiguration.isGooglePayReady(
+        apiConfiguration: ApiConfiguration.State
+    ): Boolean {
         return googlePay?.environment?.let { environment ->
             isGooglePayReadyForEnvironment(
-                when (environment) {
+                environment = when (environment) {
                     PaymentSheet.GooglePayConfiguration.Environment.Production ->
                         GooglePayEnvironment.Production
                     PaymentSheet.GooglePayConfiguration.Environment.Test ->
                         GooglePayEnvironment.Test
-                }
+                },
+                apiConfiguration = apiConfiguration
             )
         } ?: false
     }
 
-    private suspend fun isGooglePaySupportedOnDevice(): Boolean {
-        return isGooglePayReadyForEnvironment(GooglePayEnvironment.Production)
+    private suspend fun isGooglePaySupportedOnDevice(apiConfiguration: ApiConfiguration.State): Boolean {
+        return isGooglePayReadyForEnvironment(GooglePayEnvironment.Production, apiConfiguration)
     }
 
     @Suppress("CyclomaticComplexMethod")
@@ -861,7 +872,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val treatValidationErrorAsFailure = !state.stripeIntent.isConfirmed || isReloadingAfterProcessDeath
 
         if (state.validationError != null && treatValidationErrorAsFailure) {
-            eventReporter.onLoadFailed(state.validationError)
+            eventReporter.onLoadFailed(state.validationError, paymentMethodMetadata.apiConfiguration.publishableKey)
         } else {
             eventReporter.onLoadSucceeded(
                 paymentSelection = state.paymentSelection,
@@ -874,7 +885,10 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         error: Throwable,
     ) {
         logger.error("Failure loading PaymentSheetState", error)
-        eventReporter.onLoadFailed(error)
+        val publishableKey = runCatching {
+            apiConfigurationResolver.resolve(null).publishableKey
+        }.getOrDefault("")
+        eventReporter.onLoadFailed(error, publishableKey)
     }
 
     private fun logIfMissingExternalPaymentMethods(
@@ -918,13 +932,16 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         }
     }
 
-    private fun fetchPaymentMethodMessaging(elementsSession: ElementsSession) {
+    private fun fetchPaymentMethodMessaging(
+        elementsSession: ElementsSession,
+        apiConfiguration: ApiConfiguration.State,
+    ) {
         val variant = elementsSession.experimentsData?.experimentAssignments[
             ExperimentAssignment.OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS
         ] ?: return
 
         if (variant == "treatment") {
-            paymentMethodMessagePromotionsHelper.fetchPromotionsAsync(elementsSession.stripeIntent)
+            paymentMethodMessagePromotionsHelper.fetchPromotionsAsync(elementsSession.stripeIntent, apiConfiguration)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.networking.ApiRequest
@@ -22,12 +22,11 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 internal interface PaymentMethodMessagePromotionsHelper {
-    fun fetchPromotionsAsync(intent: StripeIntent)
+    fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State)
 
     fun getPromotionIfAvailableForCode(
         code: PaymentMethodCode,
@@ -50,14 +49,13 @@ internal interface PaymentMethodMessagePromotionsHelper {
 @Singleton
 internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     @IOContext private val workContext: CoroutineContext,
     private val eventReporter: EventReporter
 ) : PaymentMethodMessagePromotionsHelper {
     private var promotionsDeferred: Deferred<Result<PaymentMethodMessagePromotionList>>? = null
 
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         eventReporter.onPaymentMethodMessagePromotionsFetchBegin()
         promotionsDeferred?.cancel()
         promotionsDeferred = null
@@ -68,8 +66,8 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
                 country = intent.countryCode,
                 locale = Locale.getDefault().language,
                 requestOptions = ApiRequest.Options(
-                    apiKey = lazyPaymentConfig.get().publishableKey,
-                    stripeAccount = lazyPaymentConfig.get().stripeAccountId
+                    apiKey = apiConfiguration.publishableKey,
+                    stripeAccount = apiConfiguration.stripeAccountId
                 )
             )
         }
@@ -124,7 +122,7 @@ internal class PrefetchedPaymentMethodMessagePromotionsHelper(
     private val promotions: List<PaymentMethodMessagePromotion>?,
     private val eventReporter: EventReporter
 ) : PaymentMethodMessagePromotionsHelper {
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         // NO-OP
     }
 
@@ -164,7 +162,7 @@ internal class PrefetchedPaymentMethodMessagePromotionsHelper(
 }
 
 internal class NoOpPromotionsHelper @Inject constructor() : PaymentMethodMessagePromotionsHelper {
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         // NO-OP
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
@@ -19,6 +19,7 @@ internal interface RetrieveCustomerEmail {
         configuration: CommonConfiguration,
         customerMetadata: CustomerMetadata?,
         customerEmail: String?,
+        stripeAccountId: String?
     ): String?
 }
 
@@ -31,6 +32,7 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
         configuration: CommonConfiguration,
         customerMetadata: CustomerMetadata?,
         customerEmail: String?,
+        stripeAccountId: String?
     ): String? {
         return durationProvider.measureDuration(
             DurationProvider.Key.PaymentSheetLoadRetrieveCustomer,
@@ -44,6 +46,7 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
                     defaultEmail ?: retrieveEmailFromApi(
                         customerId = customerMetadata.id,
                         ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
+                        stripeAccountId = stripeAccountId
                     )
                 }
                 is CustomerMetadata.CheckoutSession,
@@ -55,10 +58,12 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
     private suspend fun retrieveEmailFromApi(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?
     ): String? {
         return customerRepository.retrieveCustomer(
             customerId = customerId,
             ephemeralKeySecret = ephemeralKeySecret,
+            stripeAccountId = stripeAccountId,
         )?.email
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutController.Address
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networktesting.NetworkRule
@@ -103,10 +104,14 @@ internal class CheckoutSessionTaxRegionUpdaterTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         val updater = CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
@@ -104,7 +104,7 @@ internal class CheckoutSessionTaxRegionUpdaterTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKeyProvider = { "pk_test_123" },
+                publishableKey = "pk_test_123",
             ),
             apiConfigurationProvider = {
                 ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -191,7 +191,7 @@ class CustomerAdapterTest {
     fun `retrievePaymentMethods filters with paymentMethodTypes`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
-        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any()))
+        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), any()))
             .thenReturn(Result.success(emptyList()))
 
         val adapter = createAdapter(
@@ -208,6 +208,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
+            stripeAccountId = any()
         )
     }
 
@@ -259,6 +260,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
+            stripeAccountId = any()
         )
     }
 
@@ -777,7 +779,7 @@ class CustomerAdapterTest {
             timeProvider = timeProvider,
             customerRepository = customerRepository,
             prefsRepositoryFactory = prefsRepositoryFactory,
-            workContext = testDispatcher
+            workContext = testDispatcher,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -30,6 +30,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -191,7 +192,7 @@ class CustomerAdapterTest {
     fun `retrievePaymentMethods filters with paymentMethodTypes`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
-        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), any()))
+        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), isNull()))
             .thenReturn(Result.success(emptyList()))
 
         val adapter = createAdapter(
@@ -208,7 +209,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
-            stripeAccountId = any()
+            stripeAccountId = isNull()
         )
     }
 
@@ -260,7 +261,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
-            stripeAccountId = any()
+            stripeAccountId = isNull()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -33,6 +34,7 @@ class CustomerSheetTest {
     @Before
     fun setup() {
         val appContext = ApplicationProvider.getApplicationContext<Application>()
+        PaymentConfiguration.init(appContext, "pk_test_123")
 
         val activityInfo = ActivityInfo().apply {
             name = TestActivity::class.java.name

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet.data
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetFixtures
@@ -721,6 +722,9 @@ class CustomerAdapterDataSourceTest {
             customerAdapter = adapter,
             elementsSessionRepository = elementsSessionRepository,
             errorReporter = errorReporter,
+            apiConfigurationProvider = {
+                ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+            },
             workContext = coroutineContext,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -267,6 +268,9 @@ class CustomerSessionPaymentMethodDataSourceTest {
             customerRepository = customerRepository,
             errorReporter = errorReporter,
             workContext = coroutineContext,
+            apiConfigProvider = {
+                ApiConfiguration.State("pk_123", null)
+            }
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethodFixtures
@@ -241,7 +242,10 @@ class CustomerSessionSavedSelectionDataSourceTest {
             prefsRepositoryFactory = {
                 prefsRepository
             },
-            workContext = coroutineContext
+            workContext = coroutineContext,
+            apiConfigProvider = {
+                ApiConfiguration.State("pk_123", null)
+            }
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.utils.FakeCustomerSessionProvider
 import com.stripe.android.isInstanceOf
@@ -511,6 +512,9 @@ class DefaultCustomerSessionElementsSessionManagerTest {
                 onIntentConfiguration = onIntentConfiguration,
                 onProvidesCustomerSessionClientSecret = onCustomerSessionClientSecret,
             ),
+            apiConfigurationProvider = {
+                ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+            },
             timeProvider = timeProvider,
             workContext = coroutineContext,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -42,6 +42,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.testing.CoroutineTestRule
@@ -65,6 +66,7 @@ import org.junit.Test
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -454,6 +456,9 @@ internal class DefaultCustomerSheetLoaderTest {
                 workContext = coroutineContext,
                 customerAdapter = FakeCustomerAdapter(),
                 errorReporter = FakeErrorReporter(),
+                apiConfigurationProvider = {
+                    ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+                },
             )
         )
 
@@ -868,11 +873,7 @@ internal class DefaultCustomerSheetLoaderTest {
             eventReporter = eventReporter,
             errorReporter = errorReporter,
             workContext = workContext,
-            paymentConfiguration = {
-                PaymentConfiguration(
-                    publishableKey = "pk_test_123",
-                )
-            },
+            apiConfigurationResolver = ApiConfigurationResolver(Provider { PaymentConfiguration("pk_test_123") })
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.FakeCustomerAdapter
@@ -18,6 +19,7 @@ import com.stripe.android.isInstanceOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
+import org.junit.Before
 import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
@@ -25,6 +27,11 @@ import kotlin.time.Duration.Companion.seconds
 @RunWith(AndroidJUnit4::class)
 class CustomerSheetHacksTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(application, "pk_test_123")
+    }
 
     @After
     fun teardown() {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -83,6 +83,10 @@ internal interface CustomerSheetTestHelper {
             publishableKey = "pk_test_123",
             stripeAccountId = null,
         ),
+        apiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
+            publishableKey = paymentConfiguration.publishableKey,
+            stripeAccountId = paymentConfiguration.stripeAccountId,
+        ),
         configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(
             merchantDisplayName = "Example",
             googlePayEnabled = isGooglePayAvailable,
@@ -128,7 +132,10 @@ internal interface CustomerSheetTestHelper {
             configuration = configuration,
             integrationType = integrationType,
             statusBarColor = null,
-            paymentConfiguration = PaymentConfiguration(if (isLiveMode) "pk_live" else "pk_test"),
+            paymentConfiguration = PaymentConfiguration(
+                publishableKey = if (isLiveMode) "pk_live" else apiConfiguration.publishableKey,
+                stripeAccountId = apiConfiguration.stripeAccountId,
+            ),
             logger = Logger.noop(),
             productUsage = emptySet(),
             confirmationHandlerFactory = confirmationHandler?.let { ConfirmationHandler.Factory { _ -> it } }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link
 
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
@@ -306,6 +307,7 @@ internal object TestFactory {
         ),
         cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
         linkBrand = LinkBrand.Link,
+        apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
     )
 
     val LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING = LINK_CONFIGURATION.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.ui.signup
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -118,6 +119,7 @@ class SignUpScreenStateTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.LinkBrand
@@ -83,6 +84,10 @@ internal object PaymentMethodMetadataFactory {
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
         shouldUseAutocompleteProxyEndpoints: Boolean = false,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        apiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
+            publishableKey = "pk_test_123",
+            stripeAccountId = null,
+        ),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -156,6 +161,7 @@ internal object PaymentMethodMetadataFactory {
             cardArts = cardArts,
             shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
             paymentMethodLayout = paymentMethodLayout,
+            apiConfiguration = apiConfiguration,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkConfiguration
@@ -1162,6 +1163,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1236,6 +1241,10 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1298,6 +1307,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         // When flag is false, should use default funding types, not the configured ones
@@ -1337,6 +1350,10 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = true,
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = DEFAULT_CUSTOMER_INTEGRATION_METADATA,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1396,6 +1413,10 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -2116,6 +2137,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata.availableWallets)
@@ -2186,6 +2211,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = true,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata.isTapToAddSupported).isTrue()
@@ -2211,6 +2240,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = true,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata.isTapToAddSupported).isTrue()
@@ -2240,6 +2273,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata.isTapToAddSupported).isFalse()
@@ -2381,6 +2418,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
     }
 
@@ -2408,6 +2449,10 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = false,
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = DEFAULT_CUSTOMER_INTEGRATION_METADATA,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
     }
 
@@ -2455,6 +2500,7 @@ internal class PaymentMethodMetadataTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -185,6 +186,7 @@ class LinkFormElementTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", null),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
@@ -770,6 +771,7 @@ class ConfirmationHandlerOptionKtxTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -159,10 +159,14 @@ internal suspend fun createIntentConfirmationInterceptor(
                     analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
                     paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                         context = ApplicationProvider.getApplicationContext(),
-                        publishableKey = "pk",
+                        publishableKeyProvider = { "pk" },
                     ),
-                    publishableKeyProvider = { "pk" },
-                    stripeAccountIdProvider = { null },
+                    apiConfigurationProvider = {
+                        ApiConfiguration.State(
+                            publishableKey = "pk",
+                            stripeAccountId = null,
+                        )
+                    },
                 )
                 return CheckoutSessionConfirmationInterceptor(
                     integrationMetadata = integrationMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -159,7 +159,7 @@ internal suspend fun createIntentConfirmationInterceptor(
                     analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
                     paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                         context = ApplicationProvider.getApplicationContext(),
-                        publishableKeyProvider = { "pk" },
+                        publishableKey = "pk",
                     ),
                     apiConfigurationProvider = {
                         ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.test.core.app.ActivityScenario
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -217,6 +218,16 @@ internal interface ExtendedPaymentElementConfirmationTestModule {
             publishableKey = "pk_123",
             stripeAccountId = null,
         )
+
+        @Provides
+        fun providesApiConfigurationProvider(
+            paymentConfiguration: PaymentConfiguration,
+        ): () -> ApiConfiguration.State = {
+            ApiConfiguration.State(
+                publishableKey = paymentConfiguration.publishableKey,
+                stripeAccountId = paymentConfiguration.stripeAccountId,
+            )
+        }
 
         @Provides
         @Named(PUBLISHABLE_KEY)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.test.core.app.ActivityScenario
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -212,6 +213,16 @@ internal interface PaymentElementConfirmationTestModule {
             publishableKey = "pk_123",
             stripeAccountId = null,
         )
+
+        @Provides
+        fun providesApiConfigurationProvider(
+            paymentConfiguration: PaymentConfiguration,
+        ): () -> ApiConfiguration.State = {
+            ApiConfiguration.State(
+                publishableKey = paymentConfiguration.publishableKey,
+                stripeAccountId = paymentConfiguration.stripeAccountId,
+            )
+        }
 
         @Provides
         @Named(PUBLISHABLE_KEY)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
@@ -454,10 +455,14 @@ class CheckoutSessionConfirmationInterceptorTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         val interceptor = CheckoutSessionConfirmationInterceptor(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -455,7 +455,7 @@ class CheckoutSessionConfirmationInterceptorTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKeyProvider = { "pk_test_123" },
+                publishableKey = "pk_test_123",
             ),
             apiConfigurationProvider = {
                 ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
@@ -818,6 +819,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                 cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
                 linkBrand = LinkBrand.Link,
+                apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             ),
             userInput = userInput,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -198,6 +199,16 @@ internal interface LpmNetworkTestModule {
             return PaymentConfiguration(
                 publishableKey = publishableKeyProvider(),
                 stripeAccountId = stripeAccountIdProvider(),
+            )
+        }
+
+        @Provides
+        fun providesApiConfigurationProvider(
+            paymentConfiguration: PaymentConfiguration,
+        ): () -> ApiConfiguration.State = {
+            ApiConfiguration.State(
+                publishableKey = paymentConfiguration.publishableKey,
+                stripeAccountId = paymentConfiguration.stripeAccountId,
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -143,8 +144,12 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
                 context = ApplicationProvider.getApplicationContext(),
                 publishableKey = "pk_test_123",
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         return CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -166,8 +167,12 @@ internal class SheetTaxRegionUpdaterTest {
                 context = ApplicationProvider.getApplicationContext(),
                 publishableKey = "pk_test_123",
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         return CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -205,10 +205,10 @@ internal class PaymentSheetViewModelTest {
     fun `init should fire analytics event`() {
         val beforeSessionId = AnalyticsRequestFactory.sessionId
         createViewModel()
-        verify(eventReporter).onInit()
+        // verify(eventReporter).onInit()
 
         // Creating the view model should regenerate the analytics sessionId.
-        assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
+        // assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
     }
 
     @Test
@@ -2062,7 +2062,7 @@ internal class PaymentSheetViewModelTest {
     fun `Sends correct analytics event when using normal intent`() = runTest {
         createViewModel()
 
-        verify(eventReporter).onInit()
+        // verify(eventReporter).onInit()
     }
 
     @Test
@@ -2081,7 +2081,7 @@ internal class PaymentSheetViewModelTest {
 
         createViewModelForDeferredIntent()
 
-        verify(eventReporter).onInit()
+        // verify(eventReporter).onInit()
     }
 
     @Test
@@ -2100,7 +2100,7 @@ internal class PaymentSheetViewModelTest {
 
         createViewModelForDeferredIntent()
 
-        verify(eventReporter).onInit()
+        // verify(eventReporter).onInit()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.common.taptoadd.TapToAddNextStep
 import com.stripe.android.core.Logger
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
@@ -60,8 +59,6 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
@@ -78,7 +75,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.ARGS_DEFERRED_INTENT
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.BILLING_DETAILS_FORM_DETAILS
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
-import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
@@ -199,16 +195,6 @@ internal class PaymentSheetViewModelTest {
     @AfterTest
     fun cleanup() {
         Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `init should fire analytics event`() {
-        val beforeSessionId = AnalyticsRequestFactory.sessionId
-        createViewModel()
-        // verify(eventReporter).onInit()
-
-        // Creating the view model should regenerate the analytics sessionId.
-        // assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
     }
 
     @Test
@@ -2056,51 +2042,6 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(awaitItem()).isEqualTo(PaymentSheetViewState.Reset(UserErrorMessage(error.resolvableString)))
         }
-    }
-
-    @Test
-    fun `Sends correct analytics event when using normal intent`() = runTest {
-        createViewModel()
-
-        // verify(eventReporter).onInit()
-    }
-
-    @Test
-    fun `Sends correct analytics event when using deferred intent with client-side confirmation`() = runTest {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
-            .createIntentCallback { _, _ ->
-                error("Should not be called!")
-            }
-            .confirmCustomPaymentMethodCallback { _, _ ->
-                error("Should not be called!")
-            }
-            .externalPaymentMethodConfirmHandler { _, _ ->
-                error("Should not be called!")
-            }
-            .build()
-
-        createViewModelForDeferredIntent()
-
-        // verify(eventReporter).onInit()
-    }
-
-    @Test
-    fun `Sends correct analytics event when using deferred intent with server-side confirmation`() = runTest {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
-            .createIntentCallback { _, _ ->
-                error("Should not be called!")
-            }
-            .confirmCustomPaymentMethodCallback { _, _ ->
-                error("Should not be called!")
-            }
-            .externalPaymentMethodConfirmHandler { _, _ ->
-                error("Should not be called!")
-            }
-            .build()
-
-        createViewModelForDeferredIntent()
-
-        // verify(eventReporter).onInit()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -59,7 +59,7 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onInit fires event`() = runScenario {
-        eventReporter.onInit()
+        eventReporter.onInit("pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_init")
@@ -103,11 +103,12 @@ class DefaultEventReporterTest {
                 reset = true,
             )
         )
-        eventReporter.onLoadStarted(initializedViaCompose = true)
+        eventReporter.onLoadStarted(initializedViaCompose = true, publishableKey = "pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_load_started")
         assertThat(request.params).containsEntry("compose", true)
+        assertThat(request.params).containsEntry("publishable_key", "pk_test_123")
     }
 
     @Test
@@ -189,12 +190,13 @@ class DefaultEventReporterTest {
             )
         )
         val error = RuntimeException("Test error")
-        eventReporter.onLoadFailed(error = error)
+        eventReporter.onLoadFailed(error = error, publishableKey = "pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_load_failed")
         assertThat(request.params).containsEntry("duration", 2.0f)
         assertThat(request.params).containsEntry("error_message", "java.lang.RuntimeException")
+        assertThat(request.params).containsEntry("publishable_key", "pk_test_123")
     }
 
     @Test
@@ -267,7 +269,7 @@ class DefaultEventReporterTest {
         durationProvider.completedDurations[DurationProvider.Key.PaymentSheetLoadSessionLoad] = 200.milliseconds
 
         val error = RuntimeException("Test error")
-        eventReporter.onLoadFailed(error = error)
+        eventReporter.onLoadFailed(error = error, publishableKey = "pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_load_failed")
@@ -288,7 +290,7 @@ class DefaultEventReporterTest {
             )
         )
         val error = RuntimeException("Test error")
-        eventReporter.onLoadFailed(error = error)
+        eventReporter.onLoadFailed(error = error, publishableKey = "pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_load_failed")
@@ -1520,7 +1522,7 @@ class DefaultEventReporterTest {
         val analyticsRequestV2Executor = FakeAnalyticsRequestV2Executor()
         val paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
             context = context,
-            publishableKey = "pk_test_123",
+            publishableKeyProvider = { "pk_test_123" },
             defaultProductUsageTokens = setOf(""),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1522,7 +1522,7 @@ class DefaultEventReporterTest {
         val analyticsRequestV2Executor = FakeAnalyticsRequestV2Executor()
         val paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
             context = context,
-            publishableKeyProvider = { "pk_test_123" },
+            publishableKey = "pk_test_123",
             defaultProductUsageTokens = setOf(""),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -140,9 +140,6 @@ internal class FakeEventReporter : EventReporter {
         _pmmPromotionsDisplayed.ensureAllEventsConsumed()
     }
 
-    override fun onInit() {
-    }
-
     override fun onDismiss() {
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLoadingEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLoadingEventReporter.kt
@@ -6,6 +6,9 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class FakeLoadingEventReporter : LoadingEventReporter {
+    private val _initTurbine = Turbine<InitCall>()
+    val initTurbine: ReceiveTurbine<InitCall> = _initTurbine
+
     private val _loadStartedTurbine = Turbine<LoadStartedCall>()
     val loadStartedTurbine: ReceiveTurbine<LoadStartedCall> = _loadStartedTurbine
 
@@ -23,6 +26,7 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
     val lpmSpecFailureTurbine: ReceiveTurbine<LpmSpecFailureCall> = _lpmSpecFailureTurbine
 
     fun validate() {
+        _initTurbine.ensureAllEventsConsumed()
         _loadStartedTurbine.ensureAllEventsConsumed()
         _loadSucceededTurbine.ensureAllEventsConsumed()
         _loadFailedTurbine.ensureAllEventsConsumed()
@@ -30,7 +34,11 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
         _lpmSpecFailureTurbine.ensureAllEventsConsumed()
     }
 
-    override fun onLoadStarted(initializedViaCompose: Boolean) {
+    override fun onInit(publishableKey: String) {
+        _initTurbine.add(InitCall(publishableKey))
+    }
+
+    override fun onLoadStarted(initializedViaCompose: Boolean, publishableKey: String) {
         _loadStartedTurbine.add(
             LoadStartedCall(
                 initializedViaCompose = initializedViaCompose,
@@ -50,7 +58,7 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
         )
     }
 
-    override fun onLoadFailed(error: Throwable) {
+    override fun onLoadFailed(error: Throwable, publishableKey: String) {
         _loadFailedTurbine.add(
             LoadFailedCall(
                 error = error,
@@ -73,6 +81,10 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
             )
         )
     }
+
+    class InitCall(
+        val publishableKey: String,
+    )
 
     class LoadStartedCall(
         val initializedViaCompose: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -37,10 +38,14 @@ class CheckoutSessionRepositoryTest {
         analyticsRequestExecutor = analyticsRequestExecutor,
         paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
             context = ApplicationProvider.getApplicationContext(),
-            publishableKey = "pk_test_123",
+            publishableKeyProvider = { "pk_test_123" },
         ),
-        publishableKeyProvider = { "pk_test_123" },
-        stripeAccountIdProvider = { null },
+        apiConfigurationProvider = {
+            ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            )
+        },
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -38,7 +38,7 @@ class CheckoutSessionRepositoryTest {
         analyticsRequestExecutor = analyticsRequestExecutor,
         paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
             context = ApplicationProvider.getApplicationContext(),
-            publishableKeyProvider = { "pk_test_123" },
+            publishableKey = "pk_test_123",
         ),
         apiConfigurationProvider = {
             ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.ListPaymentMethodsParams
@@ -40,7 +38,6 @@ internal class CustomerRepositoryTest {
 
     private val repository = CustomerApiRepository(
         stripeRepository,
-        { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, "acct_123") },
         Logger.getInstance(false),
         workContext = testDispatcher,
         errorReporter = errorReporter
@@ -63,6 +60,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
+                stripeAccountId = null
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -92,6 +90,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.PayPal),
                 true,
+                stripeAccountId = null
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -165,6 +164,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
+                stripeAccountId = null
             ).getOrThrow()
 
             assertThat(result).hasSize(1)
@@ -222,6 +222,7 @@ internal class CustomerRepositoryTest {
             ephemeralKeySecret = "ephemeral_key",
             listOf(PaymentMethod.Type.Card),
             true,
+            stripeAccountId = null
         ).getOrThrow()
 
         assertThat(result).hasSize(2)
@@ -241,6 +242,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = true,
+                stripeAccountId = null
             )
 
             assertThat(result.getOrNull()).isEmpty()
@@ -260,6 +262,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = false,
+                stripeAccountId = null
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -274,7 +277,6 @@ internal class CustomerRepositoryTest {
             val errorReporter = FakeErrorReporter()
             val repository = CustomerApiRepository(
                 failsOnceStripeRepository(),
-                { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                 Logger.getInstance(false),
                 workContext = testDispatcher,
                 errorReporter = errorReporter
@@ -286,6 +288,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = true,
+                stripeAccountId = null
             )
 
             assertThat(result.getOrNull()).containsExactly(
@@ -307,7 +310,6 @@ internal class CustomerRepositoryTest {
             val errorReporter = FakeErrorReporter()
             val repository = CustomerApiRepository(
                 failsOnceStripeRepository(),
-                { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                 Logger.getInstance(false),
                 workContext = testDispatcher,
                 errorReporter = errorReporter
@@ -319,6 +321,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = false,
+                stripeAccountId = null
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -345,6 +348,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -361,6 +365,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result.isFailure).isTrue()
@@ -383,6 +388,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 customerSessionClientSecret = "cuss_123",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -408,6 +414,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethodToRemove.id,
+                stripeAccountId = null
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(paymentMethodsToRemove)
@@ -434,6 +441,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = usBankAccount.id,
+                stripeAccountId = null
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(listOf(usBankAccount))
@@ -458,6 +466,7 @@ internal class CustomerRepositoryTest {
                 customerId = FAKE_CUSTOMER_ID,
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = paymentMethodToRemove.id,
+                stripeAccountId = null
             )
 
             val duplicates = paymentMethods.filter { paymentMethod ->
@@ -488,6 +497,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethods.first().id,
+                stripeAccountId = null
             )
 
             assertThat(result.isFailure).isTrue()
@@ -516,6 +526,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result).isEqualTo(
@@ -533,6 +544,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result).isEqualTo(error)
@@ -548,7 +560,8 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                params = PaymentMethodUpdateParams.createCard()
+                params = PaymentMethodUpdateParams.createCard(),
+                stripeAccountId = null
             )
 
             assertThat(result).isEqualTo(success)
@@ -564,7 +577,8 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                params = PaymentMethodUpdateParams.createCard()
+                params = PaymentMethodUpdateParams.createCard(),
+                stripeAccountId = null
             )
 
             assertThat(result).isEqualTo(error)
@@ -577,7 +591,6 @@ internal class CustomerRepositoryTest {
             workContext = coroutineContext,
             errorReporter = errorReporter,
             stripeRepository = stripeRepository,
-            lazyPaymentConfig = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, "acct_123") },
             logger = Logger.getInstance(false),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.repositories
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -326,14 +327,19 @@ class DefaultSavedPaymentMethodRepositoryTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
         val repository = DefaultSavedPaymentMethodRepository(
             customerRepository = customerRepository,
             checkoutSessionRepository = checkoutSessionRepository,
+            apiConfigProvider = { ApiConfiguration.State("pk_123", null) }
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -327,7 +327,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKeyProvider = { "pk_test_123" },
+                publishableKey = "pk_test_123",
             ),
             apiConfigurationProvider = {
                 ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -3,10 +3,9 @@ package com.stripe.android.paymentsheet.repositories
 import androidx.core.os.LocaleListCompat
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
@@ -58,6 +57,7 @@ internal class ElementsSessionRepositoryTest {
                 customPaymentMethods = emptyList(),
                 savedPaymentMethodSelectionId = null,
                 countryOverride = null,
+                apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             ).getOrThrow()
         }
 
@@ -91,6 +91,7 @@ internal class ElementsSessionRepositoryTest {
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
                     countryOverride = null,
+                    apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
                 ).getOrThrow()
             }
 
@@ -119,6 +120,7 @@ internal class ElementsSessionRepositoryTest {
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
                     countryOverride = null,
+                    apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
                 ).getOrThrow()
             }
 
@@ -137,7 +139,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -149,6 +150,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -172,7 +174,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -189,6 +190,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -210,6 +212,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(any())
@@ -231,6 +234,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(any())
@@ -248,7 +252,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -266,6 +269,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -282,7 +286,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -299,6 +302,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -317,7 +321,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -334,6 +337,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -352,7 +356,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -366,6 +369,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -384,7 +388,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -414,6 +417,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -433,7 +437,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -455,6 +458,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -476,7 +480,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -506,6 +509,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -546,6 +550,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -593,6 +598,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -629,6 +635,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -657,6 +664,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             linkDisallowedFundingSourceCreation = setOf("somethingThatsNotAllowed"),
         )
 
@@ -681,6 +689,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -703,6 +712,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -730,6 +740,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -763,6 +774,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -793,6 +805,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -816,6 +829,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -839,6 +853,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -862,6 +877,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -890,6 +906,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -914,6 +931,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -928,7 +946,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "client_secret",
             ),
@@ -937,6 +955,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "uk_12345", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -954,7 +973,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.DEFERRED_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
                 clientSecret = "client_secret",
             ),
@@ -963,6 +982,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "uk_12345", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -980,7 +1000,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.DEFERRED_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
@@ -995,6 +1015,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "uk_12345", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -1005,13 +1026,10 @@ internal class ElementsSessionRepositoryTest {
         assertThat(params["mobile_app_id"]).isEqualTo(APP_ID)
     }
 
-    private fun createRepository(
-        publishableKey: String = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
-    ) = RealElementsSessionRepository(
+    private fun createRepository() = RealElementsSessionRepository(
         ApplicationProvider.getApplicationContext(),
         stripeNetworkClient,
         stripeRepository,
-        { PaymentConfiguration(publishableKey) },
         testDispatcher,
         clientParams = TEST_CLIENT_PARAMS,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.ui.inline.LinkSignupMode
@@ -946,6 +947,7 @@ class DefaultAnalyticsMetadataFactoryTest {
                 clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                 cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
                 linkBrand = LinkBrand.Link,
+                apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             ),
             loginState = LinkState.LoginState.LoggedOut,
             signupModeResult = signupModeResult,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.model.AccountStatus
@@ -44,6 +45,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            apiConfiguration = DEFAULT_API_CONFIGURATION,
         )
 
         assertThat(retrieveCustomerEmail.invokedWith?.customerEmail).isEqualTo(customerWithEmail.email)
@@ -102,6 +104,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = initializationMode,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            apiConfiguration = DEFAULT_API_CONFIGURATION,
         )
 
         assertThat(result).isInstanceOf<LinkDisabledState>()
@@ -124,6 +127,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            apiConfiguration = DEFAULT_API_CONFIGURATION,
         )
 
         assertThat(linkStateResult).isInstanceOf<LinkState>()
@@ -161,6 +165,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            apiConfiguration = DEFAULT_API_CONFIGURATION,
         )
 
         assertThat(cardFundingFilterFactory.invokedWith).isEqualTo(expectedFundingTypes)
@@ -242,6 +247,7 @@ internal class DefaultCreateLinkStateTest {
             configuration: CommonConfiguration,
             customerMetadata: CustomerMetadata?,
             customerEmail: String?,
+            stripeAccountId: String?,
         ): String? {
             invokedWith = Invocation(
                 configuration = configuration,
@@ -268,6 +274,11 @@ internal class DefaultCreateLinkStateTest {
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
             checkoutSessionId = null,
+        )
+
+        val DEFAULT_API_CONFIGURATION = ApiConfiguration.State(
+            publishableKey = "pk_test_123",
+            stripeAccountId = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
@@ -726,7 +725,6 @@ internal class DefaultPaymentElementLoaderTest {
                 assertThat(startCalls.awaitItem()).isEqualTo(
                     FakeTapToAddConnectionStarter.StartCall(
                         config = config.asCommonConfiguration(),
-                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                     )
                 )
 
@@ -777,7 +775,6 @@ internal class DefaultPaymentElementLoaderTest {
                 assertThat(startCalls.awaitItem()).isEqualTo(
                     FakeTapToAddConnectionStarter.StartCall(
                         config = config.asCommonConfiguration(),
-                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                     )
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
@@ -78,6 +79,7 @@ import com.stripe.android.paymentsheet.analytics.FakeLoadingEventReporter
 import com.stripe.android.paymentsheet.analytics.FakeLogFcLiteExperiment
 import com.stripe.android.paymentsheet.analytics.FakeLogLinkHoldbackExperiment
 import com.stripe.android.paymentsheet.analytics.FakePaymentMethodMessagePromotionsExperimentHandler
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.toSavedSelection
@@ -182,6 +184,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -203,6 +206,7 @@ internal class DefaultPaymentElementLoaderTest {
             "When a Configuration is passed to PaymentSheet, the Merchant display name cannot be an empty string."
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -223,6 +227,7 @@ internal class DefaultPaymentElementLoaderTest {
             "The PaymentIntent client_secret cannot be an empty string."
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -249,6 +254,7 @@ internal class DefaultPaymentElementLoaderTest {
             "When a CustomerConfiguration is passed to PaymentSheet, the Customer ID cannot be an empty string."
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -276,6 +282,7 @@ internal class DefaultPaymentElementLoaderTest {
             "Conflicting ephemeralKeySecrets between CustomerConfiguration and CustomerConfiguration.customerAccessType"
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -304,6 +311,7 @@ internal class DefaultPaymentElementLoaderTest {
                 "Customer information is provided by the checkout session."
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -324,6 +332,7 @@ internal class DefaultPaymentElementLoaderTest {
         ).getOrThrow()
         assertThat(result.paymentMethodMetadata.customerMetadata).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -354,6 +363,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -396,6 +406,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -471,6 +482,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -500,6 +512,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -527,6 +540,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -554,7 +568,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -581,7 +596,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -608,7 +624,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -642,7 +659,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -673,6 +691,7 @@ internal class DefaultPaymentElementLoaderTest {
 
                 assertThat(result.paymentMethodMetadata.isTapToAddSupported).isFalse()
 
+                assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
             }
@@ -705,11 +724,15 @@ internal class DefaultPaymentElementLoaderTest {
                 ).getOrThrow()
 
                 assertThat(startCalls.awaitItem()).isEqualTo(
-                    FakeTapToAddConnectionStarter.StartCall(config = config.asCommonConfiguration())
+                    FakeTapToAddConnectionStarter.StartCall(
+                        config = config.asCommonConfiguration(),
+                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    )
                 )
 
                 assertThat(result.paymentMethodMetadata.isTapToAddSupported).isTrue()
 
+                assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
             }
@@ -752,11 +775,15 @@ internal class DefaultPaymentElementLoaderTest {
                 ).getOrThrow()
 
                 assertThat(startCalls.awaitItem()).isEqualTo(
-                    FakeTapToAddConnectionStarter.StartCall(config = config.asCommonConfiguration())
+                    FakeTapToAddConnectionStarter.StartCall(
+                        config = config.asCommonConfiguration(),
+                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    )
                 )
 
                 assertThat(result.paymentMethodMetadata.isTapToAddSupported).isFalse()
 
+                assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
             }
@@ -792,7 +819,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -826,7 +854,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -857,7 +886,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(userFacingLogger.getLoggedMessages())
                 .containsExactlyElementsIn(listOf("GooglePayConfiguration is not set."))
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -885,7 +915,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -921,7 +952,8 @@ internal class DefaultPaymentElementLoaderTest {
                 PaymentMethod.Type.USBankAccount
             )
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -951,7 +983,8 @@ internal class DefaultPaymentElementLoaderTest {
             val request = customerRepository.getPaymentMethodsRequests.awaitItem()
             assertThat(request.types).doesNotContain(PaymentMethod.Type.AuBecsDebit)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -981,7 +1014,8 @@ internal class DefaultPaymentElementLoaderTest {
             val actualException = loadResult.exceptionOrNull()
             assertThat(actualException?.cause).isEqualTo(expectedException)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
         }
 
@@ -1008,7 +1042,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(result.customer?.paymentMethods)
                 .containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -1040,7 +1075,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(result.customer?.paymentMethods)
                 .containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD, cardWithAmexWallet)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -1054,6 +1090,7 @@ internal class DefaultPaymentElementLoaderTest {
                     ephemeralKeySecret: String,
                     types: List<PaymentMethod.Type>,
                     silentlyFail: Boolean,
+                    stripeAccountId: String?
                 ): Result<List<PaymentMethod>> {
                     requestPaymentMethodTypes = types
                     return Result.success(
@@ -1091,6 +1128,7 @@ internal class DefaultPaymentElementLoaderTest {
                 PaymentMethod.Type.USBankAccount,
             )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1117,6 +1155,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1139,6 +1178,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.validationError).isEqualTo(PaymentSheetLoadingException.InvalidConfirmationMethod(Manual))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
@@ -1165,6 +1205,7 @@ internal class DefaultPaymentElementLoaderTest {
         val expectedPaymentMethod = requireNotNull(PAYMENT_METHODS.first())
         assertThat(result.paymentSelection).isEqualTo(PaymentSelection.Saved(expectedPaymentMethod))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1183,6 +1224,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedIn)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1201,6 +1243,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.NeedsVerification)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1219,6 +1262,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.NeedsVerification)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1237,6 +1281,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedOut)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1269,6 +1314,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1293,6 +1339,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.shippingDetails).isNotNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1329,6 +1376,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.passthroughModeEnabled).isTrue()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1385,6 +1433,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.flags).containsExactlyEntriesIn(expectedFlags)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1411,6 +1460,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(cardBrandChoice?.eligible).isTrue()
         assertThat(cardBrandChoice?.preferredNetworks).isEqualTo(listOf("cartes_bancaires"))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1437,6 +1487,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(cardBrandChoice?.eligible).isFalse()
         assertThat(cardBrandChoice?.preferredNetworks).isEqualTo(listOf("cartes_bancaires"))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1474,6 +1525,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1510,6 +1562,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1533,6 +1586,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1553,6 +1607,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1573,6 +1628,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1593,6 +1649,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1616,6 +1673,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1636,6 +1694,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1664,6 +1723,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.customerInfo?.phone)
             .isEqualTo(shippingDetails.phoneNumber)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1702,6 +1762,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.customerInfo?.email)
             .isEqualTo("email@stripe.com")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1806,6 +1867,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
@@ -2004,6 +2066,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         val loadSucceededCall = eventReporter.loadSucceededTurbine.awaitItem()
         assertThat(loadSucceededCall.paymentSelection)
@@ -2060,6 +2123,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isTrue()
         val loadSucceededCall = eventReporter.loadSucceededTurbine.awaitItem()
         assertThat(loadSucceededCall.paymentSelection).isNull()
@@ -2090,6 +2154,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result).isInstanceOf<IllegalStateException>()
         assertThat(result?.message).isEqualTo("No callback for deferred intent.")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isTrue()
         val loadFailedCall = eventReporter.loadFailedTurbine.awaitItem()
         assertThat(loadFailedCall.error.message).isEqualTo("No callback for deferred intent.")
@@ -2108,6 +2173,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         assertThat(eventReporter.loadFailedTurbine.awaitItem().error).isEqualTo(error)
     }
@@ -2132,6 +2198,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         assertThat(eventReporter.loadFailedTurbine.awaitItem().error).isEqualTo(error)
     }
@@ -2164,6 +2231,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         assertThat(eventReporter.loadFailedTurbine.awaitItem().error)
             .isEqualTo(PaymentSheetLoadingException.InvalidConfirmationMethod(Manual))
@@ -2186,6 +2254,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         assertThat(eventReporter.elementsSessionLoadFailedTurbine.awaitItem().error).isEqualTo(error)
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -2213,6 +2282,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.cbcEligibility)
             .isEqualTo(CardBrandChoiceEligibility.Eligible(listOf()))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2239,6 +2309,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2278,6 +2349,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2300,6 +2372,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2330,6 +2403,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2355,6 +2429,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2380,6 +2455,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2411,6 +2487,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2449,7 +2526,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -2480,6 +2558,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2507,6 +2586,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2576,6 +2656,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2654,6 +2735,7 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(result.paymentMethodMetadata.linkState).isNull()
         }
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2776,6 +2858,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
@@ -2832,7 +2915,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(state.customer?.paymentMethods).isEqualTo(cards)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -2883,7 +2967,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -2934,7 +3019,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -2985,7 +3071,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3036,7 +3123,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3087,7 +3175,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3121,7 +3210,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3171,7 +3261,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
                 .isEqualTo(true)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
     }
@@ -3214,7 +3305,8 @@ internal class DefaultPaymentElementLoaderTest {
                         .eventName
                 )
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
         }
 
@@ -3258,7 +3350,8 @@ internal class DefaultPaymentElementLoaderTest {
                         .eventName
                 )
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3300,7 +3393,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(state.customer?.paymentMethods).isEqualTo(cards)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3343,7 +3437,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3435,7 +3530,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3479,7 +3575,8 @@ internal class DefaultPaymentElementLoaderTest {
             val linkState = result.getOrThrow().paymentMethodMetadata.linkState
             assertThat(linkState?.configuration?.customerInfo?.email).isEqualTo(customerEmail)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3514,7 +3611,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(repository.lastParams?.savedPaymentMethodSelectionId)
                 .isEqualTo("pm_1234321")
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
         }
 
@@ -3553,6 +3651,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(repository.lastParams?.linkDisallowedFundingSourceCreation)
             .containsExactly("somethingThatsNotAllowed")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -3587,7 +3686,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(repository.lastParams?.savedPaymentMethodSelectionId).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
         }
 
@@ -3793,7 +3893,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3890,7 +3991,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
                 .isEqualTo(PaymentMethodOrientation.Vertical)
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3900,6 +4002,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
             .isEqualTo(PaymentMethodOrientation.Horizontal)
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -3916,7 +4019,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
                 .isEqualTo(PaymentMethodOrientation.Horizontal)
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3932,7 +4036,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
                 .isEqualTo(PaymentMethodOrientation.Vertical)
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3958,7 +4063,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
                 .isEqualTo(PaymentMethodOrientation.Vertical)
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -4088,6 +4194,7 @@ internal class DefaultPaymentElementLoaderTest {
             result.paymentMethodMetadata.clientAttributionMetadata
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4119,6 +4226,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkState).isNotNull()
         assertThat(result.paymentMethodMetadata.supportedPaymentMethodTypes()).contains("link")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4149,6 +4257,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkState).isNull()
         assertThat(result.paymentMethodMetadata.supportedPaymentMethodTypes()).doesNotContain("link")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4186,6 +4295,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4218,6 +4328,7 @@ internal class DefaultPaymentElementLoaderTest {
         integrityRequestManager.awaitPrepareCall()
         integrityRequestManager.ensureAllEventsConsumed()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4249,6 +4360,7 @@ internal class DefaultPaymentElementLoaderTest {
         // Verify prepare was not called by ensuring all events are consumed (no calls made)
         integrityRequestManager.ensureAllEventsConsumed()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4282,6 +4394,7 @@ internal class DefaultPaymentElementLoaderTest {
         integrityRequestManager.awaitPrepareCall()
         integrityRequestManager.ensureAllEventsConsumed()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4323,6 +4436,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(helper.calls.awaitItem()).isNotNull()
         val exposure = reporter.experimentExposureCalls.awaitItem()
         assertThat(exposure.experiment.group).isEqualTo("treatment")
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4363,6 +4477,7 @@ internal class DefaultPaymentElementLoaderTest {
         helper.calls.expectNoEvents()
         val exposure = reporter.experimentExposureCalls.awaitItem()
         assertThat(exposure.experiment.group).isEqualTo("control")
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4399,6 +4514,7 @@ internal class DefaultPaymentElementLoaderTest {
         )
         helper.calls.expectNoEvents()
         reporter.experimentExposureCalls.expectNoEvents()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4449,6 +4565,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4481,6 +4598,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(actualExternalPaymentMethods).isEqualTo(expectedExternalPaymentMethods)
         assertThat(userFacingLogger.getLoggedMessages()).containsExactlyElementsIn(expectedLogMessages)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4511,6 +4629,7 @@ internal class DefaultPaymentElementLoaderTest {
         val abTest = logLinkHoldbackExperiment.calls.awaitItem()
         assertThat(abTest.experiment).isEqualTo(ElementsSession.ExperimentAssignment.LINK_AB_TEST)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4538,6 +4657,7 @@ internal class DefaultPaymentElementLoaderTest {
         val abTest = logLinkHoldbackExperiment.calls.awaitItem()
         assertThat(abTest.experiment).isEqualTo(ElementsSession.ExperimentAssignment.LINK_AB_TEST)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4559,6 +4679,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.integrationMetadata).isEqualTo(IntegrationMetadata.CryptoOnramp)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isTrue()
         eventReporter.loadSucceededTurbine.awaitItem()
     }
@@ -4604,6 +4725,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4661,6 +4783,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(createCall.isTapToAddAvailable).isFalse()
         analyticsMetadataFactory.validate()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4694,6 +4817,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(userFacingLogger.getLoggedMessages()).containsExactlyElementsIn(expectedLogMessages)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4726,6 +4850,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
 
         val loadSucceededCall = eventReporter.loadSucceededTurbine.awaitItem()
@@ -4878,6 +5003,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
         ).isNotNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4901,6 +5027,7 @@ internal class DefaultPaymentElementLoaderTest {
         // No legacy ephemeral key customer, so fetchSavedPaymentMethods should not be timed
         assertThat(durationProvider.completedDuration(DurationProvider.Key.PaymentSheetLoadPrefetchPMs)).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4920,6 +5047,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -5048,7 +5176,9 @@ internal class DefaultPaymentElementLoaderTest {
             paymentElementCallbackIdentifier = PAYMENT_ELEMENT_CALLBACKS_IDENTIFIER,
             analyticsMetadataFactory = analyticsMetadataFactory,
             tapToAddConnectionStarter = tapToAddConnectionStarter,
-            paymentConfiguration = { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
+            apiConfigurationResolver = ApiConfigurationResolver {
+                PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test_123")
+            },
             createCustomerState = CreateCustomerState(
                 paymentMethodFilter = paymentMethodFilter,
                 errorReporter = errorReporter,
@@ -5161,6 +5291,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet.state
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -27,7 +27,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `fetchPromotionsAsync calls repository`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val request = fakeRepository.calls.awaitItem()
         assertThat(request.amount).isEqualTo(1099)
@@ -38,7 +41,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode returns promotion if available and in treatment`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -52,7 +58,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode returns null if not available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val metadata = getMetadata("treatment")
         val result = helper.getPromotionIfAvailableForCode(
@@ -65,7 +74,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed fires event with true when promotion available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -76,7 +88,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed fires event with false when promotion not available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val metadata = getMetadata("treatment")
         helper.reportPromotionDisplayed("afterpay_clearpay", metadata)
@@ -86,7 +101,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed does not fire event when not in treatment`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -96,7 +114,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed does not fire event for unsupported PM`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -106,7 +127,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode does not return promotion if variant is control`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -115,7 +139,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionProvider returns null for control`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -124,7 +151,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionProvider returns null for unsupported PMs`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -133,7 +163,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `returns promotion provider for treatment group supported pm`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -159,9 +192,6 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
         val helper = DefaultPaymentMethodMessagePromotionsHelper(
             stripeRepository = fakeRepository,
-            lazyPaymentConfig = {
-                PaymentConfiguration("pk_123")
-            },
             viewModelScope = this,
             workContext = testDispatcher,
             eventReporter = eventReporter

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
@@ -100,6 +100,7 @@ internal class DefaultRetrieveCustomerEmailTest {
             configuration = configuration,
             customerMetadata = customerMetadata,
             customerEmail = customerEmail,
+            stripeAccountId = null,
         )
 
         Scenario(
@@ -127,6 +128,7 @@ internal class DefaultRetrieveCustomerEmailTest {
         override suspend fun retrieveCustomer(
             customerId: String,
             ephemeralKeySecret: String,
+            stripeAccountId: String?
         ) = null.also {
             retrieveCalls.add(RetrieveCall(customerId, ephemeralKeySecret))
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
@@ -29,8 +29,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
-                publishableKey = "pk_test_123",
-                isLiveMode = false,
             )
         ).isTrue()
     }
@@ -49,8 +47,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
-                publishableKey = "pk_test_123",
-                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -69,8 +65,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
-                publishableKey = "pk_test_123",
-                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -89,8 +83,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = null,
-                publishableKey = "pk_test_123",
-                isLiveMode = false,
             )
         ).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
@@ -29,6 +29,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isTrue()
     }
@@ -47,6 +49,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -65,6 +69,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -83,6 +89,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = null,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -20,6 +21,7 @@ internal class ElementsSessionLoaderTest {
             ),
             configuration = DEFAULT_CONFIG,
             savedPaymentMethodSelection = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         assertThat(result.stripeIntent)
@@ -36,6 +38,7 @@ internal class ElementsSessionLoaderTest {
             ),
             configuration = DEFAULT_CONFIG,
             savedPaymentMethodSelection = savedSelection,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         assertThat(elementsSessionRepository.lastParams?.savedPaymentMethodSelectionId)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.utils
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodMessageLearnMore
@@ -19,7 +20,7 @@ internal class FakePaymentMethodMessagePromotionsHelper(
     val reportPromotionDisplayedCalls: ReceiveTurbine<Pair<PaymentMethodCode, Boolean>> =
         _reportPromotionDisplayedCalls
 
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         _calls.add(Unit)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
@@ -9,7 +9,5 @@ internal class FakeTapToAddAvailabilityFactory(
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
-        publishableKey: String,
-        isLiveMode: Boolean,
     ): Boolean = isAvailableResult
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
@@ -9,5 +9,7 @@ internal class FakeTapToAddAvailabilityFactory(
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ): Boolean = isAvailableResult
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
@@ -5,12 +5,14 @@ import app.cash.turbine.Turbine
 import com.stripe.android.common.model.CommonConfiguration
 
 internal class FakeTapToAddConnectionStarter private constructor(
-    override val isSupported: Boolean = false,
+    private val isSupportedValue: Boolean = false,
 ) : TapToAddConnectionStarter {
     private val startCalls: Turbine<StartCall> = Turbine()
 
-    override fun start(config: CommonConfiguration) {
-        startCalls.add(StartCall(config))
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = isSupportedValue
+
+    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
+        startCalls.add(StartCall(config, publishableKey))
     }
 
     fun ensureAllEventsConsumed() {
@@ -18,7 +20,8 @@ internal class FakeTapToAddConnectionStarter private constructor(
     }
 
     data class StartCall(
-        val config: CommonConfiguration
+        val config: CommonConfiguration,
+        val publishableKey: String,
     )
 
     class Scenario(
@@ -45,6 +48,6 @@ internal class FakeTapToAddConnectionStarter private constructor(
 
         fun create(
             isSupported: Boolean = false,
-        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupported = isSupported)
+        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupportedValue = isSupported)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
@@ -5,14 +5,12 @@ import app.cash.turbine.Turbine
 import com.stripe.android.common.model.CommonConfiguration
 
 internal class FakeTapToAddConnectionStarter private constructor(
-    private val isSupportedValue: Boolean = false,
+    override val isSupported: Boolean = false,
 ) : TapToAddConnectionStarter {
     private val startCalls: Turbine<StartCall> = Turbine()
 
-    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = isSupportedValue
-
-    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
-        startCalls.add(StartCall(config, publishableKey))
+    override fun start(config: CommonConfiguration) {
+        startCalls.add(StartCall(config))
     }
 
     fun ensureAllEventsConsumed() {
@@ -20,8 +18,7 @@ internal class FakeTapToAddConnectionStarter private constructor(
     }
 
     data class StartCall(
-        val config: CommonConfiguration,
-        val publishableKey: String,
+        val config: CommonConfiguration
     )
 
     class Scenario(
@@ -48,6 +45,6 @@ internal class FakeTapToAddConnectionStarter private constructor(
 
         fun create(
             isSupported: Boolean = false,
-        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupportedValue = isSupported)
+        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupported = isSupported)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
@@ -22,7 +22,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported).isTrue()
+        assertThat(starter.isSupported("pk_test_123", false)).isTrue()
     }
 
     @Test
@@ -34,7 +34,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported).isFalse()
+        assertThat(starter.isSupported("pk_test_123", false)).isFalse()
     }
 
     @Test
@@ -50,13 +50,15 @@ internal class TapToAddConnectionStarterTest {
             merchantDisplayName = "Books & Things",
         )
 
-        starter.start(commonConfiguration)
+        starter.start(commonConfiguration, "pk_test_123", false)
         advanceUntilIdle()
 
         assertThat(manager.connectCalls.awaitItem()).isEqualTo(
             FakeTapToAddConnectionManager.ConnectCall(
                 config = TapToAddConnectionManager.ConnectionConfig(
                     merchantDisplayName = "Books & Things",
+                    publishableKey = "pk_test_123",
+                    isLiveMode = false,
                 ),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
@@ -22,7 +22,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported("pk_test_123", false)).isTrue()
+        assertThat(starter.isSupported).isTrue()
     }
 
     @Test
@@ -34,7 +34,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported("pk_test_123", false)).isFalse()
+        assertThat(starter.isSupported).isFalse()
     }
 
     @Test
@@ -50,15 +50,13 @@ internal class TapToAddConnectionStarterTest {
             merchantDisplayName = "Books & Things",
         )
 
-        starter.start(commonConfiguration, "pk_test_123", false)
+        starter.start(commonConfiguration)
         advanceUntilIdle()
 
         assertThat(manager.connectCalls.awaitItem()).isEqualTo(
             FakeTapToAddConnectionManager.ConnectCall(
                 config = TapToAddConnectionManager.ConnectionConfig(
                     merchantDisplayName = "Books & Things",
-                    publishableKey = "pk_test_123",
-                    isLiveMode = false,
                 ),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.utils
 
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
@@ -118,6 +119,10 @@ internal object LinkTestUtils {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = linkBrand,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -60,6 +60,7 @@ internal open class FakeCustomerRepository(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer? {
         _retrieveCustomerRequests.add(
             RetrieveCustomerRequest(
@@ -76,6 +77,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>> {
         _getPaymentMethodsRequests.add(
             GetPaymentMethodsRequest(
@@ -93,6 +95,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -110,6 +113,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -127,6 +131,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = onAttachPaymentMethod()
 
     override suspend fun updatePaymentMethod(
@@ -134,6 +139,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _updateRequests.add(
             UpdateRequest(
@@ -151,6 +157,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer> {
         _setDefaultPaymentMethodRequests.add(
             SetDefaultRequest(
@@ -167,6 +174,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = onRetrievePaymentMethod(paymentMethodId)
 
     data class RetrieveCustomerRequest(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.StripeIntent
@@ -43,6 +44,7 @@ internal class FakeElementsSessionRepository(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
         lastParams = Params(


### PR DESCRIPTION
# Summary
Resolve one API configuration snapshot at PaymentSheet load start, use it throughout loading, and retain it in `PaymentMethodMetadata` for post-load consumers.

Committed and created by Codex.

# Motivation
Session loading, customer requests, Google Pay readiness, messaging, analytics, and confirmation must not observe different credentials during one PaymentSheet lifecycle.

`ApiConfigurationModule` exposes a lazy metadata-backed provider for post-load Dagger graphs. Narrow request-options and key-only adapters bridge consumers that still expect legacy dependencies. They are intentionally unavailable before metadata loads; pre-load work receives the resolved state explicitly. Subsequent stack layers migrate those consumers and the cleanup layer removes obsolete bindings.

Three confirmation test components contain transitional `PaymentConfiguration`-backed providers on this branch: `PaymentElementConfirmationTestModule`, `ExtendedPaymentElementConfirmationTestModule`, and `LpmNetworkTestModule`. Each currently reconstructs `ApiConfiguration.State` inside `providesApiConfigurationProvider()` to satisfy the new `() -> ApiConfiguration.State` dependency.

A later test-cleanup layer makes the paired state an explicit binding. The Payment Element and Extended Payment Element fixtures provide `ApiConfiguration.State` separately and adapt it with `providesApiConfigurationStateProvider(state) = { state }`. The LPM network component binds the state directly at its factory boundary and derives any remaining `PaymentConfiguration` fixture from that state, reversing the current ownership. The function providers remain because `ApiRequestOptionsModule` consumes them; the duplicated state reconstruction and ambient credential ownership are what get removed.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — internal loading and analytics wiring only.

# Changelog
Not applicable — no public API or intended UI change.
