### PR TITLE
Extract Native Link form helper factory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/NativeLinkFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/NativeLinkFormHelperFactory.kt
@@ -1,0 +1,54 @@
+package com.stripe.android.link.ui.paymentmenthod
+
+import androidx.lifecycle.viewModelScope
+import com.stripe.android.link.injection.NativeLinkComponent
+import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.FormHelper
+import com.stripe.android.paymentsheet.LinkInlineHandler
+import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
+import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
+import com.stripe.android.paymentsheet.addresselement.analytics.NoOpAddressLauncherEventReporter
+import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+
+internal class NativeLinkFormHelperFactory(
+    private val parentComponent: NativeLinkComponent,
+) {
+    fun create(): FormHelper {
+        return DefaultFormHelper(
+            coroutineScope = parentComponent.viewModel.viewModelScope,
+            linkInlineHandler = LinkInlineHandler.create(),
+            cardAccountRangeRepositoryFactory = parentComponent.cardAccountRangeRepositoryFactory,
+            paymentMethodMetadata = parentComponent.paymentMethodMetadata,
+            newPaymentSelectionProvider = { null },
+            linkConfigurationCoordinator = null,
+            selectionUpdater = {},
+            setAsDefaultMatchesSaveForFutureUse =
+                FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+            eventReporter = parentComponent.eventReporter,
+            savedStateHandle = parentComponent.viewModel.savedStateHandle,
+            autocompleteAddressInteractorFactory = createAutocompleteAddressInteractorFactory(),
+            isLinkUI = true,
+            automaticallyLaunchedCardScanFormDataHelper = null,
+            tapToAddHelper = null,
+            paymentMethodMessagePromotionsHelper = null,
+            isNfcScanningAvailable = null,
+        )
+    }
+
+    private fun createAutocompleteAddressInteractorFactory(): AutocompleteAddressInteractor.Factory {
+        return PaymentElementAutocompleteAddressInteractor.Factory(
+            launcher = parentComponent.autocompleteLauncher,
+            autocompleteConfig = AutocompleteAddressInteractor.Config(
+                googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
+                autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
+                isInlineAutocompleteEnabled = true,
+            ),
+            placesClient = null,
+            stripeAutocompleteRepository = null,
+            coroutineScope = null,
+            shouldUseAutocompleteProxyEndpointsProvider = { false },
+            eventReporter = NoOpAddressLauncherEventReporter,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/PaymentMethodViewModel.kt
@@ -23,13 +23,8 @@ import com.stripe.android.link.ui.PrimaryButtonState
 import com.stripe.android.link.ui.completePaymentButtonLabel
 import com.stripe.android.link.withDismissalDisabled
 import com.stripe.android.model.PaymentMethod
-import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
-import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
-import com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractor
-import com.stripe.android.paymentsheet.addresselement.analytics.NoOpAddressLauncherEventReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
-import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -196,28 +191,7 @@ internal class PaymentMethodViewModel @Inject constructor(
                             dismissalCoordinator = parentComponent.dismissalCoordinator,
                             linkLaunchMode = parentComponent.linkLaunchMode
                         ),
-                        formHelper = DefaultFormHelper.create(
-                            coroutineScope = parentComponent.viewModel.viewModelScope,
-                            cardAccountRangeRepositoryFactory = parentComponent.cardAccountRangeRepositoryFactory,
-                            paymentMethodMetadata = parentComponent.paymentMethodMetadata,
-                            eventReporter = parentComponent.eventReporter,
-                            savedStateHandle = parentComponent.viewModel.savedStateHandle,
-                            autocompleteAddressInteractorFactory =
-                                PaymentElementAutocompleteAddressInteractor.Factory(
-                                    launcher = parentComponent.autocompleteLauncher,
-                                    autocompleteConfig = AutocompleteAddressInteractor.Config(
-                                        googlePlacesApiKey = parentComponent.configuration.googlePlacesApiKey,
-                                        autocompleteCountries = AUTOCOMPLETE_DEFAULT_COUNTRIES,
-                                        isInlineAutocompleteEnabled = true,
-                                    ),
-                                    placesClient = null,
-                                    stripeAutocompleteRepository = null,
-                                    coroutineScope = null,
-                                    shouldUseAutocompleteProxyEndpointsProvider = { false },
-                                    eventReporter = NoOpAddressLauncherEventReporter,
-                                ),
-                            isLinkUI = true,
-                        ),
+                        formHelper = NativeLinkFormHelperFactory(parentComponent).create(),
                         logger = parentComponent.logger,
                         dismissalCoordinator = parentComponent.dismissalCoordinator,
                         linkLaunchMode = parentComponent.linkLaunchMode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -23,7 +23,6 @@ import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
-import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
@@ -93,35 +92,6 @@ internal class DefaultFormHelper(
                 tapToAddHelper = viewModel.tapToAddHelper,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
-            )
-        }
-
-        fun create(
-            coroutineScope: CoroutineScope,
-            cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
-            autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
-            paymentMethodMetadata: PaymentMethodMetadata,
-            eventReporter: EventReporter,
-            savedStateHandle: SavedStateHandle,
-            isLinkUI: Boolean = false,
-        ): FormHelper {
-            return DefaultFormHelper(
-                coroutineScope = coroutineScope,
-                linkInlineHandler = LinkInlineHandler.create(),
-                cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
-                paymentMethodMetadata = paymentMethodMetadata,
-                newPaymentSelectionProvider = { null },
-                linkConfigurationCoordinator = null,
-                selectionUpdater = {},
-                setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
-                eventReporter = eventReporter,
-                savedStateHandle = savedStateHandle,
-                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-                isLinkUI = isLinkUI,
-                automaticallyLaunchedCardScanFormDataHelper = null,
-                tapToAddHelper = null,
-                paymentMethodMessagePromotionsHelper = null,
-                isNfcScanningAvailable = null,
             )
         }
     }


### PR DESCRIPTION
# Summary

Move Native Link form-helper construction into `NativeLinkFormHelperFactory`, keeping Link-specific autocomplete and form configuration out of `PaymentMethodViewModel` and removing the obsolete generic `DefaultFormHelper.create` overload.

This is PR 1 of 5 and targets `master`.

# Motivation

Native Link has a distinct set of form dependencies. Giving that surface its own factory makes the construction boundary explicit and prepares `DefaultFormHelper` for a focused responsibility split in a later PR.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.link.ui.paymentmethod.PaymentMethodViewModelTest' :paymentsheet:detekt`
- `git diff --check`

No tests were ignored.

# Screenshots

Not applicable — this is an internal construction refactor with no UI changes.

# Changelog

Not applicable — this internal refactor does not change public API or user-visible behavior.

Committed and created by Codex.
