### PR TITLE
Remove isGooglePaySupported check

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -117,7 +117,6 @@ internal class DefaultEventReporter @Inject internal constructor(
                     DurationProvider.Key.PaymentSheetLoadRetrieveCustomer -> "retrieveCustomer"
                     DurationProvider.Key.PaymentSheetLoadComputePaymentMethodTypes -> "computePaymentMethodTypes"
                     // These are specific to Android
-                    DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported -> "isGooglePaySupported"
                     DurationProvider.Key.PaymentSheetLoadIsGooglePayReady -> "isGooglePayReady"
                     DurationProvider.Key.PaymentSheetLoadRetrieveSavedPaymentMethodSelection ->
                         "retrieveSavedPaymentMethodSelection"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
@@ -38,7 +38,7 @@ internal class DefaultAnalyticsMetadataFactory @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         integrationMetadata: IntegrationMetadata,
         elementsSession: ElementsSession,
-        isGooglePaySupported: Boolean,
+        isGooglePayReady: Boolean,
         configuration: PaymentElementLoader.Configuration,
         customerMetadata: CustomerMetadata?,
         linkStateResult: LinkStateResult?,
@@ -69,7 +69,7 @@ internal class DefaultAnalyticsMetadataFactory @Inject constructor(
             )
         )
 
-        put("google_pay_enabled", SimpleBoolean(isGooglePaySupported))
+        put("google_pay_enabled", SimpleBoolean(isGooglePayReady))
 
         put("tap_to_add_available", SimpleBoolean(isTapToAddAvailable))
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -36,7 +36,6 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
-import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
@@ -264,7 +263,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val lpmRepository: LpmRepository,
     private val logger: Logger,
     private val eventReporter: LoadingEventReporter,
-    private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
     private val createLinkState: CreateLinkState,
     private val logLinkHoldbackExperiment: LogLinkHoldbackExperiment,
@@ -292,7 +290,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             initializationMode: PaymentElementLoader.InitializationMode,
             integrationMetadata: IntegrationMetadata,
             elementsSession: ElementsSession,
-            isGooglePaySupported: Boolean,
+            isGooglePayReady: Boolean,
             configuration: PaymentElementLoader.Configuration,
             customerMetadata: CustomerMetadata?,
             linkStateResult: LinkStateResult?,
@@ -319,13 +317,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         eventReporter.onLoadStarted(metadata.initializedViaCompose)
         tapToAddConnectionStarter.start(configuration)
 
-        val isGooglePaySupportedOnDevice = async {
-            durationProvider.measureDuration(
-                DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported
-            ) {
-                isGooglePaySupportedOnDevice()
-            }
-        }
         val isGooglePaySupportedByConfiguration = async {
             durationProvider.measureDuration(
                 DurationProvider.Key.PaymentSheetLoadIsGooglePayReady
@@ -392,9 +383,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
         val paymentMethodMetadata = async {
             val linkStateResult = linkState.await()
-            val isGooglePaySupported = isGooglePaySupportedOnDevice.completeResultOrNull {
-                errorReporter.report(ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_SKIPPED_DURING_LOAD)
-            } ?: false
 
             durationProvider.measureDuration(DurationProvider.Key.PaymentSheetLoadComputePaymentMethodTypes) {
                 createPaymentMethodMetadata(
@@ -403,7 +391,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     configuration = configuration,
                     linkStateResult = linkStateResult,
                     isGooglePayReady = isGooglePayReady,
-                    isGooglePaySupported = isGooglePaySupported,
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
@@ -551,7 +538,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         configuration: CommonConfiguration,
         linkStateResult: LinkStateResult,
         isGooglePayReady: Boolean,
-        isGooglePaySupported: Boolean,
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
@@ -586,7 +572,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             initializationMode = initializationMode,
             integrationMetadata = integrationMetadata,
             elementsSession = elementsSession,
-            isGooglePaySupported = isGooglePaySupported,
+            isGooglePayReady = isGooglePayReady,
             configuration = integrationConfiguration,
             customerMetadata = customerMetadata,
             linkStateResult = linkStateResult,
@@ -712,10 +698,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                 }
             )
         } ?: false
-    }
-
-    private suspend fun isGooglePaySupportedOnDevice(): Boolean {
-        return isGooglePayReadyForEnvironment(GooglePayEnvironment.Production)
     }
 
     @Suppress("CyclomaticComplexMethod")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -791,7 +791,7 @@ class DefaultAnalyticsMetadataFactoryTest {
             initializationMode = initializationMode,
             integrationMetadata = integrationMetadata,
             elementsSession = elementsSession,
-            isGooglePaySupported = isGooglePaySupported,
+            isGooglePayReady = isGooglePaySupported,
             configuration = configuration,
             customerMetadata = customerMetadata,
             linkStateResult = linkStateResult,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -44,7 +44,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFi
 import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
-import com.stripe.android.model.ElementsSession.ExperimentAssignment
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkDisabledReason
 import com.stripe.android.model.LinkMode
@@ -5035,7 +5034,6 @@ internal class DefaultPaymentElementLoaderTest {
             lpmRepository = LpmRepository(),
             logger = Logger.noop(),
             eventReporter = eventReporter,
-            errorReporter = errorReporter,
             workContext = testDispatcher,
             createLinkState = createLinkState,
             logLinkHoldbackExperiment = logLinkHoldbackExperiment,

--- a/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/utils/DurationProvider.kt
@@ -24,7 +24,6 @@ interface DurationProvider {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     enum class Key {
         Loading,
-        PaymentSheetLoadIsGooglePaySupported,
         PaymentSheetLoadIsGooglePayReady,
         PaymentSheetLoadRetrieveSavedPaymentMethodSelection,
         PaymentSheetLoadSessionLoad,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Remove isGooglePaySupported check

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
We just use this for analytics and we're reporting something which is different from what I'd expect -- we say that google pay is enabled if it's supported on the customer device, but we actually decide whether to show it based on the isGooglePayReady value, which reads from elements/session and actually respects whether the merchant enabled google pay and their gpay environment

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

TODO