### PR TITLE
Use form definitions for vertical initial screen

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.ui.transformToPaymentMethodCreateParams
+import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
@@ -118,5 +119,27 @@ internal class DefaultFormDefinitionFactory(
             paymentMethodMessagingPromotionsHelper = paymentMethodMessagePromotionsHelper,
             isNfcScanningAvailable = isNfcScanningAvailable,
         )
+    }
+
+    companion object {
+        fun create(
+            viewModel: BaseSheetViewModel,
+            paymentMethodMetadata: PaymentMethodMetadata,
+        ): FormDefinitionFactory {
+            return DefaultFormDefinitionFactory(
+                linkInlineHandler = LinkInlineHandler.create(),
+                cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
+                paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = { viewModel.newPaymentSelection },
+                linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
+                setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
+                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+                isLinkUI = false,
+                automaticallyLaunchedCardScanFormDataHelper = null,
+                tapToAddHelper = viewModel.tapToAddHelper,
+                paymentMethodMessagePromotionsHelper = null,
+                isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
+            )
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeInitialScreenFactory.kt
@@ -1,20 +1,14 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import androidx.lifecycle.viewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
-import com.stripe.android.paymentsheet.BaseSheetFormHelperFactory
 import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.DefaultFormDefinitionFactory
 import com.stripe.android.paymentsheet.FormHelper
-import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
-import com.stripe.android.paymentsheet.utils.childScope
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 
 internal object VerticalModeInitialScreenFactory {
     fun create(
@@ -62,11 +56,10 @@ internal object VerticalModeInitialScreenFactory {
             (viewModel.selection.value as? PaymentSelection.New?)?.let { newPaymentSelection ->
                 val paymentMethodCode = newPaymentSelection.paymentMethodCreateParams.typeCode
 
-                // This form helper is discarded after this synchronous lookup, so cancel its scope immediately.
-                val formTypeScope = viewModel.viewModelScope.childScope(Dispatchers.Main)
-                val formType = createFormHelper(viewModel, formTypeScope, paymentMethodMetadata)
-                    .formTypeForCode(paymentMethodCode)
-                formTypeScope.cancel()
+                val formType = DefaultFormDefinitionFactory.create(
+                    viewModel = viewModel,
+                    paymentMethodMetadata = paymentMethodMetadata
+                ).formTypeForCode(paymentMethodCode)
 
                 if (formType == FormHelper.FormType.UserInteractionRequired) {
                     add(
@@ -84,19 +77,5 @@ internal object VerticalModeInitialScreenFactory {
                 }
             }
         }
-    }
-
-    private fun createFormHelper(
-        viewModel: BaseSheetViewModel,
-        coroutineScope: CoroutineScope,
-        paymentMethodMetadata: PaymentMethodMetadata,
-    ): FormHelper {
-        return BaseSheetFormHelperFactory(viewModel).create(
-            coroutineScope = coroutineScope,
-            paymentMethodMetadata = paymentMethodMetadata,
-            linkInlineHandler = LinkInlineHandler.create(),
-            shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
-            paymentMethodMessagePromotionsHelper = null,
-        )
     }
 }


### PR DESCRIPTION
# Summary

Use `DefaultFormDefinitionFactory` directly when determining the vertical-mode initial screen, eliminating the temporary `DefaultFormHelper`, child coroutine scope, and immediate cancellation.

This is PR 4 of 5 and depends on PR 3.

# Motivation

Initial-screen selection only needs a synchronous form-type lookup. Creating a live selection coordinator for that lookup adds lifecycle work that the caller immediately discards.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.verticalmode.VerticalModeInitialScreenFactoryTest' :paymentsheet:detekt`
- `git diff --check`

No tests were ignored.

# Screenshots

Not applicable — this is an internal lifecycle refactor with no UI changes.

# Changelog

Not applicable — this internal refactor does not change public API or user-visible behavior.

Committed and created by Codex.
