### PR TITLE
Harden analytics network tests against optional event

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.allowAnalyticsRequest
 import com.stripe.android.paymentsheet.clientAttributionMetadataParamsForDeferredIntent
 import com.stripe.android.paymentsheet.utils.GooglePayRepositoryTestRule
 import com.stripe.android.paymentsheet.utils.TestRules
@@ -59,6 +60,10 @@ internal class EmbeddedPaymentElementAnalyticsTest {
 
     @Before
     fun before() {
+        networkRule.allowAnalyticsRequest(
+            eventName = "google_pay.skipped_during_load",
+            productUsage = setOf("EmbeddedPaymentElement"),
+        )
         validateAnalyticsRequest(eventName = "mc_embedded_init")
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsAnalyticsTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,6 +40,14 @@ class CustomPaymentMethodsAnalyticsTest {
     }
 
     private val page = PaymentSheetPage(testRules.compose)
+
+    @Before
+    fun before() {
+        networkRule.allowAnalyticsRequest(
+            eventName = "google_pay.skipped_during_load",
+            productUsage = setOf("PaymentSheet"),
+        )
+    }
 
     @Test
     fun testSuccessful() = runPaymentSheetTest(

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
@@ -71,6 +71,10 @@ internal class FlowControllerAnalyticsTest {
 
     @Before
     fun before() {
+        networkRule.allowAnalyticsRequest(
+            eventName = "google_pay.skipped_during_load",
+            productUsage = setOf("PaymentSheet.FlowController"),
+        )
         validateAnalyticsRequest(eventName = "mc_custom_init")
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -29,6 +29,7 @@ import com.stripe.paymentelementnetwork.CardPaymentMethodDetails
 import com.stripe.paymentelementnetwork.setupPaymentMethodDetachResponse
 import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
 import com.stripe.paymentelementtestpages.EditPage
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -66,6 +67,14 @@ internal class PaymentSheetAnalyticsTest {
         merchantDisplayName = "Example, Inc.",
         paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
     )
+
+    @Before
+    fun before() {
+        networkRule.allowAnalyticsRequest(
+            eventName = "google_pay.skipped_during_load",
+            productUsage = setOf("PaymentSheet"),
+        )
+    }
 
     @Test
     fun testSuccessfulCardPayment() = runPaymentSheetTest(


### PR DESCRIPTION
## Summary
- audit analytics instrumentation tests that strictly mock `q.stripe.com` while loading PaymentElement state
- allow the legitimate optional `google_pay.skipped_during_load` event in PaymentSheet, FlowController, custom payment method, and Embedded Payment Element analytics tests
- leave CustomerSheet and NFC analytics tests unchanged because they do not run this Google Pay readiness path

## Testing
- diagnostic ShampooRule(2): 14 JUnit methods / 28 executions passed
- diagnostic ShampooRule(50): 14 JUnit methods / 700 executions passed in 31m 56s
  - the optional event occurred twice, exercising both present and absent outcomes
- normal rules: all 14 focused methods passed
- paymentsheet Android-test compilation, Detekt, and API check passed
- `:paymentsheet:lintDebug` retains the unrelated existing `ViewModelConstructorInComposable` error in `AutocompleteScreenTest.kt:69`

ShampooRule was diagnostic-only and is absent from this PR.

Committed and created by Codex.