### PR TITLE
Make Link sessions own API request options

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -136,7 +136,7 @@ internal class OnrampInteractor @Inject constructor(
         }
 
         PaymentConfiguration.init(
-            context = application,
+            context = application.applicationContext,
             publishableKey = configurationState.publishableKey,
         )
         val linkResult = linkController.configure(

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Parcelable
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.core.utils.flatMapCatching
 import com.stripe.android.crypto.onramp.CheckoutState.Status
@@ -134,8 +135,10 @@ internal class OnrampInteractor @Inject constructor(
             )
         }
 
-        // We are *not* calling `PaymentConfiguration.init()` here because we're relying on
-        // `LinkController.configure()` to do it.
+        PaymentConfiguration.init(
+            context = application,
+            publishableKey = configurationState.publishableKey,
+        )
         val linkResult = linkController.configure(
             LinkController.Configuration(
                 merchantDisplayName = configurationState.merchantDisplayName,

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -797,6 +797,7 @@ class OnrampInteractorTest {
     @Test
     fun uncategorizedExceptionFallsBackToSafeUserMessage() = runTest {
         val application = mock<Application> {
+            on { applicationContext } doReturn RuntimeEnvironment.getApplication()
             on { packageName } doReturn "com.example.app"
             on { getString(any()) } doReturn "Something went wrong. Please try again later."
         }
@@ -847,6 +848,7 @@ class OnrampInteractorTest {
     @Test
     fun appAttestationExceptionUsesSingleLocalizedFallbackUserMessage() = runTest {
         val application = mock<Application> {
+            on { applicationContext } doReturn RuntimeEnvironment.getApplication()
             on { packageName } doReturn "com.example.app"
             on { getString(any()) } doReturn
                 "This app couldn't be verified due to an attestation error. Please try again later or contact the developer if the issue persists."
@@ -1974,6 +1976,7 @@ class OnrampInteractorTest {
         val runtimeApplication = RuntimeEnvironment.getApplication()
 
         return mock {
+            on { applicationContext } doReturn runtimeApplication
             on { packageName } doReturn runtimeApplication.packageName
             on { getString(R.string.stripe_onramp_default_api_error_user_message) } doReturn
                 defaultApiErrorUserMessage

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
@@ -4,8 +4,10 @@ import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHol
 import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHoldback.EmailRecognitionSource
 import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHoldback.ProvidedDefaultValues
 import com.stripe.android.common.di.MOBILE_SESSION_ID
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.repositories.LinkRepository
@@ -48,7 +50,8 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
     private val retrieveCustomerEmail: RetrieveCustomerEmail,
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
     private val mode: EventReporter.Mode,
-    private val logger: Logger
+    private val logger: Logger,
+    private val apiConfigProvider: () -> ApiConfiguration.State
 ) : LogLinkHoldbackExperiment {
 
     override operator fun invoke(
@@ -150,8 +153,14 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
         email: String,
         sessionId: String,
     ): Boolean {
+        val config = apiConfigProvider()
+        val requestOptions = ApiRequest.Options(
+            apiKey = config.publishableKey,
+            stripeAccount = config.stripeAccountId,
+        )
         return linkDisabledApiRepository
             .lookupConsumerWithoutBackendLoggingForExposure(
+                requestOptions = requestOptions,
                 email = email,
                 sessionId = sessionId,
             )

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
@@ -51,7 +51,6 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
     private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
     private val mode: EventReporter.Mode,
     private val logger: Logger,
-    private val apiConfigProvider: () -> ApiConfiguration.State
 ) : LogLinkHoldbackExperiment {
 
     override operator fun invoke(
@@ -96,7 +95,11 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
             }
             else -> {
                 // Link is disabled — perform the lookup for experiment logging.
-                isReturningUser(email = customerEmail, sessionId = elementsSession.elementsSessionId)
+                isReturningUser(
+                    email = customerEmail,
+                    sessionId = elementsSession.elementsSessionId,
+                    apiConfiguration = state.paymentMethodMetadata.apiConfiguration,
+                )
             }
         }
 
@@ -152,11 +155,11 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
     private suspend fun isReturningUser(
         email: String,
         sessionId: String,
+        apiConfiguration: ApiConfiguration.State,
     ): Boolean {
-        val config = apiConfigProvider()
         val requestOptions = ApiRequest.Options(
-            apiKey = config.publishableKey,
-            stripeAccount = config.stripeAccountId,
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
         )
         return linkDisabledApiRepository
             .lookupConsumerWithoutBackendLoggingForExposure(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -7,7 +7,6 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.ResolvableString
@@ -73,7 +72,8 @@ internal class LinkControllerInteractor @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) {
 
-    private var configuration: LinkController.Configuration.State? = null
+    internal var configuration: LinkController.Configuration.State? = null
+        private set
 
     private val tag = "LinkControllerViewInteractor"
 
@@ -184,11 +184,6 @@ internal class LinkControllerInteractor @Inject constructor(
         val config = configuration.build()
         this.configuration = config
         updateState { State() }
-        PaymentConfiguration.init(
-            context = application,
-            publishableKey = config.publishableKey,
-            stripeAccountId = config.stripeAccountId,
-        )
         return linkConfigurationLoader.load(config)
             .flatMapCatching { linkMetadata ->
                 val component = linkComponentFactoryProvider.get()

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -5,7 +5,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import javax.inject.Inject
@@ -16,18 +16,19 @@ import javax.inject.Inject
 internal class NativeLinkActivityContract @Inject constructor(
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val requestSurface: RequestSurface,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
 ) :
     ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>() {
     override fun createIntent(context: Context, input: LinkActivityContract.Args): Intent {
-        val paymentConfiguration = PaymentConfiguration.getInstance(context)
+        val apiConfiguration = apiConfigurationProvider()
         return LinkActivity.createIntent(
             context = context,
             args = NativeLinkArgs(
                 configuration = input.configuration,
                 paymentMethodMetadata = input.paymentMethodMetadata,
                 requestSurface = requestSurface,
-                stripeAccountId = paymentConfiguration.stripeAccountId,
-                publishableKey = paymentConfiguration.publishableKey,
+                stripeAccountId = apiConfiguration.stripeAccountId,
+                publishableKey = apiConfiguration.publishableKey,
                 linkExpressMode = input.linkExpressMode,
                 launchMode = input.launchMode,
                 paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,

--- a/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/NativeLinkActivityContract.kt
@@ -9,6 +9,7 @@ import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * Contract used to explicitly launch Link natively.
@@ -16,11 +17,11 @@ import javax.inject.Inject
 internal class NativeLinkActivityContract @Inject constructor(
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val requestSurface: RequestSurface,
-    private val apiConfigurationProvider: () -> ApiConfiguration.State,
+    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
 ) :
     ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>() {
     override fun createIntent(context: Context, input: LinkActivityContract.Args): Intent {
-        val apiConfiguration = apiConfigurationProvider()
+        val apiConfiguration = apiConfigurationProvider.get()
         return LinkActivity.createIntent(
             context = context,
             args = NativeLinkArgs(

--- a/paymentsheet/src/main/java/com/stripe/android/link/WebLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/WebLinkActivityContract.kt
@@ -6,7 +6,7 @@ import android.content.Intent
 import android.util.Base64
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.BundleCompat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.link.serialization.PopupPayload
 import com.stripe.android.model.PaymentMethod
@@ -21,16 +21,17 @@ import javax.inject.Inject
  */
 internal class WebLinkActivityContract @Inject internal constructor(
     private val stripeRepository: StripeRepository,
-    private val errorReporter: ErrorReporter
+    private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
 ) : ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>() {
 
     override fun createIntent(context: Context, input: LinkActivityContract.Args): Intent {
-        val paymentConfiguration = PaymentConfiguration.getInstance(context)
+        val apiConfiguration = apiConfigurationProvider()
         val payload = PopupPayload.create(
             configuration = input.configuration,
             context = context,
-            publishableKey = paymentConfiguration.publishableKey,
-            stripeAccount = paymentConfiguration.stripeAccountId,
+            publishableKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
             paymentUserAgent = stripeRepository.buildPaymentUserAgent(),
         )
         return LinkForegroundActivity.createIntent(context, payload.toUrl())

--- a/paymentsheet/src/main/java/com/stripe/android/link/WebLinkActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/WebLinkActivityContract.kt
@@ -15,6 +15,7 @@ import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import org.json.JSONObject
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * Contract used to explicitly launch Link as a web view.
@@ -22,11 +23,11 @@ import javax.inject.Inject
 internal class WebLinkActivityContract @Inject internal constructor(
     private val stripeRepository: StripeRepository,
     private val errorReporter: ErrorReporter,
-    private val apiConfigurationProvider: () -> ApiConfiguration.State,
+    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
 ) : ActivityResultContract<LinkActivityContract.Args, LinkActivityResult>() {
 
     override fun createIntent(context: Context, input: LinkActivityContract.Args): Intent {
-        val apiConfiguration = apiConfigurationProvider()
+        val apiConfiguration = apiConfigurationProvider.get()
         val payload = PopupPayload.create(
             configuration = input.configuration,
             context = context,

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -87,6 +87,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return runCatching {
             val linkAccount = requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
             linkRepository.createLinkAccountSession(
+                requestOptions = config.requestOptions,
                 consumerSessionClientSecret = linkAccount.clientSecret,
                 intentToken = config.stripeIntent.clientSecret ?: config.elementsSessionId,
                 linkMode = config.linkMode,
@@ -127,6 +128,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
     override suspend fun logOut(linkAccount: LinkAccount): Result<ConsumerSession> {
         return runCatching {
             linkRepository.logOut(
+                requestOptions = config.requestOptions,
                 consumerSessionClientSecret = linkAccount.clientSecret,
                 consumerAccountPublishableKey = linkAccount.consumerPublishableKey,
             ).getOrThrow()
@@ -201,6 +203,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
         }.mapCatching { account ->
             linkRepository.createPaymentMethod(
+                requestOptions = config.requestOptions,
                 consumerSessionClientSecret = account.clientSecret,
                 paymentMethod = linkPaymentMethod,
                 clientAttributionMetadata = config.clientAttributionMetadata,
@@ -215,6 +218,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         return if (linkAccountValue != null) {
             linkAccountValue.let { account ->
                 linkRepository.createCardPaymentDetails(
+                    requestOptions = config.requestOptions,
                     paymentMethodCreateParams = paymentMethodCreateParams,
                     userEmail = account.email,
                     stripeIntent = config.stripeIntent,
@@ -239,6 +243,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccountValue = linkAccountHolder.linkAccountInfo.value.account
         return linkAccountValue?.let { account ->
             linkRepository.createPaymentDetailsFromPaymentMethod(
+                requestOptions = config.requestOptions,
                 paymentMethod = paymentMethod,
                 userEmail = account.email,
                 stripeIntent = config.stripeIntent,
@@ -265,6 +270,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             val paymentDetails = cardPaymentDetails.paymentDetails
             val paymentMethodCreateParams = cardPaymentDetails.originalParams
             linkRepository.shareCardPaymentDetails(
+                requestOptions = config.requestOptions,
                 id = paymentDetails.id,
                 consumerSessionClientSecret = account.clientSecret,
                 paymentMethodCreateParams = paymentMethodCreateParams,
@@ -279,6 +285,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
         return if (linkAccount != null) {
             linkRepository.createBankAccountPaymentDetails(
+                requestOptions = config.requestOptions,
                 bankAccountId = bankAccountId,
                 userEmail = linkAccount.email,
                 consumerSessionClientSecret = linkAccount.clientSecret,
@@ -304,6 +311,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             requireNotNull(linkAccountHolder.linkAccountInfo.value.account)
         }.mapCatching { account ->
             linkRepository.sharePaymentDetails(
+                requestOptions = config.requestOptions,
                 paymentDetailsId = paymentDetailsId,
                 consumerSessionClientSecret = account.clientSecret,
                 expectedPaymentMethodType = expectedPaymentMethodType,
@@ -380,6 +388,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             ?: return Result.failure(NoLinkAccountFoundException())
         linkEventsReporter.on2FAStart()
         return linkRepository.startVerification(
+            requestOptions = config.requestOptions,
             consumerSessionClientSecret = linkAccount.clientSecret,
             isResendSmsCode = isResendSmsCode
         )
@@ -397,6 +406,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.confirmVerification(
+            requestOptions = config.requestOptions,
             verificationCode = code,
             consumerSessionClientSecret = linkAccount.clientSecret,
             consentGranted = consentGranted,
@@ -415,6 +425,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
             ?: return Result.failure(NoLinkAccountFoundException())
 
         return linkRepository.postConsentUpdate(
+            requestOptions = config.requestOptions,
             consumerSessionClientSecret = linkAccount.clientSecret,
             consentGranted = consentGranted,
         )
@@ -424,6 +435,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.listPaymentDetails(
+            requestOptions = config.requestOptions,
             paymentMethodTypes = paymentMethodTypes,
             consumerSessionClientSecret = linkAccount.clientSecret,
         ).onSuccess { paymentDetailsList ->
@@ -437,6 +449,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.listShippingAddresses(
+            requestOptions = config.requestOptions,
             consumerSessionClientSecret = linkAccount.clientSecret,
         )
     }
@@ -445,6 +458,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.deletePaymentDetails(
+            requestOptions = config.requestOptions,
             paymentDetailsId = paymentDetailsId,
             consumerSessionClientSecret = linkAccount.clientSecret,
         )
@@ -457,6 +471,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.updatePaymentDetails(
+            requestOptions = config.requestOptions,
             updateParams = updateParams,
             consumerSessionClientSecret = linkAccount.clientSecret,
         ).map { updatedPaymentDetails ->
@@ -473,6 +488,7 @@ internal class DefaultLinkAccountManager @Inject constructor(
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
             ?: return Result.failure(NoLinkAccountFoundException())
         return linkRepository.updatePhoneNumber(
+            requestOptions = config.requestOptions,
             consumerSessionClientSecret = linkAccount.clientSecret,
             phoneNumber = phoneNumber,
         ).map { consumerSession ->

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAuth.kt
@@ -62,6 +62,7 @@ internal class DefaultLinkAuth @Inject constructor(
             )
         } else {
             linkRepository.lookupConsumer(
+                requestOptions = config.requestOptions,
                 email = email,
                 linkAuthIntentId = linkAuthIntentId,
                 sessionId = sessionId,
@@ -90,6 +91,7 @@ internal class DefaultLinkAuth @Inject constructor(
             )
         } else {
             linkRepository.consumerSignUp(
+                requestOptions = config.requestOptions,
                 email = email,
                 phone = phoneNumber,
                 country = country,
@@ -105,6 +107,7 @@ internal class DefaultLinkAuth @Inject constructor(
         supportedVerificationTypes: List<String>?
     ): Result<ConsumerSessionRefresh> {
         return linkRepository.refreshConsumer(
+            requestOptions = config.requestOptions,
             appId = applicationId,
             consumerSessionClientSecret = consumerSessionClientSecret,
             supportedVerificationTypes = supportedVerificationTypes
@@ -123,6 +126,7 @@ internal class DefaultLinkAuth @Inject constructor(
         return runCatching {
             val verificationToken = integrityRequestManager.requestToken().getOrThrow()
             linkRepository.mobileLookupConsumer(
+                requestOptions = config.requestOptions,
                 verificationToken = verificationToken,
                 appId = applicationId,
                 email = email,
@@ -150,6 +154,7 @@ internal class DefaultLinkAuth @Inject constructor(
         return runCatching {
             val verificationToken = integrityRequestManager.requestToken().getOrThrow()
             linkRepository.mobileSignUp(
+                requestOptions = config.requestOptions,
                 name = name,
                 email = email,
                 phoneNumber = phoneNumber,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import dagger.BindsInstance
@@ -16,9 +15,8 @@ import javax.inject.Singleton
 @Component(
     modules = [
         LinkControllerModule::class,
-        ApiConfigurationFromPaymentConfigurationModule::class,
-        ApiRequestOptionsModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
+        ApiRequestOptionsModule::class,
     ]
 )
 internal interface LinkControllerComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -3,6 +3,7 @@ package com.stripe.android.link.injection
 import android.app.Application
 import android.content.Context
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
@@ -29,6 +30,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module(

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -70,16 +70,14 @@ internal interface LinkControllerModule {
         }
 
         @Provides
-        fun provideApiConfigurationStateProvider(
+        fun provideApiConfiguration(
             interactor: Provider<LinkControllerInteractor>
-        ): () -> ApiConfiguration.State {
-            return {
-                val config = requireNotNull(interactor.get().configuration)
-                ApiConfiguration.State(
-                    publishableKey = config.publishableKey,
-                    stripeAccountId = config.stripeAccountId,
-                )
-            }
+        ): ApiConfiguration.State {
+            val config = requireNotNull(interactor.get().configuration)
+            return ApiConfiguration.State(
+                publishableKey = config.publishableKey,
+                stripeAccountId = config.stripeAccountId,
+            )
         }
 
         // TODO

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -67,6 +67,19 @@ internal interface LinkControllerModule {
             return interactor.paymentMethodMetadata
         }
 
+        @Provides
+        fun provideApiConfigurationStateProvider(
+            interactor: Provider<LinkControllerInteractor>
+        ): () -> ApiConfiguration.State {
+            return {
+                val config = requireNotNull(interactor.get().configuration)
+                ApiConfiguration.State(
+                    publishableKey = config.publishableKey,
+                    stripeAccountId = config.stripeAccountId,
+                )
+            }
+        }
+
         // TODO
         @Provides
         @Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.BuildConfig
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
@@ -152,12 +151,6 @@ internal interface NativeLinkModule {
 
     @SuppressWarnings("TooManyFunctions")
     companion object {
-        @Provides
-        @NativeLinkScope
-        fun providePaymentConfiguration(context: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(context)
-        }
-
         @Provides
         @NativeLinkScope
         fun providesLinkAccountHolder(

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -2,11 +2,10 @@ package com.stripe.android.link.repositories
 
 import android.app.Application
 import com.stripe.android.DefaultFraudDetectionDataRepository
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentMethod
@@ -40,7 +39,6 @@ import com.stripe.android.repository.ConsumersApiService
 import kotlinx.coroutines.withContext
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Named
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -50,8 +48,7 @@ import kotlin.coroutines.CoroutineContext
 internal class LinkApiRepository @Inject constructor(
     application: Application,
     private val requestSurface: RequestSurface,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
-    @Named(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     private val stripeRepository: StripeRepository,
     private val consumersApiService: ConsumersApiService,
     @IOContext private val workContext: CoroutineContext,
@@ -60,16 +57,14 @@ internal class LinkApiRepository @Inject constructor(
 ) : LinkRepository {
 
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
-        DefaultFraudDetectionDataRepository(application, workContext)
-
-    private val apiRequestOptions: ApiRequest.Options
-        get() = buildRequestOptions()
+        DefaultFraudDetectionDataRepository(application, { apiConfigProvider().publishableKey }, workContext)
 
     init {
         fraudDetectionDataRepository.refresh()
     }
 
     override suspend fun lookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         linkAuthIntentId: String?,
         sessionId: String,
@@ -84,7 +79,7 @@ internal class LinkApiRepository @Inject constructor(
                     requestSurface = requestSurface.value,
                     sessionId = sessionId,
                     doNotLogConsumerFunnelEvent = false,
-                    requestOptions = apiRequestOptions,
+                    requestOptions = requestOptions,
                     customerId = customerId,
                     supportedVerificationTypes = supportedVerificationTypes
                 )
@@ -93,6 +88,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun lookupConsumerWithoutBackendLoggingForExposure(
+        requestOptions: ApiRequest.Options,
         email: String,
         sessionId: String,
     ): Result<ConsumerSessionLookup> = withContext(workContext) {
@@ -105,7 +101,7 @@ internal class LinkApiRepository @Inject constructor(
                     sessionId = sessionId,
                     doNotLogConsumerFunnelEvent = true,
                     supportedVerificationTypes = null,
-                    requestOptions = apiRequestOptions,
+                    requestOptions = requestOptions,
                     customerId = null
                 )
             )
@@ -113,6 +109,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun mobileLookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         emailSource: EmailSource?,
         linkAuthIntentId: String?,
@@ -131,7 +128,7 @@ internal class LinkApiRepository @Inject constructor(
                 requestSurface = requestSurface.value,
                 verificationToken = verificationToken,
                 appId = appId,
-                requestOptions = apiRequestOptions,
+                requestOptions = requestOptions,
                 sessionId = sessionId,
                 customerId = customerId,
                 supportedVerificationTypes = supportedVerificationTypes,
@@ -141,6 +138,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun refreshConsumer(
+        requestOptions: ApiRequest.Options,
         appId: String,
         consumerSessionClientSecret: String,
         supportedVerificationTypes: List<String>?,
@@ -151,12 +149,13 @@ internal class LinkApiRepository @Inject constructor(
                 consumerSessionClientSecret = consumerSessionClientSecret,
                 supportedVerificationTypes = supportedVerificationTypes,
                 requestSurface = requestSurface.value,
-                requestOptions = apiRequestOptions,
+                requestOptions = requestOptions,
             )
         }
     }
 
     override suspend fun consumerSignUp(
+        requestOptions: ApiRequest.Options,
         email: String,
         phone: String?,
         country: String?,
@@ -178,11 +177,12 @@ internal class LinkApiRepository @Inject constructor(
                 consentAction = consentAction,
                 requestSurface = requestSurface.value
             ),
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun mobileSignUp(
+        requestOptions: ApiRequest.Options,
         name: String?,
         email: String,
         phoneNumber: String?,
@@ -211,11 +211,12 @@ internal class LinkApiRepository @Inject constructor(
                 verificationToken = verificationToken,
                 appId = appId
             ),
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun createCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -229,7 +230,7 @@ internal class LinkApiRepository @Inject constructor(
                 email = userEmail,
             ),
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         ).mapCatching {
             val paymentDetails = it.paymentDetails.first()
             val extraParams = extraConfirmationParams(paymentMethodCreateParams.toParamMap())
@@ -258,6 +259,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun createPaymentDetailsFromPaymentMethod(
+        requestOptions: ApiRequest.Options,
         paymentMethod: PaymentMethod,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -269,7 +271,7 @@ internal class LinkApiRepository @Inject constructor(
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentMethodId = paymentMethod.id,
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
             customerEphemeralKey = customerEphemeralKey,
         ).mapCatching {
             LinkPaymentDetails.Saved(
@@ -280,6 +282,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun createBankAccountPaymentDetails(
+        requestOptions: ApiRequest.Options,
         bankAccountId: String,
         userEmail: String,
         consumerSessionClientSecret: String,
@@ -294,7 +297,7 @@ internal class LinkApiRepository @Inject constructor(
                 clientAttributionMetadata = clientAttributionMetadata.toParams(),
             ),
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         ).mapCatching {
             it.paymentDetails.first()
         }.onFailure {
@@ -306,6 +309,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun shareCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
         consumerSessionClientSecret: String,
@@ -326,7 +330,7 @@ internal class LinkApiRepository @Inject constructor(
             extraParams = mapOf(
                 "payment_method_options" to extraConfirmationParams(paymentMethodCreateParams.toParamMap()),
             ) + allowRedisplay + billingPhone + paymentMethodParams + clientAttributionMetadataParams,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         ).onFailure {
             errorReporter.report(ErrorReporter.ExpectedErrorEvent.LINK_SHARE_CARD_FAILURE, StripeException.create(it))
         }.map { paymentMethod ->
@@ -344,6 +348,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun sharePaymentDetails(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String?,
@@ -368,15 +373,13 @@ internal class LinkApiRepository @Inject constructor(
             allowRedisplayParams +
             clientAttributionMetadataParams
 
-        // Allow using a custom API key so that payment methods can be created under the
-        // merchant-of-record if necessary.
-        val requestOptions = buildRequestOptions(apiKey)
+        val effectiveOptions = buildRequestOptions(requestOptions, apiKey)
 
         consumersApiService.sharePaymentDetails(
             consumerSessionClientSecret = consumerSessionClientSecret,
             paymentDetailsId = paymentDetailsId,
             expectedPaymentMethodType = expectedPaymentMethodType,
-            requestOptions = requestOptions,
+            requestOptions = effectiveOptions,
             requestSurface = requestSurface.value,
             extraParams = extraParams,
             billingPhone = billingPhone,
@@ -384,6 +387,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun createPaymentMethod(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentMethod: LinkPaymentMethod,
         clientAttributionMetadata: ClientAttributionMetadata,
@@ -397,22 +401,24 @@ internal class LinkApiRepository @Inject constructor(
         )
         stripeRepository.createPaymentMethod(
             paymentMethodCreateParams = params,
-            options = apiRequestOptions,
+            options = requestOptions,
         )
     }
 
     override suspend fun logOut(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,
     ): Result<ConsumerSession> = withContext(workContext) {
         stripeRepository.logOut(
             consumerSessionClientSecret = consumerSessionClientSecret,
             consumerAccountPublishableKey = consumerAccountPublishableKey,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun startVerification(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         isResendSmsCode: Boolean
     ): Result<ConsumerSession> {
@@ -425,7 +431,7 @@ internal class LinkApiRepository @Inject constructor(
                     type = VerificationType.SMS,
                     customEmailType = null,
                     connectionsMerchantName = null,
-                    requestOptions = apiRequestOptions,
+                    requestOptions = requestOptions,
                     isResendSmsCode = isResendSmsCode
                 )
             )
@@ -433,6 +439,7 @@ internal class LinkApiRepository @Inject constructor(
     }
 
     override suspend fun confirmVerification(
+        requestOptions: ApiRequest.Options,
         verificationCode: String,
         consumerSessionClientSecret: String,
         consentGranted: Boolean?
@@ -445,13 +452,14 @@ internal class LinkApiRepository @Inject constructor(
                     requestSurface = requestSurface.value,
                     type = VerificationType.SMS,
                     consentGranted = consentGranted,
-                    requestOptions = apiRequestOptions,
+                    requestOptions = requestOptions,
                 )
             )
         }
     }
 
     override suspend fun postConsentUpdate(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consentGranted: Boolean,
     ): Result<Unit> = withContext(workContext) {
@@ -459,53 +467,58 @@ internal class LinkApiRepository @Inject constructor(
             consumerSessionClientSecret = consumerSessionClientSecret,
             consentGranted = consentGranted,
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun listPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodTypes: Set<String>,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails> {
         return stripeRepository.listPaymentDetails(
             clientSecret = consumerSessionClientSecret,
             paymentMethodTypes = paymentMethodTypes,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun listShippingAddresses(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
     ): Result<ConsumerShippingAddresses> {
         return stripeRepository.listShippingAddresses(
             clientSecret = consumerSessionClientSecret,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun deletePaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
     ): Result<Unit> {
         return stripeRepository.deletePaymentDetails(
             clientSecret = consumerSessionClientSecret,
             paymentDetailsId = paymentDetailsId,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun updatePaymentDetails(
+        requestOptions: ApiRequest.Options,
         updateParams: ConsumerPaymentDetailsUpdateParams,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails> {
         return stripeRepository.updatePaymentDetails(
             clientSecret = consumerSessionClientSecret,
             paymentDetailsUpdateParams = updateParams,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun createLinkAccountSession(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         intentToken: String?,
         linkMode: LinkMode?,
@@ -515,11 +528,12 @@ internal class LinkApiRepository @Inject constructor(
             intentToken = intentToken,
             linkMode = linkMode,
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     override suspend fun updatePhoneNumber(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         phoneNumber: String,
     ): Result<ConsumerSession> = withContext(workContext) {
@@ -527,12 +541,13 @@ internal class LinkApiRepository @Inject constructor(
             consumerSessionClientSecret = consumerSessionClientSecret,
             phoneNumber = phoneNumber,
             requestSurface = requestSurface.value,
-            requestOptions = apiRequestOptions,
+            requestOptions = requestOptions,
         )
     }
 
     private fun buildRequestOptions(
-        customApiKey: String? = null,
+        defaultOptions: ApiRequest.Options,
+        customApiKey: String?,
     ): ApiRequest.Options {
         return if (customApiKey != null) {
             ApiRequest.Options(
@@ -540,10 +555,7 @@ internal class LinkApiRepository @Inject constructor(
                 stripeAccount = null,
             )
         } else {
-            ApiRequest.Options(
-                apiKey = publishableKeyProvider(),
-                stripeAccount = stripeAccountIdProvider(),
-            )
+            defaultOptions
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -373,6 +373,8 @@ internal class LinkApiRepository @Inject constructor(
             allowRedisplayParams +
             clientAttributionMetadataParams
 
+        // Allow using a custom API key so that payment methods can be created under the
+        // merchant-of-record if necessary.
         val effectiveOptions = buildRequestOptions(requestOptions, apiKey)
 
         consumersApiService.sharePaymentDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkApiRepository.kt
@@ -39,6 +39,7 @@ import com.stripe.android.repository.ConsumersApiService
 import kotlinx.coroutines.withContext
 import java.util.Locale
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -48,7 +49,7 @@ import kotlin.coroutines.CoroutineContext
 internal class LinkApiRepository @Inject constructor(
     application: Application,
     private val requestSurface: RequestSurface,
-    private val apiConfigProvider: () -> ApiConfiguration.State,
+    private val apiConfigProvider: Provider<ApiConfiguration.State>,
     private val stripeRepository: StripeRepository,
     private val consumersApiService: ConsumersApiService,
     @IOContext private val workContext: CoroutineContext,
@@ -57,7 +58,7 @@ internal class LinkApiRepository @Inject constructor(
 ) : LinkRepository {
 
     private val fraudDetectionDataRepository: FraudDetectionDataRepository =
-        DefaultFraudDetectionDataRepository(application, { apiConfigProvider().publishableKey }, workContext)
+        DefaultFraudDetectionDataRepository(application, { apiConfigProvider.get().publishableKey }, workContext)
 
     init {
         fraudDetectionDataRepository.refresh()

--- a/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/repositories/LinkRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.link.repositories
 
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.model.ClientAttributionMetadata
@@ -33,6 +34,7 @@ internal interface LinkRepository {
      *                   retrieval of displayable payment details.
      */
     suspend fun lookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         linkAuthIntentId: String?,
         sessionId: String,
@@ -46,6 +48,7 @@ internal interface LinkRepository {
      * Link global holdback to look up consumers in the event Link is disabled.
      */
     suspend fun lookupConsumerWithoutBackendLoggingForExposure(
+        requestOptions: ApiRequest.Options,
         email: String,
         sessionId: String,
     ): Result<ConsumerSessionLookup>
@@ -57,6 +60,7 @@ internal interface LinkRepository {
      *                   retrieval of displayable payment details.
      */
     suspend fun mobileLookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         emailSource: EmailSource?,
         linkAuthIntentId: String?,
@@ -72,6 +76,7 @@ internal interface LinkRepository {
      * Refresh the mobile consumer session.
      */
     suspend fun refreshConsumer(
+        requestOptions: ApiRequest.Options,
         appId: String,
         consumerSessionClientSecret: String,
         supportedVerificationTypes: List<String>?,
@@ -81,6 +86,7 @@ internal interface LinkRepository {
      * Sign up for a new Link account.
      */
     suspend fun consumerSignUp(
+        requestOptions: ApiRequest.Options,
         email: String,
         phone: String?,
         country: String?,
@@ -90,6 +96,7 @@ internal interface LinkRepository {
     ): Result<ConsumerSessionSignup>
 
     suspend fun mobileSignUp(
+        requestOptions: ApiRequest.Options,
         name: String?,
         email: String,
         phoneNumber: String?,
@@ -107,6 +114,7 @@ internal interface LinkRepository {
      * Create a new card payment method in the consumer account.
      */
     suspend fun createCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -115,6 +123,7 @@ internal interface LinkRepository {
     ): Result<LinkPaymentDetails.New>
 
     suspend fun createPaymentDetailsFromPaymentMethod(
+        requestOptions: ApiRequest.Options,
         paymentMethod: PaymentMethod,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -124,6 +133,7 @@ internal interface LinkRepository {
     ): Result<LinkPaymentDetails.Saved>
 
     suspend fun createBankAccountPaymentDetails(
+        requestOptions: ApiRequest.Options,
         bankAccountId: String,
         userEmail: String,
         consumerSessionClientSecret: String,
@@ -131,6 +141,7 @@ internal interface LinkRepository {
     ): Result<ConsumerPaymentDetails.PaymentDetails>
 
     suspend fun shareCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
         consumerSessionClientSecret: String,
@@ -138,6 +149,7 @@ internal interface LinkRepository {
     ): Result<LinkPaymentDetails.Passthrough>
 
     suspend fun sharePaymentDetails(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String?,
@@ -149,12 +161,14 @@ internal interface LinkRepository {
     ): Result<SharePaymentDetails>
 
     suspend fun createPaymentMethod(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentMethod: LinkPaymentMethod,
         clientAttributionMetadata: ClientAttributionMetadata
     ): Result<PaymentMethod>
 
     suspend fun logOut(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,
     ): Result<ConsumerSession>
@@ -163,6 +177,7 @@ internal interface LinkRepository {
      * Start an SMS verification.
      */
     suspend fun startVerification(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         isResendSmsCode: Boolean = false
     ): Result<ConsumerSession>
@@ -171,6 +186,7 @@ internal interface LinkRepository {
      * Confirm an SMS verification code.
      */
     suspend fun confirmVerification(
+        requestOptions: ApiRequest.Options,
         verificationCode: String,
         consumerSessionClientSecret: String,
         consentGranted: Boolean?,
@@ -180,6 +196,7 @@ internal interface LinkRepository {
      * Update consent status for the signed in consumer.
      */
     suspend fun postConsentUpdate(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consentGranted: Boolean,
     ): Result<Unit>
@@ -188,6 +205,7 @@ internal interface LinkRepository {
      * Fetch all saved payment methods for the signed in consumer.
      */
     suspend fun listPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodTypes: Set<String>,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails>
@@ -196,6 +214,7 @@ internal interface LinkRepository {
      * Fetch all shipping addresses for the signed in consumer.
      */
     suspend fun listShippingAddresses(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
     ): Result<ConsumerShippingAddresses>
 
@@ -203,6 +222,7 @@ internal interface LinkRepository {
      * Delete the payment method from the consumer account.
      */
     suspend fun deletePaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
     ): Result<Unit>
@@ -211,11 +231,13 @@ internal interface LinkRepository {
      * Update an existing payment method in the consumer account.
      */
     suspend fun updatePaymentDetails(
+        requestOptions: ApiRequest.Options,
         updateParams: ConsumerPaymentDetailsUpdateParams,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails>
 
     suspend fun createLinkAccountSession(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         intentToken: String?,
         linkMode: LinkMode?,
@@ -225,6 +247,7 @@ internal interface LinkRepository {
      * Update the phone number for the signed in consumer.
      */
     suspend fun updatePhoneNumber(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         phoneNumber: String,
     ): Result<ConsumerSession>

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -20,6 +20,7 @@ import com.stripe.android.repository.ConsumersApiServiceImpl
 import dagger.Module
 import dagger.Provides
 import java.util.Locale
+import javax.inject.Provider
 import javax.inject.Qualifier
 import kotlin.coroutines.CoroutineContext
 
@@ -59,7 +60,7 @@ internal class LinkHoldbackExposureModule {
     @LinkDisabledApiRepository
     fun providesLinkRepository(
         application: Application,
-        apiConfigProvider: () -> ApiConfiguration.State,
+        apiConfigProvider: Provider<ApiConfiguration.State>,
         requestSurface: RequestSurface,
         stripeRepository: StripeRepository,
         @IOContext workContext: CoroutineContext,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/LinkHoldbackExposureModule.kt
@@ -6,10 +6,9 @@ import com.stripe.android.common.analytics.experiment.DefaultLogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.DefaultLogLinkHoldbackExperiment
 import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.link.repositories.LinkApiRepository
@@ -21,7 +20,6 @@ import com.stripe.android.repository.ConsumersApiServiceImpl
 import dagger.Module
 import dagger.Provides
 import java.util.Locale
-import javax.inject.Named
 import javax.inject.Qualifier
 import kotlin.coroutines.CoroutineContext
 
@@ -61,8 +59,7 @@ internal class LinkHoldbackExposureModule {
     @LinkDisabledApiRepository
     fun providesLinkRepository(
         application: Application,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+        apiConfigProvider: () -> ApiConfiguration.State,
         requestSurface: RequestSurface,
         stripeRepository: StripeRepository,
         @IOContext workContext: CoroutineContext,
@@ -82,8 +79,7 @@ internal class LinkHoldbackExposureModule {
         return LinkApiRepository(
             application = application,
             requestSurface = requestSurface,
-            publishableKeyProvider = publishableKeyProvider,
-            stripeAccountIdProvider = stripeAccountIdProvider,
+            apiConfigProvider = apiConfigProvider,
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = workContext,

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -4,7 +4,6 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHoldback.EmailRecognitionSource
 import com.stripe.android.common.model.CommonConfigurationFactory
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.CONSUMER_SESSION
 import com.stripe.android.link.TestFactory.PUBLISHABLE_KEY
@@ -77,7 +76,6 @@ class LogLinkGlobalHoldbackExposureTest {
             retrieveCustomerEmail = retrieveCustomerEmail,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
             mode = EventReporter.Mode.Complete,
-            apiConfigProvider = { ApiConfiguration.State(PUBLISHABLE_KEY, null) },
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -4,6 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHoldback.EmailRecognitionSource
 import com.stripe.android.common.model.CommonConfigurationFactory
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.CONSUMER_SESSION
 import com.stripe.android.link.TestFactory.PUBLISHABLE_KEY
@@ -76,6 +77,7 @@ class LogLinkGlobalHoldbackExposureTest {
             retrieveCustomerEmail = retrieveCustomerEmail,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
             mode = EventReporter.Mode.Complete,
+            apiConfigProvider = { ApiConfiguration.State(PUBLISHABLE_KEY, null) },
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerCoordinatorTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.testing.CoroutineTestRule
@@ -13,6 +14,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -54,6 +56,11 @@ internal class LinkControllerCoordinatorTest {
     private val confirmSetupIntentResults = mutableListOf<LinkController.ConfirmSetupIntentResult>()
 
     private val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.INITIALIZED)
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(), "pk_test_123")
+    }
 
     private fun createCoordinator(
         activityResult: LinkActivityResult? = null

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,6 +77,11 @@ class LinkControllerInteractorTest {
     // Track injected scopes so any finite work still running after a failed test is canceled.
     @get:Rule
     val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(application, "pk_test_123")
+    }
 
     @Test
     fun `Initial state is correct`() = runTest {
@@ -161,6 +167,7 @@ class LinkControllerInteractorTest {
                 publishableKey = "pk_123",
                 stripeAccountId = "acct_123"
             )
+        PaymentConfiguration.init(application, "pk_123", "acct_123")
         assertThat(interactor.configure(controllerConfig).isSuccess).isTrue()
         assertThat(linkComponent.configuration).isEqualTo(loadedConfiguration)
         val paymentConfiguration = PaymentConfiguration.getInstance(application)

--- a/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/NativeLinkActivityContractTest.kt
@@ -6,12 +6,10 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networking.RequestSurface
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -19,24 +17,17 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class NativeLinkActivityContractTest {
 
-    @Before
-    fun before() {
-        PaymentConfiguration.init(
-            context = ApplicationProvider.getApplicationContext(),
-            publishableKey = "pk_test_abcdefg",
-        )
-    }
-
-    @After
-    fun after() {
-        PaymentConfiguration.clearInstance()
-    }
+    private val testApiConfiguration = ApiConfiguration.State(
+        publishableKey = "pk_test_abcdefg",
+        stripeAccountId = null,
+    )
 
     @Test
     fun `intent is created correctly`() {
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
         val args = LinkActivityContract.Args(
             configuration = TestFactory.LINK_CONFIGURATION,
@@ -78,7 +69,8 @@ class NativeLinkActivityContractTest {
 
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
 
         val result = contract.parseResult(
@@ -93,7 +85,8 @@ class NativeLinkActivityContractTest {
     fun `complete with canceled result when result not found`() {
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
 
         val result = contract.parseResult(
@@ -113,7 +106,8 @@ class NativeLinkActivityContractTest {
     fun `unknown result code results in canceled`() {
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
 
         val result = contract.parseResult(42, Intent())
@@ -130,7 +124,8 @@ class NativeLinkActivityContractTest {
     fun `canceled result code is handled correctly`() {
         val contract = NativeLinkActivityContract(
             paymentElementCallbackIdentifier = LINK_CALLBACK_TEST_IDENTIFIER,
-            requestSurface = REQUEST_SURFACE
+            requestSurface = REQUEST_SURFACE,
+            apiConfigurationProvider = { testApiConfiguration },
         )
 
         val result = contract.parseResult(Activity.RESULT_CANCELED, Intent())

--- a/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/WebLinkActivityContractTest.kt
@@ -5,15 +5,13 @@ import android.content.Intent
 import androidx.core.net.toUri
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.FakeStripeRepository
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.FakeErrorReporter
-import org.junit.After
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -21,18 +19,10 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class WebLinkActivityContractTest {
 
-    @Before
-    fun before() {
-        PaymentConfiguration.init(
-            context = ApplicationProvider.getApplicationContext(),
-            publishableKey = "pk_test_abcdefg",
-        )
-    }
-
-    @After
-    fun after() {
-        PaymentConfiguration.clearInstance()
-    }
+    private val testApiConfiguration = ApiConfiguration.State(
+        publishableKey = "pk_test_abcdefg",
+        stripeAccountId = null,
+    )
 
     @Test
     fun `intent is created correctly`() {
@@ -185,6 +175,6 @@ class WebLinkActivityContractTest {
         stripeRepository: StripeRepository = FakeStripeRepository(),
         errorReporter: FakeErrorReporter = FakeErrorReporter()
     ): WebLinkActivityContract {
-        return WebLinkActivityContract(stripeRepository, errorReporter)
+        return WebLinkActivityContract(stripeRepository, errorReporter, { testApiConfiguration })
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/DefaultLinkAccountManagerTest.kt
@@ -5,6 +5,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.AuthenticationException
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentDetails
@@ -432,6 +433,7 @@ class DefaultLinkAccountManagerTest {
             )
             var callCount = 0
             override suspend fun createCardPaymentDetails(
+                requestOptions: ApiRequest.Options,
                 paymentMethodCreateParams: PaymentMethodCreateParams,
                 userEmail: String,
                 stripeIntent: StripeIntent,
@@ -446,6 +448,7 @@ class DefaultLinkAccountManagerTest {
             }
 
             override suspend fun lookupConsumer(
+                requestOptions: ApiRequest.Options,
                 email: String?,
                 linkAuthIntentId: String?,
                 sessionId: String,
@@ -454,6 +457,7 @@ class DefaultLinkAccountManagerTest {
             ): Result<ConsumerSessionLookup> {
                 callCount += 1
                 return super.lookupConsumer(
+                    requestOptions = requestOptions,
                     email = email,
                     linkAuthIntentId = linkAuthIntentId,
                     sessionId = sessionId,
@@ -482,6 +486,7 @@ class DefaultLinkAccountManagerTest {
             var createPaymentDetailsFromPaymentMethodCallCount = 0
             var capturedCustomerEphemeralKey = "not_called"
             override suspend fun createPaymentDetailsFromPaymentMethod(
+                requestOptions: ApiRequest.Options,
                 paymentMethod: PaymentMethod,
                 userEmail: String,
                 stripeIntent: StripeIntent,
@@ -546,6 +551,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var shareCardPaymentDetailsCallCount = 0
             override suspend fun shareCardPaymentDetails(
+                requestOptions: ApiRequest.Options,
                 paymentMethodCreateParams: PaymentMethodCreateParams,
                 id: String,
                 consumerSessionClientSecret: String,
@@ -557,6 +563,7 @@ class DefaultLinkAccountManagerTest {
                     shareCardPaymentDetailsCallCount += 1
                 }
                 return super.shareCardPaymentDetails(
+                    requestOptions = requestOptions,
                     paymentMethodCreateParams = paymentMethodCreateParams,
                     id = id,
                     consumerSessionClientSecret = consumerSessionClientSecret,
@@ -588,11 +595,12 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var callCount = 0
             override suspend fun startVerification(
+                requestOptions: ApiRequest.Options,
                 consumerSessionClientSecret: String,
                 isResendSmsCode: Boolean
             ): Result<ConsumerSession> {
                 callCount += 1
-                return super.startVerification(consumerSessionClientSecret, isResendSmsCode)
+                return super.startVerification(requestOptions, consumerSessionClientSecret, isResendSmsCode)
             }
         }
         val accountManager = accountManager(linkRepository = linkRepository)
@@ -663,12 +671,14 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var callCount = 0
             override suspend fun confirmVerification(
+                requestOptions: ApiRequest.Options,
                 verificationCode: String,
                 consumerSessionClientSecret: String,
                 consentGranted: Boolean?
             ): Result<ConsumerSession> {
                 callCount += 1
                 return super.confirmVerification(
+                    requestOptions = requestOptions,
                     verificationCode = verificationCode,
                     consumerSessionClientSecret = consumerSessionClientSecret,
                     consentGranted = consentGranted
@@ -699,6 +709,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var callCount = 0
             override suspend fun confirmVerification(
+                requestOptions: ApiRequest.Options,
                 verificationCode: String,
                 consumerSessionClientSecret: String,
                 consentGranted: Boolean?
@@ -729,6 +740,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var paymentMethodTypes: Set<String>? = null
             override suspend fun listPaymentDetails(
+                requestOptions: ApiRequest.Options,
                 paymentMethodTypes: Set<String>,
                 consumerSessionClientSecret: String,
             ): Result<ConsumerPaymentDetails> {
@@ -751,6 +763,7 @@ class DefaultLinkAccountManagerTest {
         val linkRepository = object : FakeLinkRepository() {
             var paymentMethodTypes: Set<String>? = null
             override suspend fun listPaymentDetails(
+                requestOptions: ApiRequest.Options,
                 paymentMethodTypes: Set<String>,
                 consumerSessionClientSecret: String,
             ): Result<ConsumerPaymentDetails> {
@@ -960,6 +973,7 @@ class DefaultLinkAccountManagerTest {
     fun `createLinkAccountSession returns repository result on success`() = runSuspendTest {
         val linkRepository = object : FakeLinkRepository() {
             override suspend fun createLinkAccountSession(
+                requestOptions: ApiRequest.Options,
                 consumerSessionClientSecret: String,
                 intentToken: String?,
                 linkMode: LinkMode?,
@@ -1003,6 +1017,7 @@ class DefaultLinkAccountManagerTest {
         var capturedIntentToken: String? = null
         val linkRepository = object : FakeLinkRepository() {
             override suspend fun createLinkAccountSession(
+                requestOptions: ApiRequest.Options,
                 consumerSessionClientSecret: String,
                 intentToken: String?,
                 linkMode: LinkMode?,
@@ -1032,6 +1047,7 @@ class DefaultLinkAccountManagerTest {
         var capturedIntentToken: String? = null
         val linkRepository = object : FakeLinkRepository() {
             override suspend fun createLinkAccountSession(
+                requestOptions: ApiRequest.Options,
                 consumerSessionClientSecret: String,
                 intentToken: String?,
                 linkMode: LinkMode?,

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
@@ -68,7 +68,7 @@ class DefaultLinkEventsReporterTest {
             analyticsRequestExecutor = analyticsRequestExecutor,
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = application,
-                publishableKey = "pk_1234"
+                publishableKeyProvider = { "pk_1234" },
             ),
             errorReporter = FakeErrorReporter(),
             workContext = testScope.coroutineContext,

--- a/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/analytics/DefaultLinkEventsReporterTest.kt
@@ -68,7 +68,7 @@ class DefaultLinkEventsReporterTest {
             analyticsRequestExecutor = analyticsRequestExecutor,
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = application,
-                publishableKeyProvider = { "pk_1234" },
+                publishableKey = "pk_1234",
             ),
             errorReporter = FakeErrorReporter(),
             workContext = testScope.coroutineContext,

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/FakeLinkRepository.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link.repositories
 
 import app.cash.turbine.Turbine
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.LinkPaymentDetails
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.TestFactory
@@ -63,6 +64,7 @@ internal open class FakeLinkRepository : LinkRepository {
     private val mobileSignUpCalls = Turbine<MobileSignUpCall>()
 
     override suspend fun lookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         linkAuthIntentId: String?,
         sessionId: String,
@@ -79,6 +81,7 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun lookupConsumerWithoutBackendLoggingForExposure(
+        requestOptions: ApiRequest.Options,
         email: String,
         sessionId: String
     ): Result<ConsumerSessionLookup> {
@@ -92,6 +95,7 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun mobileLookupConsumer(
+        requestOptions: ApiRequest.Options,
         email: String?,
         emailSource: EmailSource?,
         linkAuthIntentId: String?,
@@ -116,12 +120,14 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun refreshConsumer(
+        requestOptions: ApiRequest.Options,
         appId: String,
         consumerSessionClientSecret: String,
         supportedVerificationTypes: List<String>?
     ): Result<ConsumerSessionRefresh> = refreshConsumerResult
 
     override suspend fun consumerSignUp(
+        requestOptions: ApiRequest.Options,
         email: String,
         phone: String?,
         country: String?,
@@ -131,6 +137,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ) = consumerSignUpResult
 
     override suspend fun mobileSignUp(
+        requestOptions: ApiRequest.Options,
         name: String?,
         email: String,
         phoneNumber: String?,
@@ -161,6 +168,7 @@ internal open class FakeLinkRepository : LinkRepository {
     }
 
     override suspend fun createCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -169,6 +177,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ) = createCardPaymentDetailsResult
 
     override suspend fun createPaymentDetailsFromPaymentMethod(
+        requestOptions: ApiRequest.Options,
         paymentMethod: PaymentMethod,
         userEmail: String,
         stripeIntent: StripeIntent,
@@ -178,6 +187,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ): Result<LinkPaymentDetails.Saved> = createPaymentDetailsFromPaymentMethodResult
 
     override suspend fun createBankAccountPaymentDetails(
+        requestOptions: ApiRequest.Options,
         bankAccountId: String,
         userEmail: String,
         consumerSessionClientSecret: String,
@@ -185,6 +195,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ) = createBankAccountPaymentDetailsResult
 
     override suspend fun shareCardPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodCreateParams: PaymentMethodCreateParams,
         id: String,
         consumerSessionClientSecret: String,
@@ -192,6 +203,7 @@ internal open class FakeLinkRepository : LinkRepository {
     ): Result<LinkPaymentDetails.Passthrough> = shareCardPaymentDetailsResult
 
     override suspend fun sharePaymentDetails(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
         expectedPaymentMethodType: String?,
@@ -203,58 +215,69 @@ internal open class FakeLinkRepository : LinkRepository {
     ): Result<SharePaymentDetails> = sharePaymentDetails
 
     override suspend fun createPaymentMethod(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         paymentMethod: LinkPaymentMethod,
         clientAttributionMetadata: ClientAttributionMetadata,
     ) = createPaymentMethod
 
     override suspend fun logOut(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?
     ) = logOutResult
 
     override suspend fun startVerification(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         isResendSmsCode: Boolean
     ) = startVerificationResult
 
     override suspend fun confirmVerification(
+        requestOptions: ApiRequest.Options,
         verificationCode: String,
         consumerSessionClientSecret: String,
         consentGranted: Boolean?
     ): Result<ConsumerSession> = confirmVerificationResult
 
     override suspend fun postConsentUpdate(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         consentGranted: Boolean,
     ): Result<Unit> = postConsentUpdateResult
 
     override suspend fun listPaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentMethodTypes: Set<String>,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails> = listPaymentDetailsResult
 
     override suspend fun listShippingAddresses(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
     ): Result<ConsumerShippingAddresses> = listShippingAddressesResult
 
     override suspend fun deletePaymentDetails(
+        requestOptions: ApiRequest.Options,
         paymentDetailsId: String,
         consumerSessionClientSecret: String,
     ): Result<Unit> = deletePaymentDetailsResult
 
     override suspend fun updatePaymentDetails(
+        requestOptions: ApiRequest.Options,
         updateParams: ConsumerPaymentDetailsUpdateParams,
         consumerSessionClientSecret: String,
     ): Result<ConsumerPaymentDetails> = updatePaymentDetailsResult
 
     override suspend fun createLinkAccountSession(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         intentToken: String?,
         linkMode: LinkMode?,
     ): Result<LinkAccountSession> = createLinkAccountSessionResult
 
     override suspend fun updatePhoneNumber(
+        requestOptions: ApiRequest.Options,
         consumerSessionClientSecret: String,
         phoneNumber: String,
     ): Result<ConsumerSession> = updatePhoneNumberResult

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.repositories
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.FakeConsumersApiService
@@ -74,6 +75,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.lookupConsumer(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             linkAuthIntentId = null,
             sessionId = SESSION_ID,
@@ -111,6 +113,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.lookupConsumer(
+            requestOptions = DEFAULT_OPTIONS,
             email = "email",
             linkAuthIntentId = null,
             sessionId = SESSION_ID,
@@ -127,6 +130,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.mobileLookupConsumer(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             linkAuthIntentId = null,
             verificationToken = TestFactory.VERIFICATION_TOKEN,
@@ -174,6 +178,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.mobileLookupConsumer(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             linkAuthIntentId = null,
             verificationToken = TestFactory.VERIFICATION_TOKEN,
@@ -194,6 +199,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.consumerSignUp(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             phone = TestFactory.CUSTOMER_PHONE,
             country = TestFactory.COUNTRY,
@@ -224,6 +230,7 @@ class LinkApiRepositoryTest {
         consumersApiService.signUpResult = Result.failure(error)
 
         val result = linkRepository.consumerSignUp(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             phone = TestFactory.CUSTOMER_PHONE,
             country = TestFactory.COUNTRY,
@@ -241,6 +248,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.mobileSignUp(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             phoneNumber = TestFactory.CUSTOMER_PHONE,
             country = TestFactory.COUNTRY,
@@ -278,6 +286,7 @@ class LinkApiRepositoryTest {
         consumersApiService.mobileSignUpResult = Result.failure(error)
 
         val result = linkRepository.mobileSignUp(
+            requestOptions = DEFAULT_OPTIONS,
             email = TestFactory.EMAIL,
             phoneNumber = TestFactory.CUSTOMER_PHONE,
             country = TestFactory.COUNTRY,
@@ -300,6 +309,7 @@ class LinkApiRepositoryTest {
         val email = "email@stripe.com"
 
         linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             userEmail = email,
             stripeIntent = paymentIntent,
@@ -342,6 +352,7 @@ class LinkApiRepositoryTest {
         val email = "email@stripe.com"
 
         linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParamsWithoutBillingAddress,
             userEmail = email,
             stripeIntent = paymentIntent,
@@ -381,6 +392,7 @@ class LinkApiRepositoryTest {
             val createParams = cardPaymentMethodCreateParams.copy(allowRedisplay = allowRedisplay)
 
             val linkDetails = linkRepository.createCardPaymentDetails(
+                requestOptions = DEFAULT_OPTIONS,
                 paymentMethodCreateParams = createParams,
                 userEmail = email,
                 stripeIntent = paymentIntent,
@@ -399,6 +411,7 @@ class LinkApiRepositoryTest {
             val email = "email@stripe.com"
 
             linkRepository.createCardPaymentDetails(
+                requestOptions = DEFAULT_OPTIONS,
                 paymentMethodCreateParams = cardPaymentMethodCreateParams,
                 userEmail = email,
                 stripeIntent = paymentIntent,
@@ -438,6 +451,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(fakeConsumersApiService)
 
         val result = linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             userEmail = "jenny@example.com",
             stripeIntent = paymentIntent,
@@ -471,6 +485,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success(paymentDetails))
 
         val result = linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             userEmail = email,
             stripeIntent = paymentIntent,
@@ -538,6 +553,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.failure(RuntimeException("error")))
 
         val result = linkRepository.createCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             userEmail = "email@stripe.com",
             stripeIntent = paymentIntent,
@@ -565,6 +581,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.createPaymentDetailsFromPaymentMethod(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethod = paymentMethod,
             userEmail = "email@stripe.com",
             stripeIntent = paymentIntent,
@@ -609,6 +626,7 @@ class LinkApiRepositoryTest {
         val linkRepository = linkRepository(consumersApiService)
 
         val result = linkRepository.createPaymentDetailsFromPaymentMethod(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethod = paymentMethod,
             userEmail = "email@stripe.com",
             stripeIntent = paymentIntent,
@@ -633,6 +651,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.failure(RuntimeException("error")))
 
         val result = linkRepository.createBankAccountPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             bankAccountId = "id_123",
             userEmail = "email@stripe.com",
             consumerSessionClientSecret = "secret",
@@ -650,6 +669,7 @@ class LinkApiRepositoryTest {
     fun `createBankAccountPaymentDetails sends client attribution metadata properly`() = runTest {
         val clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA
         linkRepository.createBankAccountPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             bankAccountId = "id_123",
             userEmail = "email@stripe.com",
             consumerSessionClientSecret = "secret",
@@ -686,6 +706,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
 
         val result = linkRepository.shareCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
             id = paymentDetailsId,
@@ -740,6 +761,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
 
         val result = linkRepository.shareCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
             id = paymentDetailsId,
@@ -774,6 +796,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.failure(RuntimeException("error")))
 
         val result = linkRepository.shareCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams,
             consumerSessionClientSecret = consumerSessionSecret,
             id = "csmrpd*AYq4D_sXdAAAAOQ0",
@@ -805,7 +828,10 @@ class LinkApiRepositoryTest {
     @Test
     fun `startVerification sends correct parameters`() = runTest {
         val secret = "secret"
-        linkRepository.startVerification(secret)
+        linkRepository.startVerification(
+            requestOptions = DEFAULT_OPTIONS,
+            consumerSessionClientSecret = secret,
+        )
 
         verify(consumersApiService).startConsumerVerification(
             consumerSessionClientSecret = secret,
@@ -836,7 +862,10 @@ class LinkApiRepositoryTest {
         )
             .thenReturn(consumerSession)
 
-        val result = linkRepository.startVerification("secret")
+        val result = linkRepository.startVerification(
+            requestOptions = DEFAULT_OPTIONS,
+            consumerSessionClientSecret = "secret",
+        )
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrNull()).isEqualTo(consumerSession)
@@ -858,7 +887,10 @@ class LinkApiRepositoryTest {
         )
             .thenThrow(RuntimeException("error"))
 
-        val result = linkRepository.startVerification("secret")
+        val result = linkRepository.startVerification(
+            requestOptions = DEFAULT_OPTIONS,
+            consumerSessionClientSecret = "secret",
+        )
 
         assertThat(result.isFailure).isTrue()
     }
@@ -866,7 +898,11 @@ class LinkApiRepositoryTest {
     @Test
     fun `listPaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
-        linkRepository.listPaymentDetails(setOf("card"), secret)
+        linkRepository.listPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
+            paymentMethodTypes = setOf("card"),
+            consumerSessionClientSecret = secret,
+        )
 
         verify(stripeRepository).listPaymentDetails(
             eq(secret),
@@ -884,6 +920,7 @@ class LinkApiRepositoryTest {
         val paymentDetailsId = "csmrpd*AYq4D_sXdAAAAOQ0"
 
         linkRepository.sharePaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             consumerSessionClientSecret = consumerSessionSecret,
             paymentDetailsId = paymentDetailsId,
             expectedPaymentMethodType = "card",
@@ -905,7 +942,11 @@ class LinkApiRepositoryTest {
     fun `deletePaymentDetails sends correct parameters`() = runTest {
         val secret = "secret"
         val id = "payment_details_id"
-        linkRepository.deletePaymentDetails(id, secret)
+        linkRepository.deletePaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
+            paymentDetailsId = id,
+            consumerSessionClientSecret = secret,
+        )
 
         verify(stripeRepository).deletePaymentDetails(
             eq(secret),
@@ -918,7 +959,11 @@ class LinkApiRepositoryTest {
     fun `deletePaymentDetails returns successful result`() = runTest {
         whenever(stripeRepository.deletePaymentDetails(any(), any(), any())).thenReturn(Result.success(Unit))
 
-        val result = linkRepository.deletePaymentDetails("id", "secret")
+        val result = linkRepository.deletePaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
+            paymentDetailsId = "id",
+            consumerSessionClientSecret = "secret",
+        )
 
         assertThat(result.isSuccess).isTrue()
     }
@@ -929,7 +974,11 @@ class LinkApiRepositoryTest {
         whenever(stripeRepository.deletePaymentDetails(any(), any(), any()))
             .thenReturn(Result.failure(error))
 
-        val result = linkRepository.deletePaymentDetails("id", "secret")
+        val result = linkRepository.deletePaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
+            paymentDetailsId = "id",
+            consumerSessionClientSecret = "secret",
+        )
 
         assertThat(result.exceptionOrNull()).isEqualTo(error)
     }
@@ -943,8 +992,9 @@ class LinkApiRepositoryTest {
         )
 
         linkRepository.updatePaymentDetails(
-            params,
-            secret,
+            requestOptions = DEFAULT_OPTIONS,
+            updateParams = params,
+            consumerSessionClientSecret = secret,
         )
 
         verify(stripeRepository).updatePaymentDetails(
@@ -960,11 +1010,12 @@ class LinkApiRepositoryTest {
             .thenReturn(Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS))
 
         val result = linkRepository.updatePaymentDetails(
-            ConsumerPaymentDetailsUpdateParams(
+            requestOptions = DEFAULT_OPTIONS,
+            updateParams = ConsumerPaymentDetailsUpdateParams(
                 "id",
                 clientAttributionMetadataParams = mapOf("merchant_integration_source" to "elements"),
             ),
-            "secret",
+            consumerSessionClientSecret = "secret",
         )
 
         assertThat(result.getOrNull()).isEqualTo(TestFactory.CONSUMER_PAYMENT_DETAILS)
@@ -977,11 +1028,12 @@ class LinkApiRepositoryTest {
             .thenReturn(Result.failure(error))
 
         val result = linkRepository.updatePaymentDetails(
-            ConsumerPaymentDetailsUpdateParams(
+            requestOptions = DEFAULT_OPTIONS,
+            updateParams = ConsumerPaymentDetailsUpdateParams(
                 "id",
                 clientAttributionMetadataParams = mapOf("merchant_integration_source" to "elements"),
             ),
-            "secret",
+            consumerSessionClientSecret = "secret",
         )
 
         assertThat(result.exceptionOrNull()).isEqualTo(error)
@@ -1000,6 +1052,7 @@ class LinkApiRepositoryTest {
         ).thenReturn(Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD))
 
         val result = linkRepository.shareCardPaymentDetails(
+            requestOptions = DEFAULT_OPTIONS,
             paymentMethodCreateParams = cardPaymentMethodCreateParams.copy(allowRedisplay = allowRedisplay),
             consumerSessionClientSecret = "consumer_session_secret",
             id = "csmrpd*AYq4D_sXdAAAAOQ0",
@@ -1032,13 +1085,17 @@ class LinkApiRepositoryTest {
         return LinkApiRepository(
             application = ApplicationProvider.getApplicationContext(),
             requestSurface = RequestSurface.PaymentElement,
-            publishableKeyProvider = { PUBLISHABLE_KEY },
-            stripeAccountIdProvider = { STRIPE_ACCOUNT_ID },
+            apiConfigProvider = {
+                ApiConfiguration.State(
+                    publishableKey = PUBLISHABLE_KEY,
+                    stripeAccountId = STRIPE_ACCOUNT_ID,
+                )
+            },
             stripeRepository = stripeRepository,
             consumersApiService = consumersApiService,
             workContext = Dispatchers.IO,
             locale = Locale.US,
-            errorReporter = errorReporter
+            errorReporter = errorReporter,
         )
     }
 
@@ -1077,5 +1134,9 @@ class LinkApiRepositoryTest {
         const val STRIPE_ACCOUNT_ID = "stripeAccountId"
         const val CONSUMER_SURFACE = "android_payment_element"
         const val SESSION_ID = "sess_123"
+        val DEFAULT_OPTIONS = ApiRequest.Options(
+            apiKey = PUBLISHABLE_KEY,
+            stripeAccount = STRIPE_ACCOUNT_ID,
+        )
     }
 }


### PR DESCRIPTION
# Summary
Store API configuration in Link session and Activity contracts, and require Link callers to pass `ApiRequest.Options` explicitly to repository operations.

Because Link no longer initializes process-wide `PaymentConfiguration` as a side effect of configuration, Crypto Onramp now initializes that compatibility state explicitly from its own publishable key before configuring Link.

Changed classes and entry points:

- `OnrampInteractor`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `LogLinkHoldbackExperiment`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `LinkControllerInteractor`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `NativeLinkActivityContract`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `WebLinkActivityContract`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `DefaultLinkAccountManager`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `DefaultLinkAuth`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `LinkControllerComponent`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `LinkControllerModule`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `NativeLinkModule`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `LinkApiRepository`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `LinkRepository`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.
- `LinkHoldbackExposureModule`: make Link operations use session-owned request options, or replace the removed Link initialization side effect.

Committed and created by Codex.

# Motivation
Link can use session, consumer, or merchant-of-record credentials that differ from process-wide configuration. Explicit request ownership prevents repository calls from silently selecting the wrong key or connected account.

`LinkControllerModule` temporarily derives a lazy state provider from the controller configuration for existing Dagger consumers, while `ApiRequestOptionsOnlyModule` adapts it for unmigrated request-options injections. `buildRequestOptions` is a compatibility utility for operation-specific key overrides: a custom key intentionally clears the connected account; otherwise the caller's complete options are preserved. Cleanup removes the generic injection adapters, while the override utility remains because it represents Link behavior rather than migration scaffolding.

The Onramp initialization is an intentional bridge for its remaining global consumers. It replaces the implicit Link side effect at the ownership boundary and is retained when the later peripheral-module layer migrates those consumers to lazy paired state. Unit-test application fixtures provide Robolectric's real application context so the bridge can initialize preferences and fraud-detection dependencies exactly as production does.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — Link request wiring only.

# Changelog
Not applicable — no public API or intended UI change.
