### PR TITLE
Propagate API configuration to Tap to Add and Card Scan

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncher.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncher.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.asStateFlow
 internal class CardScanStripeLauncher(
     context: Context,
     private val eventsReporter: CardScanEventsReporter,
+    private val publishableKey: String,
     private val enableMlKitCardScan: Boolean,
     private val elementsSessionId: String?,
     private val disableSsdOcrCardScan: Boolean,
@@ -53,6 +54,7 @@ internal class CardScanStripeLauncher(
             CardScanSheetParams(
                 CardScanConfiguration(
                     elementsSessionId = elementsSessionId,
+                    publishableKey = publishableKey,
                     enableMlKitTextRecognition = enableMlKitCardScan,
                     disableSsdOcr = disableSsdOcrCardScan,
                 )
@@ -113,6 +115,7 @@ internal class CardScanStripeLauncher(
         @Composable
         internal fun rememberCardScanStripeLauncher(
             eventsReporter: CardScanEventsReporter,
+            publishableKey: String,
             enableMlKitCardScan: Boolean = false,
             elementsSessionId: String? = null,
             disableSsdOcrCardScan: Boolean = false,
@@ -121,11 +124,12 @@ internal class CardScanStripeLauncher(
             val context = LocalContext.current.applicationContext
             val isLaunchingState = rememberSaveable { mutableStateOf(false) }
             val launcher = remember(
-                eventsReporter, context, enableMlKitCardScan, elementsSessionId, disableSsdOcrCardScan,
+                eventsReporter, context, publishableKey, enableMlKitCardScan, elementsSessionId, disableSsdOcrCardScan,
             ) {
                 CardScanStripeLauncher(
                     context = context,
                     eventsReporter = eventsReporter,
+                    publishableKey = publishableKey,
                     enableMlKitCardScan = enableMlKitCardScan,
                     elementsSessionId = elementsSessionId,
                     disableSsdOcrCardScan = disableSsdOcrCardScan,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/RememberCardScanLauncher.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/cardscan/RememberCardScanLauncher.kt
@@ -14,6 +14,7 @@ internal fun rememberCardScanLauncher(
     isStripeCardScanAllowed: Boolean = false,
     enableMlKitCardScan: Boolean = false,
     disableSsdOcrCardScan: Boolean = false,
+    publishableKey: String,
     onResult: (CardScanResult) -> Unit,
     isStripeCardScanAvailable: IsStripeCardScanAvailable = DefaultIsStripeCardScanAvailable(),
 ): CardScanLauncher? {
@@ -27,6 +28,7 @@ internal fun rememberCardScanLauncher(
     return if (isStripeCardScanAllowed && isStripeCardScanAvailable() && hasActiveStripeScanner) {
         rememberCardScanStripeLauncher(
             eventsReporter = eventsReporter,
+            publishableKey = publishableKey,
             enableMlKitCardScan = enableMlKitCardScan,
             elementsSessionId = elementsSessionId,
             disableSsdOcrCardScan = disableSsdOcrCardScan,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardScanAction.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardScanAction.kt
@@ -12,6 +12,7 @@ class CardScanAction(
     private val isStripeCardScanAllowed: Boolean,
     private val enableMlKitCardScan: Boolean,
     private val disableSsdOcrCardScan: Boolean,
+    private val publishableKey: String,
     val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
 ) : CardDetailsAction {
     @Composable
@@ -21,6 +22,7 @@ class CardScanAction(
             isStripeCardScanAllowed = isStripeCardScanAllowed,
             enableMlKitCardScan = enableMlKitCardScan,
             disableSsdOcrCardScan = disableSsdOcrCardScan,
+            publishableKey = publishableKey,
             onResult = { result ->
                 (result as? CardScanResult.Completed)?.scannedCard?.let { scannedCard ->
                     onScannedCard(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncherTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/cardscan/CardScanStripeLauncherTest.kt
@@ -106,6 +106,7 @@ class CardScanStripeLauncherTest {
         val launcher = CardScanStripeLauncher(
             context = ApplicationProvider.getApplicationContext(),
             eventsReporter = fakeEventsReporter,
+            publishableKey = "pk_test_123",
             enableMlKitCardScan = false,
             elementsSessionId = null,
             disableSsdOcrCardScan = false,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardScanActionTest.kt
@@ -136,6 +136,7 @@ internal class CardScanActionTest {
             isStripeCardScanAllowed = false,
             enableMlKitCardScan = false,
             disableSsdOcrCardScan = false,
+            publishableKey = "pk_test_123",
             automaticallyLaunchedCardScanFormDataHelper = helper,
         )
         val scenario = Scenario(onScannedCardCalls = onScannedCardCalls)

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
@@ -9,7 +9,8 @@ import com.stripe.android.common.nfcscan.tapzone.TapZoneModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.payments.core.injection.ApiConfigurationFromPublishableKeyModule
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component
@@ -40,8 +41,9 @@ internal interface NfcScanningViewModelComponent {
         NfcHardwareDelegateModule::class,
         NfcCardScannerModule::class,
         NfcScanningEventReporterModule::class,
-        ApiConfigurationFromPublishableKeyModule::class,
         TapZoneModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsModule::class,
     ]
 )
 internal interface NfcScanningViewModelModule {

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
@@ -9,6 +9,7 @@ import com.stripe.android.common.nfcscan.tapzone.TapZoneModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.payments.core.injection.ApiConfigurationToNamedModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import dagger.Binds
@@ -43,6 +44,7 @@ internal interface NfcScanningViewModelComponent {
         NfcScanningEventReporterModule::class,
         TapZoneModule::class,
         ApiConfigurationModule::class,
+        ApiConfigurationToNamedModule::class,
         ApiRequestOptionsModule::class,
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/NfcScanningViewModelComponent.kt
@@ -9,8 +9,8 @@ import com.stripe.android.common.nfcscan.tapzone.TapZoneModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import dagger.Binds
 import dagger.BindsInstance
 import dagger.Component

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporterModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporterModule.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.common.nfcscan.analytics
 
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -44,11 +43,6 @@ internal interface NfcScanningEventReporterModule {
                 else -> "mc_"
             }
         }
-
-        @Provides
-        fun provideApiConfigurationState(
-            paymentMethodMetadata: PaymentMethodMetadata
-        ): ApiConfiguration.State = paymentMethodMetadata.apiConfiguration
 
         @Provides
         fun provideDurationProvider(): DurationProvider {

--- a/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporterModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/nfcscan/analytics/NfcScanningEventReporterModule.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.common.nfcscan.analytics
 
-import android.content.Context
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
@@ -48,10 +46,9 @@ internal interface NfcScanningEventReporterModule {
         }
 
         @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(context: Context): () -> String = {
-            PaymentConfiguration.getInstance(context).publishableKey
-        }
+        fun provideApiConfigurationState(
+            paymentMethodMetadata: PaymentMethodMetadata
+        ): ApiConfiguration.State = paymentMethodMetadata.apiConfiguration
 
         @Provides
         fun provideDurationProvider(): DurationProvider {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -220,6 +220,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                 isStripeCardScanAllowed = metadata.isStripeCardScanAllowed,
                 enableMlKitCardScan = metadata.enableMlKitCardScan,
                 disableSsdOcrCardScan = metadata.disableSsdOcrCardScan,
+                publishableKey = metadata.apiConfiguration.publishableKey,
                 automaticallyLaunchedCardScanFormDataHelper =
                     arguments.automaticallyLaunchedCardScanFormDataHelper,
             )

--- a/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanDemoActivity.kt
+++ b/stripecardscan-example/src/main/java/com/stripe/android/stripecardscan/example/CardScanDemoActivity.kt
@@ -24,6 +24,7 @@ class CardScanDemoActivity : AppCompatActivity() {
                     elementsSessionId = null,
                     enableMlKitTextRecognition = viewBinding.enableMlKitCheckbox.isChecked,
                     disableSsdOcr = viewBinding.disableSsdOcrCheckbox.isChecked,
+                    publishableKey = "pk_123"
                 )
             )
         }

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanActivity.kt
@@ -221,7 +221,7 @@ internal class CardScanActivity : ScanActivity(), SimpleScanStateful<CardScanSta
             BundleCompat.getParcelable(it, INTENT_PARAM_REQUEST, CardScanSheetParams::class.java)
         }
         val cardScanConfiguration = cardScanSheetParams?.cardScanConfiguration
-            ?: CardScanConfiguration(elementsSessionId = null)
+            ?: CardScanConfiguration(elementsSessionId = null, publishableKey = "")
 
         scanFlow = createScanFlow(
             enableMlKitTextRecognition = cardScanConfiguration.enableMlKitTextRecognition,

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanConfiguration.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanConfiguration.kt
@@ -8,6 +8,7 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class CardScanConfiguration(
     val elementsSessionId: String?,
+    val publishableKey: String,
     val enableMlKitTextRecognition: Boolean = false,
     val disableSsdOcr: Boolean = false,
 ) : Parcelable

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/cardscan/CardScanSheet.kt
@@ -148,7 +148,7 @@ class CardScanSheet private constructor() {
      * https://paper.dropbox.com/doc/Bouncer-Web-API-Review--BTOclListnApWjHdpv4DoaOuAg-Wy0HGlL0XfwAOz9hHuzS1#:h2=Creating-a-CardImageVerificati
      */
     fun present() {
-        present(CardScanConfiguration(elementsSessionId = null))
+        present(CardScanConfiguration(elementsSessionId = null, publishableKey = ""))
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripecardscan/src/main/java/com/stripe/android/stripecardscan/di/CardScanModule.kt
+++ b/stripecardscan/src/main/java/com/stripe/android/stripecardscan/di/CardScanModule.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.stripecardscan.di
 
 import android.app.Application
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultAnalyticsRequestExecutor
@@ -13,6 +11,7 @@ import com.stripe.android.core.utils.ContextUtils.packageInfo
 import com.stripe.android.core.utils.DefaultDurationProvider
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.stripecardscan.BuildConfig
+import com.stripe.android.stripecardscan.cardscan.CardScanConfiguration
 import com.stripe.android.stripecardscan.cardscan.CardScanEventsReporter
 import com.stripe.android.stripecardscan.cardscan.DefaultCardScanEventsReporter
 import dagger.Binds
@@ -39,12 +38,12 @@ internal interface CardScanModule {
         @Singleton
         internal fun provideAnalyticsRequestFactory(
             application: Application,
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String
+            configuration: CardScanConfiguration,
         ): AnalyticsRequestFactory = AnalyticsRequestFactory(
             packageManager = application.packageManager,
             packageName = application.packageName.orEmpty(),
             packageInfo = application.packageInfo,
-            publishableKeyProvider = publishableKeyProvider,
+            publishableKeyProvider = { configuration.publishableKey },
             networkTypeProvider = NetworkTypeDetector(application)::invoke,
         )
 
@@ -56,12 +55,6 @@ internal interface CardScanModule {
         @Provides
         @Named(ENABLE_LOGGING)
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
-
-        @Provides
-        @Named(PUBLISHABLE_KEY)
-        fun providePublishableKey(
-            application: Application
-        ): () -> String = { PaymentConfiguration.getInstance(application.applicationContext).publishableKey }
 
         @Provides
         @Singleton

--- a/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
+++ b/stripecardscan/src/test/java/com/stripe/android/stripecardscan/cardscan/DefaultCardScanEventsReporterTest.kt
@@ -213,7 +213,7 @@ internal class DefaultCardScanEventsReporterTest {
                 pluginTypeProvider = { null }
             ),
             durationProvider = durationProvider,
-            cardScanConfiguration = CardScanConfiguration(ELEMENTS_SESSION_ID)
+            cardScanConfiguration = CardScanConfiguration(ELEMENTS_SESSION_ID, publishableKey = "pk_test_123")
         )
 
         testBlock(eventsReporter, analyticsRequestExecutor)


### PR DESCRIPTION
# Summary
Complete the remaining peripheral credential propagation for Card Scan.

Card Scan carries the initiating publishable key explicitly through `CardScanConfiguration`, its Activity contract, launcher, and analytics construction.

Changed classes and entry points:

- `CardScanStripeLauncher`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `RememberCardScanLauncher`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `CardScanAction`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `NfcScanningViewModelComponent`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `NfcScanningEventReporterModule`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `CardDefinition`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `CardScanDemoActivity`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `CardScanActivity`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `CardScanConfiguration`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `CardScanSheet`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.
- `CardScanModule`: carry the initiating publishable key through Card Scan/NFC launch, Activity, and analytics boundaries.

Committed and created by Codex.

# Motivation
Card Scan runs across an Activity and possible recreation boundary and cannot read PaymentSheet metadata directly. Adding the publishable key to its internal configuration is the compatibility bridge that preserves the credential selected by the initiating flow instead of consulting the current global `PaymentConfiguration` later.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — internal analytics and Activity credential propagation only.

# Changelog
Not applicable — no public API or intended visual change.
