### PR TITLE
Require coroutine scope for UI definitions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -469,6 +469,7 @@ internal class CustomerSheetViewModel(
                 formElements = paymentMethodMetadata.formElementsForCode(
                     code = paymentMethod.code,
                     uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
+                        coroutineScope = viewModelScope,
                         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
                         /*
                          * `CustomerSheet` does not implement `Link` so we don't need a coordinator or callback.
@@ -818,6 +819,7 @@ internal class CustomerSheetViewModel(
         val formElements = paymentMethodMetadata.formElementsForCode(
             code = selectedPaymentMethod.code,
             uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
+                coroutineScope = viewModelScope,
                 cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
                 /*
                  * `CustomerSheet` does not implement `Link` so we don't need a coordinator or callback.

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/NativeLinkFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/paymentmenthod/NativeLinkFormHelperFactory.kt
@@ -27,6 +27,7 @@ internal class NativeLinkFormHelperFactory(
             eventReporter = parentComponent.eventReporter,
             savedStateHandle = parentComponent.viewModel.savedStateHandle,
             formDefinitionFactory = DefaultFormDefinitionFactory(
+                coroutineScope = parentComponent.viewModel.viewModelScope,
                 linkInlineHandler = linkInlineHandler,
                 cardAccountRangeRepositoryFactory = parentComponent.cardAccountRangeRepositoryFactory,
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -30,9 +30,11 @@ import com.stripe.android.ui.core.elements.SharedDataSpec
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.CoroutineScope
 
 internal sealed interface UiDefinitionFactory {
     data class Arguments(
+        val coroutineScope: CoroutineScope,
         val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
         val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
         val initialValues: Map<IdentifierSpec, String?>,
@@ -64,6 +66,7 @@ internal sealed interface UiDefinitionFactory {
             ): Arguments
 
             class Default(
+                private val coroutineScope: CoroutineScope,
                 private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
                 private val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
                 private val linkInlineHandler: LinkInlineHandler?,
@@ -88,6 +91,7 @@ internal sealed interface UiDefinitionFactory {
                     requiresMandate: Boolean,
                 ): Arguments {
                     return Arguments(
+                        coroutineScope = coroutineScope,
                         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
                         linkConfigurationCoordinator = linkConfigurationCoordinator,
                         merchantName = metadata.merchantName,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -49,6 +49,7 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
             eventReporter = eventReporter,
             savedStateHandle = savedStateHandle,
             formDefinitionFactory = createFormDefinitionFactory(
+                coroutineScope = coroutineScope,
                 setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
                 paymentMethodMetadata = paymentMethodMetadata,
                 automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
@@ -60,6 +61,7 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
     }
 
     fun createFormDefinitionFactory(
+        coroutineScope: CoroutineScope,
         setAsDefaultMatchesSaveForFutureUse: Boolean,
         paymentMethodMetadata: PaymentMethodMetadata,
         automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
@@ -68,6 +70,7 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
         linkInlineHandler: LinkInlineHandler,
     ): FormDefinitionFactory {
         return DefaultFormDefinitionFactory(
+            coroutineScope = coroutineScope,
             linkInlineHandler = linkInlineHandler,
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
             paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedSelectionChooser.kt
@@ -13,6 +13,8 @@ import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -32,6 +34,9 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
     private val formHelperFactory: EmbeddedFormHelperFactory,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
 ) : EmbeddedSelectionChooser {
+    // Compatibility checks only inspect synchronously constructed form metadata.
+    private val coroutineScope = CoroutineScope(Job().apply { cancel() })
+
     private var previousConfiguration: CommonConfiguration?
         get() = savedStateHandle[PREVIOUS_CONFIGURATION_KEY]
         set(value) = savedStateHandle.set(PREVIOUS_CONFIGURATION_KEY, value)
@@ -148,6 +153,7 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
         paymentMethodMetadata: PaymentMethodMetadata,
     ): Boolean {
         val newFormDefinitionFactory = formHelperFactory.createFormDefinitionFactory(
+            coroutineScope = coroutineScope,
             paymentMethodMetadata = paymentMethodMetadata,
             // Card scan auto-launch is only relevant in the form, not when selecting the default.
             automaticallyLaunchedCardScanFormDataHelper = null,
@@ -163,6 +169,7 @@ internal class DefaultEmbeddedSelectionChooser @Inject constructor(
         }
         return previousPaymentMethodMetadata?.let { previousPaymentMethodMetadata ->
             val previousFormDefinitionFactory = formHelperFactory.createFormDefinitionFactory(
+                coroutineScope = coroutineScope,
                 paymentMethodMetadata = previousPaymentMethodMetadata,
                 // Card scan auto-launch is only relevant in the form, not when selecting the default.
                 automaticallyLaunchedCardScanFormDataHelper = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/NullUiDefinitionFactoryHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/NullUiDefinitionFactoryHelper.kt
@@ -6,10 +6,14 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.AccountRange
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
 
 internal object NullUiDefinitionFactoryHelper {
     val nullEmbeddedUiDefinitionFactory = UiDefinitionFactory.Arguments.Factory.Default(
+        // This factory only creates form elements for synchronous metadata inspection.
+        coroutineScope = CoroutineScope(Job().apply { cancel() }),
         cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
         linkConfigurationCoordinator = null,
         linkInlineHandler = null,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
@@ -25,6 +25,7 @@ internal class BaseSheetFormHelperFactory(
             eventReporter = viewModel.eventReporter,
             savedStateHandle = viewModel.savedStateHandle,
             formDefinitionFactory = createFormDefinitionFactory(
+                coroutineScope = coroutineScope,
                 paymentMethodMetadata = paymentMethodMetadata,
                 linkInlineHandler = linkInlineHandler,
                 automaticallyLaunchedCardScanFormDataHelper = createAutomaticallyLaunchedCardScanFormDataHelper(
@@ -37,12 +38,14 @@ internal class BaseSheetFormHelperFactory(
     }
 
     private fun createFormDefinitionFactory(
+        coroutineScope: CoroutineScope,
         paymentMethodMetadata: PaymentMethodMetadata,
         linkInlineHandler: LinkInlineHandler,
         automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
         paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
     ): FormDefinitionFactory {
         return DefaultFormDefinitionFactory(
+            coroutineScope = coroutineScope,
             linkInlineHandler = linkInlineHandler,
             cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
             paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet
 
+import androidx.lifecycle.viewModelScope
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
 import com.stripe.android.common.taptoadd.TapToAddHelper
@@ -19,6 +20,7 @@ import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
+import kotlinx.coroutines.CoroutineScope
 
 internal interface FormDefinitionFactory {
     fun formElementsForCode(code: PaymentMethodCode): List<FormElement>
@@ -34,6 +36,7 @@ internal interface FormDefinitionFactory {
 }
 
 internal class DefaultFormDefinitionFactory(
+    private val coroutineScope: CoroutineScope,
     private val linkInlineHandler: LinkInlineHandler,
     private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     private val paymentMethodMetadata: PaymentMethodMetadata,
@@ -96,6 +99,7 @@ internal class DefaultFormDefinitionFactory(
         val currentSelection = newPaymentSelectionProvider(code)?.takeIf { it.getType() == code }
 
         return UiDefinitionFactory.Arguments.Factory.Default(
+            coroutineScope = coroutineScope,
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
             linkConfigurationCoordinator = linkConfigurationCoordinator,
             linkInlineHandler = linkInlineHandler,
@@ -127,6 +131,7 @@ internal class DefaultFormDefinitionFactory(
             paymentMethodMetadata: PaymentMethodMetadata,
         ): FormDefinitionFactory {
             return DefaultFormDefinitionFactory(
+                coroutineScope = viewModel.viewModelScope,
                 linkInlineHandler = LinkInlineHandler.create(),
                 cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -42,6 +42,8 @@ import com.stripe.android.testing.SetupIntentFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -144,6 +146,7 @@ internal class CustomerSheetScreenshotTest {
             ).formElementsForCode(
                 code = PaymentMethod.Type.Card.code,
                 uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
+                    coroutineScope = CoroutineScope(Dispatchers.Unconfined),
                     cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                     linkConfigurationCoordinator = null,
                     onLinkInlineSignupStateChanged = {},

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -124,6 +125,7 @@ internal class PaymentMethodScreenScreenshotTest {
             ),
         )
         val uiDefinitionArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
+            coroutineScope = CoroutineScope(dispatcher),
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             linkConfigurationCoordinator = null,
             linkInlineHandler = null,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/BillingAddressFormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/BillingAddressFormElementsBuilderTest.kt
@@ -19,6 +19,8 @@ import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionElement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -159,6 +161,7 @@ class BillingAddressFormElementsBuilderTest {
     ): UiDefinitionFactory.Arguments {
         val context = ApplicationProvider.getApplicationContext<Application>()
         return UiDefinitionFactory.Arguments(
+            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
             initialValues = initialValues,
             initialLinkUserInput = null,
             shippingValues = shippingValues,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/FormElementsBuilderTest.kt
@@ -22,6 +22,8 @@ import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.SimpleTextElement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -238,6 +240,7 @@ class FormElementsBuilderTest {
     ): UiDefinitionFactory.Arguments {
         val context = ApplicationProvider.getApplicationContext<Application>()
         return UiDefinitionFactory.Arguments(
+            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
             initialValues = initialValues,
             initialLinkUserInput = null,
             shippingValues = shippingValues,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElementsTest.kt
@@ -43,6 +43,8 @@ import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -439,6 +441,7 @@ private object TransformSpecToElementsFactory {
 
         return TransformSpecToElements(
             UiDefinitionFactory.Arguments(
+                coroutineScope = CoroutineScope(Dispatchers.Unconfined),
                 initialValues = mapOf(),
                 initialLinkUserInput = null,
                 saveForFutureUseInitialValue = true,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -18,6 +18,8 @@ import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormData
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 
 internal object TestUiDefinitionFactoryArgumentsFactory {
     fun create(
@@ -41,6 +43,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             null
         }
         val delegate = UiDefinitionFactory.Arguments.Factory.Default(
+            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory(context),
             paymentMethodCreateParams = paymentMethodCreateParams,
             paymentMethodOptionsParams = paymentMethodOptionsParams,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -245,6 +245,7 @@ internal class FormHelperTest {
                 eventReporter = FakeEventReporter(),
                 savedStateHandle = SavedStateHandle(),
                 formDefinitionFactory = DefaultFormDefinitionFactory(
+                    coroutineScope = coroutineScope,
                     linkInlineHandler = linkInlineHandler,
                     cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                     paymentMethodMetadata = paymentMethodMetadata,
@@ -775,14 +776,16 @@ internal class FormHelperTest {
             { throw AssertionError("Not implemented") },
         selectionUpdater: (PaymentSelection?) -> Unit = { throw AssertionError("Not implemented") },
     ): FormHelper {
+        val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher()))
         return DefaultFormHelper(
-            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(UnconfinedTestDispatcher())),
+            coroutineScope = coroutineScope,
             paymentMethodMetadata = paymentMethodMetadata,
             linkInlineHandler = linkInlineHandler,
             selectionUpdater = selectionUpdater,
             eventReporter = eventReporter,
             savedStateHandle = SavedStateHandle(),
             formDefinitionFactory = DefaultFormDefinitionFactory(
+                coroutineScope = coroutineScope,
                 linkInlineHandler = linkInlineHandler,
                 cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                 paymentMethodMetadata = paymentMethodMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/FakeAddPaymentMethodInteractor.kt
@@ -10,6 +10,8 @@ import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import org.mockito.kotlin.mock
 
@@ -45,6 +47,7 @@ internal class FakeAddPaymentMethodInteractor(
                 metadata = metadata,
             )
             val uiDefinitionArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
+                coroutineScope = CoroutineScope(Dispatchers.Unconfined),
                 cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                 linkConfigurationCoordinator = null,
                 onLinkInlineSignupStateChanged = { throw AssertionError("Not expected") },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeVerticalModeFormInteractor.kt
@@ -6,6 +6,8 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.StateFlow
 import org.mockito.Mockito.mock
 
@@ -35,6 +37,7 @@ internal class FakeVerticalModeFormInteractor private constructor(
                 metadata = metadata,
             )
             val uiDefinitionArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
+                coroutineScope = CoroutineScope(Dispatchers.Unconfined),
                 cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                 linkConfigurationCoordinator = null,
                 linkInlineHandler = null,


### PR DESCRIPTION
# Summary
Require a `CoroutineScope` in `UiDefinitionFactory.Arguments` and propagate lifecycle-owned scopes through PaymentSheet, CustomerSheet, Embedded Payment Element, Checkout, and Link form-definition callers.

Committed and created by Codex.

# Motivation
UI definitions need a non-null coroutine scope for lifecycle-bound asynchronous work. Requiring the dependency prevents factories from constructing arguments without explicitly choosing the owning scope.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:
- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:compileDebugUnitTestKotlin`
- `./gradlew :paymentsheet:detekt`

No tests were newly ignored.

# Screenshots
Not applicable: this changes dependency wiring and has no visual impact.

# Changelog
Not applicable: this is an internal implementation change with no user-facing API or behavior change.
