### PR TITLE
Avoid retaining card number controllers

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -17,7 +17,6 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.CardAccountRangeService
-import com.stripe.android.cards.CardAccountRangeService.AccountRangesState
 import com.stripe.android.cards.CardNumber
 import com.stripe.android.cards.DefaultCardAccountRangeService
 import com.stripe.android.cards.DefaultStaticCardAccountRanges
@@ -42,19 +41,12 @@ import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import kotlin.coroutines.CoroutineContext
 import com.stripe.android.R as PaymentsCoreR
 
@@ -80,16 +72,6 @@ internal class DefaultCardNumberController(
     cardBrandChoiceConfig: CardBrandChoiceConfig = CardBrandChoiceConfig.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter = DefaultCardFundingFilter,
-    private val coroutineScope: CoroutineScope = CoroutineScope(uiContext + SupervisorJob()),
-    private val accountRangeService: CardAccountRangeService = DefaultCardAccountRangeService(
-        cardAccountRangeRepository,
-        uiContext,
-        workContext,
-        staticCardAccountRanges,
-        cardBrandFilter = cardBrandFilter,
-        cardFundingFilter = cardFundingFilter,
-        coroutineScope = coroutineScope
-    ),
 ) : CardNumberController() {
     override val capitalization: KeyboardCapitalization = cardTextFieldConfig.capitalization
     override val keyboardType: KeyboardType = cardTextFieldConfig.keyboard
@@ -102,6 +84,7 @@ internal class DefaultCardNumberController(
     override val fieldValue: StateFlow<String> = _fieldValue.asStateFlow()
 
     private val latestBinBasedPanLength = MutableStateFlow<Int?>(null)
+    private val latestSuccessfulAccountRanges = MutableStateFlow<List<AccountRange>>(emptyList())
 
     override val visualTransformation = combineAsStateFlow(
         fieldValue,
@@ -126,6 +109,27 @@ internal class DefaultCardNumberController(
 
     private val isEligibleForCardBrandChoice = cardBrandChoiceConfig is CardBrandChoiceConfig.Eligible
     private val brandChoices = MutableStateFlow<List<CardBrand>>(listOf())
+
+    private val accountRangeService: CardAccountRangeService = DefaultCardAccountRangeService(
+        cardAccountRangeRepository = cardAccountRangeRepository,
+        uiContext = uiContext,
+        workContext = workContext,
+        staticCardAccountRanges = staticCardAccountRanges,
+        cardBrandFilter = cardBrandFilter,
+        cardFundingFilter = cardFundingFilter,
+        accountRangeResultListener = object : CardAccountRangeService.AccountRangeResultListener {
+            override fun onAccountRangesResult(
+                accountRanges: List<AccountRange>,
+                unfilteredAccountRanges: List<AccountRange>
+            ) {
+                latestSuccessfulAccountRanges.value = accountRanges
+                accountRanges.firstOrNull()?.panLength?.let { panLength ->
+                    latestBinBasedPanLength.value = panLength
+                }
+                brandChoices.value = unfilteredAccountRanges.map { it.brand }.distinct()
+            }
+        }
+    )
 
     private val preferredBrands = when (cardBrandChoiceConfig) {
         is CardBrandChoiceConfig.Eligible -> cardBrandChoiceConfig.preferredBrands
@@ -160,20 +164,15 @@ internal class DefaultCardNumberController(
      * option  of not determining the card brand unless the user selects one. We use an implied
      * card brand (VISA, Mastercard) internally to pass state validation.
      */
-    private val impliedCardBrand = combine(
-        flow = _fieldValue,
-        flow2 = accountRangeService.accountRangesStateFlow
-            .map { it.ranges }
+    private val impliedCardBrand = combineAsStateFlow(
+        _fieldValue,
+        accountRangeService.accountRangesStateFlow
     ) { fieldValue, accountRanges ->
         impliedBrandValue(
-            accountRange = accountRanges.firstOrNull(),
+            accountRange = accountRanges.ranges.firstOrNull(),
             number = fieldValue
         )
-    }.stateIn(
-        scope = coroutineScope,
-        initialValue = impliedBrandValue(),
-        started = SharingStarted.Eagerly
-    )
+    }
 
     override val cardBrandFlow = if (isEligibleForCardBrandChoice) {
         combineAsStateFlow(
@@ -186,11 +185,11 @@ internal class DefaultCardNumberController(
         impliedCardBrand
     }
 
-    override val trailingIcon: StateFlow<TextFieldIcon?> = combine(
-        flow = _fieldValue,
-        flow2 = brandChoices,
-        flow3 = selectedCardBrandFlow,
-        flow4 = accountRangeService.accountRangesStateFlow
+    override val trailingIcon: StateFlow<TextFieldIcon?> = combineAsStateFlow(
+        _fieldValue,
+        brandChoices,
+        selectedCardBrandFlow,
+        accountRangeService.accountRangesStateFlow
     ) { number, brands, chosen, accountRangeState ->
         trailingIconValue(
             number = number,
@@ -198,27 +197,19 @@ internal class DefaultCardNumberController(
             chosen = chosen,
             accountRange = accountRangeState.ranges.firstOrNull()
         )
-    }.stateIn(
-        scope = coroutineScope,
-        initialValue = trailingIconValue(),
-        started = SharingStarted.Eagerly
-    )
+    }
 
-    private val _fieldState = combine(
-        flow = impliedCardBrand,
-        flow2 = _fieldValue,
-        flow3 = accountRangeService.accountRangesStateFlow.filterIsInstance<AccountRangesState.Success>()
+    private val _fieldState = combineAsStateFlow(
+        impliedCardBrand,
+        _fieldValue,
+        latestSuccessfulAccountRanges
     ) { brand, fieldValue, accountRanges ->
         textFieldState(
             brand = brand,
-            accountRanges = accountRanges.ranges,
+            accountRanges = accountRanges,
             number = fieldValue
         )
-    }.stateIn(
-        scope = coroutineScope,
-        initialValue = textFieldState(),
-        started = SharingStarted.Eagerly
-    )
+    }
 
     override val fieldState: StateFlow<TextFieldState> = _fieldState
 
@@ -236,8 +227,10 @@ internal class DefaultCardNumberController(
      * An error must be emitted if it is visible or not visible.
      **/
     override val validationMessage: StateFlow<FieldValidationMessage?> =
-        combineAsStateFlow(visibleValidationMessage, _fieldState) { visibleError, fieldState ->
-            fieldState.getValidationMessage()?.takeIf { visibleError }
+        combineAsStateFlow(_fieldState, _hasFocus, _isValidating) { fieldState, hasFocus, isValidating ->
+            fieldState.getValidationMessage()?.takeIf {
+                fieldState.shouldShowValidationMessage(hasFocus, isValidating)
+            }
         }
 
     override val isComplete: StateFlow<Boolean> = _fieldState.mapAsStateFlow { it.isValid() }
@@ -249,19 +242,6 @@ internal class DefaultCardNumberController(
 
     init {
         onRawValueChange(initialValue ?: "")
-
-        coroutineScope.launch(uiContext) {
-            accountRangeService.accountRangeResultFlow
-                .collect { result ->
-                    val newAccountRange = result.accountRanges.firstOrNull()
-                    newAccountRange?.panLength?.let { panLength ->
-                        latestBinBasedPanLength.value = panLength
-                    }
-
-                    val newBrandChoices = result.unfilteredAccountRanges.map { it.brand }.distinct()
-                    brandChoices.value = newBrandChoices
-                }
-        }
     }
 
     /**
@@ -399,7 +379,7 @@ internal class DefaultCardNumberController(
             brand,
             accountRanges,
             number,
-            numberAllowedDigits = accountRangeService.accountRange?.panLength
+            numberAllowedDigits = latestSuccessfulAccountRanges.value.firstOrNull()?.panLength
                 ?: brand.getMaxLengthForCardNumber(number)
         )
     }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -20,7 +20,9 @@ import com.stripe.android.cards.CardNumber
 import com.stripe.android.cards.StaticCardAccountRangeSource
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.AccountRange
+import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardFunding
 import com.stripe.android.networking.PaymentAnalyticsEvent
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
@@ -38,6 +40,7 @@ import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeCardBrandFilter
 import com.stripe.android.utils.TestUtils.idleLooper
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -102,6 +105,30 @@ internal class CardNumberControllerTest {
             assertThat(awaitItem().value)
                 .isEqualTo("4242424242424242")
         }
+    }
+
+    @Test
+    fun `validation uses last successful ranges while account range query is in flight`() = runTest {
+        val repository = ControllableCardAccountRangeRepository()
+        val firstResult = repository.enqueueResult()
+        val cardNumberController = createController(
+            cardAccountRangeRepository = repository,
+            cardBrandChoiceConfig = CardBrandChoiceConfig.Eligible(
+                preferredBrands = emptyList(),
+                initialBrand = null,
+            ),
+        )
+
+        cardNumberController.onValueChange("4242424242424242")
+        firstResult.complete(listOf(accountRange("424242", panLength = 19, AccountRange.BrandInfo.Visa)))
+        assertThat(cardNumberController.isComplete.value).isFalse()
+
+        val secondResult = repository.enqueueResult()
+        cardNumberController.onValueChange("5555555555554444")
+        assertThat(cardNumberController.isComplete.value).isFalse()
+
+        secondResult.complete(listOf(accountRange("555555", panLength = 16, AccountRange.BrandInfo.Mastercard)))
+        assertThat(cardNumberController.isComplete.value).isTrue()
     }
 
     @Test
@@ -896,14 +923,15 @@ internal class CardNumberControllerTest {
     private fun createController(
         initialValue: String? = null,
         cardBrandChoiceConfig: CardBrandChoiceConfig = CardBrandChoiceConfig.Ineligible,
-        cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter
+        cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
+        cardAccountRangeRepository: CardAccountRangeRepository = FakeCardAccountRangeRepository(),
     ): DefaultCardNumberController {
         return DefaultCardNumberController(
             cardTextFieldConfig = CardNumberConfig(
                 isCardBrandChoiceEligible = false,
                 cardBrandFilter = cardBrandFilter
             ),
-            cardAccountRangeRepository = FakeCardAccountRangeRepository(),
+            cardAccountRangeRepository = cardAccountRangeRepository,
             uiContext = testDispatcher,
             workContext = testDispatcher,
             initialValue = initialValue,
@@ -933,6 +961,36 @@ internal class CardNumberControllerTest {
 
         override val loading: StateFlow<Boolean> = stateFlowOf(false)
     }
+
+    private class ControllableCardAccountRangeRepository : CardAccountRangeRepository {
+        private val results = ArrayDeque<CompletableDeferred<List<AccountRange>?>>()
+
+        fun enqueueResult() = CompletableDeferred<List<AccountRange>?>().also(results::addLast)
+
+        override suspend fun getAccountRange(cardNumber: CardNumber.Unvalidated): AccountRange? {
+            return getAccountRanges(cardNumber)?.firstOrNull()
+        }
+
+        override suspend fun getAccountRanges(cardNumber: CardNumber.Unvalidated): List<AccountRange>? {
+            return results.removeFirst().await()
+        }
+
+        override val loading: StateFlow<Boolean> = stateFlowOf(false)
+    }
+
+    private fun accountRange(
+        bin: String,
+        panLength: Int,
+        brandInfo: AccountRange.BrandInfo,
+    ) = AccountRange(
+        binRange = BinRange(
+            low = bin + "0".repeat(panLength - bin.length),
+            high = bin + "9".repeat(panLength - bin.length),
+        ),
+        panLength = panLength,
+        brandInfo = brandInfo,
+        funding = CardFunding.Unknown,
+    )
 
     private companion object {
         const val TEST_TAG = "CardNumberElement"


### PR DESCRIPTION
# Summary
Remove persistent coroutine work from `DefaultCardNumberController`. Account-range results now update controller caches through `AccountRangeResultListener`, and card brand, icon, and validation state use derived state flows without eager collectors.

This also removes the `CoroutineScope` parameter that was threaded through card form definitions and controllers.

Committed and created by Codex.

# Motivation
Discarded card controllers could remain children of a shared scope, commonly a `viewModelScope`, because each controller started eager state collectors and an indefinite account-range collector. This retained obsolete controllers until the owning ViewModel cleared.

The account-range service still uses finite repository-query jobs, while an idle controller owns no coroutine work. Validation continues using the last successful account ranges while a replacement query is loading.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran `./gradlew :payments-ui-core:testDebugUnitTest` successfully. Added regression coverage for validation during an in-flight account-range query and after its successful result. No tests were newly ignored.

# Screenshots
Not applicable — this changes coroutine ownership and derived state behavior without visual UI changes.

# Changelog
Not applicable — this is an internal lifecycle fix with no supported public API change.
