### PR TITLE
Enforce LPM billing-address fixture coverage

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
@@ -3,7 +3,9 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodDefinition
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodRegistry
 import com.stripe.android.lpmfoundations.paymentmethod.TestUiDefinitionFactoryArgumentsFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
@@ -43,6 +45,21 @@ internal class LpmBillingAddressFormValuesToParamsTest {
     @Test
     fun `has unique configs`() {
         assertThat(lpmBillingAddressTestConfigurations).containsNoDuplicates()
+    }
+
+    @Test
+    fun `specialized flow definitions remain registered`() {
+        assertThat(PaymentMethodRegistry.all).containsAtLeastElementsIn(specializedFlowDefinitions)
+    }
+
+    @Test
+    fun `covers every registered LPM without a specialized billing flow`() {
+        val expected = PaymentMethodRegistry.all - specializedFlowDefinitions
+        val covered = lpmBillingAddressTestConfigurations
+            .map { it.paymentMethodType }
+            .distinct()
+
+        assertThat(covered).containsExactlyElementsIn(expected.map { it.type })
     }
 
     @Test
@@ -121,6 +138,13 @@ internal class LpmBillingAddressFormValuesToParamsTest {
         )
     }
 }
+
+// These definitions render or collect billing details through specialized flows outside the shared LPM form harness.
+private val specializedFlowDefinitions: Set<PaymentMethodDefinition> = setOf(
+    CardDefinition,
+    InstantDebitsDefinition,
+    UsBankAccountDefinition,
+)
 
 internal data class LpmBillingAddressFormValuesToParamsTestCase(
     val name: String,


### PR DESCRIPTION
# Summary

Adds a test-only contract requiring every registered payment-method type to have shared LPM billing-address fixtures.

Card, Instant Debits, and US bank account are explicitly exempt because their dedicated flows render or collect billing details outside the shared LPM form harness. The contract also prevents stale exemptions.

# Motivation

A newly registered LPM could previously omit the shared fixtures that drive billing-address parameter assertions and Paparazzi coverage. This guard keeps registry coverage complete while preserving the existing requirement for `Never`, `AutomaticWithoutTax`, and `Full` billing modes.

Dynamic external and custom payment methods remain out of scope because they are not entries in `PaymentMethodRegistry.all`.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

The focused unit suite, PaymentSheet detekt and API checks, and the path-aware pre-push hook passed. No snapshots changed.

# Screenshots

Not applicable. This is a test-only change.

# Changelog

None. No user-visible behavior changed.

Committed and created by Codex.