### PR TITLE
Avoid retaining idle Link controllers

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -53,6 +53,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.json.JSONObject
 import javax.inject.Inject
 import javax.inject.Provider
@@ -113,11 +115,11 @@ internal class LinkControllerInteractor @Inject constructor(
         MutableSharedFlow<LinkController.PresentResult>(extraBufferCapacity = 1)
     val presentResultFlow = _presentResultFlow.asSharedFlow()
 
-    private val _presentSelectionSucceededFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val createPaymentMethodMutex = Mutex()
 
-    init {
+    private fun createPaymentMethodForPresentResult() {
         coroutineScope.launch {
-            _presentSelectionSucceededFlow.collect {
+            createPaymentMethodMutex.withLock {
                 val pmResult = performCreatePaymentMethod(apiKey = null)
                 updateState { it.copy(createdPaymentMethod = pmResult.getOrNull()) }
                 val presentResult = pmResult.fold(
@@ -435,7 +437,7 @@ internal class LinkControllerInteractor @Inject constructor(
                 is LinkActivityResult.Completed -> {
                     logger.debug("$tag: present PM selected, creating payment method")
                     updateState { it.copy(selectedPaymentMethod = result.selectedPayment) }
-                    _presentSelectionSucceededFlow.tryEmit(Unit)
+                    createPaymentMethodForPresentResult()
                 }
                 is LinkActivityResult.Failed -> {
                     logger.debug("$tag: present failed")

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -27,11 +27,14 @@ import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.utils.FakeActivityResultLauncher
 import com.stripe.android.utils.FakeLinkComponent
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
 import org.junit.Rule
@@ -67,8 +70,7 @@ class LinkControllerInteractorTest {
     private val linkComponentFactoryProvider: Provider<LinkComponent.Factory> =
         Provider { FakeLinkComponent.Factory(linkComponent) }
 
-    // Each created interactor owns a scope with a perpetual collector in its init; track and cancel
-    // them so the scopes don't outlive the test.
+    // Track injected scopes so any finite work still running after a failed test is canceled.
     @get:Rule
     val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
@@ -81,6 +83,16 @@ class LinkControllerInteractorTest {
                 LinkController.State()
             )
         }
+    }
+
+    @Test
+    fun `constructing interactor does not start child coroutine`() = runTest {
+        val parentJob = Job()
+        val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher + parentJob))
+
+        createInteractor(coroutineScope)
+
+        assertThat(parentJob.children.toList()).isEmpty()
     }
 
     @Test
@@ -1075,8 +1087,9 @@ class LinkControllerInteractorTest {
         }
     }
 
-    private fun createInteractor(): LinkControllerInteractor {
-        val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher))
+    private fun createInteractor(
+        coroutineScope: CoroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher)),
+    ): LinkControllerInteractor {
         return LinkControllerInteractor(
             application = application,
             logger = logger,
@@ -1404,6 +1417,73 @@ class LinkControllerInteractorTest {
             assertThat(result).isInstanceOf(LinkController.PresentResult.Completed::class.java)
             assertThat((result as LinkController.PresentResult.Completed).paymentMethod)
                 .isEqualTo(expectedPaymentMethod)
+        }
+    }
+
+    @Test
+    fun `completed present work leaves no child coroutine`() = runTest {
+        val parentJob = Job()
+        val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher + parentJob))
+        val interactor = createInteractor(coroutineScope)
+        configure(interactor)
+        interactor.presentFull(FakeActivityResultLauncher())
+
+        interactor.presentResultFlow.test {
+            interactor.onLinkActivityResult(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                    selectedPayment = createTestPaymentMethod(),
+                    shippingAddress = null,
+                )
+            )
+            assertThat(awaitItem()).isInstanceOf(LinkController.PresentResult.Completed::class.java)
+        }
+        advanceUntilIdle()
+
+        assertThat(parentJob.children.toList()).isEmpty()
+    }
+
+    @Test
+    fun `rapid completed present results create payment methods serially`() = runTest {
+        val interactor = createInteractor()
+        configure(interactor)
+        val firstResult = CompletableDeferred<Result<com.stripe.android.model.PaymentMethod>>()
+        val secondResult = CompletableDeferred<Result<com.stripe.android.model.PaymentMethod>>()
+        val results = ArrayDeque(listOf(firstResult, secondResult))
+        linkAccountManager.createPaymentMethodResultProvider = { results.removeFirst().await() }
+        val firstPaymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val secondPaymentMethod = firstPaymentMethod.copy(id = "pm_second")
+
+        interactor.presentResultFlow.test {
+            interactor.presentFull(FakeActivityResultLauncher())
+            interactor.onLinkActivityResult(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                    selectedPayment = createTestPaymentMethod(cvc = "111"),
+                    shippingAddress = null,
+                )
+            )
+            assertThat(linkAccountManager.createPaymentMethodCalls.awaitItem().collectedCvc).isEqualTo("111")
+
+            interactor.presentFull(FakeActivityResultLauncher())
+            interactor.onLinkActivityResult(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                    selectedPayment = createTestPaymentMethod(cvc = "222"),
+                    shippingAddress = null,
+                )
+            )
+            linkAccountManager.createPaymentMethodCalls.expectNoEvents()
+            expectNoEvents()
+
+            firstResult.complete(Result.success(firstPaymentMethod))
+            assertThat((awaitItem() as LinkController.PresentResult.Completed).paymentMethod)
+                .isEqualTo(firstPaymentMethod)
+            assertThat(linkAccountManager.createPaymentMethodCalls.awaitItem().collectedCvc).isEqualTo("222")
+
+            secondResult.complete(Result.success(secondPaymentMethod))
+            assertThat((awaitItem() as LinkController.PresentResult.Completed).paymentMethod)
+                .isEqualTo(secondPaymentMethod)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/FakeLinkAccountManager.kt
@@ -108,6 +108,10 @@ internal open class FakeLinkAccountManager(
     var createPaymentMethodResult: Result<com.stripe.android.model.PaymentMethod> = Result.success(
         value = PaymentMethodFixtures.CARD_PAYMENT_METHOD
     )
+    var createPaymentMethodResultProvider: suspend () -> Result<com.stripe.android.model.PaymentMethod> = {
+        createPaymentMethodResult
+    }
+    val createPaymentMethodCalls = Turbine<LinkPaymentMethod>()
     var sharePaymentDetails: Result<SharePaymentDetails> = Result.success(TestFactory.LINK_SHARE_PAYMENT_DETAILS)
     var updatePaymentDetailsResult = Result.success(TestFactory.CONSUMER_PAYMENT_DETAILS)
     var updatePhoneNumberResult: Result<LinkAccount> = Result.success(TestFactory.LINK_ACCOUNT)
@@ -261,7 +265,8 @@ internal open class FakeLinkAccountManager(
     override suspend fun createPaymentMethod(
         linkPaymentMethod: LinkPaymentMethod
     ): Result<com.stripe.android.model.PaymentMethod> {
-        return createPaymentMethodResult
+        createPaymentMethodCalls.add(linkPaymentMethod)
+        return createPaymentMethodResultProvider()
     }
 
     override suspend fun startVerification(isResendSmsCode: Boolean): Result<LinkAccount> {


### PR DESCRIPTION
# Summary
Replace `LinkControllerInteractor`'s construction-time, indefinite presentation-result collector with finite payment-method creation work launched only after a completed full Link presentation.

A mutex serializes rapid completed presentations while preserving success, failure, and state updates.

Committed and created by Codex.

# Motivation
Every standalone Link controller started an indefinite collector during construction. Because the standalone controller has no close or destroy API, even an unused controller could remain retained by its injected parent scope.

Idle controllers now start no child coroutine, and completed payment-method creation leaves no child job behind. Only finite in-flight network work can temporarily retain the interactor.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran `./gradlew :paymentsheet:testDebugUnitTest` successfully. Added regressions for idle construction, child-job cleanup after completion, and serialization of rapid full-presentation completions. Existing success, failure, missing-selection, state-update, and cancellation coverage remains green. No tests were newly ignored.

# Screenshots
Not applicable — this is a coroutine lifecycle change with no visual UI changes.

# Changelog
Not applicable — this is an internal lifecycle fix with no public or restricted API change.
