### PR TITLE
Extract base sheet form helper factory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
+import kotlinx.coroutines.CoroutineScope
+
+internal class BaseSheetFormHelperFactory(
+    private val viewModel: BaseSheetViewModel,
+) {
+    fun create(
+        coroutineScope: CoroutineScope,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        linkInlineHandler: LinkInlineHandler,
+        shouldCreateAutomaticallyLaunchedCardScanFormDataHelper: Boolean,
+        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+    ): FormHelper {
+        return DefaultFormHelper(
+            coroutineScope = coroutineScope,
+            linkInlineHandler = linkInlineHandler,
+            cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
+            paymentMethodMetadata = paymentMethodMetadata,
+            newPaymentSelectionProvider = { viewModel.newPaymentSelection },
+            selectionUpdater = viewModel::updateSelection,
+            linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
+            setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
+            eventReporter = viewModel.eventReporter,
+            savedStateHandle = viewModel.savedStateHandle,
+            autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+            automaticallyLaunchedCardScanFormDataHelper = createAutomaticallyLaunchedCardScanFormDataHelper(
+                shouldCreate = shouldCreateAutomaticallyLaunchedCardScanFormDataHelper,
+                paymentMethodMetadata = paymentMethodMetadata,
+            ),
+            tapToAddHelper = viewModel.tapToAddHelper,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+            isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
+        )
+    }
+
+    private fun createAutomaticallyLaunchedCardScanFormDataHelper(
+        shouldCreate: Boolean,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): AutomaticallyLaunchedCardScanFormDataHelper? {
+        if (!shouldCreate) {
+            return null
+        }
+
+        val hasSeenAutomaticCardScanLaunch =
+            viewModel.newPaymentSelection?.paymentSelection is PaymentSelection.New.Card &&
+                viewModel.newPaymentSelection?.getPaymentMethodCreateParams() != null
+
+        return AutomaticallyLaunchedCardScanFormDataHelper(
+            openCardScanAutomaticallyConfig = paymentMethodMetadata.openCardScanAutomatically,
+            savedStateHandle = viewModel.savedStateHandle,
+            hasAutomaticallyLaunchedCardScanInitialValue = hasSeenAutomaticCardScanLaunch,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -21,7 +21,6 @@ import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
-import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
@@ -51,49 +50,6 @@ internal class DefaultFormHelper(
 ) : FormHelper {
     companion object {
         internal const val PREVIOUSLY_COMPLETED_PAYMENT_FORM = "previously_completed_payment_form"
-        fun create(
-            viewModel: BaseSheetViewModel,
-            coroutineScope: CoroutineScope,
-            paymentMethodMetadata: PaymentMethodMetadata,
-            linkInlineHandler: LinkInlineHandler = LinkInlineHandler.create(),
-            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper: Boolean = false,
-            paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
-        ): FormHelper {
-            return DefaultFormHelper(
-                coroutineScope = coroutineScope,
-                linkInlineHandler = linkInlineHandler,
-                cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
-                paymentMethodMetadata = paymentMethodMetadata,
-                newPaymentSelectionProvider = {
-                    viewModel.newPaymentSelection
-                },
-                linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
-                selectionUpdater = {
-                    viewModel.updateSelection(it)
-                },
-                setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
-                eventReporter = viewModel.eventReporter,
-                savedStateHandle = viewModel.savedStateHandle,
-                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
-                automaticallyLaunchedCardScanFormDataHelper =
-                if (shouldCreateAutomaticallyLaunchedCardScanFormDataHelper) {
-                    val hasSeenAutomaticCardScanLaunch =
-                        viewModel.newPaymentSelection?.paymentSelection is PaymentSelection.New.Card &&
-                            viewModel.newPaymentSelection?.getPaymentMethodCreateParams() != null
-
-                    AutomaticallyLaunchedCardScanFormDataHelper(
-                        openCardScanAutomaticallyConfig = paymentMethodMetadata.openCardScanAutomatically,
-                        savedStateHandle = viewModel.savedStateHandle,
-                        hasAutomaticallyLaunchedCardScanInitialValue = hasSeenAutomaticCardScanLaunch,
-                    )
-                } else {
-                    null
-                },
-                tapToAddHelper = viewModel.tapToAddHelper,
-                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
-                isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
-            )
-        }
     }
 
     private val lastFormValues = MutableSharedFlow<Pair<FormFieldValues?, String>>(replay = 1)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -5,7 +5,8 @@ import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
-import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.BaseSheetFormHelperFactory
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -94,10 +95,10 @@ internal class DefaultAddPaymentMethodInteractor(
             paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
         ): AddPaymentMethodInteractor {
             val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Main)
-            val formHelper = DefaultFormHelper.create(
-                viewModel = viewModel,
+            val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                 coroutineScope = coroutineScope,
                 paymentMethodMetadata = paymentMethodMetadata,
+                linkInlineHandler = LinkInlineHandler.create(),
                 shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -11,10 +11,11 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.BaseSheetFormHelperFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.FormHelper.FormType
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.analytics.code
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
@@ -136,10 +137,11 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
         ): PaymentMethodVerticalLayoutInteractor {
             val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Default)
             val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
-            val formHelper = DefaultFormHelper.create(
-                viewModel = viewModel,
+            val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                 coroutineScope = formHelperScope,
                 paymentMethodMetadata = paymentMethodMetadata,
+                linkInlineHandler = LinkInlineHandler.create(),
+                shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )
             val isCurrentScreen = viewModel.navigationHandler.currentScreen.mapAsStateFlow {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormInteractor.kt
@@ -4,8 +4,9 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.FormHeaderInformation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher
+import com.stripe.android.paymentsheet.BaseSheetFormHelperFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
@@ -125,10 +126,10 @@ internal class DefaultVerticalModeFormInteractor(
         ): VerticalModeFormInteractor {
             val coroutineScope = viewModel.viewModelScope.childScope(Dispatchers.Default)
             val formHelperScope = coroutineScope.childScope(Dispatchers.Main)
-            val formHelper = DefaultFormHelper.create(
-                viewModel = viewModel,
+            val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                 coroutineScope = formHelperScope,
                 paymentMethodMetadata = paymentMethodMetadata,
+                linkInlineHandler = LinkInlineHandler.create(),
                 shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -3,14 +3,16 @@ package com.stripe.android.paymentsheet.verticalmode
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
+import com.stripe.android.paymentsheet.BaseSheetFormHelperFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
 
@@ -60,15 +62,10 @@ internal object VerticalModeInitialScreenFactory {
             (viewModel.selection.value as? PaymentSelection.New?)?.let { newPaymentSelection ->
                 val paymentMethodCode = newPaymentSelection.paymentMethodCreateParams.typeCode
 
-                // This form helper only answers formTypeForCode synchronously and is then discarded, so give it a
-                // scope we cancel immediately rather than leaking its init collector on viewModelScope for the life
-                // of the sheet.
+                // This form helper is discarded after this synchronous lookup, so cancel its scope immediately.
                 val formTypeScope = viewModel.viewModelScope.childScope(Dispatchers.Main)
-                val formType = DefaultFormHelper.create(
-                    viewModel = viewModel,
-                    coroutineScope = formTypeScope,
-                    paymentMethodMetadata = paymentMethodMetadata
-                ).formTypeForCode(paymentMethodCode)
+                val formType = createFormHelper(viewModel, formTypeScope, paymentMethodMetadata)
+                    .formTypeForCode(paymentMethodCode)
                 formTypeScope.cancel()
 
                 if (formType == FormHelper.FormType.UserInteractionRequired) {
@@ -87,5 +84,19 @@ internal object VerticalModeInitialScreenFactory {
                 }
             }
         }
+    }
+
+    private fun createFormHelper(
+        viewModel: BaseSheetViewModel,
+        coroutineScope: CoroutineScope,
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): FormHelper {
+        return BaseSheetFormHelperFactory(viewModel).create(
+            coroutineScope = coroutineScope,
+            paymentMethodMetadata = paymentMethodMetadata,
+            linkInlineHandler = LinkInlineHandler.create(),
+            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
+            paymentMethodMessagePromotionsHelper = null,
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperOpenCardScanAutomaticallyTest.kt
@@ -152,11 +152,12 @@ internal class FormHelperOpenCardScanAutomaticallyTest {
         ),
         block: (List<FormElement>) -> Unit,
     ) {
-        val defaultFormHelper = DefaultFormHelper.create(
-            viewModel = viewModel,
+        val defaultFormHelper = BaseSheetFormHelperFactory(viewModel).create(
             coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = paymentMethodMetadata,
-            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true
+            linkInlineHandler = LinkInlineHandler.create(),
+            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = true,
+            paymentMethodMessagePromotionsHelper = null,
         )
 
         val formElements = defaultFormHelper.formElementsForCode(PaymentMethod.Type.Card.code)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -1375,11 +1375,11 @@ internal class PaymentOptionsViewModelTest {
         val viewModel = createLinkViewModel()
 
         val linkInlineHandler = LinkInlineHandler.create()
-        val formHelper = DefaultFormHelper.create(
-            viewModel = viewModel,
+        val formHelper = BaseSheetFormHelperFactory(viewModel).create(
             coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
             linkInlineHandler = linkInlineHandler,
+            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
             paymentMethodMessagePromotionsHelper = null
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -813,11 +813,12 @@ internal class PaymentSheetViewModelTest {
             )
 
             val linkInlineHandler = LinkInlineHandler.create()
-            val formHelper = DefaultFormHelper.create(
-                viewModel = viewModel,
+            val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                 coroutineScope = viewModel.viewModelScope,
                 paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
                 linkInlineHandler = linkInlineHandler,
+                shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
+                paymentMethodMessagePromotionsHelper = null,
             )
 
             formHelper.onFormFieldValuesChanged(
@@ -1610,10 +1611,12 @@ internal class PaymentSheetViewModelTest {
             stripeIntent = PaymentIntentFixtures.PI_OFF_SESSION,
         )
 
-        val observedArgs = DefaultFormHelper.create(
-            viewModel = viewModel,
+        val observedArgs = BaseSheetFormHelperFactory(viewModel).create(
             coroutineScope = viewModel.viewModelScope,
             paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
+            linkInlineHandler = LinkInlineHandler.create(),
+            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
+            paymentMethodMessagePromotionsHelper = null,
         ).createFormArguments(
             paymentMethodCode = LpmRepositoryTestHelpers.card.code,
         )
@@ -2790,11 +2793,12 @@ internal class PaymentSheetViewModelTest {
                 assertThat(awaitItem()?.enabled).isFalse()
 
                 val linkInlineHandler = LinkInlineHandler.create()
-                val formHelper = DefaultFormHelper.create(
-                    viewModel = viewModel,
+                val formHelper = BaseSheetFormHelperFactory(viewModel).create(
                     coroutineScope = viewModel.viewModelScope,
                     paymentMethodMetadata = requireNotNull(viewModel.paymentMethodMetadata.value),
                     linkInlineHandler = linkInlineHandler,
+                    shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
+                    paymentMethodMessagePromotionsHelper = null,
                 )
 
                 formHelper.onFormFieldValuesChanged(


### PR DESCRIPTION
# Summary

Move Base Sheet form-helper construction into `BaseSheetFormHelperFactory`, including automatic card-scan setup, and migrate PaymentSheet and vertical-mode callers away from the overloaded `DefaultFormHelper.create` entry point.

This is PR 2 of 5 and depends on PR 1.

# Motivation

Base Sheet assembly depends on `BaseSheetViewModel` and several sheet-specific services. Isolating that wiring makes the helper itself easier to split by responsibility without changing form behavior.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.FormHelperOpenCardScanAutomaticallyTest' --tests 'com.stripe.android.paymentsheet.PaymentOptionsViewModelTest' --tests 'com.stripe.android.paymentsheet.PaymentSheetViewModelTest' --tests 'com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactoryTest' :paymentsheet:detekt`
- `git diff --check`

No tests were ignored.

# Screenshots

Not applicable — this is an internal construction refactor with no UI changes.

# Changelog

Not applicable — this internal refactor does not change public API or user-visible behavior.

Committed and created by Codex.
