### PR TITLE
Honor Link appearance in payment method preview icons

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -23,6 +23,7 @@ import com.stripe.android.link.exceptions.MissingConfigurationException
 import com.stripe.android.link.injection.LinkComponent
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.model.toLoginState
+import com.stripe.android.link.theme.isDarkTheme
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.wallet.displayName
 import com.stripe.android.link.ui.wallet.makeFallbackCardName
@@ -147,15 +148,20 @@ internal class LinkControllerInteractor @Inject constructor(
 
     val selectedPaymentMethodPreview: StateFlow<LinkController.PaymentMethodPreview?> =
         _state.mapAsStateFlow { state ->
+            val isDarkTheme = state.linkConfiguration?.linkAppearance?.style.isDarkTheme(
+                isSystemDarkTheme = application.isSystemDarkTheme()
+            )
             state.selectedPaymentMethod?.details?.toPreview(
                 context = application,
                 iconLoader = cachedIconLoader,
                 reduceLinkBranding = state.linkConfiguration?.linkAppearance?.reduceLinkBranding ?: false,
+                isDarkTheme = isDarkTheme
             )
         }
 
     fun state(context: Context): StateFlow<LinkController.State> {
         return combineAsStateFlow(_internalLinkAccount, _state) { account, state ->
+            val isDarkTheme = state.linkConfiguration?.linkAppearance?.style.isDarkTheme(context.isSystemDarkTheme())
             LinkController.State(
                 elementsSessionId = state.linkConfiguration?.elementsSessionId,
                 internalLinkAccount = account,
@@ -165,6 +171,7 @@ internal class LinkControllerInteractor @Inject constructor(
                         context = context,
                         iconLoader = cachedIconLoader,
                         reduceLinkBranding = state.linkConfiguration?.linkAppearance?.reduceLinkBranding ?: false,
+                        isDarkTheme = isDarkTheme
                     ),
                 createdPaymentMethod = state.createdPaymentMethod,
             )
@@ -828,7 +835,8 @@ internal fun PaymentMethodPreviewDetails.toPreview(
     iconLoader: PaymentSelection.IconLoader
 ): LinkController.PaymentMethodPreview {
     val label = context.getString(com.stripe.android.R.string.stripe_link)
-    val drawableResourceId = getIconDrawableRes(this, context.isSystemDarkTheme())
+    val isDarkTheme = context.isSystemDarkTheme()
+    val drawableResourceId = getIconDrawableRes(this, isDarkTheme)
     val sublabel = buildString {
         val name: ResolvableString
         val last4: String
@@ -865,7 +873,7 @@ internal fun PaymentMethodPreviewDetails.toPreview(
                 drawableResourceIdNight = null,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
-                useDarkThemeIcon = null,
+                useDarkThemeIcon = isDarkTheme,
             )
         },
         label = label,
@@ -878,6 +886,7 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
     context: Context,
     iconLoader: PaymentSelection.IconLoader,
     reduceLinkBranding: Boolean,
+    isDarkTheme: Boolean,
 ): LinkController.PaymentMethodPreview {
     val label = context.getString(com.stripe.android.R.string.stripe_link)
     val sublabel = buildString {
@@ -889,7 +898,7 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
         append(last4)
     }
     val drawableResourceId = if (reduceLinkBranding) {
-        getIconDrawableRes(context.isSystemDarkTheme())
+        getIconDrawableRes(isDarkTheme)
     } else {
         getLinkIconArrow()
     }
@@ -913,7 +922,7 @@ internal fun ConsumerPaymentDetails.PaymentDetails.toPreview(
                 drawableResourceIdNight = null,
                 lightThemeIconUrl = null,
                 darkThemeIconUrl = null,
-                useDarkThemeIcon = null,
+                useDarkThemeIcon = isDarkTheme,
             )
         },
         label = label,

--- a/paymentsheet/src/main/java/com/stripe/android/link/theme/Theme.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/theme/Theme.kt
@@ -104,10 +104,15 @@ internal fun DefaultLinkTheme(
 
 @Composable
 internal fun isLinkDarkTheme(appearance: LinkAppearance.State?): Boolean {
-    return when (appearance?.style) {
+    val isSystemInDarkTheme = isSystemInDarkTheme()
+    return appearance?.style.isDarkTheme(isSystemInDarkTheme)
+}
+
+internal fun LinkAppearance.Style?.isDarkTheme(isSystemDarkTheme: Boolean): Boolean {
+    return when (this) {
+        LinkAppearance.Style.AUTOMATIC, null -> isSystemDarkTheme
         LinkAppearance.Style.ALWAYS_LIGHT -> false
         LinkAppearance.Style.ALWAYS_DARK -> true
-        LinkAppearance.Style.AUTOMATIC, null -> isSystemInDarkTheme()
     }
 }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.parsers.PaymentMethodJsonParser
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
@@ -39,6 +40,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
 import java.util.Optional
 import javax.inject.Provider
 import kotlin.jvm.optionals.getOrNull
@@ -706,6 +709,36 @@ class LinkControllerInteractorTest {
     }
 
     @Test
+    @Config(qualifiers = "notnight")
+    fun `selectedPaymentMethodPreview uses always dark Link appearance on light system`() = runTest {
+        val interactor = createInteractor()
+        configure(interactor)
+        setLinkAppearance(LinkAppearance.Style.ALWAYS_DARK)
+        selectBankPaymentMethod(interactor)
+
+        val preview = interactor.selectedPaymentMethodPreview.first()
+        val drawable = requireNotNull(preview).imageLoader()
+
+        assertThat(shadowOf(drawable).createdFromResId)
+            .isEqualTo(R.drawable.stripe_link_bank_with_bg_night)
+    }
+
+    @Test
+    @Config(qualifiers = "night")
+    fun `state preview uses always light Link appearance on dark system`() = runTest {
+        val interactor = createInteractor()
+        configure(interactor)
+        setLinkAppearance(LinkAppearance.Style.ALWAYS_LIGHT)
+        selectBankPaymentMethod(interactor)
+
+        val preview = interactor.state(application).first().selectedPaymentMethodPreview
+        val drawable = requireNotNull(preview).imageLoader()
+
+        assertThat(shadowOf(drawable).createdFromResId)
+            .isEqualTo(R.drawable.stripe_link_bank_with_bg_day)
+    }
+
+    @Test
     fun `onLinkActivityResult() with Failed result`() = runTest {
         val interactor = createInteractor()
         configure(interactor)
@@ -1132,6 +1165,30 @@ class LinkControllerInteractorTest {
             collectedCvc = cvc,
             billingPhone = billingPhone
         )
+    }
+
+    private fun setLinkAppearance(style: LinkAppearance.Style) {
+        linkComponent.configuration = linkComponent.configuration.copy(
+            linkAppearance = LinkAppearance()
+                .style(style)
+                .reduceLinkBranding(true)
+                .build(),
+        )
+    }
+
+    private fun selectBankPaymentMethod(interactor: LinkControllerInteractor) {
+        interactor.updateState {
+            it.copy(
+                selectedPaymentMethod = LinkPaymentMethod.ConsumerPaymentDetails(
+                    details = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT.copy(
+                        bankAccountName = null,
+                        bankIconCode = null,
+                    ),
+                    collectedCvc = null,
+                    billingPhone = null,
+                )
+            )
+        }
     }
 
     private suspend fun configureWithAttestation(

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerPaymentMethodPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerPaymentMethodPreviewScreenshotTest.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.uicore.image.DefaultStripeImageLoader
+import com.stripe.android.uicore.isSystemDarkTheme
 import org.junit.Rule
 import org.junit.Test
 
@@ -58,6 +59,7 @@ class LinkControllerPaymentMethodPreviewScreenshotTest {
                                     imageLoader = DefaultStripeImageLoader(context),
                                 ),
                                 reduceLinkBranding = true,
+                                isDarkTheme = context.isSystemDarkTheme(),
                             )
                         )
                     }

--- a/paymentsheet/src/test/java/com/stripe/android/link/theme/ThemeTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/theme/ThemeTest.kt
@@ -1,0 +1,85 @@
+package com.stripe.android.link.theme
+
+import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import com.stripe.android.link.LinkAppearance
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+internal class ThemeTest {
+    @Test
+    fun `isDarkTheme resolves expected theme`(
+        @TestParameter(valuesProvider = ThemeTestCaseProvider::class)
+        testCase: ThemeTestCase,
+    ) {
+        assertThat(testCase.style.isDarkTheme(testCase.isSystemDarkTheme))
+            .isEqualTo(testCase.expected)
+    }
+}
+
+internal object ThemeTestCaseProvider : TestParameterValuesProvider() {
+    override fun provideValues(
+        context: Context?,
+    ): List<ThemeTestCase> = listOf(
+        ThemeTestCase(
+            name = "Automatic on light system",
+            style = LinkAppearance.Style.AUTOMATIC,
+            isSystemDarkTheme = false,
+            expected = false,
+        ),
+        ThemeTestCase(
+            name = "Automatic on dark system",
+            style = LinkAppearance.Style.AUTOMATIC,
+            isSystemDarkTheme = true,
+            expected = true,
+        ),
+        ThemeTestCase(
+            name = "Always light on light system",
+            style = LinkAppearance.Style.ALWAYS_LIGHT,
+            isSystemDarkTheme = false,
+            expected = false,
+        ),
+        ThemeTestCase(
+            name = "Always light on dark system",
+            style = LinkAppearance.Style.ALWAYS_LIGHT,
+            isSystemDarkTheme = true,
+            expected = false,
+        ),
+        ThemeTestCase(
+            name = "Always dark on light system",
+            style = LinkAppearance.Style.ALWAYS_DARK,
+            isSystemDarkTheme = false,
+            expected = true,
+        ),
+        ThemeTestCase(
+            name = "Always dark on dark system",
+            style = LinkAppearance.Style.ALWAYS_DARK,
+            isSystemDarkTheme = true,
+            expected = true,
+        ),
+        ThemeTestCase(
+            name = "Missing style on light system",
+            style = null,
+            isSystemDarkTheme = false,
+            expected = false,
+        ),
+        ThemeTestCase(
+            name = "Missing style on dark system",
+            style = null,
+            isSystemDarkTheme = true,
+            expected = true,
+        ),
+    )
+}
+
+internal data class ThemeTestCase(
+    val name: String,
+    val style: LinkAppearance.Style?,
+    val isSystemDarkTheme: Boolean,
+    val expected: Boolean,
+) {
+    override fun toString(): String = name
+}


### PR DESCRIPTION
## Summary

Honour Link appearance in payment method preview icons by passing `isDarkTheme` from Link Appearance to `PaymentOptionFactory`

## Testing

New tests added

Committed and created by Codex.
