### PR TITLE
Use theme mode for payment option icons

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentsheet.model.label
 import com.stripe.android.paymentsheet.model.lightThemeIconUrl
 import com.stripe.android.paymentsheet.model.mandateTextFromPaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.paymentMethodType
+import com.stripe.android.uicore.isSystemDarkTheme
 import javax.inject.Inject
 
 @OptIn(CheckoutSessionPreview::class)
@@ -64,7 +65,7 @@ internal class DefaultCheckoutPaymentOptionDisplayDataFactory @Inject constructo
                     drawableResourceIdNight = selection.drawableResourceIdNight,
                     lightThemeIconUrl = selection.lightThemeIconUrl,
                     darkThemeIconUrl = selection.darkThemeIconUrl,
-                    useDarkThemeIcon = null,
+                    useDarkThemeIcon = context.isSystemDarkTheme(),
                 )
             },
             label = selection.label(

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -835,7 +835,8 @@ internal fun PaymentMethodPreviewDetails.toPreview(
     iconLoader: PaymentSelection.IconLoader
 ): LinkController.PaymentMethodPreview {
     val label = context.getString(com.stripe.android.R.string.stripe_link)
-    val drawableResourceId = getIconDrawableRes(this, context.isSystemDarkTheme())
+    val isDarkTheme = context.isSystemDarkTheme()
+    val drawableResourceId = getIconDrawableRes(this, isDarkTheme)
     val sublabel = buildString {
         val name: ResolvableString
         val last4: String
@@ -872,7 +873,7 @@ internal fun PaymentMethodPreviewDetails.toPreview(
                 drawableResourceIdNight = null,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
-                useDarkThemeIcon = null,
+                useDarkThemeIcon = isDarkTheme,
             )
         },
         label = label,
@@ -897,7 +898,7 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
         append(last4)
     }
     val drawableResourceId = if (reduceLinkBranding) {
-        getIconDrawableRes(context.isSystemDarkTheme())
+        getIconDrawableRes(isDarkTheme)
     } else {
         getLinkIconArrow()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -23,6 +23,7 @@ import com.stripe.android.link.exceptions.MissingConfigurationException
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.toLoginState
+import com.stripe.android.link.theme.isDarkTheme
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.wallet.displayName
 import com.stripe.android.link.ui.wallet.makeFallbackCardName
@@ -147,15 +148,20 @@ internal class LinkControllerInteractor @Inject constructor(
 
     val selectedPaymentMethodPreview: StateFlow<LinkController.PaymentMethodPreview?> =
         _state.mapAsStateFlow { state ->
+            val isDarkTheme = state.linkConfiguration?.linkAppearance?.style.isDarkTheme(
+                isSystemDarkTheme = application.isSystemDarkTheme()
+            )
             state.selectedPaymentMethod?.details?.toPreview(
                 context = application,
                 iconLoader = cachedIconLoader,
                 reduceLinkBranding = state.linkConfiguration?.linkAppearance?.reduceLinkBranding ?: false,
+                isDarkTheme = isDarkTheme
             )
         }
 
     fun state(context: Context): StateFlow<LinkController.State> {
         return combineAsStateFlow(_internalLinkAccount, _state) { account, state ->
+            val isDarkTheme = state.linkConfiguration?.linkAppearance?.style.isDarkTheme(context.isSystemDarkTheme())
             LinkController.State(
                 elementsSessionId = state.linkConfiguration?.elementsSessionId,
                 internalLinkAccount = account,
@@ -165,6 +171,7 @@ internal class LinkControllerInteractor @Inject constructor(
                         context = context,
                         iconLoader = cachedIconLoader,
                         reduceLinkBranding = state.linkConfiguration?.linkAppearance?.reduceLinkBranding ?: false,
+                        isDarkTheme = isDarkTheme
                     ),
                 createdPaymentMethod = state.createdPaymentMethod,
             )
@@ -878,6 +885,7 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
     context: Context,
     iconLoader: PaymentSelection.IconLoader,
     reduceLinkBranding: Boolean,
+    isDarkTheme: Boolean,
 ): LinkController.PaymentMethodPreview {
     val label = context.getString(com.stripe.android.R.string.stripe_link)
     val sublabel = buildString {
@@ -913,7 +921,7 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
                 drawableResourceIdNight = null,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
-                useDarkThemeIcon = null,
+                useDarkThemeIcon = isDarkTheme,
             )
         },
         label = label,

--- a/paymentsheet/src/main/java/com/stripe/android/link/theme/Theme.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/theme/Theme.kt
@@ -104,10 +104,15 @@ internal fun DefaultLinkTheme(
 
 @Composable
 internal fun isLinkDarkTheme(appearance: LinkAppearance.State?): Boolean {
-    return when (appearance?.style) {
+    val isSystemInDarkTheme = isSystemInDarkTheme()
+    return appearance?.style.isDarkTheme(isSystemInDarkTheme)
+}
+
+internal fun LinkAppearance.Style?.isDarkTheme(isSystemDarkTheme: Boolean): Boolean {
+    return when (this) {
+        LinkAppearance.Style.AUTOMATIC, null -> isSystemDarkTheme
         LinkAppearance.Style.ALWAYS_LIGHT -> false
         LinkAppearance.Style.ALWAYS_DARK -> true
-        LinkAppearance.Style.AUTOMATIC, null -> isSystemInDarkTheme()
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -1,13 +1,10 @@
 package com.stripe.android.paymentsheet.model
 
 import android.content.Context
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.PaymentOptionCardArtDrawableLoader
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.ui.MIN_LUMINANCE_FOR_LIGHT_ICON
 import com.stripe.android.paymentsheet.ui.isDarkTheme
 import com.stripe.android.uicore.isSystemDarkTheme
 import javax.inject.Inject
@@ -39,15 +36,16 @@ internal class PaymentOptionFactory @Inject constructor(
                     drawableResourceIdNight = drawableResourceId,
                     lightThemeIconUrl = lightThemeIconUrl,
                     darkThemeIconUrl = darkThemeIconUrl,
-                    useDarkThemeIcon = appearance?.shouldUseDarkThemeIcon(context),
+                    useDarkThemeIcon = appearance.shouldUseDarkThemeIcon(context),
                 )
             },
         )
     }
 }
 
-internal fun PaymentSheet.Appearance.shouldUseDarkThemeIcon(context: Context): Boolean {
-    return themeMode.isDarkTheme(context.isSystemDarkTheme())
+internal fun PaymentSheet.Appearance?.shouldUseDarkThemeIcon(context: Context): Boolean {
+    val isSystemDarkTheme = context.isSystemDarkTheme()
+    return this?.themeMode?.isDarkTheme(isSystemDarkTheme) ?: isSystemDarkTheme
 }
 
 internal val PaymentSelection.shippingDetails: AddressDetails?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentOptionFactory.kt
@@ -47,9 +47,7 @@ internal class PaymentOptionFactory @Inject constructor(
 }
 
 internal fun PaymentSheet.Appearance.shouldUseDarkThemeIcon(context: Context): Boolean {
-    val isDark = themeMode.isDarkTheme(context.isSystemDarkTheme())
-    val componentColor = Color(getColors(isDark).component)
-    return componentColor.luminance() < MIN_LUMINANCE_FOR_LIGHT_ICON
+    return themeMode.isDarkTheme(context.isSystemDarkTheme())
 }
 
 internal val PaymentSelection.shippingDetails: AddressDetails?

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -1,15 +1,13 @@
 package com.stripe.android.paymentsheet.model
 
-import android.content.res.Configuration
 import android.content.res.Resources
-import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.ShapeDrawable
 import android.os.Parcelable
 import androidx.annotation.DrawableRes
 import androidx.annotation.VisibleForTesting
-import androidx.compose.ui.graphics.luminance
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.graphics.drawable.toDrawable
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.strings.resolvableString
@@ -33,13 +31,11 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.BankFormScreenState
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountTextBuilder
-import com.stripe.android.paymentsheet.ui.MIN_LUMINANCE_FOR_LIGHT_ICON
 import com.stripe.android.paymentsheet.ui.createCardLabel
 import com.stripe.android.paymentsheet.ui.getCardBrandIcon
 import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.paymentsheet.ui.getLinkIconArrow
 import com.stripe.android.paymentsheet.ui.getSavedPaymentMethodIcon
-import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.image.StripeImageLoader
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -281,34 +277,21 @@ internal sealed class PaymentSelection : Parcelable {
         private val resources: Resources,
         private val imageLoader: StripeImageLoader,
     ) {
-        private fun isDarkTheme(): Boolean {
-            return resources.configuration?.uiMode?.and(Configuration.UI_MODE_NIGHT_MASK) ==
-                Configuration.UI_MODE_NIGHT_YES ||
-                isCustomDarkTheme()
-        }
-
-        /**
-         * Some users implement a custom dark mode and will pass dark colors into colors light.
-         */
-        private fun isCustomDarkTheme(): Boolean {
-            return StripeTheme.colorsLightMutable.component.luminance() < MIN_LUMINANCE_FOR_LIGHT_ICON
-        }
 
         suspend fun load(
             @DrawableRes drawableResourceId: Int,
             @DrawableRes drawableResourceIdNight: Int?,
             lightThemeIconUrl: String?,
             darkThemeIconUrl: String?,
-            useDarkThemeIcon: Boolean?,
+            useDarkThemeIcon: Boolean,
         ): Drawable {
-            val shouldUseDarkThemeIcon = useDarkThemeIcon ?: isDarkTheme()
 
             fun loadResource(): Drawable {
                 @Suppress("DEPRECATION")
                 return runCatching {
                     ResourcesCompat.getDrawable(
                         resources,
-                        if (shouldUseDarkThemeIcon) {
+                        if (useDarkThemeIcon) {
                             drawableResourceIdNight ?: drawableResourceId
                         } else {
                             drawableResourceId
@@ -319,14 +302,12 @@ internal sealed class PaymentSelection : Parcelable {
             }
 
             suspend fun loadIcon(url: String): Drawable {
-                return imageLoader.load(url).getOrNull()?.let {
-                    BitmapDrawable(resources, it)
-                } ?: loadResource()
+                return imageLoader.load(url).getOrNull()?.toDrawable(resources) ?: loadResource()
             }
 
             // If the payment option has an icon URL, we prefer it.
             // Some payment options don't have an icon URL, and are loaded locally via resource.
-            return if (shouldUseDarkThemeIcon && darkThemeIconUrl != null) {
+            return if (useDarkThemeIcon && darkThemeIconUrl != null) {
                 loadIcon(darkThemeIconUrl)
             } else if (lightThemeIconUrl != null) {
                 loadIcon(lightThemeIconUrl)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/model/PaymentSelection.kt
@@ -285,7 +285,6 @@ internal sealed class PaymentSelection : Parcelable {
             darkThemeIconUrl: String?,
             useDarkThemeIcon: Boolean,
         ): Drawable {
-
             fun loadResource(): Drawable {
                 @Suppress("DEPRECATION")
                 return runCatching {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
@@ -6,6 +6,7 @@ import android.graphics.drawable.Drawable
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.account.LinkAccountHolder
@@ -22,6 +23,7 @@ import com.stripe.android.testing.FakeStripeImageLoader
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.Test
 
 @OptIn(CheckoutSessionPreview::class)
@@ -150,6 +152,32 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
     }
 
     @Test
+    @Config(qualifiers = "notnight")
+    fun `imageLoader uses light icon on light system`() = runScenario {
+        val option = factory.create(
+            selection = customPaymentMethod,
+            paymentMethodMetadata = metadata,
+        )
+
+        option?.imageLoader?.invoke()
+
+        assertThat(imageLoader.awaitLoadCall().url).isEqualTo(LIGHT_ICON_URL)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `imageLoader uses dark icon on dark system`() = runScenario {
+        val option = factory.create(
+            selection = customPaymentMethod,
+            paymentMethodMetadata = metadata,
+        )
+
+        option?.imageLoader?.invoke()
+
+        assertThat(imageLoader.awaitLoadCall().url).isEqualTo(DARK_ICON_URL)
+    }
+
+    @Test
     fun `create uses link account brand for saved Link passthrough card label`() = runScenario(
         linkAccount = LinkAccount(
             TestFactory.CONSUMER_SESSION.copy(linkBrand = LinkBrand.Onelink),
@@ -174,11 +202,12 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
+        val imageLoader = FakeStripeImageLoader()
         Scenario(
             factory = DefaultCheckoutPaymentOptionDisplayDataFactory(
                 iconLoader = PaymentSelection.IconLoader(
                     resources = context.resources,
-                    imageLoader = FakeStripeImageLoader(),
+                    imageLoader = imageLoader,
                 ),
                 cardArtDrawableLoader = { cardArt },
                 context = context,
@@ -188,12 +217,28 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
             ),
             metadata = metadata,
             cardArt = cardArt,
-        ).block()
+            imageLoader = imageLoader,
+        ).apply { block() }
+        imageLoader.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val factory: DefaultCheckoutPaymentOptionDisplayDataFactory,
         val metadata: PaymentMethodMetadata,
         val cardArt: Drawable?,
+        val imageLoader: FakeStripeImageLoader,
     )
+
+    private companion object {
+        const val LIGHT_ICON_URL = "light_icon_url"
+        const val DARK_ICON_URL = "dark_icon_url"
+
+        val customPaymentMethod = PaymentSelection.CustomPaymentMethod(
+            id = "cpm_123",
+            billingDetails = null,
+            label = "Custom".resolvableString,
+            lightThemeIconUrl = LIGHT_ICON_URL,
+            darkThemeIconUrl = DARK_ICON_URL,
+        )
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
@@ -39,6 +40,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 import java.util.Optional
 import javax.inject.Provider
 import kotlin.jvm.optionals.getOrNull
@@ -706,6 +709,36 @@ class LinkControllerInteractorTest {
     }
 
     @Test
+    @Config(qualifiers = "notnight")
+    fun `selectedPaymentMethodPreview uses always dark Link appearance on light system`() = runTest {
+        val interactor = createInteractor()
+        configure(interactor)
+        setLinkAppearance(LinkAppearance.Style.ALWAYS_DARK)
+        selectBankPaymentMethod(interactor)
+
+        val preview = interactor.selectedPaymentMethodPreview.first()
+        val drawable = requireNotNull(preview).imageLoader()
+
+        assertThat(shadowOf(drawable).createdFromResId)
+            .isEqualTo(R.drawable.stripe_link_bank_with_bg_night)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `state preview uses always light Link appearance on dark system`() = runTest {
+        val interactor = createInteractor()
+        configure(interactor)
+        setLinkAppearance(LinkAppearance.Style.ALWAYS_LIGHT)
+        selectBankPaymentMethod(interactor)
+
+        val preview = interactor.state(application).first().selectedPaymentMethodPreview
+        val drawable = requireNotNull(preview).imageLoader()
+
+        assertThat(shadowOf(drawable).createdFromResId)
+            .isEqualTo(R.drawable.stripe_link_bank_with_bg_day)
+    }
+
+    @Test
     fun `onLinkActivityResult() with Failed result`() = runTest {
         val interactor = createInteractor()
         configure(interactor)
@@ -1132,6 +1165,30 @@ class LinkControllerInteractorTest {
             collectedCvc = cvc,
             billingPhone = billingPhone
         )
+    }
+
+    private fun setLinkAppearance(style: LinkAppearance.Style) {
+        linkComponent.configuration = linkComponent.configuration.copy(
+            linkAppearance = LinkAppearance()
+                .style(style)
+                .reduceLinkBranding(true)
+                .build(),
+        )
+    }
+
+    private fun selectBankPaymentMethod(interactor: LinkControllerInteractor) {
+        interactor.updateState {
+            it.copy(
+                selectedPaymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(
+                    details = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT.copy(
+                        bankAccountName = null,
+                        bankIconCode = null,
+                    ),
+                    collectedCvc = null,
+                    billingPhone = null,
+                )
+            )
+        }
     }
 
     private suspend fun configureWithAttestation(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerPaymentMethodPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerPaymentMethodPreviewScreenshotTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
+import com.stripe.android.uicore.isSystemDarkTheme
 import org.junit.Rule
 import org.junit.Test
 
@@ -58,6 +59,7 @@ class LinkControllerPaymentMethodPreviewScreenshotTest {
                                     imageLoader = DefaultStripeImageLoader(context),
                                 ),
                                 reduceLinkBranding = true,
+                                isDarkTheme = context.isSystemDarkTheme(),
                             )
                         )
                     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/theme/ThemeTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/theme/ThemeTest.kt
@@ -1,0 +1,85 @@
+package com.stripe.android.link.theme
+
+import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import com.stripe.android.link.LinkAppearance
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+internal class ThemeTest {
+    @Test
+    fun `isDarkTheme resolves expected theme`(
+        @TestParameter(valuesProvider = ThemeTestCaseProvider::class)
+        testCase: ThemeTestCase,
+    ) {
+        assertThat(testCase.style.isDarkTheme(testCase.isSystemDarkTheme))
+            .isEqualTo(testCase.expected)
+    }
+}
+
+internal object ThemeTestCaseProvider : TestParameterValuesProvider() {
+    override fun provideValues(
+        context: Context?,
+    ): List<ThemeTestCase> = listOf(
+        ThemeTestCase(
+            name = "Automatic on light system",
+            style = LinkAppearance.Style.AUTOMATIC,
+            isSystemDarkTheme = false,
+            expected = false,
+        ),
+        ThemeTestCase(
+            name = "Automatic on dark system",
+            style = LinkAppearance.Style.AUTOMATIC,
+            isSystemDarkTheme = true,
+            expected = true,
+        ),
+        ThemeTestCase(
+            name = "Always light on light system",
+            style = LinkAppearance.Style.ALWAYS_LIGHT,
+            isSystemDarkTheme = false,
+            expected = false,
+        ),
+        ThemeTestCase(
+            name = "Always light on dark system",
+            style = LinkAppearance.Style.ALWAYS_LIGHT,
+            isSystemDarkTheme = true,
+            expected = false,
+        ),
+        ThemeTestCase(
+            name = "Always dark on light system",
+            style = LinkAppearance.Style.ALWAYS_DARK,
+            isSystemDarkTheme = false,
+            expected = true,
+        ),
+        ThemeTestCase(
+            name = "Always dark on dark system",
+            style = LinkAppearance.Style.ALWAYS_DARK,
+            isSystemDarkTheme = true,
+            expected = true,
+        ),
+        ThemeTestCase(
+            name = "Missing style on light system",
+            style = null,
+            isSystemDarkTheme = false,
+            expected = false,
+        ),
+        ThemeTestCase(
+            name = "Missing style on dark system",
+            style = null,
+            isSystemDarkTheme = true,
+            expected = true,
+        ),
+    )
+}
+
+internal data class ThemeTestCase(
+    val name: String,
+    val style: LinkAppearance.Style?,
+    val isSystemDarkTheme: Boolean,
+    val expected: Boolean,
+) {
+    override fun toString(): String = name
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentOptionFactoryTest.kt
@@ -278,8 +278,18 @@ class PaymentOptionFactoryTest {
 
     @Test
     @Config(qualifiers = "notnight")
-    fun `always dark with bright component uses light icon`() = runIconScenario(
+    fun `always dark with bright component uses dark icon`() = runIconScenario(
         themeMode = PaymentSheet.ThemeMode.AlwaysDark,
+        lightComponent = Color.Black,
+        darkComponent = Color.White,
+    ) {
+        assertThat(loadedUrl).isEqualTo(DARK_ICON_URL)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `always light with dark component uses light icon`() = runIconScenario(
+        themeMode = PaymentSheet.ThemeMode.AlwaysLight,
         lightComponent = Color.Black,
         darkComponent = Color.White,
     ) {
@@ -287,11 +297,17 @@ class PaymentOptionFactoryTest {
     }
 
     @Test
+    @Config(qualifiers = "notnight")
+    fun `missing appearance uses light icon on light system`() = runIconScenario(
+        appearance = null,
+    ) {
+        assertThat(loadedUrl).isEqualTo(LIGHT_ICON_URL)
+    }
+
+    @Test
     @Config(qualifiers = "night")
-    fun `always light with dark component uses dark icon`() = runIconScenario(
-        themeMode = PaymentSheet.ThemeMode.AlwaysLight,
-        lightComponent = Color.Black,
-        darkComponent = Color.White,
+    fun `missing appearance uses dark icon on dark system`() = runIconScenario(
+        appearance = null,
     ) {
         assertThat(loadedUrl).isEqualTo(DARK_ICON_URL)
     }
@@ -334,6 +350,18 @@ class PaymentOptionFactoryTest {
         lightComponent: Color,
         darkComponent: Color,
         block: IconScenario.() -> Unit,
+    ) = runIconScenario(
+        appearance = PaymentSheet.Appearance.Builder()
+            .colorsLight(PaymentSheet.Colors.Builder.light().component(lightComponent).build())
+            .colorsDark(PaymentSheet.Colors.Builder.dark().component(darkComponent).build())
+            .themeMode(themeMode)
+            .build(),
+        block = block,
+    )
+
+    private fun runIconScenario(
+        appearance: PaymentSheet.Appearance?,
+        block: IconScenario.() -> Unit,
     ) = runTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         val imageLoader = FakeStripeImageLoader()
@@ -345,11 +373,6 @@ class PaymentOptionFactoryTest {
             cardArtDrawableLoader = { null },
             context = context,
         )
-        val appearance = PaymentSheet.Appearance.Builder()
-            .colorsLight(PaymentSheet.Colors.Builder.light().component(lightComponent).build())
-            .colorsDark(PaymentSheet.Colors.Builder.dark().component(darkComponent).build())
-            .themeMode(themeMode)
-            .build()
         val selection = PaymentSelection.CustomPaymentMethod(
             id = "cpm_123",
             billingDetails = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
@@ -131,7 +131,6 @@ internal class PaymentSelectionIconLoaderTest {
         darkIconUrl = null,
         iconRes = iconRes,
         iconResNight = null,
-        // Should we add tests fpr this?
         useDarkThemeIcon = false,
         block = block,
     )
@@ -180,7 +179,7 @@ internal class PaymentSelectionIconLoaderTest {
         )
         advanceUntilIdle()
 
-        val expectedUrl = if (useDarkThemeIcon == true && darkIconUrl != null) darkIconUrl else iconUrl
+        val expectedUrl = if (useDarkThemeIcon && darkIconUrl != null) darkIconUrl else iconUrl
         val loadedUrl = expectedUrl?.let { imageLoader.awaitLoadCall().url }
         Scenario(drawable = drawable, loadedUrl = loadedUrl).apply { block() }
         imageLoader.ensureAllEventsConsumed()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/model/PaymentSelectionIconLoaderTest.kt
@@ -131,7 +131,8 @@ internal class PaymentSelectionIconLoaderTest {
         darkIconUrl = null,
         iconRes = iconRes,
         iconResNight = null,
-        useDarkThemeIcon = null,
+        // Should we add tests fpr this?
+        useDarkThemeIcon = false,
         block = block,
     )
 
@@ -156,7 +157,7 @@ internal class PaymentSelectionIconLoaderTest {
         darkIconUrl: String?,
         iconRes: Int?,
         iconResNight: Int?,
-        useDarkThemeIcon: Boolean?,
+        useDarkThemeIcon: Boolean,
         block: Scenario.() -> Unit,
     ) = runTest(testDispatcher) {
         val imageLoader = FakeStripeImageLoader(


### PR DESCRIPTION
## Summary

- select payment option icons from the configured theme mode or system theme instead of component luminance
- propagate Link appearance overrides to reduced-branding payment method previews
- add coverage for payment option factories, Link theme resolution, Link previews, and screenshot stability

## Testing

- `./gradlew :paymentsheet:testDebugUnitTest` with the affected test classes
- `./gradlew :paymentsheet:verifyPaparazziDebug --tests "com.stripe.android.link.LinkControllerPaymentMethodPreviewScreenshotTest"`
- `./gradlew :paymentsheet:detekt :paymentsheet:apiCheck`
- `git diff --check`

Committed and created by Codex.
