### PR TITLE
Make checkout analytics test tolerate optional event

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkDispatcher.kt
@@ -15,9 +15,21 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
     private val unmatchedRequests: MutableList<UnmatchedRequest> = Collections.synchronizedList(mutableListOf())
 
     fun enqueue(vararg requestMatcher: RequestMatcher, responseFactory: (MockResponse) -> Unit) {
+        enqueue(required = true, requestMatcher = requestMatcher, responseFactory = responseFactory)
+    }
+
+    fun enqueueOptional(vararg requestMatcher: RequestMatcher, responseFactory: (MockResponse) -> Unit) {
+        enqueue(required = false, requestMatcher = requestMatcher, responseFactory = responseFactory)
+    }
+
+    private fun enqueue(
+        required: Boolean,
+        requestMatcher: Array<out RequestMatcher>,
+        responseFactory: (MockResponse) -> Unit,
+    ) {
         validateEnqueueState()
         enqueuedResponses.add(
-            Entry(RequestMatchers.composite(*requestMatcher)) {
+            Entry(RequestMatchers.composite(*requestMatcher), required = required) {
                 val response = MockResponse()
                 response.setResponseCode(200)
                 responseFactory(response)
@@ -58,9 +70,10 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
     fun validate() {
         val exceptionMessage = StringBuilder()
         if (hasResponsesInQueue()) {
+            val requiredResponses = enqueuedResponses.filter(Entry::required)
             exceptionMessage.append(
-                "Mock responses is not empty. Remaining: ${enqueuedResponses.size}.\nRemaining Matchers: " +
-                    remainingMatchersDescription()
+                "Mock responses is not empty. Remaining: ${requiredResponses.size}.\nRemaining Matchers: " +
+                    requiredResponses.joinToString { it.requestMatcher.toString() }
             )
         }
         addExtraRequestsToExceptionMessage(exceptionMessage)
@@ -83,20 +96,16 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
 
     private fun hasResponsesInQueue(): Boolean {
         if (validationTimeout == null) {
-            return enqueuedResponses.size != 0
+            return enqueuedResponses.any(Entry::required)
         }
 
         var timeWaited = 0.milliseconds
         val sleepDuration = 100.milliseconds
-        while (enqueuedResponses.size != 0 && timeWaited < validationTimeout) {
+        while (enqueuedResponses.any(Entry::required) && timeWaited < validationTimeout) {
             Thread.sleep(sleepDuration.inWholeMilliseconds)
             timeWaited = timeWaited.plus(sleepDuration)
         }
-        return enqueuedResponses.size != 0
-    }
-
-    private fun remainingMatchersDescription(): String {
-        return enqueuedResponses.joinToString { it.requestMatcher.toString() }
+        return enqueuedResponses.any(Entry::required)
     }
 
     private fun extraRequestDescriptions(): String {
@@ -162,6 +171,7 @@ internal class NetworkDispatcher(private val validationTimeout: Duration?) : Dis
 
 private class Entry(
     val requestMatcher: RequestMatcher,
+    val required: Boolean = true,
     val responseFactory: (TestRecordedRequest) -> MockResponse
 )
 

--- a/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/NetworkRule.kt
@@ -67,6 +67,21 @@ class NetworkRule private constructor(
         }
     }
 
+    fun enqueueOptional(
+        vararg requestMatcher: RequestMatcher,
+        applyDefaultAuthorization: Boolean = true,
+        ensureResponseIsValidJson: Boolean = true,
+        responseFactory: (MockResponse) -> Unit
+    ) {
+        val matchers = withDefaultAuthorization(requestMatcher, applyDefaultAuthorization)
+        mockWebServer.dispatcher.enqueueOptional(*matchers) { response ->
+            responseFactory(response)
+            if (ensureResponseIsValidJson) {
+                assertResponseBodyIsValidJson(response)
+            }
+        }
+    }
+
     fun enqueue(
         vararg requestMatcher: RequestMatcher,
         applyDefaultAuthorization: Boolean = true,

--- a/network-testing/src/test/java/com/stripe/android/networktesting/NetworkDispatcherTest.kt
+++ b/network-testing/src/test/java/com/stripe/android/networktesting/NetworkDispatcherTest.kt
@@ -34,6 +34,23 @@ class NetworkDispatcherTest {
     }
 
     @Test
+    fun `validate succeeds when optional mock remains unconsumed`() = runScenario {
+        enqueueOptional(RequestMatchers.path("/v1/optional"))
+
+        dispatcher.validate()
+    }
+
+    @Test
+    fun `dispatch matches and consumes optional response`() = runScenario {
+        enqueueOptional(RequestMatchers.path("/v1/optional"))
+
+        val response = dispatch(path = "/v1/optional")
+
+        assertThat(response.status).isEqualTo("HTTP/1.1 200 OK")
+        dispatcher.validate()
+    }
+
+    @Test
     fun `validate fails when extra requests were made`() = runScenario {
         enqueue(
             RequestMatchers.path("/v1/confirm"),
@@ -83,6 +100,10 @@ class NetworkDispatcherTest {
 
         fun enqueue(vararg matchers: RequestMatcher) {
             dispatcher.enqueue(*matchers) { it.setBody("{}") }
+        }
+
+        fun enqueueOptional(vararg matchers: RequestMatcher) {
+            dispatcher.enqueueOptional(*matchers) { it.setBody("{}") }
         }
 
         fun dispatch(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedContentPage
+import com.stripe.android.paymentsheet.allowAnalyticsRequest
 import com.stripe.android.paymentsheet.validateAnalyticsRequest
 import com.stripe.android.paymentsheet.utils.GooglePayRepositoryTestRule
 import com.stripe.android.paymentsheet.utils.TestRules
@@ -93,6 +94,10 @@ internal class CheckoutPaymentElementAnalyticsTest {
             }
         },
         setup = { controller ->
+            networkRule.allowAnalyticsRequest(
+                eventName = "google_pay.skipped_during_load",
+                productUsage = setOf("Checkout"),
+            )
             networkRule.validateAnalyticsRequest(
                 eventName = "mc_load_started",
                 productUsage = setOf("Checkout"),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/NetworkRuleExtensions.kt
@@ -21,3 +21,17 @@ internal fun NetworkRule.validateAnalyticsRequest(
         response.status = "HTTP/1.1 200 OK"
     }
 }
+
+internal fun NetworkRule.allowAnalyticsRequest(
+    eventName: String,
+    productUsage: Set<String>,
+) {
+    enqueueOptional(
+        host("q.stripe.com"),
+        method("GET"),
+        analyticsPayloadField("event", eventName),
+        analyticsPayloadField("product_usage", productUsage.joinToString(",")),
+    ) { response ->
+        response.status = "HTTP/1.1 200 OK"
+    }
+}


### PR DESCRIPTION
# Summary

Make checkout analytics test tolerate optional event- #14191

- add optional request expectations to `NetworkRule`
- allow the legitimate `google_pay.skipped_during_load` analytics event in `CheckoutPaymentElementAnalyticsTest` without requiring it
- keep production loading behavior unchanged

# Motivation
CheckoutPaymentElementAnalyticsTest was occasionally failing due to an expected error event getting thrown during the load pipeline. This error event genuinely is indeterministic, so I updated the tests to account for the possibility that it does happen or that it doesn't.

# Testing (According to codex)
- diagnostic ShampooRule(2): passed (2 executions)
- diagnostic ShampooRule(50): passed (50 executions, iterations 0–49, no failures)
  - the optional event occurred in 9 iterations and was absent in 41, exercising both outcomes
- normal rule: focused `:paymentsheet:pixel2api33DebugAndroidTest` passed
- `:network-testing:testDebugUnitTest --tests com.stripe.android.networktesting.NetworkDispatcherTest` passed
- module-qualified network-testing compile, unit tests, Detekt, and lint passed
- paymentsheet Android-test compilation, Detekt, and API check passed
- `:paymentsheet:lintDebug` retains the unrelated existing `ViewModelConstructorInComposable` error in `AutocompleteScreenTest.kt:69`

ShampooRule was diagnostic-only and is absent from this PR.

Committed and created by Codex.