### PR TITLE
Protect unsaved Address Element changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ NEXT_VERSION_BUMP: PATCH
 ### PaymentSheet
 * [FIXED] Fixed an issue where Klarna billing address fields did not update when the country changed.
 
+### AddressElement
+* [CHANGED] Address Element now asks customers to confirm before discarding unsaved address changes.
+
 ## 23.17.0 - 2026-08-24
 
 ### PaymentSheet

--- a/paymentsheet/res/values/strings.xml
+++ b/paymentsheet/res/values/strings.xml
@@ -20,6 +20,14 @@
   <string name="stripe_cashapp_afterpay_subtitle">Buy now or pay later with Cash App Afterpay</string>
   <!-- This shows the message on Buy Now Pay Later LPM, clearpay. -->
   <string name="stripe_clearpay_subtitle">Buy now or pay later with Clearpay</string>
+  <!-- Title for the dialog shown when closing Address Element with unsaved changes. -->
+  <string name="stripe_paymentsheet_address_element_discard_changes_title">Discard changes?</string>
+  <!-- Message for the dialog shown when closing Address Element with unsaved changes. -->
+  <string name="stripe_paymentsheet_address_element_discard_changes_body">Your address changes have not been saved.</string>
+  <!-- Destructive action for the dialog shown when closing Address Element with unsaved changes. -->
+  <string name="stripe_paymentsheet_address_element_discard_changes_confirm">Discard changes</string>
+  <!-- Secondary action for the dialog shown when closing Address Element with unsaved changes. -->
+  <string name="stripe_paymentsheet_address_element_discard_changes_dismiss">Keep editing</string>
   <!-- Used as the title for prompting the user if they want to close the sheet -->
   <string name="stripe_confirm_close_form_body">Your payment information will not be saved.</string>
   <!-- Used as the title for prompting the user if they want to close the sheet -->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -11,8 +11,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.NavHostController
@@ -22,10 +24,13 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.parseAppearance
+import com.stripe.android.ui.core.elements.SimpleDialogElementUI
 import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.StripeBottomSheetState
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
+import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.fadeOut
 import kotlinx.coroutines.launch
 
@@ -66,7 +71,7 @@ internal class AddressElementActivity : ComponentActivity() {
             val bottomSheetState = rememberStripeBottomSheetState()
 
             BackHandler {
-                viewModel.navigator.onBack()
+                viewModel.onBack()
             }
 
             viewModel.navigator.onDismiss = { result ->
@@ -86,10 +91,12 @@ internal class AddressElementActivity : ComponentActivity() {
         bottomSheetState: StripeBottomSheetState,
         navController: NavHostController,
     ) {
+        val showDiscardConfirmation by viewModel.showDiscardConfirmation.collectAsState()
+
         StripeTheme {
             ElementsBottomSheetLayout(
                 state = bottomSheetState,
-                onDismissed = viewModel.navigator::dismiss,
+                onDismissed = viewModel::dismiss,
             ) {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     NavHost(
@@ -97,7 +104,11 @@ internal class AddressElementActivity : ComponentActivity() {
                         startDestination = AddressElementScreen.InputAddress.route,
                     ) {
                         composable(AddressElementScreen.InputAddress.route) {
-                            InputAddressScreen(viewModel.inputAddressViewModelSubcomponentFactoryProvider)
+                            InputAddressScreen(
+                                inputAddressViewModelSubcomponentFactoryProvider =
+                                viewModel.inputAddressViewModelSubcomponentFactoryProvider,
+                                onCloseClick = viewModel::dismiss,
+                            )
                         }
                         composable(
                             AddressElementScreen.Autocomplete.route,
@@ -121,6 +132,13 @@ internal class AddressElementActivity : ComponentActivity() {
                     }
                 }
             }
+
+            if (showDiscardConfirmation) {
+                AddressElementDismissalDialog(
+                    onDiscardChanges = viewModel::discardChanges,
+                    onKeepEditing = viewModel::keepEditing,
+                )
+            }
         }
     }
 
@@ -137,4 +155,20 @@ internal class AddressElementActivity : ComponentActivity() {
         super.finish()
         fadeOut()
     }
+}
+
+@Composable
+internal fun AddressElementDismissalDialog(
+    onDiscardChanges: () -> Unit,
+    onKeepEditing: () -> Unit,
+) {
+    SimpleDialogElementUI(
+        titleText = stringResource(R.string.stripe_paymentsheet_address_element_discard_changes_title),
+        messageText = stringResource(R.string.stripe_paymentsheet_address_element_discard_changes_body),
+        confirmText = stringResource(R.string.stripe_paymentsheet_address_element_discard_changes_confirm),
+        dismissText = stringResource(R.string.stripe_paymentsheet_address_element_discard_changes_dismiss),
+        destructive = true,
+        onConfirmListener = onDiscardChanges,
+        onDismissListener = onKeepEditing,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDismissalCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementDismissalCoordinator.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class AddressElementDismissalCoordinator @Inject constructor() {
+    private val _isDirty = MutableStateFlow(false)
+    val isDirty: StateFlow<Boolean> = _isDirty.asStateFlow()
+
+    private val _showDiscardConfirmation = MutableStateFlow(false)
+    val showDiscardConfirmation: StateFlow<Boolean> = _showDiscardConfirmation.asStateFlow()
+
+    fun setDirty(isDirty: Boolean) {
+        _isDirty.value = isDirty
+    }
+
+    fun requestDismiss(): Boolean {
+        if (isDirty.value) {
+            _showDiscardConfirmation.value = true
+            return false
+        }
+
+        return true
+    }
+
+    fun keepEditing() {
+        _showDiscardConfirmation.value = false
+    }
+
+    fun discardChanges() {
+        _showDiscardConfirmation.value = false
+        _isDirty.value = false
+    }
+
+    fun markSaved() {
+        _showDiscardConfirmation.value = false
+        _isDirty.value = false
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
@@ -24,7 +24,7 @@ internal interface AddressElementNavigator {
 
     fun dismiss(result: AddressLauncherResult = AddressLauncherResult.Canceled())
 
-    fun onBack()
+    fun onBack(): Boolean
 
     sealed interface AutocompleteEvent : Parcelable {
         val address: PaymentSheet.Address?
@@ -68,11 +68,5 @@ internal class NavHostAddressElementNavigator @Inject constructor() : AddressEle
         onDismiss?.invoke(result)
     }
 
-    override fun onBack() {
-        navigationController?.let { navController ->
-            if (!navController.popBackStack()) {
-                dismiss()
-            }
-        }
-    }
+    override fun onBack(): Boolean = navigationController?.popBackStack() ?: false
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcomponent
 import com.stripe.android.paymentsheet.injection.DaggerAddressElementViewModelFactoryComponent
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -13,7 +14,32 @@ internal class AddressElementViewModel @Inject internal constructor(
     val navigator: NavHostAddressElementNavigator,
     val inputAddressViewModelSubcomponentFactoryProvider: Provider<InputAddressViewModelSubcomponent.Factory>,
     val autoCompleteViewModelSubcomponentFactoryProvider: Provider<AutocompleteViewModelSubcomponent.Factory>,
+    private val dismissalCoordinator: AddressElementDismissalCoordinator,
 ) : ViewModel() {
+
+    val showDiscardConfirmation: StateFlow<Boolean> =
+        dismissalCoordinator.showDiscardConfirmation
+
+    fun dismiss() {
+        if (dismissalCoordinator.requestDismiss()) {
+            navigator.dismiss()
+        }
+    }
+
+    fun onBack() {
+        if (!navigator.onBack()) {
+            dismiss()
+        }
+    }
+
+    fun keepEditing() {
+        dismissalCoordinator.keepEditing()
+    }
+
+    fun discardChanges() {
+        dismissalCoordinator.discardChanges()
+        navigator.dismiss(AddressLauncherResult.Canceled())
+    }
 
     internal class Factory(
         private val applicationSupplier: () -> Application,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModel.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.addresselement
 import android.app.Application
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcomponent
 import com.stripe.android.paymentsheet.injection.DaggerAddressElementViewModelFactoryComponent
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
@@ -21,7 +22,9 @@ internal class AddressElementViewModel @Inject internal constructor(
         dismissalCoordinator.showDiscardConfirmation
 
     fun dismiss() {
-        if (dismissalCoordinator.requestDismiss()) {
+        if (!FeatureFlags.enableAddressElementUnsavedChanges.isEnabled ||
+            dismissalCoordinator.requestDismiss()
+        ) {
             navigator.dismiss()
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -96,7 +96,8 @@ internal fun InputAddressScreen(
 
 @Composable
 internal fun InputAddressScreen(
-    inputAddressViewModelSubcomponentFactoryProvider: Provider<InputAddressViewModelSubcomponent.Factory>
+    inputAddressViewModelSubcomponentFactoryProvider: Provider<InputAddressViewModelSubcomponent.Factory>,
+    onCloseClick: () -> Unit,
 ) {
     val viewModel: InputAddressViewModel = viewModel(
         factory = InputAddressViewModel.Factory(
@@ -136,7 +137,7 @@ internal fun InputAddressScreen(
                 checkboxChecked = checkboxChecked
             )
         },
-        onCloseClick = { viewModel.navigator.dismiss() },
+        onCloseClick = onCloseClick,
         topContent = {
             val currentState = billingSameAsShippingState
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -13,6 +13,7 @@ import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -27,6 +28,7 @@ internal class InputAddressViewModel @Inject constructor(
     val args: AddressElementActivityContract.Args,
     val navigator: AddressElementNavigator,
     private val eventReporter: AddressLauncherEventReporter,
+    private val dismissalCoordinator: AddressElementDismissalCoordinator,
     @Named(AddressElementViewModelModule.INLINE_PLACES_CLIENT)
     private val placesClient: PlacesClientProxy?,
 ) : ViewModel(), AutocompleteAddressInteractor {
@@ -43,6 +45,12 @@ internal class InputAddressViewModel @Inject constructor(
     private val initialShippingAddress = unparsedInitialShippingAddress?.let {
         addressFormatParser.parse(it)
     }
+
+    private val initialAddress = unparsedInitialShippingAddress ?: unparsedInitialBillingAddress
+    private val normalizedInitialFormValues = addressFormatParser
+        .parse(initialAddress ?: AddressDetails())
+        .mapValues { it.value.orEmpty() }
+    private val initialCheckboxChecked = unparsedInitialShippingAddress?.isCheckboxSelected ?: false
 
     private val initialInputsAreTheSame = initialBillingAddress == initialShippingAddress
 
@@ -113,6 +121,8 @@ internal class InputAddressViewModel @Inject constructor(
         config = args.config,
     )
 
+    val isDirty: StateFlow<Boolean> = dismissalCoordinator.isDirty
+
     private val _formEnabled = MutableStateFlow(true)
     val formEnabled: StateFlow<Boolean> = _formEnabled
 
@@ -154,8 +164,10 @@ internal class InputAddressViewModel @Inject constructor(
             }
         }
 
-        viewModelScope.launch {
+        // Register before returning so dirty tracking is active before the UI can accept input.
+        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
             addressFormController.uncompletedFormValues.collectLatest { formValues ->
+                updateDirtyState(formValues)
                 val currentBillingSameAsShippingState = _shippingSameAsBillingState.value
 
                 if (currentBillingSameAsShippingState is ShippingSameAsBillingState.Show) {
@@ -180,6 +192,8 @@ internal class InputAddressViewModel @Inject constructor(
         unparsedInitialShippingAddress?.isCheckboxSelected?.let {
             _checkboxChecked.value = it
         }
+
+        updateDirtyState(addressFormController.uncompletedFormValues.value)
     }
 
     override fun register(onEvent: (AutocompleteAddressInteractor.Event) -> Unit) {
@@ -238,6 +252,7 @@ internal class InputAddressViewModel @Inject constructor(
                 editDistance = addressDetails.editDistance(collectedAddress.value)
             )
         }
+        dismissalCoordinator.markSaved()
         navigator.dismiss(
             AddressLauncherResult.Succeeded(addressDetails)
         )
@@ -263,6 +278,15 @@ internal class InputAddressViewModel @Inject constructor(
 
     fun clickCheckbox(newValue: Boolean) {
         _checkboxChecked.value = newValue
+        updateDirtyState(addressFormController.uncompletedFormValues.value)
+    }
+
+    private fun updateDirtyState(formValues: Map<IdentifierSpec, FormFieldEntry>) {
+        val currentValues = formValues.mapValues { it.value.value.orEmpty() }
+        dismissalCoordinator.setDirty(
+            currentValues != normalizedInitialFormValues ||
+                _checkboxChecked.value != initialCheckboxChecked
+        )
     }
 
     fun onEnterManually() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementDismissalDialogTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementDismissalDialogTest.kt
@@ -1,0 +1,94 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import android.os.Build
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertAny
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
+import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_CONFIRM_BUTTON
+import com.stripe.android.ui.core.elements.TEST_TAG_DIALOG_DISMISS_BUTTON
+import com.stripe.android.ui.core.elements.TEST_TAG_SIMPLE_DIALOG
+import com.stripe.android.uicore.DefaultStripeTheme
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+internal class AddressElementDismissalDialogTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+
+    @Test
+    fun `dialog displays copy and discard invokes callback`() {
+        var discardChangesCount = 0
+        var keepEditingCount = 0
+
+        composeRule.setContent {
+            DefaultStripeTheme {
+                AddressElementDismissalDialog(
+                    onDiscardChanges = { discardChangesCount++ },
+                    onKeepEditing = { keepEditingCount++ },
+                )
+            }
+        }
+
+        composeRule.onNodeWithTag(TEST_TAG_SIMPLE_DIALOG).onChildren().assertAny(
+            hasText("Discard changes?")
+        )
+        composeRule.onNodeWithTag(TEST_TAG_SIMPLE_DIALOG).onChildren().assertAny(
+            hasText("Your address changes have not been saved.")
+        )
+        composeRule.onNodeWithTag(TEST_TAG_DIALOG_CONFIRM_BUTTON).assert(hasText("Discard changes"))
+        composeRule.onNodeWithTag(TEST_TAG_DIALOG_DISMISS_BUTTON).assert(hasText("Keep editing"))
+
+        composeRule.onNodeWithTag(TEST_TAG_DIALOG_CONFIRM_BUTTON).performClick()
+
+        assertThat(discardChangesCount).isEqualTo(1)
+        assertThat(keepEditingCount).isEqualTo(0)
+    }
+
+    @Test
+    fun `keep editing callback dismisses dialog`() {
+        var dialogVisible by mutableStateOf(true)
+        var keepEditingCount = 0
+
+        composeRule.setContent {
+            DefaultStripeTheme {
+                if (dialogVisible) {
+                    AddressElementDismissalDialog(
+                        onDiscardChanges = {},
+                        onKeepEditing = {
+                            keepEditingCount++
+                            dialogVisible = false
+                        },
+                    )
+                }
+            }
+        }
+
+        composeRule.onNodeWithTag(TEST_TAG_DIALOG_DISMISS_BUTTON).performClick()
+        composeRule.waitForIdle()
+
+        assertThat(keepEditingCount).isEqualTo(1)
+        composeRule.onNodeWithTag(TEST_TAG_SIMPLE_DIALOG).assertDoesNotExist()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModelTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcomponent
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
+import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.FeatureFlagTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -18,6 +19,9 @@ internal class AddressElementViewModelTest {
         featureFlag = FeatureFlags.enableAddressElementUnsavedChanges,
         isEnabled = true,
     )
+
+    @get:Rule
+    val viewModelStoreRule = ViewModelStoreTestRule()
 
     @Test
     fun `clean dismissal exits immediately`() {
@@ -126,6 +130,6 @@ internal class AddressElementViewModelTest {
             autoCompleteViewModelSubcomponentFactoryProvider =
             mock<Provider<AutocompleteViewModelSubcomponent.Factory>>(),
             dismissalCoordinator = coordinator,
-        )
+        ).also { viewModelStoreRule.track(it) }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModelTest.kt
@@ -1,0 +1,108 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import androidx.navigation.NavHostController
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcomponent
+import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import javax.inject.Provider
+
+internal class AddressElementViewModelTest {
+    @Test
+    fun `clean dismissal exits immediately`() {
+        var result: AddressLauncherResult? = null
+        val viewModel = createViewModel { result = it }
+
+        viewModel.dismiss()
+
+        assertThat(result).isEqualTo(AddressLauncherResult.Canceled())
+    }
+
+    @Test
+    fun `dirty dismissal shows confirmation dialog`() {
+        var result: AddressLauncherResult? = null
+        val coordinator = AddressElementDismissalCoordinator()
+        val viewModel = createViewModel(coordinator) { result = it }
+        coordinator.setDirty(true)
+
+        viewModel.dismiss()
+
+        assertThat(viewModel.showDiscardConfirmation.value).isTrue()
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `keep editing closes dialog and preserves dirty state`() {
+        val coordinator = AddressElementDismissalCoordinator()
+        val viewModel = createViewModel(coordinator)
+        coordinator.setDirty(true)
+        viewModel.dismiss()
+
+        viewModel.keepEditing()
+
+        assertThat(viewModel.showDiscardConfirmation.value).isFalse()
+        assertThat(coordinator.isDirty.value).isTrue()
+    }
+
+    @Test
+    fun `discarding changes returns canceled`() {
+        var result: AddressLauncherResult? = null
+        val coordinator = AddressElementDismissalCoordinator()
+        val viewModel = createViewModel(coordinator) { result = it }
+        coordinator.setDirty(true)
+        viewModel.dismiss()
+
+        viewModel.discardChanges()
+
+        assertThat(result).isEqualTo(AddressLauncherResult.Canceled())
+        assertThat(viewModel.showDiscardConfirmation.value).isFalse()
+        assertThat(coordinator.isDirty.value).isFalse()
+    }
+
+    @Test
+    fun `repeated dismissal requests do not duplicate confirmation state`() {
+        val coordinator = AddressElementDismissalCoordinator()
+        val viewModel = createViewModel(coordinator)
+        coordinator.setDirty(true)
+
+        viewModel.dismiss()
+        viewModel.dismiss()
+
+        assertThat(viewModel.showDiscardConfirmation.value).isTrue()
+    }
+
+    @Test
+    fun `back from autocomplete does not request dismissal`() {
+        var result: AddressLauncherResult? = null
+        val coordinator = AddressElementDismissalCoordinator()
+        val navigator = NavHostAddressElementNavigator()
+        val navigationController = mock<NavHostController>()
+        whenever(navigationController.popBackStack()).thenReturn(true)
+        navigator.navigationController = navigationController
+        val viewModel = createViewModel(coordinator, navigator) { result = it }
+        coordinator.setDirty(true)
+
+        viewModel.onBack()
+
+        assertThat(result).isNull()
+        assertThat(viewModel.showDiscardConfirmation.value).isFalse()
+    }
+
+    private fun createViewModel(
+        coordinator: AddressElementDismissalCoordinator = AddressElementDismissalCoordinator(),
+        navigator: NavHostAddressElementNavigator = NavHostAddressElementNavigator(),
+        onDismiss: (AddressLauncherResult) -> Unit = {},
+    ): AddressElementViewModel {
+        navigator.onDismiss = onDismiss
+        return AddressElementViewModel(
+            navigator = navigator,
+            inputAddressViewModelSubcomponentFactoryProvider =
+            mock<Provider<InputAddressViewModelSubcomponent.Factory>>(),
+            autoCompleteViewModelSubcomponentFactoryProvider =
+            mock<Provider<AutocompleteViewModelSubcomponent.Factory>>(),
+            dismissalCoordinator = coordinator,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModelTest.kt
@@ -2,14 +2,23 @@ package com.stripe.android.paymentsheet.addresselement
 
 import androidx.navigation.NavHostController
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.paymentsheet.injection.AutocompleteViewModelSubcomponent
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
+import com.stripe.android.testing.FeatureFlagTestRule
+import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import javax.inject.Provider
 
 internal class AddressElementViewModelTest {
+    @get:Rule
+    val unsavedChangesFeatureFlagTestRule = FeatureFlagTestRule(
+        featureFlag = FeatureFlags.enableAddressElementUnsavedChanges,
+        isEnabled = true,
+    )
+
     @Test
     fun `clean dismissal exits immediately`() {
         var result: AddressLauncherResult? = null
@@ -31,6 +40,20 @@ internal class AddressElementViewModelTest {
 
         assertThat(viewModel.showDiscardConfirmation.value).isTrue()
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `dirty dismissal exits immediately when feature flag is disabled`() {
+        unsavedChangesFeatureFlagTestRule.setEnabled(false)
+        var result: AddressLauncherResult? = null
+        val coordinator = AddressElementDismissalCoordinator()
+        val viewModel = createViewModel(coordinator) { result = it }
+        coordinator.setDirty(true)
+
+        viewModel.dismiss()
+
+        assertThat(result).isEqualTo(AddressLauncherResult.Canceled())
+        assertThat(viewModel.showDiscardConfirmation.value).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -37,6 +38,7 @@ class InputAddressViewModelTest {
 
     private fun createViewModel(
         address: AddressDetails? = null,
+        dismissalCoordinator: AddressElementDismissalCoordinator = AddressElementDismissalCoordinator(),
         config: AddressLauncher.Configuration = AddressLauncher.Configuration.Builder()
             .address(address)
             .build()
@@ -48,6 +50,7 @@ class InputAddressViewModelTest {
             ),
             navigator,
             eventReporter,
+            dismissalCoordinator,
             placesClient = null,
         ).also { viewModelStoreRule.track(it) }
     }
@@ -55,8 +58,10 @@ class InputAddressViewModelTest {
     @get:Rule
     val viewModelStoreRule = ViewModelStoreTestRule()
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     @get:Rule
-    val coroutineTestRule = CoroutineTestRule()
+    val coroutineTestRule = CoroutineTestRule(testDispatcher)
 
     @Test
     fun `onScreenShown fires onShow with initial country`() {
@@ -202,6 +207,205 @@ class InputAddressViewModelTest {
     fun `default checkbox should emit false to start by default`() = runTest(UnconfinedTestDispatcher()) {
         val viewModel = createViewModel()
         assertThat(viewModel.checkboxChecked.value).isFalse()
+    }
+
+    @Test
+    fun `empty form starts clean`() = runTest(testDispatcher) {
+        val viewModel = createViewModel()
+
+        assertThat(viewModel.isDirty.value).isFalse()
+    }
+
+    @Test
+    fun `prefilled form starts clean`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            address = AddressDetails(
+                name = "Jane Doe",
+                address = PaymentSheet.Address(
+                    city = "San Francisco",
+                    country = "US",
+                    line1 = "123 Apple Street",
+                    postalCode = "94107",
+                    state = "CA",
+                ),
+            )
+        )
+
+        assertThat(viewModel.isDirty.value).isFalse()
+    }
+
+    @OptIn(AddressElementSameAsBillingPreview::class)
+    @Test
+    fun `same as billing form starts clean`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            config = AddressLauncher.Configuration.Builder()
+                .allowedCountries(setOf("US"))
+                .billingAddress(
+                    PaymentSheet.BillingDetails(
+                        name = "John Doe",
+                        address = PaymentSheet.Address(
+                            city = "San Francisco",
+                            country = "US",
+                            line1 = "123 Apple Street",
+                            postalCode = "94107",
+                            state = "CA",
+                        ),
+                    )
+                )
+                .build()
+        )
+
+        assertThat(viewModel.isDirty.value).isFalse()
+    }
+
+    @Test
+    fun `incomplete address edit makes form dirty and reverting clears it`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                config = AddressLauncher.Configuration.Builder()
+                    .allowedCountries(setOf("US"))
+                    .build()
+            )
+
+            viewModel.setRawValues(
+                mapOf(
+                    IdentifierSpec.Country to "US",
+                    IdentifierSpec.Line1 to "123 Main",
+                )
+            )
+            assertThat(viewModel.isDirty.value).isTrue()
+
+            viewModel.setRawValues(
+                mapOf(
+                    IdentifierSpec.Country to "US",
+                    IdentifierSpec.Line1 to "",
+                )
+            )
+            assertThat(viewModel.isDirty.value).isFalse()
+        }
+
+    @OptIn(AddressElementSameAsBillingPreview::class)
+    @Test
+    fun `same as billing edit makes form dirty and reverting clears it`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                config = AddressLauncher.Configuration.Builder()
+                    .allowedCountries(setOf("US"))
+                    .billingAddress(
+                        PaymentSheet.BillingDetails(
+                            name = "John Doe",
+                            address = PaymentSheet.Address(
+                                city = "San Francisco",
+                                country = "US",
+                                line1 = "123 Apple Street",
+                                postalCode = "94107",
+                                state = "CA",
+                            ),
+                        )
+                    )
+                    .build()
+            )
+
+            viewModel.clickBillingSameAsShipping(newValue = false)
+            advanceUntilIdle()
+            assertThat(
+                viewModel.addressFormController.uncompletedFormValues.value[IdentifierSpec.Line1]?.value
+            ).isNotEqualTo("123 Apple Street")
+            assertThat(viewModel.isDirty.value).isTrue()
+
+            viewModel.clickBillingSameAsShipping(newValue = true)
+            advanceUntilIdle()
+            assertThat(viewModel.isDirty.value).isFalse()
+        }
+
+    @Test
+    fun `autocomplete edit makes form dirty`() = runTest(testDispatcher) {
+        val autocompleteEvents = MutableStateFlow<AddressElementNavigator.AutocompleteEvent?>(null)
+        whenever(
+            navigator.getResultFlow<AddressElementNavigator.AutocompleteEvent?>(
+                AddressElementNavigator.AutocompleteEvent.KEY
+            )
+        ).thenReturn(autocompleteEvents)
+
+        val viewModel = createViewModel(
+            config = AddressLauncher.Configuration.Builder()
+                .allowedCountries(setOf("US"))
+                .build()
+        )
+
+        autocompleteEvents.value = AddressElementNavigator.AutocompleteEvent.OnBack(
+            PaymentSheet.Address(
+                city = "San Francisco",
+                country = "US",
+                line1 = "123 Apple Street",
+                postalCode = "94107",
+                state = "CA",
+            )
+        )
+        advanceUntilIdle()
+
+        assertThat(
+            viewModel.addressFormController.uncompletedFormValues.value[IdentifierSpec.Line1]?.value
+        ).isEqualTo("123 Apple Street")
+        assertThat(viewModel.isDirty.value).isTrue()
+
+        autocompleteEvents.value = AddressElementNavigator.AutocompleteEvent.OnBack(
+            PaymentSheet.Address(country = "US")
+        )
+        advanceUntilIdle()
+
+        assertThat(viewModel.isDirty.value).isFalse()
+    }
+
+    @Test
+    fun `additional checkbox edit makes form dirty and reverting clears it`() =
+        runTest(testDispatcher) {
+            val viewModel = createViewModel(
+                config = AddressLauncher.Configuration.Builder()
+                    .additionalFields(
+                        AddressLauncher.AdditionalFieldsConfiguration(
+                            checkboxLabel = "Use this address",
+                        )
+                    )
+                    .build()
+            )
+
+            viewModel.clickCheckbox(true)
+            assertThat(viewModel.isDirty.value).isTrue()
+
+            viewModel.clickCheckbox(false)
+            assertThat(viewModel.isDirty.value).isFalse()
+        }
+
+    @Test
+    fun `successful save clears dirty state`() = runTest(testDispatcher) {
+        val viewModel = createViewModel(
+            config = AddressLauncher.Configuration.Builder()
+                .allowedCountries(setOf("US"))
+                .build()
+        )
+        viewModel.setRawValues(
+            mapOf(
+                IdentifierSpec.Country to "US",
+                IdentifierSpec.Line1 to "123 Main",
+            )
+        )
+        assertThat(viewModel.isDirty.value).isTrue()
+
+        viewModel.clickPrimaryButton(
+            completedFormValues = mapOf(
+                IdentifierSpec.Name to FormFieldEntry("Jane Doe", isComplete = true),
+                IdentifierSpec.Line1 to FormFieldEntry("123 Main", isComplete = true),
+                IdentifierSpec.City to FormFieldEntry("San Francisco", isComplete = true),
+                IdentifierSpec.State to FormFieldEntry("CA", isComplete = true),
+                IdentifierSpec.PostalCode to FormFieldEntry("94107", isComplete = true),
+                IdentifierSpec.Country to FormFieldEntry("US", isComplete = true),
+            ),
+            checkboxChecked = false,
+        )
+
+        assertThat(viewModel.isDirty.value).isFalse()
+        verify(navigator).dismiss(any())
     }
 
     @Test
@@ -999,6 +1203,7 @@ class InputAddressViewModelTest {
             ),
             navigator,
             eventReporter,
+            AddressElementDismissalCoordinator(),
             placesClient = FakePlacesClientProxy(
                 findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),
                 fetchPlaceResult = Result.success(Address()),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAddressElementNavigator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAddressElementNavigator.kt
@@ -29,8 +29,9 @@ internal class TestAddressElementNavigator private constructor() : AddressElemen
         dismissCalls.add(Call.Dismiss(result))
     }
 
-    override fun onBack() {
+    override fun onBack(): Boolean {
         onBackCalls.add(Call.OnBack)
+        return true
     }
 
     sealed interface Call {

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/FeatureFlags.kt
@@ -24,6 +24,7 @@ object FeatureFlags {
     val disableNfcScanningSecurity = FeatureFlag("Disable NFC Scanning Security")
     val disablePassiveCaptchaWarmup = FeatureFlag("Disable Passive Captcha Warm-Up")
     val forceTapToAddWithTerminal = FeatureFlag("Tap to Add: Force Terminal integration to be available")
+    val enableAddressElementUnsavedChanges = FeatureFlag("Address Element: Unsaved Changes")
 }
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)


### PR DESCRIPTION
# Summary
Address Element now protects unsaved address edits behind the client-side `FeatureFlags.enableAddressElementUnsavedChanges` gate. Unchanged root dismissal still closes immediately. When the flag is enabled and the rendered address or additional checkbox differs from its initial value, Address Element shows a discard confirmation dialog.

# Motivation
Closing the Address Element with partial edits currently loses the customer's input without confirmation. This adds the standalone AddressLauncher behavior needed before Checkout can reuse the flow, while keeping rollout reversible through the client-side flag.

The activity-scoped dismissal coordinator is shared by the root and input view models:

```text
form values / checkbox -> dirty state -> root dismissal
                                      ├─ clean: cancel immediately
                                      └─ dirty: Discard changes? dialog
                                           ├─ Keep editing: remain open
                                           └─ Discard changes: return Canceled
```

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused Address Element unit and Compose tests pass. `:paymentsheet:detekt` and `:stripe-core:detekt` pass. `:paymentsheet:apiCheck` and `:stripe-core:apiCheck` pass, and `paymentsheet/api/paymentsheet.api` is unchanged. A combined `apiDump apiCheck` invocation is not valid under the repository's current Gradle task dependency validation, while the separate API dump/check runs passed.

Coverage includes clean, prefilled, and same-as-billing forms; incomplete input, autocomplete, checkbox, and same-as-billing edits; reverting edits; successful save; root dismissal; keep editing; discard; autocomplete back navigation; repeated dismissal requests; and the flag-disabled regression path. The shared dialog test verifies copy, both callbacks, and dismissal.

# Screenshots
No new Paparazzi snapshots. The implementation uses the existing `SimpleDialogElementUI` presentation and test tags.

# Changelog
* [CHANGED] Address Element now asks customers to confirm before discarding unsaved address changes.

This PR intentionally contains no Checkout-specific mode, SAE types, public API, generated API baseline, or API artifact changes.

Committed and created by Codex.
