### PR TITLE
Separate form definitions from selection coordination

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/NativeLinkFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/NativeLinkFormHelperFactory.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.ui.paymentmenthod
 
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.link.injection.NativeLinkComponent
+import com.stripe.android.paymentsheet.DefaultFormDefinitionFactory
 import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.LinkInlineHandler
@@ -15,24 +16,31 @@ internal class NativeLinkFormHelperFactory(
     private val parentComponent: NativeLinkComponent,
 ) {
     fun create(): FormHelper {
+        val linkInlineHandler = LinkInlineHandler.create()
+        val paymentMethodMetadata = parentComponent.paymentMethodMetadata
+
         return DefaultFormHelper(
             coroutineScope = parentComponent.viewModel.viewModelScope,
-            linkInlineHandler = LinkInlineHandler.create(),
-            cardAccountRangeRepositoryFactory = parentComponent.cardAccountRangeRepositoryFactory,
-            paymentMethodMetadata = parentComponent.paymentMethodMetadata,
-            newPaymentSelectionProvider = { null },
-            linkConfigurationCoordinator = null,
+            linkInlineHandler = linkInlineHandler,
+            paymentMethodMetadata = paymentMethodMetadata,
             selectionUpdater = {},
-            setAsDefaultMatchesSaveForFutureUse =
-                FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
             eventReporter = parentComponent.eventReporter,
             savedStateHandle = parentComponent.viewModel.savedStateHandle,
-            autocompleteAddressInteractorFactory = createAutocompleteAddressInteractorFactory(),
-            isLinkUI = true,
-            automaticallyLaunchedCardScanFormDataHelper = null,
-            tapToAddHelper = null,
-            paymentMethodMessagePromotionsHelper = null,
-            isNfcScanningAvailable = null,
+            formDefinitionFactory = DefaultFormDefinitionFactory(
+                linkInlineHandler = linkInlineHandler,
+                cardAccountRangeRepositoryFactory = parentComponent.cardAccountRangeRepositoryFactory,
+                paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = { null },
+                linkConfigurationCoordinator = null,
+                setAsDefaultMatchesSaveForFutureUse =
+                    FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
+                autocompleteAddressInteractorFactory = createAutocompleteAddressInteractorFactory(),
+                isLinkUI = true,
+                automaticallyLaunchedCardScanFormDataHelper = null,
+                tapToAddHelper = null,
+                paymentMethodMessagePromotionsHelper = null,
+                isNfcScanningAvailable = null,
+            ),
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -8,7 +8,9 @@ import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.DefaultFormDefinitionFactory
 import com.stripe.android.paymentsheet.DefaultFormHelper
+import com.stripe.android.paymentsheet.FormDefinitionFactory
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
@@ -38,39 +40,60 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
         paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
         selectionUpdater: (PaymentSelection?) -> Unit,
     ): FormHelper {
+        val linkInlineHandler = LinkInlineHandler.create()
         return DefaultFormHelper(
             coroutineScope = coroutineScope,
-            linkInlineHandler = LinkInlineHandler.create(),
-            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+            linkInlineHandler = linkInlineHandler,
             paymentMethodMetadata = paymentMethodMetadata,
-            newPaymentSelectionProvider = { code ->
-                val currentSelection = embeddedSelectionHolder.selection.value
-                    ?.takeIf { it.paymentMethodType == code }
-                    ?: embeddedSelectionHolder.getPreviousNewSelection(code)
-                when (currentSelection) {
-                    is PaymentSelection.ExternalPaymentMethod -> {
-                        NewPaymentOptionSelection.External(currentSelection)
-                    }
-                    is PaymentSelection.CustomPaymentMethod -> {
-                        NewPaymentOptionSelection.Custom(currentSelection)
-                    }
-                    is PaymentSelection.New -> {
-                        NewPaymentOptionSelection.New(currentSelection)
-                    }
-                    else -> null
-                }
-            },
             selectionUpdater = selectionUpdater,
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
-            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
             eventReporter = eventReporter,
             savedStateHandle = savedStateHandle,
+            formDefinitionFactory = createFormDefinitionFactory(
+                setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+                paymentMethodMetadata = paymentMethodMetadata,
+                automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+                tapToAddHelper = tapToAddHelper,
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                linkInlineHandler = linkInlineHandler,
+            ),
+        )
+    }
+
+    fun createFormDefinitionFactory(
+        setAsDefaultMatchesSaveForFutureUse: Boolean,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+        tapToAddHelper: TapToAddHelper?,
+        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+        linkInlineHandler: LinkInlineHandler,
+    ): FormDefinitionFactory {
+        return DefaultFormDefinitionFactory(
+            linkInlineHandler = linkInlineHandler,
+            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+            paymentMethodMetadata = paymentMethodMetadata,
+            newPaymentSelectionProvider = ::newPaymentSelection,
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
+            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
             autocompleteAddressInteractorFactory = null,
+            isLinkUI = false,
             automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
             tapToAddHelper = tapToAddHelper,
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
             isNfcScanningAvailable = isNfcScanningAvailable,
         )
+    }
+
+    private fun newPaymentSelection(code: PaymentMethodCode): NewPaymentOptionSelection? {
+        return when (
+            val currentSelection = embeddedSelectionHolder.selection.value
+                ?.takeIf { it.paymentMethodType == code }
+                ?: embeddedSelectionHolder.getPreviousNewSelection(code)
+        ) {
+            is PaymentSelection.ExternalPaymentMethod -> NewPaymentOptionSelection.External(currentSelection)
+            is PaymentSelection.CustomPaymentMethod -> NewPaymentOptionSelection.Custom(currentSelection)
+            is PaymentSelection.New -> NewPaymentOptionSelection.New(currentSelection)
+            else -> null
+        }
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
@@ -20,19 +20,38 @@ internal class BaseSheetFormHelperFactory(
         return DefaultFormHelper(
             coroutineScope = coroutineScope,
             linkInlineHandler = linkInlineHandler,
+            paymentMethodMetadata = paymentMethodMetadata,
+            selectionUpdater = viewModel::updateSelection,
+            eventReporter = viewModel.eventReporter,
+            savedStateHandle = viewModel.savedStateHandle,
+            formDefinitionFactory = createFormDefinitionFactory(
+                paymentMethodMetadata = paymentMethodMetadata,
+                linkInlineHandler = linkInlineHandler,
+                automaticallyLaunchedCardScanFormDataHelper = createAutomaticallyLaunchedCardScanFormDataHelper(
+                    shouldCreate = shouldCreateAutomaticallyLaunchedCardScanFormDataHelper,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                ),
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+            ),
+        )
+    }
+
+    private fun createFormDefinitionFactory(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        linkInlineHandler: LinkInlineHandler,
+        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+    ): FormDefinitionFactory {
+        return DefaultFormDefinitionFactory(
+            linkInlineHandler = linkInlineHandler,
             cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
             paymentMethodMetadata = paymentMethodMetadata,
             newPaymentSelectionProvider = { viewModel.newPaymentSelection },
-            selectionUpdater = viewModel::updateSelection,
             linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
             setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
-            eventReporter = viewModel.eventReporter,
-            savedStateHandle = viewModel.savedStateHandle,
             autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
-            automaticallyLaunchedCardScanFormDataHelper = createAutomaticallyLaunchedCardScanFormDataHelper(
-                shouldCreate = shouldCreateAutomaticallyLaunchedCardScanFormDataHelper,
-                paymentMethodMetadata = paymentMethodMetadata,
-            ),
+            isLinkUI = false,
+            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
             tapToAddHelper = viewModel.tapToAddHelper,
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
             isNfcScanningAvailable = viewModel.isNfcScanningAvailable,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/DefaultFormHelper.kt
@@ -1,57 +1,32 @@
 package com.stripe.android.paymentsheet
 
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.cards.CardAccountRangeRepository
-import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
-import com.stripe.android.common.taptoadd.TapToAddHelper
-import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
-import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.FormHelper.FormType
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
-import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
-import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
-import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.FormElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
+private const val PREVIOUSLY_COMPLETED_PAYMENT_FORM = "previously_completed_payment_form"
+
 internal class DefaultFormHelper(
     private val coroutineScope: CoroutineScope,
     private val linkInlineHandler: LinkInlineHandler,
-    private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     private val paymentMethodMetadata: PaymentMethodMetadata,
-    private val newPaymentSelectionProvider: (PaymentMethodCode) -> NewPaymentOptionSelection?,
     private val selectionUpdater: (PaymentSelection?) -> Unit,
-    private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
-    private val setAsDefaultMatchesSaveForFutureUse: Boolean,
     private val eventReporter: EventReporter,
     private val savedStateHandle: SavedStateHandle,
-    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
-    private val isLinkUI: Boolean = false,
-    private val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
-    private val tapToAddHelper: TapToAddHelper?,
-    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
-    private val isNfcScanningAvailable: IsNfcScanningAvailable?,
-) : FormHelper {
-    companion object {
-        internal const val PREVIOUSLY_COMPLETED_PAYMENT_FORM = "previously_completed_payment_form"
-    }
-
+    formDefinitionFactory: FormDefinitionFactory,
+) : FormHelper, FormDefinitionFactory by formDefinitionFactory {
     private val lastFormValues = MutableSharedFlow<Pair<FormFieldValues?, String>>(replay = 1)
 
     private val paymentSelection: Flow<PaymentSelection?> = combine(
@@ -80,56 +55,9 @@ internal class DefaultFormHelper(
         }
     }
 
-    override fun formElementsForCode(code: String): List<FormElement> {
-        return paymentMethodMetadata.formElementsForCode(
-            code = code,
-            uiDefinitionFactoryArgumentsFactory = createArgumentsFactory(code),
-        ) ?: emptyList()
-    }
-
-    override fun createFormArguments(
-        paymentMethodCode: PaymentMethodCode,
-    ): FormArguments {
-        return FormArgumentsFactory.create(
-            paymentMethodCode = paymentMethodCode,
-            metadata = paymentMethodMetadata,
-        )
-    }
-
     override fun onFormFieldValuesChanged(formValues: FormFieldValues?, selectedPaymentMethodCode: String) {
         coroutineScope.launch {
             lastFormValues.emit(formValues to selectedPaymentMethodCode)
-        }
-    }
-
-    override fun getPaymentMethodParams(
-        formValues: FormFieldValues?,
-        selectedPaymentMethodCode: String
-    ): PaymentMethodCreateParams? {
-        return formValues?.transformToPaymentMethodCreateParams(
-            paymentMethodCode = selectedPaymentMethodCode,
-            paymentMethodMetadata = paymentMethodMetadata
-        )
-    }
-
-    private fun requiresFormScreen(paymentMethodCode: String, formElements: List<FormElement>): Boolean {
-        val userInteractionAllowed = formElements.any { it.allowsUserInteraction }
-        return userInteractionAllowed ||
-            paymentMethodCode == PaymentMethod.Type.USBankAccount.code ||
-            paymentMethodCode == PaymentMethod.Type.Link.code
-    }
-
-    override fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormType {
-        val formElements = formElementsForCode(paymentMethodCode)
-        return if (requiresFormScreen(paymentMethodCode, formElements)) {
-            FormType.UserInteractionRequired
-        } else {
-            val mandate = formElements.firstNotNullOfOrNull { it.mandateText }
-            if (mandate == null) {
-                FormType.Empty
-            } else {
-                FormType.MandateOnly(mandate)
-            }
         }
     }
 
@@ -150,35 +78,5 @@ internal class DefaultFormHelper(
             eventReporter.onPaymentMethodFormCompleted(code)
             previouslyCompletedForm = code
         }
-    }
-
-    private fun createArgumentsFactory(code: String): UiDefinitionFactory.Arguments.Factory {
-        val currentSelection = newPaymentSelectionProvider(code)?.takeIf { it.getType() == code }
-
-        return UiDefinitionFactory.Arguments.Factory.Default(
-            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
-            linkInlineHandler = linkInlineHandler,
-            onLinkInlineSignupStateChanged = linkInlineHandler::onStateUpdated,
-            paymentMethodCreateParams = currentSelection?.getPaymentMethodCreateParams(),
-            paymentMethodOptionsParams = currentSelection?.getPaymentMethodOptionParams(),
-            paymentMethodExtraParams = currentSelection?.getPaymentMethodExtraParams(),
-            initialLinkUserInput = when (val selection = currentSelection?.paymentSelection) {
-                is PaymentSelection.New.Card -> selection.linkInput
-                else -> null
-            },
-            previousLinkSignupCheckboxSelection = when (val selection = currentSelection?.paymentSelection) {
-                // User entered a card and may have link input
-                is PaymentSelection.New.Card -> selection.linkInput != null
-                else -> null // Not a card, so no previous choice
-            },
-            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
-            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-            isLinkUI = isLinkUI,
-            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
-            tapToAddHelper = tapToAddHelper,
-            paymentMethodMessagingPromotionsHelper = paymentMethodMessagePromotionsHelper,
-            isNfcScanningAvailable = isNfcScanningAvailable,
-        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
@@ -1,0 +1,122 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
+import com.stripe.android.common.taptoadd.TapToAddHelper
+import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
+import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
+import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import com.stripe.android.uicore.elements.FormElement
+
+internal interface FormDefinitionFactory {
+    fun formElementsForCode(code: PaymentMethodCode): List<FormElement>
+
+    fun createFormArguments(paymentMethodCode: PaymentMethodCode): FormArguments
+
+    fun getPaymentMethodParams(
+        formValues: FormFieldValues?,
+        selectedPaymentMethodCode: PaymentMethodCode,
+    ): PaymentMethodCreateParams?
+
+    fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormHelper.FormType
+}
+
+internal class DefaultFormDefinitionFactory(
+    private val linkInlineHandler: LinkInlineHandler,
+    private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
+    private val paymentMethodMetadata: PaymentMethodMetadata,
+    private val newPaymentSelectionProvider: (PaymentMethodCode) -> NewPaymentOptionSelection?,
+    private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
+    private val setAsDefaultMatchesSaveForFutureUse: Boolean,
+    private val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    private val isLinkUI: Boolean,
+    private val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+    private val tapToAddHelper: TapToAddHelper?,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+    private val isNfcScanningAvailable: IsNfcScanningAvailable?,
+) : FormDefinitionFactory {
+    override fun formElementsForCode(code: PaymentMethodCode): List<FormElement> {
+        return paymentMethodMetadata.formElementsForCode(
+            code = code,
+            uiDefinitionFactoryArgumentsFactory = createArgumentsFactory(code),
+        ) ?: emptyList()
+    }
+
+    override fun createFormArguments(paymentMethodCode: PaymentMethodCode): FormArguments {
+        return FormArgumentsFactory.create(
+            paymentMethodCode = paymentMethodCode,
+            metadata = paymentMethodMetadata,
+        )
+    }
+
+    override fun getPaymentMethodParams(
+        formValues: FormFieldValues?,
+        selectedPaymentMethodCode: PaymentMethodCode,
+    ): PaymentMethodCreateParams? {
+        return formValues?.transformToPaymentMethodCreateParams(
+            paymentMethodCode = selectedPaymentMethodCode,
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
+    }
+
+    override fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormHelper.FormType {
+        val formElements = formElementsForCode(paymentMethodCode)
+        return if (requiresFormScreen(paymentMethodCode, formElements)) {
+            FormHelper.FormType.UserInteractionRequired
+        } else {
+            val mandate = formElements.firstNotNullOfOrNull { it.mandateText }
+            if (mandate == null) {
+                FormHelper.FormType.Empty
+            } else {
+                FormHelper.FormType.MandateOnly(mandate)
+            }
+        }
+    }
+
+    private fun requiresFormScreen(paymentMethodCode: String, formElements: List<FormElement>): Boolean {
+        val userInteractionAllowed = formElements.any { it.allowsUserInteraction }
+        return userInteractionAllowed ||
+            paymentMethodCode == PaymentMethod.Type.USBankAccount.code ||
+            paymentMethodCode == PaymentMethod.Type.Link.code
+    }
+
+    private fun createArgumentsFactory(code: PaymentMethodCode): UiDefinitionFactory.Arguments.Factory {
+        val currentSelection = newPaymentSelectionProvider(code)?.takeIf { it.getType() == code }
+
+        return UiDefinitionFactory.Arguments.Factory.Default(
+            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
+            linkInlineHandler = linkInlineHandler,
+            onLinkInlineSignupStateChanged = linkInlineHandler::onStateUpdated,
+            paymentMethodCreateParams = currentSelection?.getPaymentMethodCreateParams(),
+            paymentMethodOptionsParams = currentSelection?.getPaymentMethodOptionParams(),
+            paymentMethodExtraParams = currentSelection?.getPaymentMethodExtraParams(),
+            initialLinkUserInput = when (val selection = currentSelection?.paymentSelection) {
+                is PaymentSelection.New.Card -> selection.linkInput
+                else -> null
+            },
+            previousLinkSignupCheckboxSelection = when (val selection = currentSelection?.paymentSelection) {
+                is PaymentSelection.New.Card -> selection.linkInput != null
+                else -> null
+            },
+            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            isLinkUI = isLinkUI,
+            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+            tapToAddHelper = tapToAddHelper,
+            paymentMethodMessagingPromotionsHelper = paymentMethodMessagePromotionsHelper,
+            isNfcScanningAvailable = isNfcScanningAvailable,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormHelper.kt
@@ -1,28 +1,11 @@
 package com.stripe.android.paymentsheet
 
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.forms.FormFieldValues
-import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
-import com.stripe.android.uicore.elements.FormElement
 
-internal interface FormHelper {
-
-    fun formElementsForCode(code: String): List<FormElement>
-
-    fun createFormArguments(
-        paymentMethodCode: PaymentMethodCode,
-    ): FormArguments
+internal interface FormHelper : FormDefinitionFactory {
 
     fun onFormFieldValuesChanged(formValues: FormFieldValues?, selectedPaymentMethodCode: String)
-
-    fun getPaymentMethodParams(
-        formValues: FormFieldValues?,
-        selectedPaymentMethodCode: String
-    ): PaymentMethodCreateParams?
-
-    fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormType
 
     sealed interface FormType {
         object Empty : FormType

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -234,23 +234,30 @@ internal class FormHelperTest {
             val cardBrand = "visa"
             val name = "Joe"
             val receivedSelection = CompletableDeferred<PaymentSelection?>()
+            val linkInlineHandler = LinkInlineHandler.create()
+            val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
 
             val formHelper = DefaultFormHelper(
                 coroutineScope = coroutineScope,
-                linkInlineHandler = LinkInlineHandler.create(),
-                cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-                newPaymentSelectionProvider = { null },
-                linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                linkInlineHandler = linkInlineHandler,
+                paymentMethodMetadata = paymentMethodMetadata,
                 selectionUpdater = { selection -> receivedSelection.complete(selection) },
-                setAsDefaultMatchesSaveForFutureUse = false,
                 eventReporter = FakeEventReporter(),
                 savedStateHandle = SavedStateHandle(),
-                autocompleteAddressInteractorFactory = null,
-                automaticallyLaunchedCardScanFormDataHelper = null,
-                tapToAddHelper = null,
-                paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
-                isNfcScanningAvailable = null,
+                formDefinitionFactory = DefaultFormDefinitionFactory(
+                    linkInlineHandler = linkInlineHandler,
+                    cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    newPaymentSelectionProvider = { null },
+                    linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                    setAsDefaultMatchesSaveForFutureUse = false,
+                    autocompleteAddressInteractorFactory = null,
+                    isLinkUI = false,
+                    automaticallyLaunchedCardScanFormDataHelper = null,
+                    tapToAddHelper = null,
+                    paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(),
+                    isNfcScanningAvailable = null,
+                ),
             )
 
             val formFieldValues = FormFieldValues(
@@ -770,20 +777,25 @@ internal class FormHelperTest {
     ): FormHelper {
         return DefaultFormHelper(
             coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
-            cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             paymentMethodMetadata = paymentMethodMetadata,
-            newPaymentSelectionProvider = newPaymentSelectionProvider,
-            linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
             linkInlineHandler = linkInlineHandler,
             selectionUpdater = selectionUpdater,
-            setAsDefaultMatchesSaveForFutureUse = false,
             eventReporter = eventReporter,
             savedStateHandle = SavedStateHandle(),
-            autocompleteAddressInteractorFactory = null,
-            automaticallyLaunchedCardScanFormDataHelper = null,
-            tapToAddHelper = tapToAddHelper,
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
-            isNfcScanningAvailable = null,
+            formDefinitionFactory = DefaultFormDefinitionFactory(
+                linkInlineHandler = linkInlineHandler,
+                cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
+                paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = newPaymentSelectionProvider,
+                linkConfigurationCoordinator = FakeLinkConfigurationCoordinator(),
+                setAsDefaultMatchesSaveForFutureUse = false,
+                autocompleteAddressInteractorFactory = null,
+                isLinkUI = false,
+                automaticallyLaunchedCardScanFormDataHelper = null,
+                tapToAddHelper = tapToAddHelper,
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                isNfcScanningAvailable = null,
+            ),
         )
     }
 


### PR DESCRIPTION
# Summary

Extract the synchronous form-definition operations from `DefaultFormHelper` into `FormDefinitionFactory`. `DefaultFormHelper` continues to own form-value collection, payment-selection updates, and completion analytics while delegating form construction, argument creation, parameter transformation, and form-type lookup.

This is PR 3 of 5 and depends on PR 2.

# Motivation

Definition lookup and live selection coordination have different lifecycle requirements. Separating them creates a scope-free definition boundary while preserving the existing `FormHelper` behavior for interactive consumers.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.FormHelperTest' --tests 'com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactoryTest' --tests 'com.stripe.android.link.ui.paymentmethod.PaymentMethodViewModelTest' --tests 'com.stripe.android.paymentsheet.FormHelperOpenCardScanAutomaticallyTest' :paymentsheet:detekt`
- `git diff --check`

No tests were ignored.

# Screenshots

Not applicable — this is an internal architecture refactor with no UI changes.

# Changelog

Not applicable — this internal refactor does not change public API or user-visible behavior.

Committed and created by Codex.
