### PR TITLE
Use form definitions for embedded selection restoration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
@@ -3,18 +3,16 @@ package com.stripe.android.paymentelement.embedded.content
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.containsVolatileDifferences
-import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentsheet.FormHelper
-import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
-import kotlinx.coroutines.CoroutineScope
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -32,8 +30,6 @@ internal fun interface EmbeddedSelectionChooser {
 internal class DefaultEmbeddedSelectionChooser @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val formHelperFactory: EmbeddedFormHelperFactory,
-    private val eventReporter: EventReporter,
-    @ViewModelScope private val coroutineScope: CoroutineScope,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
 ) : EmbeddedSelectionChooser {
     private var previousConfiguration: CommonConfiguration?
@@ -151,35 +147,34 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
         previousSelection: PaymentSelection.New,
         paymentMethodMetadata: PaymentMethodMetadata,
     ): Boolean {
-        val newFormHelper = formHelperFactory.create(
-            coroutineScope = coroutineScope,
+        val newFormDefinitionFactory = formHelperFactory.createFormDefinitionFactory(
             paymentMethodMetadata = paymentMethodMetadata,
-            eventReporter = eventReporter,
             // Card scan auto-launch is only relevant in the form, not when selecting the default.
             automaticallyLaunchedCardScanFormDataHelper = null,
             tapToAddHelper = null,
             // Not important for determining formType so use default value
             setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
             paymentMethodMessagePromotionsHelper = null,
-        ) {}
-        val newFormType = newFormHelper.formTypeForCode(previousSelection.paymentMethodType)
+            linkInlineHandler = LinkInlineHandler.create(),
+        )
+        val newFormType = newFormDefinitionFactory.formTypeForCode(previousSelection.paymentMethodType)
         if (newFormType != FormHelper.FormType.UserInteractionRequired) {
             return true
         }
         return previousPaymentMethodMetadata?.let { previousPaymentMethodMetadata ->
-            val previousFormHelper = formHelperFactory.create(
-                coroutineScope = coroutineScope,
+            val previousFormDefinitionFactory = formHelperFactory.createFormDefinitionFactory(
                 paymentMethodMetadata = previousPaymentMethodMetadata,
-                eventReporter = eventReporter,
                 // Card scan auto-launch is only relevant in the form, not when selecting the default.
                 automaticallyLaunchedCardScanFormDataHelper = null,
                 tapToAddHelper = null,
                 // Not important for determining formType so use default value
                 setAsDefaultMatchesSaveForFutureUse = FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE,
-                paymentMethodMessagePromotionsHelper = null
-            ) {}
-            val previousFormElements = previousFormHelper.formElementsForCode(previousSelection.paymentMethodType)
-            val newFormElements = newFormHelper.formElementsForCode(previousSelection.paymentMethodType)
+                paymentMethodMessagePromotionsHelper = null,
+                linkInlineHandler = LinkInlineHandler.create(),
+            )
+            val previousFormElements =
+                previousFormDefinitionFactory.formElementsForCode(previousSelection.paymentMethodType)
+            val newFormElements = newFormDefinitionFactory.formElementsForCode(previousSelection.paymentMethodType)
             previousFormElements.size >= newFormElements.size
         } == true
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -23,13 +23,11 @@ import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelecti
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
-import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeStripeImageLoader
 import com.stripe.android.uicore.FormInsets
@@ -44,11 +42,7 @@ import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -61,9 +55,6 @@ import kotlin.test.assertFailsWith
 )
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutStateLoaderTest {
-
-    @get:Rule
-    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
     fun `loadInitial commits state with payment method metadata`() = runScenario {
@@ -260,8 +251,6 @@ internal class CheckoutStateLoaderTest {
                     savedStateHandle = savedStateHandle,
                     isNfcScanningAvailable = FakeIsNfcScanningAvailable(result = false),
                 ),
-                eventReporter = FakeEventReporter(),
-                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
                 internalRowSelectionCallback = { null },
             )
         },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSelectionChooserTest.kt
@@ -16,17 +16,12 @@ import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser.Companion.PREVIOUS_CONFIGURATION_KEY
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser.Companion.PREVIOUS_PAYMENT_METHOD_METADATA_KEY
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -34,9 +29,6 @@ import org.junit.Test
 internal class DefaultEmbeddedSelectionChooserTest {
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
-
-    @get:Rule
-    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     private val defaultConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
         .build()
@@ -494,8 +486,6 @@ internal class DefaultEmbeddedSelectionChooserTest {
             chooser = DefaultEmbeddedSelectionChooser(
                 savedStateHandle = savedStateHandle,
                 formHelperFactory = formHelperFactory,
-                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
-                eventReporter = FakeEventReporter(),
                 internalRowSelectionCallback = { internalRowSelectionCallback }
             ),
             savedStateHandle = savedStateHandle,


### PR DESCRIPTION
# Summary

Use `FormDefinitionFactory` directly when Embedded Payment Element evaluates whether a previous selection can be restored. Remove the chooser's unused coroutine-scope and event-reporter dependencies and simplify its tests.

This is PR 5 of 5 and depends on PR 4.

# Motivation

Selection restoration only compares form types and elements. It does not need a live form-value collector, selection updater, analytics reporter, or coroutine scope.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooserTest' --tests 'com.stripe.android.checkout.CheckoutStateLoaderTest' --tests 'com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactoryTest' :paymentsheet:detekt`
- `git diff --check`

No tests were ignored.

# Screenshots

Not applicable — this is an internal lifecycle refactor with no UI changes.

# Changelog

Not applicable — this internal refactor does not change public API or user-visible behavior.

Committed and created by Codex.
