### PR TITLE
Migrate peripheral modules to API configuration state

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
@@ -6,9 +6,8 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.BuildConfig
 import com.stripe.android.Stripe
 import com.stripe.android.common.di.MobileSessionIdModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.utils.RealUserFacingLogger
@@ -23,15 +22,19 @@ import com.stripe.android.crypto.onramp.repositories.CryptoApiRepository.Compani
 import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.networking.StripeRepository
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
 import javax.inject.Singleton
 
 @Module(
-    includes = [MobileSessionIdModule::class, PaymentConfigurationModule::class, StripeNetworkClientModule::class],
+    includes = [
+        MobileSessionIdModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
+        StripeNetworkClientModule::class
+    ],
     subcomponents = [OnrampPresenterComponent::class]
 )
 internal class OnrampModule {
@@ -57,14 +60,12 @@ internal class OnrampModule {
         stripeNetworkClient: StripeNetworkClient,
         stripeRepository: StripeRepository,
         linkController: LinkController,
-        @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-        @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
+        apiConfigProvider: () -> ApiConfiguration.State,
     ): CryptoApiRepository {
         return CryptoApiRepository(
             stripeNetworkClient = stripeNetworkClient,
             stripeRepository = stripeRepository,
-            publishableKeyProvider = publishableKeyProvider,
-            stripeAccountIdProvider = stripeAccountIdProvider,
+            apiConfigProvider = apiConfigProvider,
             apiVersion = CRYPTO_ONRAMP_API_VERSION,
             linkController = linkController,
             appInfo = Stripe.appInfo

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampModule.kt
@@ -27,6 +27,7 @@ import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
+import javax.inject.Provider
 import javax.inject.Singleton
 
 @Module(
@@ -60,7 +61,7 @@ internal class OnrampModule {
         stripeNetworkClient: StripeNetworkClient,
         stripeRepository: StripeRepository,
         linkController: LinkController,
-        apiConfigProvider: () -> ApiConfiguration.State,
+        apiConfigProvider: Provider<ApiConfiguration.State>,
     ): CryptoApiRepository {
         return CryptoApiRepository(
             stripeNetworkClient = stripeNetworkClient,

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -60,6 +60,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import org.json.JSONObject
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 
 /*
@@ -72,7 +73,7 @@ internal class CryptoApiRepository @Inject constructor(
     private val stripeNetworkClient: StripeNetworkClient,
     private val stripeRepository: StripeRepository,
     private val linkController: LinkController,
-    private val apiConfigProvider: () -> ApiConfiguration.State,
+    private val apiConfigProvider: Provider<ApiConfiguration.State>,
     apiVersion: String,
     sdkVersion: String = StripeSdkVersion.VERSION,
     appInfo: AppInfo?
@@ -367,7 +368,7 @@ internal class CryptoApiRepository @Inject constructor(
     ): Result<PaymentMethod> {
         val options = ApiRequest.Options(
             apiKey = platformPublishableKey,
-            stripeAccount = apiConfigProvider().stripeAccountId,
+            stripeAccount = apiConfigProvider.get().stripeAccountId,
         )
 
         return stripeRepository.createToken(
@@ -430,15 +431,15 @@ internal class CryptoApiRepository @Inject constructor(
             expandFields = listOf("payment_method"),
             options = ApiRequest.Options(
                 apiKey = publishableKey,
-                stripeAccount = apiConfigProvider().stripeAccountId,
+                stripeAccount = apiConfigProvider.get().stripeAccountId,
             )
         )
     }
 
     private fun buildRequestOptions(): ApiRequest.Options {
         return ApiRequest.Options(
-            apiKey = apiConfigProvider().publishableKey,
-            stripeAccount = apiConfigProvider().stripeAccountId,
+            apiKey = apiConfigProvider.get().publishableKey,
+            stripeAccount = apiConfigProvider.get().stripeAccountId,
         )
     }
 

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/repositories/CryptoApiRepository.kt
@@ -1,12 +1,11 @@
 package com.stripe.android.crypto.onramp.repositories
 
 import androidx.annotation.RestrictTo
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.AppInfo
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
@@ -61,7 +60,6 @@ import kotlinx.serialization.json.encodeToJsonElement
 import kotlinx.serialization.json.jsonObject
 import org.json.JSONObject
 import javax.inject.Inject
-import javax.inject.Named
 import javax.inject.Singleton
 
 /*
@@ -74,8 +72,7 @@ internal class CryptoApiRepository @Inject constructor(
     private val stripeNetworkClient: StripeNetworkClient,
     private val stripeRepository: StripeRepository,
     private val linkController: LinkController,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
-    @Named(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     apiVersion: String,
     sdkVersion: String = StripeSdkVersion.VERSION,
     appInfo: AppInfo?
@@ -370,7 +367,7 @@ internal class CryptoApiRepository @Inject constructor(
     ): Result<PaymentMethod> {
         val options = ApiRequest.Options(
             apiKey = platformPublishableKey,
-            stripeAccount = stripeAccountIdProvider(),
+            stripeAccount = apiConfigProvider().stripeAccountId,
         )
 
         return stripeRepository.createToken(
@@ -433,15 +430,15 @@ internal class CryptoApiRepository @Inject constructor(
             expandFields = listOf("payment_method"),
             options = ApiRequest.Options(
                 apiKey = publishableKey,
-                stripeAccount = stripeAccountIdProvider(),
+                stripeAccount = apiConfigProvider().stripeAccountId,
             )
         )
     }
 
     private fun buildRequestOptions(): ApiRequest.Options {
         return ApiRequest.Options(
-            apiKey = publishableKeyProvider(),
-            stripeAccount = stripeAccountIdProvider(),
+            apiKey = apiConfigProvider().publishableKey,
+            stripeAccount = apiConfigProvider().stripeAccountId,
         )
     }
 

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/CryptoApiRepositoryTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/CryptoApiRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.crypto.onramp
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.networking.ApiRequest
@@ -50,8 +51,12 @@ class CryptoApiRepositoryTest {
     private val cryptoApiRepository = CryptoApiRepository(
         stripeNetworkClient = stripeNetworkClient,
         stripeRepository = stripeRepository,
-        publishableKeyProvider = { "pk_test_vOo1umqsYxSrP5UXfOeL3ecm" },
-        stripeAccountIdProvider = { "TestAccountId" },
+        apiConfigProvider = {
+            ApiConfiguration.State(
+                publishableKey = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm",
+                stripeAccountId = "TestAccountId"
+            )
+        },
         apiVersion = CRYPTO_ONRAMP_API_VERSION,
         sdkVersion = StripeSdkVersion.VERSION,
         appInfo = null,

--- a/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/repository/FinancialConnectionsLiteRepository.kt
+++ b/financial-connections-lite/src/main/java/com/stripe/android/financialconnections/lite/repository/FinancialConnectionsLiteRepository.kt
@@ -24,8 +24,8 @@ internal class FinancialConnectionsLiteRepositoryImpl(
 ) : FinancialConnectionsLiteRepository {
 
     fun FinancialConnectionsSheetConfiguration.apiRequestOptions() = ApiRequest.Options(
-        publishableKeyProvider = { publishableKey },
-        stripeAccountIdProvider = { stripeAccountId },
+        apiKey = publishableKey,
+        stripeAccount = stripeAccountId,
     )
 
     override suspend fun synchronize(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.financialconnections.di
 
 import android.app.Application
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.injection.ENABLE_LOGGING
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.financialconnections.BuildConfig
 import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
 import dagger.Module
@@ -14,18 +14,13 @@ import javax.inject.Named
 internal object FinancialConnectionsSheetConfigurationModule {
 
     @Provides
-    @Named(PUBLISHABLE_KEY)
     @ActivityRetainedScope
-    fun providesPublishableKey(
+    fun providesApiConfigurationState(
         configuration: FinancialConnectionsSheetConfiguration
-    ): String = configuration.publishableKey
-
-    @Provides
-    @Named(STRIPE_ACCOUNT_ID)
-    @ActivityRetainedScope
-    fun providesStripeAccountId(
-        configuration: FinancialConnectionsSheetConfiguration
-    ): String? = configuration.stripeAccountId
+    ): ApiConfiguration.State = ApiConfiguration.State(
+        publishableKey = configuration.publishableKey,
+        stripeAccountId = configuration.stripeAccountId,
+    )
 
     @Provides
     @Named(ENABLE_LOGGING)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
@@ -15,12 +15,14 @@ internal object FinancialConnectionsSheetConfigurationModule {
 
     @Provides
     @ActivityRetainedScope
-    fun providesApiConfigurationState(
+    fun providesApiConfigurationStateProvider(
         configuration: FinancialConnectionsSheetConfiguration
-    ): ApiConfiguration.State = ApiConfiguration.State(
-        publishableKey = configuration.publishableKey,
-        stripeAccountId = configuration.stripeAccountId,
-    )
+    ): () -> ApiConfiguration.State = {
+        ApiConfiguration.State(
+            publishableKey = configuration.publishableKey,
+            stripeAccountId = configuration.stripeAccountId,
+        )
+    }
 
     @Provides
     @Named(ENABLE_LOGGING)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetConfigurationModule.kt
@@ -15,14 +15,12 @@ internal object FinancialConnectionsSheetConfigurationModule {
 
     @Provides
     @ActivityRetainedScope
-    fun providesApiConfigurationStateProvider(
+    fun providesApiConfiguration(
         configuration: FinancialConnectionsSheetConfiguration
-    ): () -> ApiConfiguration.State = {
-        ApiConfiguration.State(
-            publishableKey = configuration.publishableKey,
-            stripeAccountId = configuration.stripeAccountId,
-        )
-    }
+    ): ApiConfiguration.State = ApiConfiguration.State(
+        publishableKey = configuration.publishableKey,
+        stripeAccountId = configuration.stripeAccountId,
+    )
 
     @Provides
     @Named(ENABLE_LOGGING)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -119,11 +119,14 @@ internal interface FinancialConnectionsSheetSharedModule {
         @Provides
         @ActivityRetainedScope
         internal fun providesApiOptions(
-            apiConfiguration: ApiConfiguration.State
-        ): ApiRequest.Options = ApiRequest.Options(
-            apiKey = apiConfiguration.publishableKey,
-            stripeAccount = apiConfiguration.stripeAccountId
-        )
+            apiConfigurationProvider: () -> ApiConfiguration.State
+        ): ApiRequest.Options {
+            val apiConfiguration = apiConfigurationProvider()
+            return ApiRequest.Options(
+                apiKey = apiConfiguration.publishableKey,
+                stripeAccount = apiConfiguration.stripeAccountId
+            )
+        }
 
         @Provides
         @ActivityRetainedScope
@@ -180,14 +183,16 @@ internal interface FinancialConnectionsSheetSharedModule {
         @ActivityRetainedScope
         internal fun provideAnalyticsRequestFactory(
             application: Application,
-            apiConfiguration: ApiConfiguration.State
-        ): AnalyticsRequestFactory = AnalyticsRequestFactory(
-            packageManager = application.packageManager,
-            packageName = application.packageName.orEmpty(),
-            packageInfo = application.packageInfo,
-            publishableKeyProvider = { apiConfiguration.publishableKey },
-            networkTypeProvider = NetworkTypeDetector(application)::invoke,
-        )
+            apiConfigurationProvider: () -> ApiConfiguration.State
+        ): AnalyticsRequestFactory {
+            return AnalyticsRequestFactory(
+                packageManager = application.packageManager,
+                packageName = application.packageName.orEmpty(),
+                packageInfo = application.packageInfo,
+                publishableKeyProvider = { apiConfigurationProvider().publishableKey },
+                networkTypeProvider = NetworkTypeDetector(application)::invoke,
+            )
+        }
 
         @Provides
         @ActivityRetainedScope

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.Json
 import java.util.Locale
 import javax.inject.Named
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -119,9 +120,9 @@ internal interface FinancialConnectionsSheetSharedModule {
         @Provides
         @ActivityRetainedScope
         internal fun providesApiOptions(
-            apiConfigurationProvider: () -> ApiConfiguration.State
+            apiConfigurationProvider: Provider<ApiConfiguration.State>
         ): ApiRequest.Options {
-            val apiConfiguration = apiConfigurationProvider()
+            val apiConfiguration = apiConfigurationProvider.get()
             return ApiRequest.Options(
                 apiKey = apiConfiguration.publishableKey,
                 stripeAccount = apiConfiguration.stripeAccountId
@@ -183,13 +184,13 @@ internal interface FinancialConnectionsSheetSharedModule {
         @ActivityRetainedScope
         internal fun provideAnalyticsRequestFactory(
             application: Application,
-            apiConfigurationProvider: () -> ApiConfiguration.State
+            apiConfigurationProvider: Provider<ApiConfiguration.State>
         ): AnalyticsRequestFactory {
             return AnalyticsRequestFactory(
                 packageManager = application.packageManager,
                 packageName = application.packageName.orEmpty(),
                 packageInfo = application.packageInfo,
-                publishableKeyProvider = { apiConfigurationProvider().publishableKey },
+                publishableKeyProvider = { apiConfigurationProvider.get().publishableKey },
                 networkTypeProvider = NetworkTypeDetector(application)::invoke,
             )
         }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/FinancialConnectionsSheetSharedModule.kt
@@ -3,12 +3,12 @@ package com.stripe.android.financialconnections.di
 import android.app.Application
 import android.content.Context
 import androidx.core.os.LocaleListCompat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.ApiVersion
 import com.stripe.android.core.Logger
 import com.stripe.android.core.frauddetection.FraudDetectionDataRepository
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.core.injection.UIContext
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
@@ -119,11 +119,10 @@ internal interface FinancialConnectionsSheetSharedModule {
         @Provides
         @ActivityRetainedScope
         internal fun providesApiOptions(
-            @Named(PUBLISHABLE_KEY) publishableKey: String,
-            @Named(STRIPE_ACCOUNT_ID) stripeAccountId: String?
+            apiConfiguration: ApiConfiguration.State
         ): ApiRequest.Options = ApiRequest.Options(
-            apiKey = publishableKey,
-            stripeAccount = stripeAccountId
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId
         )
 
         @Provides
@@ -181,12 +180,12 @@ internal interface FinancialConnectionsSheetSharedModule {
         @ActivityRetainedScope
         internal fun provideAnalyticsRequestFactory(
             application: Application,
-            @Named(PUBLISHABLE_KEY) publishableKey: String
+            apiConfiguration: ApiConfiguration.State
         ): AnalyticsRequestFactory = AnalyticsRequestFactory(
             packageManager = application.packageManager,
             packageName = application.packageName.orEmpty(),
             packageInfo = application.packageInfo,
-            publishableKeyProvider = { publishableKey },
+            publishableKeyProvider = { apiConfiguration.publishableKey },
             networkTypeProvider = NetworkTypeDetector(application)::invoke,
         )
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/di/NamedConstants.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/di/NamedConstants.kt
@@ -1,11 +1,6 @@
 package com.stripe.android.financialconnections.di
 
 /**
- * Name for user's publishable key.
- */
-internal const val PUBLISHABLE_KEY = "publishableKey"
-
-/**
  * Host's applicationId.
  */
 internal const val APPLICATION_ID = "applicationId"

--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingCoordinator.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingCoordinator.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
+import javax.inject.Provider
 
 internal interface PaymentMethodMessagingCoordinator {
     val messagingContent: StateFlow<PaymentMethodMessagingContent?>
@@ -25,7 +26,7 @@ internal interface PaymentMethodMessagingCoordinator {
 
 internal class DefaultPaymentMethodMessagingCoordinator @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val apiConfigProvider: () -> ApiConfiguration.State,
+    private val apiConfigProvider: Provider<ApiConfiguration.State>,
     private val eventReporter: PaymentMethodMessagingEventReporter,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     private val errorReporter: ErrorReporter
@@ -45,8 +46,8 @@ internal class DefaultPaymentMethodMessagingCoordinator @Inject constructor(
             locale = configuration.locale,
             country = configuration.countryCode,
             requestOptions = ApiRequest.Options(
-                apiKey = apiConfigProvider().publishableKey,
-                stripeAccount = apiConfigProvider().stripeAccountId
+                apiKey = apiConfigProvider.get().publishableKey,
+                stripeAccount = apiConfigProvider.get().stripeAccountId
             )
         ).fold(
             onSuccess = { paymentMethodMessage ->

--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingCoordinator.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingCoordinator.kt
@@ -2,7 +2,7 @@
 
 package com.stripe.android.paymentmethodmessaging.element
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethodMessage
@@ -15,7 +15,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
-import javax.inject.Provider
 
 internal interface PaymentMethodMessagingCoordinator {
     val messagingContent: StateFlow<PaymentMethodMessagingContent?>
@@ -26,7 +25,7 @@ internal interface PaymentMethodMessagingCoordinator {
 
 internal class DefaultPaymentMethodMessagingCoordinator @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     private val eventReporter: PaymentMethodMessagingEventReporter,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     private val errorReporter: ErrorReporter
@@ -46,8 +45,8 @@ internal class DefaultPaymentMethodMessagingCoordinator @Inject constructor(
             locale = configuration.locale,
             country = configuration.countryCode,
             requestOptions = ApiRequest.Options(
-                apiKey = paymentConfiguration.get().publishableKey,
-                stripeAccount = paymentConfiguration.get().stripeAccountId
+                apiKey = apiConfigProvider().publishableKey,
+                stripeAccount = apiConfigProvider().stripeAccountId
             )
         ).fold(
             onSuccess = { paymentMethodMessage ->

--- a/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingModule.kt
+++ b/payment-method-messaging/src/main/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingModule.kt
@@ -13,8 +13,8 @@ import com.stripe.android.paymentmethodmessaging.element.analytics.DefaultPaymen
 import com.stripe.android.paymentmethodmessaging.element.analytics.PaymentMethodMessagingEventReporter
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
 import com.stripe.android.uicore.image.StripeImageLoader
 import com.stripe.android.uicore.isSystemDarkTheme
@@ -26,7 +26,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
 
-@Module(includes = [PaymentConfigurationModule::class])
+@Module(includes = [ApiConfigurationFromPaymentConfigurationModule::class])
 internal interface PaymentMethodMessagingModule {
 
     @Binds

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/DefaultPaymentMethodMessagingCoordinatorTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/DefaultPaymentMethodMessagingCoordinatorTest.kt
@@ -4,7 +4,7 @@ package com.stripe.android.paymentmethodmessaging.element
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentmethodmessaging.element.analytics.FakeEventReporter
@@ -133,11 +133,10 @@ internal class DefaultPaymentMethodMessagingCoordinatorTest {
         testBlock: suspend Scenario.() -> Unit
     ) = runTest {
         val repository: StripeRepository = FakeStripeRepository()
-        val paymentConfig = { PaymentConfiguration(publishableKey = "key") }
         val errorReporter = FakeErrorReporter()
         val coordinator = DefaultPaymentMethodMessagingCoordinator(
             stripeRepository = repository,
-            paymentConfiguration = paymentConfig,
+            apiConfigProvider = { ApiConfiguration.State(publishableKey = "key", stripeAccountId = null) },
             eventReporter = FakeEventReporter(),
             viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = errorReporter

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/PaymentMethodMessagingContentTest.kt
@@ -12,7 +12,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.intent.rule.IntentsRule
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentmethodmessaging.element.PaymentMethodMessagingElement.Appearance.Theme
 import com.stripe.android.paymentmethodmessaging.element.analytics.FakeEventReporter
@@ -100,7 +100,7 @@ internal class PaymentMethodMessagingContentTest {
     ) = runTest {
         val coordinator = DefaultPaymentMethodMessagingCoordinator(
             stripeRepository = FakeStripeRepository(),
-            paymentConfiguration = { PaymentConfiguration("key") },
+            apiConfigProvider = { ApiConfiguration.State(publishableKey = "key", stripeAccountId = null) },
             eventReporter = FakeEventReporter(),
             viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = FakeErrorReporter()

--- a/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/PaymentMethodMessageAnalyticsTest.kt
+++ b/payment-method-messaging/src/test/java/com/stripe/android/paymentmethodmessaging/element/analytics/PaymentMethodMessageAnalyticsTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentmethodmessaging.element.DefaultPaymentMethodMessagingCoordinator
 import com.stripe.android.paymentmethodmessaging.element.FakeStripeRepository
@@ -192,7 +192,7 @@ internal class PaymentMethodMessageAnalyticsTest {
         val errorReporter = FakeErrorReporter()
         val coordinator = DefaultPaymentMethodMessagingCoordinator(
             stripeRepository = FakeStripeRepository(),
-            paymentConfiguration = { PaymentConfiguration(publishableKey = "pk_123_test") },
+            apiConfigProvider = { ApiConfiguration.State(publishableKey = "pk_123_test", stripeAccountId = null) },
             eventReporter = eventReporter,
             viewModelScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
             errorReporter = errorReporter


### PR DESCRIPTION
# Summary
Migrate Financial Connections, Financial Connections Lite, Crypto Onramp, and Payment Method Messaging to paired API configuration state.

Changed classes and entry points:

- `OnrampModule`: migrate the peripheral module to coherent paired API-configuration state.
- `CryptoApiRepository`: migrate the peripheral module to coherent paired API-configuration state.
- `FinancialConnectionsLiteRepository`: migrate the peripheral module to coherent paired API-configuration state.
- `FinancialConnectionsSheetConfigurationModule`: migrate the peripheral module to coherent paired API-configuration state.
- `FinancialConnectionsSheetSharedModule`: migrate the peripheral module to coherent paired API-configuration state.
- `NamedConstants`: migrate the peripheral module to coherent paired API-configuration state.
- `PaymentMethodMessagingCoordinator`: migrate the peripheral module to coherent paired API-configuration state.
- `PaymentMethodMessagingModule`: migrate the peripheral module to coherent paired API-configuration state.

Committed and created by Codex.

# Motivation
Peripheral modules previously reconstructed publishable-key and Stripe-account dependencies independently, creating the same mismatch and eager-resolution risks as Payments Core.

Financial Connections derives state directly from its sheet configuration. Crypto Onramp and Payment Method Messaging include `ApiConfigurationFromPaymentConfigurationModule` as a compatibility bridge because their existing entry points still initialize the global configuration. Onramp's explicit initialization moved to stack layer 9 when Link stopped providing that side effect; this layer migrates its repository and analytics consumers to the lazy paired provider. The bridge preserves current public behavior, while obsolete module-local named bindings are removed by the cleanup layer.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

All 64 `OnrampInteractorTest` tests and Crypto Onramp Detekt passed. Crypto Onramp, Financial Connections, Financial Connections Lite, Payment Method Messaging, and PaymentSheet Example compilation passed. No tests were newly ignored.

# Screenshots
Not applicable — dependency wiring only.

# Changelog
Not applicable — no public API or intended user-visible behavior change.
