### PR TITLE
Stabilize Checkout analytics reporting

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -54,6 +54,7 @@ import com.stripe.android.ui.core.elements.ExternalPaymentMethodSpec
 import com.stripe.android.ui.core.elements.ExternalPaymentMethodsRepository
 import com.stripe.attestation.IntegrityRequestManager
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.first
@@ -319,7 +320,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         eventReporter.onLoadStarted(metadata.initializedViaCompose)
         tapToAddConnectionStarter.start(configuration)
 
-        val isGooglePaySupportedOnDevice = async {
+        // Give immediately available results a chance to complete before later load work checks isCompleted.
+        val isGooglePaySupportedOnDevice = async(start = CoroutineStart.UNDISPATCHED) {
             durationProvider.measureDuration(
                 DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported
             ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTracker.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTracker.kt
@@ -1,10 +1,8 @@
 package com.stripe.android.paymentsheet.verticalmode
 
-import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.unit.IntSize
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -16,9 +14,8 @@ import kotlinx.coroutines.launch
  * Tracks stability of payment method positioning and dispatches analytics when stable
  *
  * This class monitors UI layout changes for payment methods and waits until:
- * 1. All expected payment methods have stable coordinates (no layout changes)
- * 2. All visibility states are stable (no visibility changes)
- * 3. A debounce period passes to ensure animations are complete
+ * 1. All expected payment methods have reported coordinates
+ * 2. A debounce period passes without a layout change
  *
  * Once stable, it dispatches a single analytics event.
  */
@@ -28,14 +25,11 @@ internal class PaymentMethodInitialVisibilityTracker(
     private val coroutineScope: CoroutineScope,
 ) {
     private data class CoordinateSnapshot(
-        val positionInWindow: Offset,
         val size: IntSize,
         val boundsInWindow: Rect
     )
 
     private val visibilityMap = mutableMapOf<String, Boolean>()
-    private val previousCoordinateSnapshots = mutableMapOf<String, CoordinateSnapshot>()
-    private val coordinateStabilityMap = mutableMapOf<String, Boolean>()
     private var hasDispatched = false
 
     private var dispatchEventJob: Job? = null
@@ -52,31 +46,13 @@ internal class PaymentMethodInitialVisibilityTracker(
         return this.hasDispatched
     }
 
-    /**
-     * When this function is called from onGloballyPositioned
-     * it is guaranteed to be called twice on any given stable coordinate
-     *
-     * onGloballyPositioned is called
-     * when coordinates are first available
-     * when coordinates have moved
-     * and when the composition is finalized and stable.
-     */
     fun updateVisibility(itemCode: String, coordinates: LayoutCoordinates) {
         if (itemCode !in expectedItems || expectedItems.isEmpty()) return
         if (hasDispatched) return // Only dispatch once per tracker instance
 
-        /**
-         * Capture only the relevant fields from [LayoutCoordinates] when we know the coordinates are attached.
-         * Whether previous coordinates is/isn't attached or not is irrelevant, we only need to know
-         * the previous coordinate's boundsInWindow, positionInWindow, and size.
-         *
-         * When implemented, [LayoutCoordinates.isAttached] provides a getter to a var, so we cannot rely on being able
-         * to call `positionInWindow` and `boundsInWindow` of saved [LayoutCoordinates].
-         */
         val coordinateSnapshot: CoordinateSnapshot
         if (coordinates.isAttached) {
             coordinateSnapshot = CoordinateSnapshot(
-                positionInWindow = coordinates.positionInWindow(),
                 size = coordinates.size,
                 boundsInWindow = coordinates.boundsInWindow(),
             )
@@ -85,29 +61,8 @@ internal class PaymentMethodInitialVisibilityTracker(
         }
 
         val newVisibility = calculateVisibility(coordinateSnapshot)
-        val previousCoordinatesForItem = previousCoordinateSnapshots[itemCode]
-
-        // Check if coordinates are stable (haven't changed)
-        // Compare position, size, and window bounds to detect any layout changes
-        // All three must match exactly to consider coordinates stable
-        val coordinatesAreStable = previousCoordinatesForItem?.let { prev ->
-            prev.positionInWindow == coordinateSnapshot.positionInWindow &&
-                prev.size == coordinateSnapshot.size &&
-                prev.boundsInWindow == coordinateSnapshot.boundsInWindow
-        } ?: false // First time seeing this item, so not stable yet
-
-        // Update our tracking
-        this.previousCoordinateSnapshots[itemCode] = coordinateSnapshot
-        val wasVisibilityStable = visibilityMap[itemCode] == newVisibility
         visibilityMap[itemCode] = newVisibility
-
-        if (coordinatesAreStable && wasVisibilityStable) {
-            coordinateStabilityMap[itemCode] = true
-        } else {
-            coordinateStabilityMap.remove(itemCode)
-            // Cancel any pending dispatch since coordinates changed
-            dispatchEventJob?.cancel()
-        }
+        dispatchEventJob?.cancel()
 
         checkStabilityAndDispatch()
     }
@@ -139,13 +94,7 @@ internal class PaymentMethodInitialVisibilityTracker(
     }
 
     private fun checkStability(): Boolean {
-        if (expectedItems.size != coordinateStabilityMap.size || expectedItems.size != visibilityMap.size) {
-            return false
-        }
-
-        return expectedItems.all {
-            coordinateStabilityMap[it] == true && visibilityMap.containsKey(it)
-        }
+        return expectedItems.size == visibilityMap.size && expectedItems.all(visibilityMap::containsKey)
     }
 
     private fun checkStabilityAndDispatch() {
@@ -173,8 +122,6 @@ internal class PaymentMethodInitialVisibilityTracker(
     }
 
     fun reset() {
-        coordinateStabilityMap.clear()
-        previousCoordinateSnapshots.clear()
         visibilityMap.clear()
         hasDispatched = false
         dispatchEventJob?.cancel()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTrackerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodInitialVisibilityTrackerTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.testing.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -77,8 +78,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
             bounds = defaultBounds,
         )
 
-        // Update twice to achieve stability
-        tracker.updateVisibility("card", coordinates1)
         tracker.updateVisibility("card", coordinates1)
 
         advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
@@ -98,8 +97,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
             bounds = Rect(0f, 0f, 0f, 0f) // Hidden
         )
 
-        // Update twice to achieve stability
-        tracker.updateVisibility("card", coordinates1)
         tracker.updateVisibility("card", coordinates1)
 
         // Should not dispatch because no items are visible
@@ -119,8 +116,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
             bounds = Rect(0f, 0f, 100f, 49f) // 98% visible
         )
 
-        // Update twice to achieve stability
-        tracker.updateVisibility("card", coordinates1)
         tracker.updateVisibility("card", coordinates1)
 
         // Should dispatch because item meets visibility threshold
@@ -140,8 +135,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
             bounds = Rect(0f, 0f, 100f, 25f) // 50% visible
         )
 
-        // Update twice to achieve stability
-        tracker.updateVisibility("card", coordinates1)
         tracker.updateVisibility("card", coordinates1)
 
         // Should not dispatch because item doesn't meet visibility threshold
@@ -150,7 +143,7 @@ class PaymentMethodInitialVisibilityTrackerTest {
     }
 
     @Test
-    fun `coordinate stability - changing coordinates does not invoke callback`() = runTest {
+    fun `coordinate stability - changing coordinates resets debounce timer`() = runTest {
         val tracker = getTracker(
             expectedItems = listOf("card"),
         )
@@ -161,14 +154,18 @@ class PaymentMethodInitialVisibilityTrackerTest {
         )
         val coordinates2 = FakeLayoutCoordinates.create(
             size = defaultCoordinateSize,
-            bounds = Rect(10f, 10f, 110f, 60f) // Different position
+            bounds = Rect(1f, 1f, 101f, 51f) // Different position, still above the visibility threshold
         )
 
         tracker.updateVisibility("card", coordinates1)
-        tracker.updateVisibility("card", coordinates2) // Changes position
+        advanceTimeBy(TIME_ADVANCE_LESSER_THAN_DEBOUNCE_DELAY)
+        tracker.updateVisibility("card", coordinates2)
 
-        advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
+        advanceTimeBy(TIME_ADVANCE_LESSER_THAN_DEBOUNCE_DELAY)
         verifyNoCallback(callback)
+
+        advanceUntilIdle()
+        verify(callback).invoke(listOf("card"), emptyList())
     }
 
     @Test
@@ -179,8 +176,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
 
         val coordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
 
-        // Update twice to achieve stability
-        tracker.updateVisibility("card", coordinates)
         tracker.updateVisibility("card", coordinates)
 
         // Should not dispatch immediately
@@ -199,8 +194,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
 
         val coordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
 
-        // Update twice to achieve stability
-        tracker.updateVisibility("card", coordinates)
         tracker.updateVisibility("card", coordinates)
 
         // Should not dispatch immediately
@@ -227,8 +220,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
 
         val coordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
 
-        // Update multiple times to achieve stability
-        tracker.updateVisibility("card", coordinates)
         tracker.updateVisibility("card", coordinates)
 
         advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
@@ -249,9 +240,7 @@ class PaymentMethodInitialVisibilityTrackerTest {
 
         // Update only two of three items
         tracker.updateVisibility("card", coordinates)
-        tracker.updateVisibility("card", coordinates) // Make stable
         tracker.updateVisibility("klarna", coordinates)
-        tracker.updateVisibility("klarna", coordinates) // Make stable
 
         // Should not dispatch yet (missing paypal)
         advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
@@ -259,7 +248,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
 
         // Add the third item
         tracker.updateVisibility("paypal", coordinates)
-        tracker.updateVisibility("paypal", coordinates) // Make stable
 
         // Now should dispatch
         advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
@@ -275,7 +263,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
         val coordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
 
         // Set up for dispatch but dispose before it happens
-        tracker.updateVisibility("card", coordinates)
         tracker.updateVisibility("card", coordinates)
 
         advanceTimeBy(TIME_ADVANCE_LESSER_THAN_DEBOUNCE_DELAY)
@@ -294,10 +281,8 @@ class PaymentMethodInitialVisibilityTrackerTest {
         val coordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
 
         tracker.updateVisibility("card", coordinates)
-        tracker.updateVisibility("card", coordinates)
         tracker.reset()
 
-        tracker.updateVisibility("card", coordinates)
         tracker.updateVisibility("card", coordinates)
         advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
 
@@ -314,10 +299,7 @@ class PaymentMethodInitialVisibilityTrackerTest {
 
         val hiddenCoordinates = FakeLayoutCoordinatesFixtures.FULLY_HIDDEN_COORDINATES
 
-        // Make card visible and klarna hidden, both stable
         tracker.updateVisibility("card", visibleCoordinates)
-        tracker.updateVisibility("card", visibleCoordinates)
-        tracker.updateVisibility("klarna", hiddenCoordinates)
         tracker.updateVisibility("klarna", hiddenCoordinates)
 
         advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
@@ -335,10 +317,7 @@ class PaymentMethodInitialVisibilityTrackerTest {
 
         val hiddenCoordinates = FakeLayoutCoordinatesFixtures.FULLY_HIDDEN_COORDINATES
 
-        // Make card visible and klarna hidden, both stable
         tracker.updateVisibility("card", visibleCoordinates)
-        tracker.updateVisibility("card", visibleCoordinates)
-        tracker.updateVisibility("klarna", hiddenCoordinates)
         tracker.updateVisibility("klarna", hiddenCoordinates)
 
         advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
@@ -368,13 +347,6 @@ class PaymentMethodInitialVisibilityTrackerTest {
         verifyNoCallback(callback)
 
         val fullyVisibleCoordinates = FakeLayoutCoordinatesFixtures.FULLY_VISIBLE_COORDINATES
-
-        tracker.updateVisibility("card", fullyVisibleCoordinates)
-        tracker.updateVisibility("klarna", partiallyHiddenCoordinates)
-        tracker.updateVisibility("paypal", fullyHiddenCoordinates)
-
-        advanceTimeBy(TIME_ADVANCE_GREATER_THAN_DEBOUNCE_DELAY)
-        verifyNoCallback(callback)
 
         tracker.updateVisibility("card", fullyVisibleCoordinates)
         tracker.updateVisibility("klarna", partiallyHiddenCoordinates)


### PR DESCRIPTION
# Summary

Stabilize Checkout Payment Element analytics by removing two scheduler/layout assumptions that made `CheckoutPaymentElementAnalyticsTest` intermittent:

- Start the best-effort Google Pay device-support check with `CoroutineStart.UNDISPATCHED`, allowing an immediately available result to complete before the loader samples `Deferred.isCompleted`.
- Treat payment-method visibility tracking as a true debounce: begin the 50 ms stabilization window after every expected item has reported coordinates, then cancel and restart that window whenever layout changes.
- Update the visibility tracker unit tests to cover a single coordinate callback and verify that a later coordinate update resets the debounce.
- Add the reusable diagnostic tactics from this investigation to the repository's `fixing-flakes` skill, including strict `NetworkRule` failure interpretation, sampled `Deferred` work, the production tradeoffs of `UNDISPATCHED`, and Compose layout debouncing.

This is the only layer in the stack and targets `master`.

Committed and created by Codex.

# Motivation

The instrumentation test intentionally validates the production analytics sequence rather than accepting multiple possible event orderings. A diagnostic `ShampooRule` run exposed two independent production races.

First, iteration 6 failed because production unexpectedly sent `google_pay.skipped_during_load`. `GooglePayRepositoryTestRule` supplies an availability client whose suspend function returns immediately, but the loader created that work with normally scheduled `async`. The loader later calls `completeResultOrNull`, which samples `isCompleted` rather than awaiting because this analytics-only check must not delay loading. Depending on coroutine scheduling, the fake had either completed or had not started yet. Starting this child with `UNDISPATCHED` executes it immediately until its first suspension. The test fake therefore completes deterministically. On a real device, the Google Pay Services operation still suspends and resumes on its configured coroutine context, so the request remains asynchronous. The production-visible effects are limited to running lightweight setup earlier and reliably consuming a cached/immediate result; any work before the first suspension now occurs inline on the loader's existing work context.

Second, after fixing that race, iteration 26 failed because `mc_initial_displayed_payment_methods` was never sent. `PaymentMethodInitialVisibilityTracker` required Compose to invoke `onGloballyPositioned` twice with identical coordinates before it started its existing 50 ms debounce. Compose does not guarantee a duplicate callback for an already-stable layout. The corrected algorithm starts the debounce once all expected payment methods have reported coordinates. Every subsequent coordinate callback cancels and restarts the timer, so animations and layout movement still have to remain quiet for 50 ms before the one-time snapshot is reported.

Both production changes correspond to an observed failure and are independently required for this test on current `master`. The removed coordinate snapshot/stability maps implemented the invalid duplicate-callback requirement and are obsolete under the corrected debounce model. Most unit-test line removals delete duplicate `updateVisibility` calls that were only needed by that old requirement; the important behavioral coverage is that one callback can dispatch after the debounce and that a changed callback resets the timer.

The skill update captures the general decision points rather than this test's specific implementation. In particular, it tells future investigations to distinguish extra strict-network requests from missing expected requests, restart the 2/50 sequence when one fix exposes another race, audit `async` plus `Deferred.isCompleted` sampling, document the real production effects of undispatched starts, and avoid assuming duplicate Compose layout callbacks.

Draft PR #14199 removes the separate Google Pay device-support analytics check altogether. If that PR lands first, the `UNDISPATCHED` change in `PaymentElementLoader` will become unnecessary during conflict resolution; the visibility debounce fix remains independent.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation performed:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.verticalmode.PaymentMethodInitialVisibilityTrackerTest'` — 16 tests passed.
- Focused Pixel 2/API 33 managed-device run with diagnostic-only `ShampooRule(2)` — 2/2 iterations passed.
- The same managed-device run with diagnostic-only `ShampooRule(50)` — 50/50 iterations passed (`0` through `49`), with no failed-iteration markers; elapsed time was 1m08s.
- The focused managed-device test passed once more after restoring the normal rule configuration; elapsed time was 20s.
- `./gradlew :paymentsheet:detekt` — passed.
- `fixing-flakes` frontmatter validation using Ruby's YAML parser — passed; the skill remains below the 500-line guidance. The skill-creator `quick_validate.py` script could not start in this environment because its `PyYAML` dependency is not installed.
- `git diff --check` — passed.

The Shampoo instrumentation was used only for local reproduction and validation and is absent from this PR. No tests were ignored.

# Screenshots

| Before | After |
| ------------- | ------------- |
| Not applicable: analytics scheduling has no visual UI change. | Not applicable: analytics scheduling has no visual UI change. |

# Changelog

Not applicable. This is an internal analytics determinism and layout-stabilization correction with no public API or documented user-facing behavior change.
