### PR TITLE
Use UI definition scope for card number controller

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -28,6 +28,7 @@ import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -36,6 +37,7 @@ import kotlin.coroutines.CoroutineContext
 internal class CardDetailsController(
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     initialValues: Map<IdentifierSpec, String?>,
+    coroutineScope: CoroutineScope,
     collectName: Boolean = false,
     cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     uiContext: CoroutineContext = Dispatchers.Main,
@@ -86,6 +88,7 @@ internal class CardDetailsController(
     val numberElement = CardNumberElement(
         IdentifierSpec.CardNumber,
         DefaultCardNumberController(
+            coroutineScope = coroutineScope,
             cardTextFieldConfig = cardDetailsTextFieldConfig,
             cardAccountRangeRepository = cardAccountRangeRepositoryFactory.create(),
             uiContext = uiContext,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -17,6 +17,7 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -27,6 +28,7 @@ internal class CardDetailsElement(
     identifier: IdentifierSpec,
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     initialValues: Map<IdentifierSpec, String?>,
+    coroutineScope: CoroutineScope,
     collectName: Boolean = false,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
@@ -34,6 +36,7 @@ internal class CardDetailsElement(
     val controller: CardDetailsController = CardDetailsController(
         cardAccountRangeRepositoryFactory,
         initialValues,
+        coroutineScope,
         collectName,
         cbcEligibility,
         cardBrandFilter = cardBrandFilter,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
@@ -10,11 +10,13 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionFieldValidationController
 import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardDetailsSectionController(
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     initialValues: Map<IdentifierSpec, String?>,
+    coroutineScope: CoroutineScope,
     collectName: Boolean = false,
     cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
@@ -25,6 +27,7 @@ class CardDetailsSectionController(
         IdentifierSpec.Generic("card_detail"),
         cardAccountRangeRepositoryFactory,
         initialValues,
+        coroutineScope,
         collectName,
         cbcEligibility,
         cardBrandFilter,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
@@ -10,12 +10,14 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.forms.FormFieldEntry
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardDetailsSectionElement(
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
     initialValues: Map<IdentifierSpec, String?>,
+    coroutineScope: CoroutineScope,
     private val collectName: Boolean = false,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
@@ -23,6 +25,7 @@ class CardDetailsSectionElement(
     override val identifier: IdentifierSpec,
     private val cardDetailsAction: CardDetailsAction? = null,
     override val controller: CardDetailsSectionController = CardDetailsSectionController(
+        coroutineScope = coroutineScope,
         cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
         initialValues = initialValues,
         collectName = collectName,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -43,7 +43,6 @@ import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -75,12 +74,12 @@ internal class DefaultCardNumberController(
     cardAccountRangeRepository: CardAccountRangeRepository,
     uiContext: CoroutineContext,
     workContext: CoroutineContext,
+    private val coroutineScope: CoroutineScope,
     staticCardAccountRanges: StaticCardAccountRanges = DefaultStaticCardAccountRanges(),
     override val initialValue: String?,
     cardBrandChoiceConfig: CardBrandChoiceConfig = CardBrandChoiceConfig.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
-    private val coroutineScope: CoroutineScope = CoroutineScope(uiContext + SupervisorJob()),
     private val accountRangeService: CardAccountRangeService = DefaultCardAccountRangeService(
         cardAccountRangeRepository,
         uiContext,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -35,6 +35,8 @@ import com.stripe.android.uicore.elements.TextFieldState
 import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.isInstanceOf
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -44,8 +46,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CardDetailsControllerTest {
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     @get:Rule
-    val coroutineTestRule = CoroutineTestRule()
+    val coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private val coroutineScope = CoroutineScope(testDispatcher)
 
     @get:Rule
     val composeTestRule = createComposeRule()
@@ -484,6 +490,7 @@ class CardDetailsControllerTest {
                             identifier = IdentifierSpec.Generic("card_details"),
                             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
                             initialValues = mapOf(),
+                            coroutineScope = coroutineScope,
                         ),
                         modifier = Modifier,
                         hiddenIdentifiers = emptySet(),
@@ -511,6 +518,7 @@ class CardDetailsControllerTest {
             cardBrandFilter = cardBrandFilter,
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             initialValues = initialValues,
+            coroutineScope = coroutineScope,
             cbcEligibility = cbcEligibility,
             cardDetailsTextFieldConfig = cardDetailsTextFieldConfig,
             cvcTextFieldConfig = cvcTextFieldConfig,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.uicore.elements.FieldValidationMessage
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.forms.FormFieldEntry
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -27,6 +28,8 @@ class CardDetailsElementTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    private val coroutineScope = CoroutineScope(testDispatcher)
+
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
     @get:Rule
@@ -36,6 +39,7 @@ class CardDetailsElementTest {
     fun `test form field values returned and expiration date parsing`() = runTest {
         val cardController = CardDetailsController(
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             uiContext = testDispatcher,
             workContext = testDispatcher,
@@ -43,6 +47,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             controller = cardController
         )
@@ -71,6 +76,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = mapOf(
                 IdentifierSpec.CardNumber to "4242424242424242",
                 IdentifierSpec.CardBrand to CardBrand.Visa.code
@@ -99,6 +105,7 @@ class CardDetailsElementTest {
     fun `test form field values returned when collecting name`() = runTest {
         val cardController = CardDetailsController(
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             uiContext = testDispatcher,
@@ -107,6 +114,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             controller = cardController,
@@ -138,6 +146,7 @@ class CardDetailsElementTest {
         val cbcEligibility = CardBrandChoiceEligibility.Eligible(preferredNetworks = emptyList())
         val cardController = CardDetailsController(
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             cbcEligibility = cbcEligibility,
@@ -148,6 +157,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             controller = cardController,
@@ -181,6 +191,7 @@ class CardDetailsElementTest {
         val cbcEligibility = CardBrandChoiceEligibility.Eligible(listOf())
         val cardController = CardDetailsController(
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             cbcEligibility = cbcEligibility,
@@ -191,6 +202,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             controller = cardController,
@@ -231,6 +243,7 @@ class CardDetailsElementTest {
         val cbcEligibility = CardBrandChoiceEligibility.Eligible(listOf(CardBrand.CartesBancaires))
         val cardController = CardDetailsController(
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             cbcEligibility = cbcEligibility,
@@ -241,6 +254,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             controller = cardController,
@@ -273,6 +287,7 @@ class CardDetailsElementTest {
     fun `test card scan result should fill in card number and expiration date`() = runTest {
         val cardController = CardDetailsController(
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             uiContext = testDispatcher,
             workContext = testDispatcher,
@@ -280,6 +295,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             controller = cardController
         )
@@ -311,6 +327,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = mapOf(
                 IdentifierSpec.CardNumber to "4242424242424242",
                 IdentifierSpec.CardValidatedScan to "true",
@@ -338,6 +355,7 @@ class CardDetailsElementTest {
         val repositoryFactory = DefaultCardAccountRangeRepositoryFactory(context)
         val cardController = CardDetailsController(
             cardAccountRangeRepositoryFactory = repositoryFactory,
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             uiContext = testDispatcher,
             workContext = testDispatcher,
@@ -346,6 +364,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = repositoryFactory,
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             controller = cardController,
         )
@@ -383,6 +402,7 @@ class CardDetailsElementTest {
         val repositoryFactory = DefaultCardAccountRangeRepositoryFactory(context)
         val cardController = CardDetailsController(
             cardAccountRangeRepositoryFactory = repositoryFactory,
+            coroutineScope = coroutineScope,
             initialValues = initialValues,
             uiContext = testDispatcher,
             workContext = testDispatcher,
@@ -390,6 +410,7 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = repositoryFactory,
+            coroutineScope = coroutineScope,
             initialValues = initialValues,
             controller = cardController,
         )
@@ -410,10 +431,12 @@ class CardDetailsElementTest {
         val cardDetailsElement = CardDetailsElement(
             IdentifierSpec.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+            coroutineScope = coroutineScope,
             initialValues = emptyMap(),
             collectName = true,
             controller = CardDetailsController(
                 cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
+                coroutineScope = coroutineScope,
                 initialValues = emptyMap(),
                 collectName = true,
                 cbcEligibility = CardBrandChoiceEligibility.Ineligible,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionControllerTest.kt
@@ -8,6 +8,8 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -17,8 +19,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class CardDetailsSectionControllerTest {
 
+    private val testDispatcher = UnconfinedTestDispatcher()
+
     @get:Rule
-    val coroutineTestRule = CoroutineTestRule()
+    val coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private val coroutineScope = CoroutineScope(testDispatcher)
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
@@ -72,6 +78,7 @@ class CardDetailsSectionControllerTest {
     private fun createController() = CardDetailsSectionController(
         cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
         initialValues = emptyMap(),
+        coroutineScope = coroutineScope,
         collectName = false,
         cbcEligibility = CardBrandChoiceEligibility.Ineligible,
         cardBrandFilter = DefaultCardBrandFilter,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
@@ -86,6 +86,7 @@ internal class CardDetailsSectionElementUITest {
         val controller = CardDetailsSectionController(
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             initialValues = emptyMap(),
+            coroutineScope = backgroundScope,
             collectName = false,
             cbcEligibility = CardBrandChoiceEligibility.Ineligible,
             cardBrandFilter = DefaultCardBrandFilter,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -38,6 +38,7 @@ import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeCardBrandFilter
 import com.stripe.android.utils.TestUtils.idleLooper
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -906,6 +907,7 @@ internal class CardNumberControllerTest {
             cardAccountRangeRepository = FakeCardAccountRangeRepository(),
             uiContext = testDispatcher,
             workContext = testDispatcher,
+            coroutineScope = CoroutineScope(testDispatcher),
             initialValue = initialValue,
             cardBrandChoiceConfig = cardBrandChoiceConfig,
             cardBrandFilter = cardBrandFilter

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -124,6 +124,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
         return buildList {
             add(
                 CardDetailsSectionElement(
+                    coroutineScope = arguments.coroutineScope,
                     cardAccountRangeRepositoryFactory = arguments.cardAccountRangeRepositoryFactory,
                     initialValues = arguments.initialValues,
                     identifier = IdentifierSpec.Generic("card_details"),

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsActionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsActionTest.kt
@@ -10,6 +10,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -110,5 +112,6 @@ internal class TapToAddCardDetailsActionTest {
     private fun fakeController() = CardDetailsSectionController(
         cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
         initialValues = emptyMap(),
+        coroutineScope = CoroutineScope(Dispatchers.Unconfined),
     )
 }


### PR DESCRIPTION
# Summary
Pass the coroutine scope introduced by #14196 through the card-details element/controller chain to `DefaultCardNumberController`.

This is the second layer of the stack and depends on #14196.

Committed and created by Codex.

# Motivation
`DefaultCardNumberController` currently creates its own `SupervisorJob`-backed scope, which is not tied to the lifecycle of the form that owns it. Reusing `UiDefinitionFactory.Arguments.coroutineScope` keeps its eagerly collected flows and account-range work bound to the owning PaymentSheet lifecycle.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:
- `./gradlew :payments-ui-core:compileDebugKotlin :payments-ui-core:compileDebugUnitTestKotlin :paymentsheet:compileDebugKotlin :paymentsheet:compileDebugUnitTestKotlin`
- Focused `payments-ui-core` tests for card number, card details, section controller, and section UI
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.common.taptoadd.TapToAddCardDetailsActionTest'`
- `./gradlew :payments-ui-core:detekt :paymentsheet:detekt`

No tests were newly ignored.

# Screenshots
Not applicable: this changes coroutine-scope ownership and has no visual impact.

# Changelog
Not applicable: this is an internal lifecycle-management change with no user-facing API or behavior change.
