### PR TITLE
Rebuild CheckoutController playground settings

### DIFF
--- a/paymentsheet-example/build.gradle
+++ b/paymentsheet-example/build.gradle
@@ -66,6 +66,12 @@ sentry {
 }
 
 android {
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
+
     defaultConfig {
         applicationId "com.stripe.android.paymentsheet.example"
         versionCode 11
@@ -158,6 +164,11 @@ dependencies {
 
     testImplementation testLibs.junit
     testImplementation testLibs.truth
+    testImplementation project(':payments-core-testing')
+    testImplementation testLibs.androidx.composeUi
+    testImplementation testLibs.kotlin.coroutines
+    testImplementation testLibs.robolectric
+    testImplementation testLibs.espresso.core
 
     androidTestImplementation project(':payments-ui-core')
     androidTestImplementation project(':payments-core-testing')

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutContent.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutContent.kt
@@ -1,0 +1,53 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.stripe.android.checkout.CheckoutController.Session
+import com.stripe.android.elements.CurrencySelectorElement
+import com.stripe.android.elements.ExpressCheckoutElement
+import com.stripe.android.elements.PaymentElement
+
+@Composable
+internal fun CheckoutContent(
+    session: Session,
+    paymentElement: PaymentElement,
+    currencySelectorElement: CurrencySelectorElement,
+    expressCheckoutElement: ExpressCheckoutElement,
+    isUpdating: Boolean,
+    operationMessage: String?,
+    onApplyPromotionCode: (String) -> Unit,
+    onRemovePromotionCode: () -> Unit,
+    onUpdateEmail: (String) -> Unit,
+) {
+    Text(text = "Tax status: ${session.tax.status}", style = MaterialTheme.typography.h6)
+    Spacer(Modifier.height(16.dp))
+    LineItemsSection(session)
+    TotalSummarySection(session)
+
+    if (session.isCurrencySelectorAvailable) {
+        Spacer(Modifier.height(16.dp))
+        currencySelectorElement.Content()
+    }
+    if (session.availableExpressCheckoutPaymentMethods.isNotEmpty()) {
+        Spacer(Modifier.height(16.dp))
+        expressCheckoutElement.Content()
+    }
+    Spacer(Modifier.height(16.dp))
+    paymentElement.Content()
+    Spacer(Modifier.height(20.dp))
+    SessionOperations(
+        initialEmail = session.email.orEmpty(),
+        isUpdating = isUpdating,
+        message = operationMessage,
+        onApplyPromotionCode = onApplyPromotionCode,
+        onRemovePromotionCode = onRemovePromotionCode,
+        onUpdateEmail = onUpdateEmail,
+    )
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -1,55 +1,42 @@
-@file:OptIn(CheckoutSessionPreview::class)
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
 
 package com.stripe.android.paymentsheet.example.playground.checkout
 
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material.Button
-import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Divider
+import androidx.compose.material.AppBarDefaults
+import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.lifecycleScope
-import com.stripe.android.checkout.CheckoutController.Session
-import com.stripe.android.checkout.CheckoutController.Session.PaymentOptionDisplayData
-import com.stripe.android.checkout.CheckoutPresenter
-import com.stripe.android.elements.PaymentElement
-import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
-import com.stripe.android.uicore.format.CurrencyFormatter
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettingsUi
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.configurations
 import kotlinx.coroutines.launch
 
 internal class CheckoutControllerExampleActivity : AppCompatActivity() {
-
     private val viewModel: CheckoutControllerExampleViewModel by viewModels {
         CheckoutControllerExampleViewModel.factory
     }
 
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val presenter = viewModel.controller.createPresenter(this)
         val paymentElement = presenter.paymentElement()
+        val currencySelectorElement = presenter.currencySelectorElement()
+        val expressCheckoutElement = presenter.expressCheckoutElement()
 
         lifecycleScope.launch {
             viewModel.sessionComplete.collect {
@@ -60,272 +47,117 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
 
         setContent {
             val status by viewModel.status.collectAsState()
-            val confirmationResult by viewModel.confirmationResult.collectAsState()
+            val session by viewModel.controller.session.collectAsState()
+            val confirmationMessage by viewModel.confirmationMessage.collectAsState()
+            val operationMessage by viewModel.operationMessage.collectAsState()
+            val isUpdating by viewModel.controller.isUpdating.collectAsState()
+            val settingValues by viewModel.settings.values.collectAsState()
+            var navigationPath by rememberSaveable {
+                mutableStateOf<List<String>>(emptyList())
+            }
+            val currentConfiguration = CheckoutPlaygroundDefinitions.root.configurations()
+                .firstOrNull { it.key == navigationPath.lastOrNull() }
+                ?: CheckoutPlaygroundDefinitions.root
+            val navigateBack = {
+                if (status is CheckoutControllerExampleViewModel.Status.Settings) {
+                    navigationPath = navigationPath.dropLast(1)
+                } else {
+                    viewModel.returnToSettings()
+                }
+            }
+
+            BackHandler(
+                enabled = status !is CheckoutControllerExampleViewModel.Status.Settings || navigationPath.isNotEmpty()
+            ) { navigateBack() }
 
             PlaygroundTheme(
-                content = {
-                    CheckoutContent(
-                        status = status,
-                        presenter = presenter,
-                        paymentElement = paymentElement,
-                        onScenarioSelected = viewModel::start,
+                topBarContent = {
+                    TopAppBar(
+                        windowInsets = AppBarDefaults.topAppBarWindowInsets,
+                        title = {
+                            Text(
+                                if (status is CheckoutControllerExampleViewModel.Status.Settings) {
+                                    currentConfiguration.displayName
+                                } else {
+                                    "Checkout"
+                                }
+                            )
+                        },
+                        navigationIcon = if (
+                            status !is CheckoutControllerExampleViewModel.Status.Settings || navigationPath.isNotEmpty()
+                        ) {
+                            {
+                                IconButton(onClick = navigateBack) {
+                                    Text("‹", style = MaterialTheme.typography.h4)
+                                }
+                            }
+                        } else {
+                            null
+                        },
                     )
                 },
-                bottomBarContent = {
-                    val configured = status as? CheckoutControllerExampleViewModel.Status.Configured
-                    if (configured != null) {
-                        ConfirmationControls(
-                            paymentOption = configured.session?.paymentOptionDisplayData,
-                            confirmationResult = confirmationResult,
-                            onSelectPaymentMethod = paymentElement::present,
-                            onConfirm = {
-                                viewModel.clearConfirmationResult()
-                                presenter.confirm()
-                            },
+                content = {
+                    when (val currentStatus = status) {
+                        CheckoutControllerExampleViewModel.Status.Settings -> {
+                            CheckoutPlaygroundSettingsUi(
+                                configuration = currentConfiguration,
+                                settings = viewModel.settings,
+                                onOpenConfiguration = { navigationPath += it.key },
+                            )
+                        }
+                        CheckoutControllerExampleViewModel.Status.Loading -> LoadingContent()
+                        is CheckoutControllerExampleViewModel.Status.Error -> ErrorContent(
+                            message = currentStatus.message,
+                            onRetry = viewModel::retry,
+                            onBack = viewModel::returnToSettings,
                         )
+                        CheckoutControllerExampleViewModel.Status.Configured -> {
+                            session?.let { currentSession ->
+                                CheckoutContent(
+                                    session = currentSession,
+                                    paymentElement = paymentElement,
+                                    currencySelectorElement = currencySelectorElement,
+                                    expressCheckoutElement = expressCheckoutElement,
+                                    isUpdating = isUpdating,
+                                    operationMessage = operationMessage,
+                                    onApplyPromotionCode = viewModel::applyPromotionCode,
+                                    onRemovePromotionCode = viewModel::removePromotionCode,
+                                    onUpdateEmail = viewModel::updateEmail,
+                                )
+                            } ?: LoadingContent()
+                        }
+                    }
+                },
+                bottomBarContent = {
+                    when (status) {
+                        CheckoutControllerExampleViewModel.Status.Settings -> {
+                            if (navigationPath.isEmpty()) {
+                                SettingsActions(
+                                    canStart = settingValues.isNotEmpty() &&
+                                        viewModel.settings.validationErrors().isEmpty(),
+                                    onStart = viewModel::start,
+                                    onReset = viewModel.settings::reset,
+                                )
+                            }
+                        }
+                        CheckoutControllerExampleViewModel.Status.Configured -> {
+                            ConfirmationControls(
+                                paymentOption = session?.paymentOptionDisplayData,
+                                confirmationMessage = confirmationMessage,
+                                isUpdating = isUpdating,
+                                displayMandate = viewModel.displayMandate,
+                                onClearPaymentMethod = viewModel::clearPaymentOption,
+                                onSelectPaymentMethod = paymentElement::present,
+                                onConfirm = {
+                                    viewModel.clearConfirmationMessage()
+                                    presenter.confirm()
+                                },
+                            )
+                        }
+                        else -> Unit
                     }
                 },
             )
         }
     }
-}
-
-@Composable
-private fun CheckoutContent(
-    status: CheckoutControllerExampleViewModel.Status,
-    presenter: CheckoutPresenter,
-    paymentElement: PaymentElement,
-    onScenarioSelected: (CheckoutControllerExampleScenario) -> Unit,
-) {
-    when (status) {
-        is CheckoutControllerExampleViewModel.Status.ChooseScenario -> {
-            ScenarioChooser(onScenarioSelected)
-        }
-        is CheckoutControllerExampleViewModel.Status.Loading -> {
-            LoadingContent(status.scenario)
-        }
-        is CheckoutControllerExampleViewModel.Status.Error -> {
-            ErrorContent(status.scenario, status.message)
-        }
-        is CheckoutControllerExampleViewModel.Status.Configured -> {
-            status.session?.let { session ->
-                ScenarioSummary(status.scenario, session.tax.status)
-                LineItemsSection(session)
-                TotalSummarySection(session)
-                if (session.availableExpressCheckoutPaymentMethods.isNotEmpty()) {
-                    presenter.expressCheckoutElement().Content()
-                }
-                paymentElement.Content()
-            }
-        }
-    }
-}
-
-@Composable
-private fun ScenarioChooser(
-    onScenarioSelected: (CheckoutControllerExampleScenario) -> Unit,
-) {
-    Text(text = "Choose a session scenario", style = MaterialTheme.typography.h6)
-    Spacer(modifier = Modifier.height(16.dp))
-    CheckoutControllerExampleScenario.entries.forEach { scenario ->
-        Button(
-            onClick = { onScenarioSelected(scenario) },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(scenario.displayName)
-        }
-        Spacer(modifier = Modifier.height(8.dp))
-    }
-    Text(
-        text = "Relaunch this activity to choose another scenario.",
-        style = MaterialTheme.typography.body2,
-        color = Color.Gray,
-    )
-}
-
-@Composable
-private fun LoadingContent(scenario: CheckoutControllerExampleScenario) {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(text = "Scenario: ${scenario.displayName}")
-            Spacer(modifier = Modifier.height(12.dp))
-            CircularProgressIndicator()
-        }
-    }
-}
-
-@Composable
-private fun ErrorContent(
-    scenario: CheckoutControllerExampleScenario,
-    message: String,
-) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(text = "Scenario: ${scenario.displayName}")
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(
-            text = "Error",
-            style = MaterialTheme.typography.h6,
-            color = Color.Red,
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        Text(text = message)
-    }
-}
-
-@Composable
-private fun ScenarioSummary(
-    scenario: CheckoutControllerExampleScenario,
-    taxStatus: Session.Tax.Status,
-) {
-    Text(text = "Scenario: ${scenario.displayName}", style = MaterialTheme.typography.h6)
-    Text(text = "Tax status: $taxStatus", style = MaterialTheme.typography.body1)
-    Spacer(modifier = Modifier.height(16.dp))
-}
-
-@Composable
-private fun ConfirmationControls(
-    paymentOption: PaymentOptionDisplayData?,
-    confirmationResult: CheckoutControllerExampleViewModel.ConfirmationResult?,
-    onSelectPaymentMethod: () -> Unit,
-    onConfirm: () -> Unit,
-) {
-    PaymentOptionRow(paymentOption)
-    confirmationResult?.let { result ->
-        Spacer(modifier = Modifier.height(8.dp))
-        val message = when (result) {
-            CheckoutControllerExampleViewModel.ConfirmationResult.Canceled -> "Confirmation canceled"
-            is CheckoutControllerExampleViewModel.ConfirmationResult.Failed -> {
-                "Confirmation failed: ${result.message}"
-            }
-        }
-        Text(text = message, color = Color.Red)
-    }
-    Spacer(modifier = Modifier.height(8.dp))
-    Button(
-        onClick = onSelectPaymentMethod,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text("Select Payment Method")
-    }
-    Spacer(modifier = Modifier.height(8.dp))
-    Button(
-        onClick = onConfirm,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Text("Confirm")
-    }
-}
-
-@Composable
-private fun PaymentOptionRow(paymentOption: PaymentOptionDisplayData?) {
-    if (paymentOption != null) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Image(
-                painter = paymentOption.iconPainter,
-                contentDescription = null,
-                modifier = Modifier.size(32.dp),
-            )
-            Text(
-                text = paymentOption.label,
-                style = MaterialTheme.typography.body1,
-            )
-        }
-    } else {
-        Text(
-            text = "No payment method selected",
-            style = MaterialTheme.typography.body2,
-            color = Color.Gray,
-        )
-    }
-}
-
-@Composable
-private fun LineItemsSection(session: Session) {
-    Column(modifier = Modifier.fillMaxWidth()) {
-        Text(text = "Line Items", style = MaterialTheme.typography.h6)
-        Spacer(modifier = Modifier.height(8.dp))
-
-        for (item in session.lineItems) {
-            Row(
-                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-            ) {
-                Text(
-                    text = "${item.name} x${item.quantity}",
-                    style = MaterialTheme.typography.body2,
-                )
-                Text(
-                    text = formatAmount(item.total, session.currency),
-                    style = MaterialTheme.typography.body2,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun TotalSummarySection(session: Session) {
-    val summary = session.totalSummary ?: return
-
-    Column(modifier = Modifier.fillMaxWidth()) {
-        Divider(modifier = Modifier.padding(vertical = 12.dp))
-
-        SummaryRow(label = "Subtotal", amount = formatAmount(summary.subtotal, session.currency))
-
-        for (discount in summary.discountAmounts) {
-            SummaryRow(
-                label = discount.displayName,
-                amount = "-${formatAmount(discount.amount, session.currency)}",
-            )
-        }
-
-        summary.shippingRate?.let { shipping ->
-            val amountText = if (shipping.amount == 0L) "Free" else formatAmount(shipping.amount, session.currency)
-            SummaryRow(label = "Shipping", amount = amountText)
-        }
-
-        for (tax in summary.taxAmounts) {
-            val label = if (tax.inclusive) "${tax.displayName} (included)" else tax.displayName
-            SummaryRow(label = label, amount = formatAmount(tax.amount, session.currency))
-        }
-
-        Divider(modifier = Modifier.padding(vertical = 8.dp))
-
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(text = "Total", style = MaterialTheme.typography.subtitle1)
-            Text(
-                text = formatAmount(summary.totalDueToday, session.currency),
-                style = MaterialTheme.typography.subtitle1,
-            )
-        }
-    }
-}
-
-@Composable
-private fun SummaryRow(label: String, amount: String) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(vertical = 2.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        Text(text = label, style = MaterialTheme.typography.body2)
-        Text(text = amount, style = MaterialTheme.typography.body2)
-    }
-}
-
-private fun formatAmount(amount: Long, currency: String): String {
-    return CurrencyFormatter.format(amount, currency)
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleBackendRepository.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleBackendRepository.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.example.playground.checkout
 
 import android.content.Context
 import com.github.kittinunf.fuel.Fuel
+import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.core.requests.suspendable
 import com.github.kittinunf.result.Result
@@ -17,15 +18,14 @@ internal class CheckoutControllerExampleBackendRepository(
     private val applicationContext: Context,
 ) {
     private val json = Json { ignoreUnknownKeys = true }
-    private val backendUrl = Settings(applicationContext).playgroundBackendUrl
+    private val defaultBackendUrl = Settings(applicationContext).playgroundBackendUrl
 
-    suspend fun fetchCheckoutSessionClientSecret(
-        scenario: CheckoutControllerExampleScenario,
-    ): kotlin.Result<String> {
-        val request = CheckoutControllerExampleRequestFactory.create(scenario)
-
+    suspend fun fetchCheckoutSession(
+        request: CheckoutControllerExampleRequest,
+        backendUrl: String?,
+    ): kotlin.Result<CheckoutControllerExampleBackendResponse> {
         val apiResponse = withContext(Dispatchers.IO) {
-            Fuel.post(backendUrl + request.endpoint)
+            Fuel.post(checkoutSessionUrl(defaultBackendUrl, backendUrl, request.endpoint))
                 .jsonBody(request.body.toString())
                 .suspendable()
                 .awaitModel(CheckoutResponse.serializer(), json)
@@ -33,7 +33,7 @@ internal class CheckoutControllerExampleBackendRepository(
 
         return when (apiResponse) {
             is Result.Failure -> {
-                kotlin.Result.failure(apiResponse.getException())
+                kotlin.Result.failure(apiResponse.getException().withBackendMessage(json))
             }
             is Result.Success -> {
                 val response = apiResponse.value
@@ -47,8 +47,43 @@ internal class CheckoutControllerExampleBackendRepository(
                         IllegalStateException("No checkout session client secret in response")
                     )
 
-                kotlin.Result.success(clientSecret)
+                kotlin.Result.success(
+                    CheckoutControllerExampleBackendResponse(
+                        clientSecret = clientSecret,
+                        customerId = response.customerId,
+                    )
+                )
             }
         }
     }
 }
+
+internal data class CheckoutControllerExampleBackendResponse(
+    val clientSecret: String,
+    val customerId: String?,
+)
+
+internal fun checkoutSessionUrl(
+    defaultBackendUrl: String,
+    customBackendUrl: String?,
+    endpoint: String,
+): String {
+    return (customBackendUrl ?: defaultBackendUrl) + endpoint
+}
+
+internal fun FuelError.withBackendMessage(json: Json): Throwable {
+    val message = parseCheckoutSessionError(json, errorData)
+
+    return message?.let { IllegalStateException(it, this) } ?: this
+}
+
+internal fun parseCheckoutSessionError(json: Json, errorData: ByteArray): String? {
+    return runCatching {
+        json.decodeFromString<CheckoutSessionErrorResponse>(errorData.decodeToString()).error
+    }.getOrNull()
+}
+
+@kotlinx.serialization.Serializable
+private data class CheckoutSessionErrorResponse(
+    val error: String,
+)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
@@ -1,18 +1,12 @@
 package com.stripe.android.paymentsheet.example.playground.checkout
 
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions.session
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettings
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
-
-internal enum class CheckoutControllerExampleScenario(
-    val displayName: String,
-) {
-    NoTax("No tax"),
-    ShippingTax("Shipping tax"),
-    BillingTax("Billing tax w/ auto collection"),
-}
 
 internal data class CheckoutControllerExampleRequest(
     val endpoint: String,
@@ -20,29 +14,36 @@ internal data class CheckoutControllerExampleRequest(
 )
 
 internal object CheckoutControllerExampleRequestFactory {
-    fun create(scenario: CheckoutControllerExampleScenario): CheckoutControllerExampleRequest {
+    fun create(
+        settings: CheckoutPlaygroundSettings.Snapshot,
+        returningCustomerId: String?,
+    ): CheckoutControllerExampleRequest {
         return CheckoutControllerExampleRequest(
             endpoint = "checkout_session",
             body = buildJsonObject {
-                put("mode", "payment")
-                put("customer", "guest")
-                put("customer_email", "email@example.com")
-                put("currency", "usd")
+                val customer = settings[session.customer]
                 put(
-                    "payment_method_types",
-                    JsonArray(
-                        listOf(
-                            JsonPrimitive("card"),
-                            JsonPrimitive("us_bank_account"),
-                            JsonPrimitive("link"),
-                            JsonPrimitive("cashapp"),
-                            JsonPrimitive("klarna"),
+                    "customer",
+                    if (customer == RETURNING_CUSTOMER) returningCustomerId ?: customer else customer,
+                )
+                put("customer_email", settings[session.customerEmail])
+                put("currency", settings[session.currency].value)
+                if (settings[session.automaticPaymentMethods]) {
+                    put("automatic_payment_methods", true)
+                } else {
+                    put(
+                        "payment_method_types",
+                        JsonArray(
+                            settings[session.paymentMethodTypes].map(::JsonPrimitive)
                         )
                     )
-                )
-                put("automatic_tax", scenario != CheckoutControllerExampleScenario.NoTax)
-                put("shipping_address_collection", scenario == CheckoutControllerExampleScenario.ShippingTax)
+                }
+                put("automatic_tax", settings[session.automaticTax])
+                put("shipping_address_collection", settings[session.shippingAddressCollection])
+                put("billing_address_collection", settings[session.billingAddressCollection])
             },
         )
     }
+
+    private const val RETURNING_CUSTOMER = "returning"
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -1,4 +1,4 @@
-@file:OptIn(CheckoutSessionPreview::class)
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
 
 package com.stripe.android.paymentsheet.example.playground.checkout
 
@@ -12,8 +12,10 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.checkout.CheckoutController
-import com.stripe.android.checkout.CheckoutController.Session
-import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettings
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.checkoutControllerConfiguration
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -22,135 +24,183 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+@Suppress("TooManyFunctions")
 internal class CheckoutControllerExampleViewModel(
     private val repository: CheckoutControllerExampleBackendRepository,
     private val savedStateHandle: SavedStateHandle,
     application: Application,
 ) : ViewModel() {
-
-    private val selectedScenario = savedStateHandle.get<String>(SCENARIO_KEY)?.let(
-        CheckoutControllerExampleScenario::valueOf
-    )
-
-    private val _status = MutableStateFlow<Status>(
-        selectedScenario?.let(Status::Loading) ?: Status.ChooseScenario
-    )
-    val status: StateFlow<Status> = _status.asStateFlow()
-
-    private val _sessionComplete = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
-    val sessionComplete: SharedFlow<Unit> = _sessionComplete.asSharedFlow()
-
-    private val _confirmationResult = MutableStateFlow<ConfirmationResult?>(null)
-    val confirmationResult: StateFlow<ConfirmationResult?> = _confirmationResult.asStateFlow()
+    val settings = CheckoutPlaygroundSettings.create(application)
 
     val controller = CheckoutController.Builder(
         application = application,
         savedStateHandle = savedStateHandle,
     ).resultCallback(::onConfirmationResult).build()
 
+    private val _status = MutableStateFlow<Status>(
+        if (savedStateHandle.get<Boolean>(RUN_ACTIVE_KEY) == true && controller.session.value != null) {
+            Status.Configured
+        } else {
+            Status.Settings
+        }
+    )
+    val status: StateFlow<Status> = _status.asStateFlow()
+
+    private val _sessionComplete = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val sessionComplete: SharedFlow<Unit> = _sessionComplete.asSharedFlow()
+
+    private val _confirmationMessage = MutableStateFlow<String?>(null)
+    val confirmationMessage: StateFlow<String?> = _confirmationMessage.asStateFlow()
+
+    private val _operationMessage = MutableStateFlow<String?>(null)
+    val operationMessage: StateFlow<String?> = _operationMessage.asStateFlow()
+
+    private var activeSnapshot = settings.snapshot()
+    private var configurationJob: Job? = null
+    private var configurationGeneration = 0L
+
+    val displayMandate: Boolean
+        get() = !activeSnapshot[CheckoutPlaygroundDefinitions.Controller.payment.embeddedMandate]
+
     init {
-        selectedScenario?.let(::fetchAndConfigure)
-        viewModelScope.launch {
-            controller.session.collect { session ->
-                updateConfiguredState { it.copy(session = session) }
-            }
-        }
+        savedStateHandle[RUN_ACTIVE_KEY] = _status.value is Status.Configured
     }
 
-    fun start(scenario: CheckoutControllerExampleScenario) {
-        if (savedStateHandle.get<String>(SCENARIO_KEY) != null) {
-            return
-        }
-
-        savedStateHandle[SCENARIO_KEY] = scenario.name
-        _status.value = Status.Loading(scenario)
-        fetchAndConfigure(scenario)
+    fun returnToSettings() {
+        configurationGeneration++
+        configurationJob?.cancel()
+        configurationJob = null
+        savedStateHandle[RUN_ACTIVE_KEY] = false
+        _status.value = Status.Settings
+        clearMessages()
     }
 
-    fun clearConfirmationResult() {
-        _confirmationResult.value = null
+    fun start() {
+        if (settings.validationErrors().isNotEmpty()) return
+        activeSnapshot = settings.snapshot()
+        savedStateHandle[RUN_ACTIVE_KEY] = false
+        clearMessages()
+        _status.value = Status.Loading
+        configure(activeSnapshot)
     }
 
-    private fun onConfirmationResult(result: CheckoutController.Result) {
-        Log.d(TAG, "Result: $result")
-        _confirmationResult.value = when (result) {
-            is CheckoutController.Result.Completed -> {
-                _sessionComplete.tryEmit(Unit)
-                null
-            }
-            is CheckoutController.Result.Canceled -> ConfirmationResult.Canceled
-            is CheckoutController.Result.Failed -> {
-                ConfirmationResult.Failed(result.error.message ?: "Confirmation failed")
-            }
-        }
+    fun retry() {
+        savedStateHandle[RUN_ACTIVE_KEY] = false
+        clearMessages()
+        _status.value = Status.Loading
+        configure(activeSnapshot)
     }
 
-    private fun updateConfiguredState(update: (Status.Configured) -> Status.Configured) {
-        val current = _status.value
-        if (current is Status.Configured) {
-            _status.value = update(current)
-        }
+    fun clearConfirmationMessage() {
+        _confirmationMessage.value = null
     }
 
-    private fun fetchAndConfigure(scenario: CheckoutControllerExampleScenario) {
-        viewModelScope.launch {
-            repository.fetchCheckoutSessionClientSecret(scenario).fold(
-                onSuccess = { clientSecret ->
-                    controller.configure(
-                        clientSecret = clientSecret,
-                    ).fold(
+    fun clearPaymentOption() {
+        runOperation("Payment option cleared") { controller.clearPaymentOption() }
+    }
+
+    fun applyPromotionCode(code: String) {
+        runOperation("Promotion code applied") { controller.applyPromotionCode(code) }
+    }
+
+    fun removePromotionCode() {
+        runOperation("Promotion code removed") { controller.removePromotionCode() }
+    }
+
+    fun updateEmail(email: String) {
+        runOperation("Email updated") { controller.updateEmail(email.trim().ifEmpty { null }) }
+    }
+
+    private fun configure(snapshot: CheckoutPlaygroundSettings.Snapshot) {
+        configurationJob?.cancel()
+        val generation = ++configurationGeneration
+        configurationJob = viewModelScope.launch {
+            val request = CheckoutControllerExampleRequestFactory.create(
+                settings = snapshot,
+                returningCustomerId = settings.returningCustomerId,
+            )
+            val fetchResult = repository.fetchCheckoutSession(
+                request = request,
+                backendUrl = snapshot[CheckoutPlaygroundDefinitions.session.backendUrl],
+            )
+            if (generation != configurationGeneration) return@launch
+
+            fetchResult.fold(
+                onSuccess = { response ->
+                    val configurationResult = controller.configure(
+                        clientSecret = response.clientSecret,
+                        configuration = snapshot.checkoutControllerConfiguration(),
+                    )
+                    if (generation != configurationGeneration) return@launch
+
+                    configurationResult.fold(
                         onSuccess = {
-                            _status.value = Status.Configured(
-                                scenario = scenario,
-                                session = controller.session.value,
-                            )
+                            if (snapshot[CheckoutPlaygroundDefinitions.session.customer] == NEW_CUSTOMER) {
+                                response.customerId?.let(settings::saveReturningCustomer)
+                            }
+                            savedStateHandle[RUN_ACTIVE_KEY] = true
+                            _status.value = Status.Configured
                         },
-                        onFailure = { error ->
-                            Log.e(TAG, "Failed to configure", error)
-                            _status.value = Status.Error(
-                                scenario = scenario,
-                                message = error.message ?: "Configure failed",
-                            )
-                        },
+                        onFailure = { error -> showError("Failed to configure", error) },
                     )
                 },
-                onFailure = { error ->
-                    Log.e(TAG, "Failed to fetch checkout session", error)
-                    _status.value = Status.Error(
-                        scenario = scenario,
-                        message = error.message ?: "Unknown error",
-                    )
-                },
+                onFailure = { error -> showError("Failed to fetch checkout session", error) },
             )
         }
     }
 
+    private fun runOperation(
+        successMessage: String,
+        operation: suspend () -> Result<Unit>,
+    ) {
+        viewModelScope.launch {
+            _operationMessage.value = operation().fold(
+                onSuccess = { successMessage },
+                onFailure = { it.message ?: "Operation failed" },
+            )
+        }
+    }
+
+    private fun onConfirmationResult(result: CheckoutController.Result) {
+        Log.d(TAG, "Result: $result")
+        _confirmationMessage.value = when (result) {
+            is CheckoutController.Result.Completed -> {
+                _sessionComplete.tryEmit(Unit)
+                null
+            }
+            is CheckoutController.Result.Canceled -> "Confirmation canceled"
+            is CheckoutController.Result.Failed -> {
+                result.error.message?.let { "Confirmation failed: $it" } ?: "Confirmation failed"
+            }
+        }
+    }
+
+    private fun showError(prefix: String, error: Throwable) {
+        Log.e(TAG, prefix, error)
+        _status.value = Status.Error(error.message ?: prefix)
+    }
+
+    private fun clearMessages() {
+        _confirmationMessage.value = null
+        _operationMessage.value = null
+    }
+
     override fun onCleared() {
-        super.onCleared()
         controller.destroy()
+        super.onCleared()
     }
 
     sealed interface Status {
-        data object ChooseScenario : Status
-        data class Loading(val scenario: CheckoutControllerExampleScenario) : Status
-        data class Configured(
-            val scenario: CheckoutControllerExampleScenario,
-            val session: Session?,
-        ) : Status
-        data class Error(
-            val scenario: CheckoutControllerExampleScenario,
-            val message: String,
-        ) : Status
-    }
-
-    sealed interface ConfirmationResult {
-        data object Canceled : ConfirmationResult
-        data class Failed(val message: String) : ConfirmationResult
+        data object Settings : Status
+        data object Loading : Status
+        data object Configured : Status
+        data class Error(val message: String) : Status
     }
 
     companion object {
         private const val TAG = "CheckoutControllerExample"
-        private const val SCENARIO_KEY = "checkout_controller_example_scenario"
+        private const val RUN_ACTIVE_KEY = "checkout_controller_run_active"
+        private const val NEW_CUSTOMER = "new"
 
         val factory = viewModelFactory {
             initializer {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutStateContent.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutStateContent.kt
@@ -1,0 +1,44 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.Button
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun LoadingContent() {
+    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+internal fun ErrorContent(
+    message: String,
+    onRetry: () -> Unit,
+    onBack: () -> Unit,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text("Error", style = MaterialTheme.typography.h6, color = MaterialTheme.colors.error)
+        Spacer(Modifier.height(8.dp))
+        Text(message)
+        Spacer(Modifier.height(16.dp))
+        Button(onClick = onRetry) { Text("Retry") }
+        TextButton(onClick = onBack) { Text("Back to settings") }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutSummary.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutSummary.kt
@@ -1,0 +1,71 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Divider
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.stripe.android.checkout.CheckoutController.Session
+import com.stripe.android.uicore.format.CurrencyFormatter
+
+@Composable
+internal fun LineItemsSection(session: Session) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(text = "Line Items", style = MaterialTheme.typography.h6)
+        session.lineItems.forEach { item ->
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text("${item.name} x${item.quantity}", style = MaterialTheme.typography.body2)
+                Text(formatAmount(item.total, session.currency), style = MaterialTheme.typography.body2)
+            }
+        }
+    }
+}
+
+@Composable
+internal fun TotalSummarySection(session: Session) {
+    val summary = session.totalSummary ?: return
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Divider(modifier = Modifier.padding(vertical = 12.dp))
+        SummaryRow("Subtotal", formatAmount(summary.subtotal, session.currency))
+        summary.discountAmounts.forEach { discount ->
+            SummaryRow(discount.displayName, "-${formatAmount(discount.amount, session.currency)}")
+        }
+        summary.shippingRate?.let { shipping ->
+            SummaryRow(
+                shipping.displayName,
+                if (shipping.amount == 0L) "Free" else formatAmount(shipping.amount, session.currency),
+            )
+        }
+        summary.taxAmounts.forEach { tax ->
+            SummaryRow(
+                if (tax.inclusive) "${tax.displayName} (included)" else tax.displayName,
+                formatAmount(tax.amount, session.currency),
+            )
+        }
+        Divider(modifier = Modifier.padding(vertical = 8.dp))
+        SummaryRow("Total", formatAmount(summary.totalDueToday, session.currency))
+    }
+}
+
+@Composable
+private fun SummaryRow(label: String, amount: String) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(label)
+        Text(amount)
+    }
+}
+
+private fun formatAmount(amount: Long, currency: String): String {
+    return CurrencyFormatter.format(amount, currency)
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/ConfirmationControls.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/ConfirmationControls.kt
@@ -1,0 +1,71 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.stripe.android.checkout.CheckoutController.Session.PaymentOptionDisplayData
+
+@Composable
+internal fun ConfirmationControls(
+    paymentOption: PaymentOptionDisplayData?,
+    confirmationMessage: String?,
+    isUpdating: Boolean,
+    displayMandate: Boolean,
+    onClearPaymentMethod: () -> Unit,
+    onSelectPaymentMethod: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    PaymentOptionRow(paymentOption)
+    if (displayMandate) {
+        paymentOption?.mandateText?.let { Text(text = it, style = MaterialTheme.typography.caption) }
+    }
+    confirmationMessage?.let { message ->
+        Text(text = message, color = MaterialTheme.colors.error)
+    }
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        OutlinedButton(
+            onClick = onClearPaymentMethod,
+            enabled = !isUpdating && paymentOption != null,
+            modifier = Modifier.weight(1f),
+        ) { Text("Clear") }
+        Button(
+            onClick = onSelectPaymentMethod,
+            enabled = !isUpdating,
+            modifier = Modifier.weight(1f),
+        ) { Text("Select") }
+    }
+    Button(
+        onClick = onConfirm,
+        enabled = !isUpdating,
+        modifier = Modifier.fillMaxWidth(),
+    ) { Text("Confirm") }
+}
+
+@Composable
+private fun PaymentOptionRow(paymentOption: PaymentOptionDisplayData?) {
+    if (paymentOption == null) {
+        Text("No payment method selected", style = MaterialTheme.typography.body2, color = Color.Gray)
+        return
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Image(painter = paymentOption.iconPainter, contentDescription = null, modifier = Modifier.size(32.dp))
+        Text(paymentOption.label)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SessionOperations.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SessionOperations.kt
@@ -1,0 +1,58 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun SessionOperations(
+    initialEmail: String,
+    isUpdating: Boolean,
+    message: String?,
+    onApplyPromotionCode: (String) -> Unit,
+    onRemovePromotionCode: () -> Unit,
+    onUpdateEmail: (String) -> Unit,
+) {
+    var promotionCode by rememberSaveable { mutableStateOf("") }
+    var email by rememberSaveable(initialEmail) { mutableStateOf(initialEmail) }
+    Text("Session controls", style = MaterialTheme.typography.h6)
+    OutlinedTextField(
+        value = promotionCode,
+        onValueChange = { promotionCode = it },
+        label = { Text("Promotion code") },
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        Button(
+            onClick = { onApplyPromotionCode(promotionCode) },
+            enabled = !isUpdating && promotionCode.isNotBlank(),
+        ) { Text("Apply") }
+        OutlinedButton(onClick = onRemovePromotionCode, enabled = !isUpdating) { Text("Remove") }
+    }
+    OutlinedTextField(
+        value = email,
+        onValueChange = { email = it },
+        label = { Text("Email") },
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Button(
+        onClick = { onUpdateEmail(email) },
+        enabled = !isUpdating,
+        modifier = Modifier.fillMaxWidth(),
+    ) { Text("Update email") }
+    message?.let {
+        Text(text = it, color = MaterialTheme.colors.secondary)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SettingsActions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SettingsActions.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+internal fun SettingsActions(
+    canStart: Boolean,
+    onStart: () -> Unit,
+    onReset: () -> Unit,
+) {
+    Button(
+        onClick = onStart,
+        enabled = canStart,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text("Create Checkout Session")
+    }
+    TextButton(onClick = onReset, modifier = Modifier.fillMaxWidth()) {
+        Text("Reset to defaults")
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutCurrencySelectorDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutCurrencySelectorDefinitions.kt
@@ -1,0 +1,100 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.elements.CurrencySelectorElement
+
+internal object CheckoutCurrencySelectorDefinitions {
+    val shouldSetConfiguration = boolean(
+        key = "controller.currency_selector.should_set_configuration",
+        displayName = "Set configuration",
+        defaultValue = false,
+    )
+
+    val appearance = AppearanceDefinitions()
+
+    internal class AppearanceDefinitions {
+        val verticalPadding = decimal(
+            key = "currency.appearance.vertical_padding",
+            displayName = "Vertical padding",
+            defaultValue = 4f,
+            minimum = 0f,
+        )
+        val cornerRadius = optionalFloat(
+            key = "currency.appearance.corner_radius",
+            displayName = "Corner radius",
+            minimum = 0f,
+        )
+        val borderWidth = optionalFloat(
+            key = "currency.appearance.border_width",
+            displayName = "Border width",
+            minimum = 0f,
+        )
+        val borderColor = optionalColor(
+            key = "currency.appearance.border_color",
+            displayName = "Border color",
+        )
+        val background = optionalColor(
+            key = "currency.appearance.background",
+            displayName = "Background",
+        )
+        val selectedBackground = optionalColor(
+            key = "currency.appearance.selected_background",
+            displayName = "Selected background",
+        )
+        val textColor = optionalColor(
+            key = "currency.appearance.text_color",
+            displayName = "Text color",
+        )
+        val selectedTextColor = optionalColor(
+            key = "currency.appearance.selected_text_color",
+            displayName = "Selected text color",
+        )
+        val secondaryTextColor = optionalColor(
+            key = "currency.appearance.secondary_text_color",
+            displayName = "Secondary text color",
+        )
+        val dangerColor = optionalColor(
+            key = "currency.appearance.danger_color",
+            displayName = "Danger color",
+        )
+        val font = font(key = "currency.appearance.font")
+        val scale = decimal(
+            key = "currency.appearance.scale",
+            displayName = "Size scale factor",
+            defaultValue = 1f,
+            minimum = 0f,
+            minimumExclusive = true,
+        )
+        val label = enumChoice(
+            key = "currency.appearance.label",
+            displayName = "Label content",
+            defaultValue = CurrencySelectorElement.Configuration.Appearance.LabelContent.AUTOMATIC,
+        )
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "currency.appearance",
+            displayName = "Appearance",
+            children = arrayOf(
+                verticalPadding,
+                cornerRadius,
+                borderWidth,
+                borderColor,
+                background,
+                selectedBackground,
+                textColor,
+                selectedTextColor,
+                secondaryTextColor,
+                dangerColor,
+                font,
+                scale,
+                label,
+            ),
+        )
+    }
+
+    val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+        key = "controller.currency_selector",
+        displayName = "Currency Selector Element",
+        children = arrayOf(shouldSetConfiguration, appearance.configuration),
+    )
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutDefaultsDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutDefaultsDefinitions.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+internal object CheckoutDefaultsDefinitions {
+    val email = optionalText(
+        key = "controller.defaults.email",
+        displayName = "Email",
+        validate = optionalEmail,
+    )
+    val billing = CheckoutContactDetailsDefinitions(
+        key = "controller.defaults.billing",
+        displayName = "Billing details",
+    )
+    val shipping = CheckoutContactDetailsDefinitions(
+        key = "controller.defaults.shipping",
+        displayName = "Shipping details",
+    )
+    val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+        key = "controller.defaults",
+        displayName = "Defaults",
+        children = arrayOf(
+            email,
+            billing.configuration,
+            shipping.configuration,
+        ),
+    )
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutExpressDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutExpressDefinitions.kt
@@ -1,0 +1,128 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.elements.ExpressCheckoutElement
+
+internal object CheckoutExpressDefinitions {
+    val shouldSetConfiguration = boolean(
+        key = "controller.express_checkout.should_set_configuration",
+        displayName = "Set configuration",
+        defaultValue = false,
+    )
+
+    val link = LinkDefinitions()
+
+    internal class LinkDefinitions {
+        val display = enumChoice(
+            key = "express.link.display",
+            displayName = "Display",
+            defaultValue = ExpressCheckoutElement.Configuration.LinkConfiguration.Display.Automatic,
+        )
+        val collectMissingBilling = boolean(
+            key = "express.link.collect_missing_billing",
+            displayName = "Collect missing billing details",
+            defaultValue = true,
+        )
+        val disallowedFunding = stringCsv(
+            key = "express.link.disallow_funding",
+            displayName = "Disallowed funding sources (comma separated)",
+        )
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "express.link",
+            displayName = "Link",
+            children = arrayOf(display, collectMissingBilling, disallowedFunding),
+        )
+    }
+
+    val googlePay = CheckoutGooglePayDefinitions(
+        key = "express.google_pay",
+        displayName = "Google Pay",
+        defaultDisplay = ExpressCheckoutElement.Configuration.GooglePayConfiguration.Display.Automatic,
+        displayOptions = ExpressCheckoutElement.Configuration.GooglePayConfiguration.Display.entries,
+        defaultButtonType = ExpressCheckoutElement.Configuration.GooglePayConfiguration.ButtonType.Pay,
+        buttonTypeOptions = ExpressCheckoutElement.Configuration.GooglePayConfiguration.ButtonType.entries,
+    )
+    val shippingRequired = boolean(
+        key = "express.shipping_required",
+        displayName = "Shipping address required",
+        defaultValue = false,
+    )
+
+    val billing = BillingDefinitions()
+
+    internal class BillingDefinitions {
+        val name = enumChoice(
+            key = "express.billing.name",
+            displayName = "Name",
+            defaultValue = ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration
+                .CollectionMode.Automatic,
+        )
+        val email = enumChoice(
+            key = "express.billing.email",
+            displayName = "Email",
+            defaultValue = ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration
+                .CollectionMode.Automatic,
+        )
+        val address = enumChoice(
+            key = "express.billing.address",
+            displayName = "Address",
+            defaultValue = ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration
+                .AddressCollectionMode.Automatic,
+        )
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "express.billing",
+            displayName = "Billing details collection",
+            children = arrayOf(name, email, address),
+        )
+    }
+
+    val appearance = AppearanceDefinitions()
+
+    internal class AppearanceDefinitions {
+        val theme = enumChoice(
+            key = "express.appearance.theme",
+            displayName = "Button theme",
+            defaultValue = ExpressCheckoutElement.Configuration.Appearance.ButtonTheme.Automatic,
+        )
+
+        val layout = LayoutDefinitions()
+
+        internal class LayoutDefinitions {
+            val columns = optionalInt(
+                key = "express.appearance.layout.columns",
+                displayName = "Maximum columns",
+            )
+            val rows = optionalInt(
+                key = "express.appearance.layout.rows",
+                displayName = "Maximum rows",
+            )
+            val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+                key = "express.appearance.layout",
+                displayName = "Button layout",
+                children = arrayOf(columns, rows),
+            )
+        }
+
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "express.appearance",
+            displayName = "Appearance",
+            children = arrayOf(theme, layout.configuration),
+        )
+    }
+
+    val configuration: CheckoutPlaygroundSettingDefinition.Configuration by lazy {
+        configuration(
+            key = "controller.express_checkout",
+            displayName = "Express Checkout Element",
+            children = arrayOf(
+                shouldSetConfiguration,
+                link.configuration,
+                googlePay.configuration,
+                shippingRequired,
+                billing.configuration,
+                appearance.configuration,
+            ),
+        )
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPaymentDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPaymentDefinitions.kt
@@ -1,0 +1,295 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.model.CardBrand
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.uicore.StripeThemeDefaults
+
+internal object CheckoutPaymentDefinitions {
+    val shouldSetConfiguration = boolean(
+        key = "controller.payment_element.should_set_configuration",
+        displayName = "Set configuration",
+        defaultValue = true,
+    )
+    val embeddedMandate = boolean(
+        key = "payment.embedded_mandate",
+        displayName = "Embedded view displays mandate",
+        defaultValue = true,
+    )
+
+    val billing = BillingDefinitions()
+
+    internal class BillingDefinitions {
+        val name = enumChoice(
+            key = "payment.billing.name",
+            displayName = "Name",
+            defaultValue = PaymentElement.Configuration.BillingDetailsCollectionConfiguration
+                .CollectionMode.Automatic,
+        )
+        val address = enumChoice(
+            key = "payment.billing.address",
+            displayName = "Address",
+            defaultValue = PaymentElement.Configuration.BillingDetailsCollectionConfiguration
+                .AddressCollectionMode.Automatic,
+        )
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "payment.billing",
+            displayName = "Billing details collection",
+            children = arrayOf(name, address),
+        )
+    }
+
+    val layout = enumChoice(
+        key = "payment.layout",
+        displayName = "Payment method layout",
+        defaultValue = PaymentElement.Configuration.PaymentMethodLayout.Automatic,
+    )
+    val opensCardScanner = boolean(
+        key = "payment.opens_card_scanner",
+        displayName = "Open card scanner automatically",
+        defaultValue = false,
+    )
+    val preferredNetworks = csv(
+        key = "payment.preferred_networks",
+        displayName = "Preferred networks (comma separated)",
+        decodeItem = { code ->
+            CardBrand.entries.firstOrNull { it.code == code }
+                ?.let(Result.Companion::success)
+                ?: invalid(message = "Unknown value: $code")
+        },
+        encodeItem = CardBrand::code,
+    )
+    val methodOrder = stringCsv(
+        key = "payment.method_order",
+        displayName = "Payment method order (comma separated)",
+    )
+
+    val cardBrandAcceptance = CardBrandAcceptanceDefinitions()
+
+    internal class CardBrandAcceptanceDefinitions {
+        val mode = choice(
+            key = "payment.card_brand_acceptance.mode",
+            displayName = "Mode",
+            defaultValue = CheckoutCardBrandAcceptanceMode.All,
+            options = CheckoutCardBrandAcceptanceMode.entries.map { it.name to it },
+            serialize = CheckoutCardBrandAcceptanceMode::name,
+        )
+        val visa = boolean(
+            key = "payment.card_brand_acceptance.visa",
+            displayName = "Visa",
+            defaultValue = false,
+        )
+        val mastercard = boolean(
+            key = "payment.card_brand_acceptance.mastercard",
+            displayName = "Mastercard",
+            defaultValue = false,
+        )
+        val amex = boolean(
+            key = "payment.card_brand_acceptance.amex",
+            displayName = "Amex",
+            defaultValue = false,
+        )
+        val discover = boolean(
+            key = "payment.card_brand_acceptance.discover",
+            displayName = "Discover",
+            defaultValue = false,
+        )
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "payment.card_brand_acceptance",
+            displayName = "Card brand acceptance",
+            children = arrayOf(
+                mode,
+                visa,
+                mastercard,
+                amex,
+                discover,
+            ),
+        )
+    }
+
+    val terms = TermsDefinitions()
+
+    internal class TermsDefinitions {
+        val values = PaymentMethod.Type.entries.associateWith { type ->
+            choice(
+                key = "payment.terms.${type.code}",
+                displayName = type.code,
+                defaultValue = CheckoutTermsDisplay.Automatic,
+                options = CheckoutTermsDisplay.entries.map { it.displayName to it },
+                serialize = CheckoutTermsDisplay::serializedValue,
+            )
+        }
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "payment.terms",
+            displayName = "Terms display",
+            children = values.values.toTypedArray(),
+        )
+    }
+
+    val appearance = AppearanceDefinitions()
+
+    internal class AppearanceDefinitions {
+        val lightColors = CheckoutPaymentColorsDefinitions(
+            key = "payment.appearance.colors_light",
+            displayName = "Light colors",
+            defaultColors = StripeThemeDefaults.colorsLight,
+        )
+        val darkColors = CheckoutPaymentColorsDefinitions(
+            key = "payment.appearance.colors_dark",
+            displayName = "Dark colors",
+            defaultColors = StripeThemeDefaults.colorsDark,
+        )
+        val themeMode = enumChoice(
+            key = "payment.appearance.theme_mode",
+            displayName = "Theme mode",
+            defaultValue = PaymentElement.Configuration.Appearance.ThemeMode.Automatic,
+        )
+
+        val primaryButton = PrimaryButtonDefinitions()
+
+        internal class PrimaryButtonDefinitions {
+            val lightColors = CheckoutPrimaryButtonColorsDefinitions(
+                key = "payment.appearance.primary_button.colors_light",
+                displayName = "Light colors",
+            )
+            val darkColors = CheckoutPrimaryButtonColorsDefinitions(
+                key = "payment.appearance.primary_button.colors_dark",
+                displayName = "Dark colors",
+            )
+
+            val shape = ShapeDefinitions()
+
+            internal class ShapeDefinitions {
+                val cornerRadius = optionalFloat(
+                    key = "payment.appearance.primary_button.shape.corner",
+                    displayName = "Corner radius",
+                    minimum = 0f,
+                )
+                val borderWidth = optionalFloat(
+                    key = "payment.appearance.primary_button.shape.border",
+                    displayName = "Border width",
+                    minimum = 0f,
+                )
+                val height = optionalFloat(
+                    key = "payment.appearance.primary_button.shape.height",
+                    displayName = "Height",
+                    minimum = 0f,
+                )
+                val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+                    key = "payment.appearance.primary_button.shape",
+                    displayName = "Shape",
+                    children = arrayOf(cornerRadius, borderWidth, height),
+                )
+            }
+
+            val typography = TypographyDefinitions()
+
+            internal class TypographyDefinitions {
+                val font = font(key = "payment.appearance.primary_button.typography.font")
+                val size = optionalFloat(
+                    key = "payment.appearance.primary_button.typography.size",
+                    displayName = "Font size",
+                    minimum = 0f,
+                    minimumExclusive = true,
+                )
+                val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+                    key = "payment.appearance.primary_button.typography",
+                    displayName = "Typography",
+                    children = arrayOf(font, size),
+                )
+            }
+
+            val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+                key = "payment.appearance.primary_button",
+                displayName = "Primary button",
+                children = arrayOf(
+                    lightColors.configuration,
+                    darkColors.configuration,
+                    shape.configuration,
+                    typography.configuration,
+                ),
+            )
+        }
+
+        val insets = InsetsDefinitions()
+
+        internal class InsetsDefinitions {
+            val horizontal = decimal(
+                key = "payment.appearance.insets.horizontal",
+                displayName = "Horizontal",
+                defaultValue = 20f,
+                minimum = 0f,
+            )
+            val vertical = decimal(
+                key = "payment.appearance.insets.vertical",
+                displayName = "Vertical",
+                defaultValue = 0f,
+                minimum = 0f,
+            )
+            val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+                key = "payment.appearance.insets",
+                displayName = "Form insets",
+                children = arrayOf(horizontal, vertical),
+            )
+        }
+
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "payment.appearance",
+            displayName = "Appearance",
+            children = arrayOf(
+                lightColors.configuration,
+                darkColors.configuration,
+                themeMode,
+                primaryButton.configuration,
+                insets.configuration,
+            ),
+        )
+    }
+
+    val googlePay = CheckoutGooglePayDefinitions(
+        key = "payment.google_pay",
+        displayName = "Google Pay",
+        defaultDisplay = PaymentElement.Configuration.GooglePayConfiguration.Display.Automatic,
+        displayOptions = PaymentElement.Configuration.GooglePayConfiguration.Display.entries,
+        defaultButtonType = PaymentElement.Configuration.GooglePayConfiguration.ButtonType.Pay,
+        buttonTypeOptions = PaymentElement.Configuration.GooglePayConfiguration.ButtonType.entries,
+    )
+
+    val link = LinkDefinitions()
+
+    internal class LinkDefinitions {
+        val display = enumChoice(
+            key = "payment.link.display",
+            displayName = "Display",
+            defaultValue = PaymentElement.Configuration.LinkConfiguration.Display.Automatic,
+        )
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+            key = "payment.link",
+            displayName = "Link",
+            children = arrayOf(display),
+        )
+    }
+
+    val configuration: CheckoutPlaygroundSettingDefinition.Configuration by lazy {
+        configuration(
+            key = "controller.payment_element",
+            displayName = "Payment Element",
+            children = arrayOf(
+                shouldSetConfiguration,
+                embeddedMandate,
+                billing.configuration,
+                layout,
+                opensCardScanner,
+                preferredNetworks,
+                methodOrder,
+                cardBrandAcceptance.configuration,
+                terms.configuration,
+                appearance.configuration,
+                googlePay.configuration,
+                link.configuration,
+            ),
+        )
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundConfigurationFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundConfigurationFactory.kt
@@ -1,0 +1,264 @@
+@file:OptIn(
+    com.stripe.android.CollectMissingLinkBillingDetailsPreview::class,
+    com.stripe.android.LinkDisallowFundingSourceCreationPreview::class,
+    com.stripe.android.paymentelement.CheckoutSessionPreview::class,
+)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.checkout.CheckoutController
+import com.stripe.android.elements.CurrencySelectorElement
+import com.stripe.android.elements.ExpressCheckoutElement
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions.Controller
+
+internal fun CheckoutPlaygroundSettings.Snapshot.checkoutControllerConfiguration(): CheckoutController.Configuration {
+    return CheckoutController.Configuration()
+        .defaults(defaults())
+        .apply {
+            if (this@checkoutControllerConfiguration[Controller.payment.shouldSetConfiguration]) {
+                paymentElement(paymentElementConfiguration())
+            }
+            if (this@checkoutControllerConfiguration[Controller.currencySelector.shouldSetConfiguration]) {
+                currencySelectorElement(currencySelectorConfiguration())
+            }
+            if (this@checkoutControllerConfiguration[Controller.express.shouldSetConfiguration]) {
+                expressCheckoutElement(expressCheckoutConfiguration())
+            }
+            this@checkoutControllerConfiguration[Controller.merchantDisplayName]?.let(::merchantDisplayName)
+        }
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.defaults(): CheckoutController.Configuration.Defaults {
+    return CheckoutController.Configuration.Defaults()
+        .email(this[Controller.defaults.email])
+        .apply {
+            contactDetails(Controller.defaults.billing)?.let(::billingDetails)
+            contactDetails(Controller.defaults.shipping)?.let(::shippingDetails)
+        }
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.contactDetails(
+    definitions: CheckoutContactDetailsDefinitions,
+): CheckoutController.Configuration.Defaults.ContactDetails? {
+    if (!this[definitions.enabled]) return null
+    return CheckoutController.Configuration.Defaults.ContactDetails()
+        .name(this[definitions.name])
+        .apply {
+            if (this@contactDetails[definitions.address.enabled]) {
+                address(
+                    CheckoutController.Address()
+                        .country(this@contactDetails[definitions.address.country].uppercase())
+                        .city(this@contactDetails[definitions.address.city])
+                        .line1(this@contactDetails[definitions.address.line1])
+                        .line2(this@contactDetails[definitions.address.line2])
+                        .postalCode(this@contactDetails[definitions.address.postalCode])
+                        .state(this@contactDetails[definitions.address.state])
+                )
+            }
+        }
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.paymentElementConfiguration(): PaymentElement.Configuration {
+    return PaymentElement.Configuration()
+        .embeddedViewDisplaysMandateText(this[Controller.payment.embeddedMandate])
+        .billingDetailsCollectionConfiguration(
+            PaymentElement.Configuration.BillingDetailsCollectionConfiguration()
+                .name(this[Controller.payment.billing.name])
+                .address(this[Controller.payment.billing.address])
+        )
+        .paymentMethodLayout(this[Controller.payment.layout])
+        .opensCardScannerAutomatically(this[Controller.payment.opensCardScanner])
+        .preferredNetworks(this[Controller.payment.preferredNetworks])
+        .paymentMethodOrder(this[Controller.payment.methodOrder])
+        .cardBrandAcceptance(cardBrandAcceptance())
+        .termsDisplay(termsDisplay())
+        .appearance(paymentAppearance())
+        .googlePayConfiguration(paymentGooglePayConfiguration())
+        .linkConfiguration(
+            PaymentElement.Configuration.LinkConfiguration()
+                .display(this[Controller.payment.link.display])
+        )
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.cardBrandAcceptance():
+    PaymentElement.Configuration.CardBrandAcceptance {
+    val brands = buildList {
+        if (this@cardBrandAcceptance[Controller.payment.cardBrandAcceptance.visa]) {
+            add(PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Visa)
+        }
+        if (this@cardBrandAcceptance[Controller.payment.cardBrandAcceptance.mastercard]) {
+            add(PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Mastercard)
+        }
+        if (this@cardBrandAcceptance[Controller.payment.cardBrandAcceptance.amex]) {
+            add(PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Amex)
+        }
+        if (this@cardBrandAcceptance[Controller.payment.cardBrandAcceptance.discover]) {
+            add(PaymentElement.Configuration.CardBrandAcceptance.BrandCategory.Discover)
+        }
+    }
+    return when (this[Controller.payment.cardBrandAcceptance.mode]) {
+        CheckoutCardBrandAcceptanceMode.All -> PaymentElement.Configuration.CardBrandAcceptance.all()
+        CheckoutCardBrandAcceptanceMode.Allowed -> PaymentElement.Configuration.CardBrandAcceptance.allowed(brands)
+        CheckoutCardBrandAcceptanceMode.Disallowed -> {
+            PaymentElement.Configuration.CardBrandAcceptance.disallowed(brands)
+        }
+    }
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.termsDisplay():
+    Map<PaymentMethod.Type, PaymentElement.Configuration.TermsDisplay> {
+    return Controller.payment.terms.values.mapNotNull { (type, definition) ->
+        this[definition].configurationValue?.let { type to it }
+    }.toMap()
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.paymentAppearance(): PaymentElement.Configuration.Appearance {
+    return PaymentElement.Configuration.Appearance()
+        .colorsLight(paymentColors(Controller.payment.appearance.lightColors, light = true))
+        .colorsDark(paymentColors(Controller.payment.appearance.darkColors, light = false))
+        .themeMode(this[Controller.payment.appearance.themeMode])
+        .primaryButton(primaryButtonAppearance())
+        .formInsetValues(
+            PaymentElement.Configuration.Appearance.Insets(
+                horizontalDp = this[Controller.payment.appearance.insets.horizontal],
+                verticalDp = this[Controller.payment.appearance.insets.vertical],
+            )
+        )
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.paymentColors(
+    definitions: CheckoutPaymentColorsDefinitions,
+    light: Boolean,
+): PaymentElement.Configuration.Appearance.Colors {
+    val colors = if (light) {
+        PaymentElement.Configuration.Appearance.Colors.light()
+    } else {
+        PaymentElement.Configuration.Appearance.Colors.dark()
+    }
+    return colors.apply {
+        this@paymentColors[definitions.primary]?.let(::primary)
+        this@paymentColors[definitions.surface]?.let(::surface)
+        this@paymentColors[definitions.component]?.let(::component)
+        this@paymentColors[definitions.componentBorder]?.let(::componentBorder)
+        this@paymentColors[definitions.componentDivider]?.let(::componentDivider)
+        this@paymentColors[definitions.onComponent]?.let(::onComponent)
+        this@paymentColors[definitions.subtitle]?.let(::subtitle)
+        this@paymentColors[definitions.placeholderText]?.let(::placeholderText)
+        this@paymentColors[definitions.onSurface]?.let(::onSurface)
+        this@paymentColors[definitions.appBarIcon]?.let(::appBarIcon)
+        this@paymentColors[definitions.error]?.let(::error)
+    }
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.primaryButtonAppearance():
+    PaymentElement.Configuration.Appearance.PrimaryButton {
+    return PaymentElement.Configuration.Appearance.PrimaryButton()
+        .colorsLight(primaryButtonColors(Controller.payment.appearance.primaryButton.lightColors, light = true))
+        .colorsDark(primaryButtonColors(Controller.payment.appearance.primaryButton.darkColors, light = false))
+        .shape(
+            PaymentElement.Configuration.Appearance.PrimaryButton.Shape()
+                .cornerRadiusDp(this[Controller.payment.appearance.primaryButton.shape.cornerRadius])
+                .borderStrokeWidthDp(this[Controller.payment.appearance.primaryButton.shape.borderWidth])
+                .heightDp(this[Controller.payment.appearance.primaryButton.shape.height])
+        )
+        .typography(
+            PaymentElement.Configuration.Appearance.PrimaryButton.Typography()
+                .fontResId(this[Controller.payment.appearance.primaryButton.typography.font].resourceId)
+                .fontSizeSp(this[Controller.payment.appearance.primaryButton.typography.size])
+        )
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.primaryButtonColors(
+    definitions: CheckoutPrimaryButtonColorsDefinitions,
+    light: Boolean,
+): PaymentElement.Configuration.Appearance.PrimaryButton.Colors {
+    val colors = if (light) {
+        PaymentElement.Configuration.Appearance.PrimaryButton.Colors.light()
+    } else {
+        PaymentElement.Configuration.Appearance.PrimaryButton.Colors.dark()
+    }
+    return colors.apply {
+        this@primaryButtonColors[definitions.background]?.let(::background)
+        this@primaryButtonColors[definitions.onBackground]?.let(::onBackground)
+        this@primaryButtonColors[definitions.border]?.let(::border)
+        this@primaryButtonColors[definitions.successBackground]?.let(::successBackgroundColor)
+        this@primaryButtonColors[definitions.onSuccessBackground]?.let(::onSuccessBackgroundColor)
+    }
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.paymentGooglePayConfiguration():
+    PaymentElement.Configuration.GooglePayConfiguration {
+    val definitions = Controller.payment.googlePay
+    return PaymentElement.Configuration.GooglePayConfiguration()
+        .display(this[definitions.display])
+        .buttonType(this[definitions.buttonType])
+        .additionalEnabledNetworks(this[definitions.additionalNetworks])
+        .apply {
+            this@paymentGooglePayConfiguration[definitions.label]?.let(::label)
+        }
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.currencySelectorConfiguration():
+    CurrencySelectorElement.Configuration {
+    val definitions = Controller.currencySelector.appearance
+    val appearance = CurrencySelectorElement.Configuration.Appearance()
+        .contentVerticalPaddingDp(this[definitions.verticalPadding])
+        .sizeScaleFactor(this[definitions.scale])
+        .labelContent(this[definitions.label])
+        .fontResId(this[definitions.font].resourceId)
+        .apply {
+            this@currencySelectorConfiguration[definitions.cornerRadius]?.let(::cornerRadiusDp)
+            this@currencySelectorConfiguration[definitions.borderWidth]?.let(::borderWidthDp)
+            this@currencySelectorConfiguration[definitions.borderColor]?.let(::borderColor)
+            this@currencySelectorConfiguration[definitions.background]?.let(::background)
+            this@currencySelectorConfiguration[definitions.selectedBackground]?.let(::selectedBackground)
+            this@currencySelectorConfiguration[definitions.textColor]?.let(::textColor)
+            this@currencySelectorConfiguration[definitions.selectedTextColor]?.let(::selectedTextColor)
+            this@currencySelectorConfiguration[definitions.secondaryTextColor]?.let(::textSecondaryColor)
+            this@currencySelectorConfiguration[definitions.dangerColor]?.let(::dangerColor)
+        }
+    return CurrencySelectorElement.Configuration().appearance(appearance)
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.expressCheckoutConfiguration(): ExpressCheckoutElement.Configuration {
+    return ExpressCheckoutElement.Configuration()
+        .linkConfiguration(
+            ExpressCheckoutElement.Configuration.LinkConfiguration()
+                .display(this[Controller.express.link.display])
+                .collectMissingBillingDetailsForExistingPaymentMethods(
+                    this[Controller.express.link.collectMissingBilling]
+                )
+                .disallowFundingSourceCreation(this[Controller.express.link.disallowedFunding].toSet())
+        )
+        .googlePayConfiguration(expressGooglePayConfiguration())
+        .shippingAddressRequired(this[Controller.express.shippingRequired])
+        .billingDetailsCollectionConfiguration(
+            ExpressCheckoutElement.Configuration.BillingDetailsCollectionConfiguration()
+                .name(this[Controller.express.billing.name])
+                .email(this[Controller.express.billing.email])
+                .address(this[Controller.express.billing.address])
+        )
+        .appearance(
+            ExpressCheckoutElement.Configuration.Appearance()
+                .buttonTheme(this[Controller.express.appearance.theme])
+                .buttonLayout(
+                    ExpressCheckoutElement.Configuration.Appearance.ButtonLayout()
+                        .maxColumns(this[Controller.express.appearance.layout.columns])
+                        .maxRows(this[Controller.express.appearance.layout.rows])
+                )
+        )
+}
+
+private fun CheckoutPlaygroundSettings.Snapshot.expressGooglePayConfiguration():
+    ExpressCheckoutElement.Configuration.GooglePayConfiguration {
+    val definitions = Controller.express.googlePay
+    return ExpressCheckoutElement.Configuration.GooglePayConfiguration()
+        .display(this[definitions.display])
+        .buttonType(this[definitions.buttonType])
+        .additionalEnabledNetworks(this[definitions.additionalNetworks])
+        .apply {
+            this@expressGooglePayConfiguration[definitions.label]?.let(::label)
+        }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundDefinitionGroups.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundDefinitionGroups.kt
@@ -1,0 +1,237 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.paymentsheet.example.R
+import com.stripe.android.uicore.StripeColors
+
+internal class CheckoutContactDetailsDefinitions(
+    key: String,
+    displayName: String,
+) {
+    val enabled = boolean(
+        key = "$key.enabled",
+        displayName = "Provide details",
+        defaultValue = false,
+    )
+    val name = optionalText(
+        key = "$key.name",
+        displayName = "Name",
+    )
+    val address = CheckoutAddressDefinitions(key = "$key.address")
+    val configuration = configuration(
+        key = key,
+        displayName = displayName,
+        children = arrayOf(enabled, name, address.configuration),
+    )
+}
+
+internal class CheckoutAddressDefinitions(key: String) {
+    val enabled = boolean(
+        key = "$key.enabled",
+        displayName = "Provide address",
+        defaultValue = false,
+    )
+    val country = text(
+        key = "$key.country",
+        displayName = "Country",
+        defaultValue = "US",
+        validate = { value ->
+            if (value.matches(Regex("[A-Za-z]{2}"))) null else "Use a two-letter country code"
+        },
+    )
+    val city = optionalText(key = "$key.city", displayName = "City")
+    val line1 = optionalText(key = "$key.line1", displayName = "Line 1")
+    val line2 = optionalText(key = "$key.line2", displayName = "Line 2")
+    val postalCode = optionalText(key = "$key.postal_code", displayName = "Postal code")
+    val state = optionalText(key = "$key.state", displayName = "State")
+    val configuration = configuration(
+        key = key,
+        displayName = "Address",
+        children = arrayOf(
+            enabled,
+            country,
+            city,
+            line1,
+            line2,
+            postalCode,
+            state,
+        ),
+    )
+}
+
+internal class CheckoutPaymentColorsDefinitions(
+    key: String,
+    displayName: String,
+    defaultColors: StripeColors,
+) {
+    val primary = optionalColor(
+        key = "$key.primary",
+        displayName = "Primary",
+        defaultValue = defaultColors.materialColors.primary,
+    )
+    val surface = optionalColor(
+        key = "$key.surface",
+        displayName = "Surface",
+        defaultValue = defaultColors.materialColors.surface,
+    )
+    val component = optionalColor(
+        key = "$key.component",
+        displayName = "Component",
+        defaultValue = defaultColors.component,
+    )
+    val componentBorder = optionalColor(
+        key = "$key.component_border",
+        displayName = "Component border",
+        defaultValue = defaultColors.componentBorder,
+    )
+    val componentDivider = optionalColor(
+        key = "$key.component_divider",
+        displayName = "Component divider",
+        defaultValue = defaultColors.componentDivider,
+    )
+    val onComponent = optionalColor(
+        key = "$key.on_component",
+        displayName = "On component",
+        defaultValue = defaultColors.onComponent,
+    )
+    val subtitle = optionalColor(
+        key = "$key.subtitle",
+        displayName = "Subtitle",
+        defaultValue = defaultColors.subtitle,
+    )
+    val placeholderText = optionalColor(
+        key = "$key.placeholder_text",
+        displayName = "Placeholder text",
+        defaultValue = defaultColors.placeholderText,
+    )
+    val onSurface = optionalColor(
+        key = "$key.on_surface",
+        displayName = "On surface",
+        defaultValue = defaultColors.materialColors.onSurface,
+    )
+    val appBarIcon = optionalColor(
+        key = "$key.app_bar_icon",
+        displayName = "App bar icon",
+        defaultValue = defaultColors.appBarIcon,
+    )
+    val error = optionalColor(
+        key = "$key.error",
+        displayName = "Error",
+        defaultValue = defaultColors.materialColors.error,
+    )
+    val configuration = configuration(
+        key = key,
+        displayName = displayName,
+        children = arrayOf(
+            primary,
+            surface,
+            component,
+            componentBorder,
+            componentDivider,
+            onComponent,
+            subtitle,
+            placeholderText,
+            onSurface,
+            appBarIcon,
+            error,
+        ),
+    )
+}
+
+internal class CheckoutPrimaryButtonColorsDefinitions(
+    key: String,
+    displayName: String,
+) {
+    val background = optionalColor(key = "$key.background", displayName = "Background")
+    val onBackground = optionalColor(key = "$key.on_background", displayName = "On background")
+    val border = optionalColor(key = "$key.border", displayName = "Border")
+    val successBackground = optionalColor(key = "$key.success_background", displayName = "Success background")
+    val onSuccessBackground = optionalColor(
+        key = "$key.on_success_background",
+        displayName = "On success background",
+    )
+    val configuration = configuration(
+        key = key,
+        displayName = displayName,
+        children = arrayOf(
+            background,
+            onBackground,
+            border,
+            successBackground,
+            onSuccessBackground,
+        ),
+    )
+}
+
+internal class CheckoutGooglePayDefinitions<DisplayType : Enum<DisplayType>, ButtonTypeValue : Enum<ButtonTypeValue>>(
+    key: String,
+    displayName: String,
+    defaultDisplay: DisplayType,
+    displayOptions: List<DisplayType>,
+    defaultButtonType: ButtonTypeValue,
+    buttonTypeOptions: List<ButtonTypeValue>,
+) {
+    val display = choice(
+        key = "$key.display",
+        displayName = "Display",
+        defaultValue = defaultDisplay,
+        options = displayOptions.map { it.name to it },
+        serialize = { it.name },
+    )
+    val label = optionalText(key = "$key.label", displayName = "Label")
+    val buttonType = choice(
+        key = "$key.button_type",
+        displayName = "Button type",
+        defaultValue = defaultButtonType,
+        options = buttonTypeOptions.map { it.name to it },
+        serialize = { it.name },
+    )
+    val additionalNetworks = stringCsv(
+        key = "$key.additional_networks",
+        displayName = "Additional networks (comma separated)",
+    )
+    val configuration = configuration(
+        key = key,
+        displayName = displayName,
+        children = arrayOf(display, label, buttonType, additionalNetworks),
+    )
+}
+
+internal enum class CheckoutCardBrandAcceptanceMode {
+    All,
+    Allowed,
+    Disallowed,
+}
+
+internal enum class CheckoutTermsDisplay(
+    val displayName: String,
+    val serializedValue: String,
+    val configurationValue: PaymentElement.Configuration.TermsDisplay?,
+) {
+    Default(
+        displayName = "Default",
+        serializedValue = "Default",
+        configurationValue = null,
+    ),
+    Automatic(
+        displayName = "Automatic",
+        serializedValue = PaymentElement.Configuration.TermsDisplay.AUTOMATIC.name,
+        configurationValue = PaymentElement.Configuration.TermsDisplay.AUTOMATIC,
+    ),
+    Never(
+        displayName = "Never",
+        serializedValue = PaymentElement.Configuration.TermsDisplay.NEVER.name,
+        configurationValue = PaymentElement.Configuration.TermsDisplay.NEVER,
+    ),
+}
+
+internal enum class CheckoutFont(
+    val serializedValue: String,
+    val resourceId: Int?,
+) {
+    Default(serializedValue = "default", resourceId = null),
+    Cursive(serializedValue = "cursive", resourceId = R.font.cursive),
+    OpenSans(serializedValue = "opensans", resourceId = R.font.opensans),
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundDefinitions.kt
@@ -1,0 +1,43 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+internal object CheckoutPlaygroundDefinitions {
+    val root: CheckoutPlaygroundSettingDefinition.Configuration by lazy {
+        configuration(
+            key = "root",
+            displayName = "Checkout Controller Playground",
+            children = arrayOf(
+                session.configuration,
+                Controller.configuration,
+            ),
+        )
+    }
+
+    val session = CheckoutSessionDefinitions
+
+    object Controller {
+        val merchantDisplayName = optionalText(
+            key = "controller.merchant_display_name",
+            displayName = "Merchant display name",
+        )
+        val defaults = CheckoutDefaultsDefinitions
+        val payment = CheckoutPaymentDefinitions
+        val currencySelector = CheckoutCurrencySelectorDefinitions
+        val express = CheckoutExpressDefinitions
+
+        val configuration: CheckoutPlaygroundSettingDefinition.Configuration by lazy {
+            configuration(
+                key = "controller",
+                displayName = "CheckoutController.Configuration",
+                children = arrayOf(
+                    merchantDisplayName,
+                    defaults.configuration,
+                    payment.configuration,
+                    currencySelector.configuration,
+                    express.configuration,
+                ),
+            )
+        }
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingDefinition.kt
@@ -1,0 +1,63 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+internal sealed interface CheckoutPlaygroundSettingDefinition {
+    val key: String
+    val displayName: String
+
+    class Configuration(
+        override val key: String,
+        override val displayName: String,
+        val children: List<CheckoutPlaygroundSettingDefinition>,
+    ) : CheckoutPlaygroundSettingDefinition
+
+    class Value<T>(
+        override val key: String,
+        override val displayName: String,
+        val defaultValue: T,
+        val options: List<Option<T>>,
+        val input: Input,
+        val isVisible: (CheckoutPlaygroundSettings) -> Boolean,
+        private val encode: (T) -> String,
+        private val decode: (String) -> Result<T>,
+    ) : CheckoutPlaygroundSettingDefinition {
+        val defaultSerializedValue: String = encode(defaultValue)
+
+        fun serialize(value: T): String = encode(value)
+
+        fun deserialize(value: String): Result<T> = decode(value)
+
+        fun validationError(value: String): String? {
+            return decode(value).exceptionOrNull()?.message
+        }
+
+        data class Option<T>(
+            val displayName: String,
+            val value: T,
+        )
+
+        enum class Input {
+            Text,
+            Email,
+            Integer,
+            Decimal,
+            Color,
+        }
+    }
+}
+
+internal fun CheckoutPlaygroundSettingDefinition.Configuration.values():
+    List<CheckoutPlaygroundSettingDefinition.Value<*>> {
+    return children.flatMap { child ->
+        when (child) {
+            is CheckoutPlaygroundSettingDefinition.Configuration -> child.values()
+            is CheckoutPlaygroundSettingDefinition.Value<*> -> listOf(child)
+        }
+    }
+}
+
+internal fun CheckoutPlaygroundSettingDefinition.Configuration.configurations():
+    List<CheckoutPlaygroundSettingDefinition.Configuration> {
+    return listOf(this) + children
+        .filterIsInstance<CheckoutPlaygroundSettingDefinition.Configuration>()
+        .flatMap { it.configurations() }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingFactories.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingFactories.kt
@@ -1,0 +1,82 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+internal fun configuration(
+    key: String,
+    displayName: String,
+    vararg children: CheckoutPlaygroundSettingDefinition,
+) = CheckoutPlaygroundSettingDefinition.Configuration(
+    key = key,
+    displayName = displayName,
+    children = children.toList(),
+)
+
+internal fun boolean(
+    key: String,
+    displayName: String,
+    defaultValue: Boolean,
+) = choice(
+    key = key,
+    displayName = displayName,
+    defaultValue = defaultValue,
+    options = listOf("On" to true, "Off" to false),
+    serialize = Boolean::toString,
+)
+
+internal inline fun <reified T : Enum<T>> enumChoice(
+    key: String,
+    displayName: String,
+    defaultValue: T,
+) = choice(
+    key = key,
+    displayName = displayName,
+    defaultValue = defaultValue,
+    options = enumValues<T>().map { it.name to it },
+    serialize = { it.name },
+)
+
+internal fun <T> choice(
+    key: String,
+    displayName: String,
+    defaultValue: T,
+    options: List<Pair<String, T>>,
+    serialize: (T) -> String,
+): CheckoutPlaygroundSettingDefinition.Value<T> {
+    return value(
+        key = key,
+        displayName = displayName,
+        defaultValue = defaultValue,
+        options = options,
+        encode = serialize,
+        decode = { serialized ->
+            options.firstOrNull { (_, option) -> serialize(option) == serialized }
+                ?.second
+                ?.let(Result.Companion::success)
+                ?: invalid(message = "Unknown value: $serialized")
+        },
+    )
+}
+
+internal fun <T> value(
+    key: String,
+    displayName: String,
+    defaultValue: T,
+    isVisible: (CheckoutPlaygroundSettings) -> Boolean = { true },
+    options: List<Pair<String, T>> = emptyList(),
+    input: CheckoutPlaygroundSettingDefinition.Value.Input = CheckoutPlaygroundSettingDefinition.Value.Input.Text,
+    encode: (T) -> String,
+    decode: (String) -> Result<T>,
+) = CheckoutPlaygroundSettingDefinition.Value(
+    key = key,
+    displayName = displayName,
+    defaultValue = defaultValue,
+    options = options.map { (name, optionValue) ->
+        CheckoutPlaygroundSettingDefinition.Value.Option(
+            displayName = name,
+            value = optionValue,
+        )
+    },
+    input = input,
+    isVisible = isVisible,
+    encode = encode,
+    decode = decode,
+)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingParsers.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingParsers.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import androidx.compose.ui.graphics.Color
+
+internal fun decodeFloat(
+    value: String,
+    minimum: Float,
+    minimumExclusive: Boolean,
+): Result<Float> {
+    val number = value.toFloatOrNull()?.takeIf(Float::isFinite)
+        ?: return invalid(message = "Enter a finite number")
+    if (number < minimum || minimumExclusive && number == minimum) {
+        return invalid(
+            message = if (minimumExclusive) "Must be greater than $minimum" else "Must be at least $minimum",
+        )
+    }
+    return Result.success(number)
+}
+
+@Suppress("MagicNumber")
+internal fun formatFloat(value: Float): String {
+    return if (value % 1f == 0f) value.toInt().toString() else value.toString()
+}
+
+@Suppress("MagicNumber")
+internal fun parseColor(value: String): Result<Color> {
+    val hex = value.removePrefix("#")
+    if (hex.length != 6 && hex.length != 8) return invalid(message = "Use #RRGGBB or #AARRGGBB")
+    val argb = (if (hex.length == 6) "FF$hex" else hex).toLongOrNull(16)
+        ?: return invalid(message = "Use #RRGGBB or #AARRGGBB")
+    return Result.success(Color(argb))
+}
+
+internal fun <T> invalid(message: String): Result<T> {
+    return Result.failure(IllegalArgumentException(message))
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
@@ -1,0 +1,182 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import android.content.Context
+import androidx.core.content.edit
+import com.stripe.android.paymentsheet.example.Settings
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+internal class CheckoutPlaygroundSettings private constructor(
+    private val root: CheckoutPlaygroundSettingDefinition.Configuration,
+    defaultValues: Map<String, String>,
+    initialValues: Map<String, String>,
+    initialReturningCustomerId: String?,
+    private val persist: (Map<String, String>) -> Unit,
+    private val persistReturningCustomerId: (String?) -> Unit,
+) {
+    private val definitionsByKey = root.values().associateBy { it.key }
+    private val defaults = definitionsByKey.values.associateWith { it.defaultSerializedValue } +
+        defaultValues.sanitized()
+    private val _values = MutableStateFlow(defaults + initialValues.sanitized())
+    val values: StateFlow<Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>> = _values.asStateFlow()
+
+    var returningCustomerId: String? = initialReturningCustomerId
+        private set
+
+    fun <T> value(definition: CheckoutPlaygroundSettingDefinition.Value<T>): T {
+        return definition.deserialize(serializedValue(definition)).getOrThrow()
+    }
+
+    fun serializedValue(definition: CheckoutPlaygroundSettingDefinition.Value<*>): String {
+        return requireNotNull(_values.value[definition])
+    }
+
+    fun <T> update(
+        definition: CheckoutPlaygroundSettingDefinition.Value<T>,
+        value: T,
+    ) {
+        updateSerialized(definition, definition.serialize(value))
+    }
+
+    fun updateSerialized(
+        definition: CheckoutPlaygroundSettingDefinition.Value<*>,
+        value: String,
+    ) {
+        _values.value += (definition to value)
+        persist(_values.value.serialized())
+    }
+
+    fun reset() {
+        _values.value = defaults
+        returningCustomerId = null
+        persist(_values.value.serialized())
+        persistReturningCustomerId(null)
+    }
+
+    fun saveReturningCustomer(customerId: String) {
+        returningCustomerId = customerId
+        persistReturningCustomerId(customerId)
+        update(CheckoutPlaygroundDefinitions.session.customer, RETURNING_CUSTOMER)
+    }
+
+    fun validationErrors(): Map<CheckoutPlaygroundSettingDefinition.Value<*>, String> {
+        return _values.value.mapNotNull { (definition, value) ->
+            definition.validationError(value)?.let { definition to it }
+        }.toMap()
+    }
+
+    fun snapshot(): Snapshot {
+        check(validationErrors().isEmpty()) { "Cannot snapshot invalid checkout playground settings." }
+        return Snapshot(_values.value.toMap())
+    }
+
+    fun asJsonString(): String {
+        return Json.encodeToString(
+            MapSerializer(String.serializer(), String.serializer()),
+            _values.value.serialized(),
+        )
+    }
+
+    private fun Map<String, String>.sanitized(): Map<CheckoutPlaygroundSettingDefinition.Value<*>, String> {
+        return mapNotNull { (key, value) ->
+            definitionsByKey[key]
+                ?.takeIf { it.validationError(value) == null }
+                ?.let { it to value }
+        }.toMap()
+    }
+
+    @JvmInline
+    value class Snapshot internal constructor(
+        private val values: Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>,
+    ) {
+        operator fun <T> get(definition: CheckoutPlaygroundSettingDefinition.Value<T>): T {
+            return definition.deserialize(requireNotNull(values[definition])).getOrThrow()
+        }
+    }
+
+    companion object {
+        private const val PREFERENCES_NAME = "CheckoutControllerPlaygroundSettings"
+        private const val PREFERENCES_KEY = "settings_v1"
+        private const val RETURNING_CUSTOMER_ID_KEY = "returning_customer_id"
+        private const val RETURNING_CUSTOMER = "returning"
+
+        fun create(context: Context): CheckoutPlaygroundSettings {
+            val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+            val values = preferences.getString(PREFERENCES_KEY, null)?.let(::decodeValues).orEmpty()
+            return CheckoutPlaygroundSettings(
+                root = CheckoutPlaygroundDefinitions.root,
+                defaultValues = mapOf(
+                    CheckoutPlaygroundDefinitions.session.backendUrl.key to Settings(context).playgroundBackendUrl
+                ),
+                initialValues = values,
+                initialReturningCustomerId = preferences.getString(RETURNING_CUSTOMER_ID_KEY, null),
+                persist = { updatedValues ->
+                    preferences.edit {
+                        putString(
+                            PREFERENCES_KEY,
+                            Json.encodeToString(
+                                MapSerializer(String.serializer(), String.serializer()),
+                                updatedValues,
+                            ),
+                        )
+                    }
+                },
+                persistReturningCustomerId = { customerId ->
+                    preferences.edit {
+                        if (customerId == null) {
+                            remove(RETURNING_CUSTOMER_ID_KEY)
+                        } else {
+                            putString(RETURNING_CUSTOMER_ID_KEY, customerId)
+                        }
+                    }
+                },
+            )
+        }
+
+        fun createInMemory(
+            json: String? = null,
+        ): CheckoutPlaygroundSettings {
+            return CheckoutPlaygroundSettings(
+                root = CheckoutPlaygroundDefinitions.root,
+                defaultValues = emptyMap(),
+                initialValues = json?.let(::decodeValues).orEmpty(),
+                initialReturningCustomerId = null,
+                persist = {},
+                persistReturningCustomerId = {},
+            )
+        }
+
+        fun createInMemory(
+            json: String?,
+            defaultBackendUrl: String,
+        ): CheckoutPlaygroundSettings {
+            return CheckoutPlaygroundSettings(
+                root = CheckoutPlaygroundDefinitions.root,
+                defaultValues = mapOf(CheckoutPlaygroundDefinitions.session.backendUrl.key to defaultBackendUrl),
+                initialValues = json?.let(::decodeValues).orEmpty(),
+                initialReturningCustomerId = null,
+                persist = {},
+                persistReturningCustomerId = {},
+            )
+        }
+
+        private fun decodeValues(json: String): Map<String, String> {
+            return try {
+                Json.decodeFromString(MapSerializer(String.serializer(), String.serializer()), json)
+            } catch (_: SerializationException) {
+                emptyMap()
+            } catch (_: IllegalArgumentException) {
+                emptyMap()
+            }
+        }
+    }
+}
+
+private fun Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>.serialized(): Map<String, String> {
+    return mapKeys { (definition, _) -> definition.key }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
@@ -1,0 +1,321 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.AlertDialog
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ExposedDropdownMenuBox
+import androidx.compose.material.ExposedDropdownMenuDefaults
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.RadioButton
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.toColorInt
+import com.godaddy.android.colorpicker.ClassicColorPicker
+import com.godaddy.android.colorpicker.HsvColor
+
+internal const val CheckoutSettingsScreenTestTag = "checkout_settings_screen"
+private const val CheckoutSettingGroupTestTagPrefix = "checkout_setting_group:"
+private const val CheckoutSettingValueTestTagPrefix = "checkout_setting_value:"
+
+@Composable
+internal fun CheckoutPlaygroundSettingsUi(
+    configuration: CheckoutPlaygroundSettingDefinition.Configuration,
+    settings: CheckoutPlaygroundSettings,
+    onOpenConfiguration: (CheckoutPlaygroundSettingDefinition.Configuration) -> Unit,
+) {
+    val values by settings.values.collectAsState()
+    Column(
+        modifier = Modifier.testTag(CheckoutSettingsScreenTestTag),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        configuration.children.filter { definition ->
+            definition !is CheckoutPlaygroundSettingDefinition.Value<*> || definition.isVisible(settings)
+        }.forEach { definition ->
+            when (definition) {
+                is CheckoutPlaygroundSettingDefinition.Configuration -> ConfigurationRow(
+                    configuration = definition,
+                    onClick = { onOpenConfiguration(definition) },
+                )
+                is CheckoutPlaygroundSettingDefinition.Value<*> -> ValueRow(
+                    definition = definition,
+                    value = requireNotNull(values[definition]),
+                    onValueChanged = { settings.updateSerialized(definition, it) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ConfigurationRow(
+    configuration: CheckoutPlaygroundSettingDefinition.Configuration,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(checkoutSettingGroupTestTag(configuration))
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = configuration.displayName,
+            style = MaterialTheme.typography.subtitle1,
+            fontWeight = FontWeight.Bold,
+        )
+        Text(text = "›", style = MaterialTheme.typography.h5)
+    }
+}
+
+@Composable
+private fun <T> ValueRow(
+    definition: CheckoutPlaygroundSettingDefinition.Value<T>,
+    value: String,
+    onValueChanged: (String) -> Unit,
+) {
+    if (definition.input == CheckoutPlaygroundSettingDefinition.Value.Input.Color) {
+        ColorValue(definition, value, onValueChanged)
+    } else if (definition.options.isEmpty()) {
+        TextValue(definition, value, onValueChanged)
+    } else if (definition.options.size <= MaxInlineOptions) {
+        RadioValue(definition, value, onValueChanged)
+    } else {
+        DropdownValue(definition, value, onValueChanged)
+    }
+}
+
+@Composable
+private fun <T> ColorValue(
+    definition: CheckoutPlaygroundSettingDefinition.Value<T>,
+    value: String,
+    onValueChanged: (String) -> Unit,
+) {
+    var showPicker by remember { mutableStateOf(false) }
+    val selectedColor = value.toComposeColorOrNull()
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(checkoutSettingValueTestTag(definition))
+            .clickable { showPicker = true }
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Column {
+            Text(text = definition.displayName, fontWeight = FontWeight.Bold)
+            Text(text = value.ifEmpty { "Default" }, style = MaterialTheme.typography.caption)
+        }
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .clip(CircleShape)
+                .background(selectedColor ?: Color.Transparent)
+                .border(1.dp, MaterialTheme.colors.onSurface, CircleShape),
+        )
+    }
+
+    if (showPicker) {
+        ColorPickerDialog(
+            initialColor = selectedColor ?: Color.Black,
+            onDismiss = { showPicker = false },
+            onClear = {
+                onValueChanged("")
+                showPicker = false
+            },
+            onColorPicked = {
+                onValueChanged(it.toSerializedColor())
+                showPicker = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun ColorPickerDialog(
+    initialColor: Color,
+    onDismiss: () -> Unit,
+    onClear: () -> Unit,
+    onColorPicked: (Color) -> Unit,
+) {
+    var currentColor by remember(initialColor) { mutableStateOf(initialColor) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = {
+            ClassicColorPicker(
+                modifier = Modifier.fillMaxSize(),
+                color = HsvColor.from(currentColor),
+                onColorChanged = { currentColor = it.toColor() },
+            )
+        },
+        buttons = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                Button(
+                    onClick = onClear,
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text("Use default")
+                }
+                Button(
+                    onClick = { onColorPicked(currentColor) },
+                    colors = ButtonDefaults.buttonColors(backgroundColor = currentColor),
+                    modifier = Modifier.weight(1f),
+                ) {
+                    Text("Pick color")
+                }
+            }
+        },
+    )
+}
+
+private fun String.toComposeColorOrNull(): Color? {
+    return runCatching { Color(toColorInt()) }.getOrNull()
+}
+
+@Suppress("MagicNumber")
+private fun Color.toSerializedColor(): String {
+    return toArgb().toLong().and(0xffffffffL).toString(16).padStart(8, '0').uppercase().let { "#$it" }
+}
+
+@Composable
+private fun <T> TextValue(
+    definition: CheckoutPlaygroundSettingDefinition.Value<T>,
+    value: String,
+    onValueChanged: (String) -> Unit,
+) {
+    val error = definition.validationError(value)
+    OutlinedTextField(
+        value = value,
+        onValueChange = onValueChanged,
+        label = { Text(definition.displayName) },
+        isError = error != null,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = when (definition.input) {
+                CheckoutPlaygroundSettingDefinition.Value.Input.Email -> KeyboardType.Email
+                CheckoutPlaygroundSettingDefinition.Value.Input.Integer -> KeyboardType.Number
+                CheckoutPlaygroundSettingDefinition.Value.Input.Decimal -> KeyboardType.Decimal
+                else -> KeyboardType.Text
+            }
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(checkoutSettingValueTestTag(definition)),
+    )
+    error?.let {
+        Text(text = it, color = MaterialTheme.colors.error, style = MaterialTheme.typography.caption)
+    }
+}
+
+@Composable
+private fun <T> RadioValue(
+    definition: CheckoutPlaygroundSettingDefinition.Value<T>,
+    value: String,
+    onValueChanged: (String) -> Unit,
+) {
+    Column(modifier = Modifier.testTag(checkoutSettingValueTestTag(definition))) {
+        Text(text = definition.displayName, fontWeight = FontWeight.Bold)
+        Row(modifier = Modifier.fillMaxWidth()) {
+            definition.options.forEach { option ->
+                Row(
+                    modifier = Modifier
+                        .selectable(
+                            selected = value == definition.serialize(option.value),
+                            onClick = { onValueChanged(definition.serialize(option.value)) },
+                        )
+                        .padding(end = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    RadioButton(selected = value == definition.serialize(option.value), onClick = null)
+                    Text(option.displayName)
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+private fun <T> DropdownValue(
+    definition: CheckoutPlaygroundSettingDefinition.Value<T>,
+    value: String,
+    onValueChanged: (String) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selected = definition.options.firstOrNull { definition.serialize(it.value) == value }
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it },
+        modifier = Modifier.testTag(checkoutSettingValueTestTag(definition)),
+    ) {
+        OutlinedTextField(
+            readOnly = true,
+            value = selected?.displayName.orEmpty(),
+            onValueChange = {},
+            label = { Text(definition.displayName) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = Modifier.fillMaxWidth(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            definition.options.forEach { option ->
+                DropdownMenuItem(
+                    onClick = {
+                        onValueChanged(definition.serialize(option.value))
+                        expanded = false
+                    }
+                ) {
+                    Text(option.displayName)
+                }
+            }
+        }
+    }
+}
+
+internal fun checkoutSettingGroupTestTag(
+    definition: CheckoutPlaygroundSettingDefinition.Configuration,
+): String = CheckoutSettingGroupTestTagPrefix + definition.key
+
+internal fun checkoutSettingValueTestTag(
+    definition: CheckoutPlaygroundSettingDefinition.Value<*>,
+): String = CheckoutSettingValueTestTagPrefix + definition.key
+
+private const val MaxInlineOptions = 4

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundValueFactories.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundValueFactories.kt
@@ -1,0 +1,192 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+
+internal val optionalEmail: (String) -> String? = { value ->
+    if (value.isBlank() || value.matches(Regex("[^@\\s]+@[^@\\s]+\\.[^@\\s]+"))) null else "Invalid email"
+}
+
+internal fun text(
+    key: String,
+    displayName: String,
+    defaultValue: String,
+    validate: (String) -> String? = { null },
+): CheckoutPlaygroundSettingDefinition.Value<String> {
+    return value(
+        key = key,
+        displayName = displayName,
+        defaultValue = defaultValue,
+        encode = { it },
+        decode = { serialized ->
+            validate(serialized)?.let { invalid(message = it) } ?: Result.success(serialized)
+        },
+    )
+}
+
+internal fun optionalText(
+    key: String,
+    displayName: String,
+    validate: (String) -> String? = { null },
+): CheckoutPlaygroundSettingDefinition.Value<String?> {
+    return value(
+        key = key,
+        displayName = displayName,
+        defaultValue = null,
+        encode = { it.orEmpty() },
+        decode = { serialized ->
+            validate(serialized)?.let { invalid(message = it) } ?: Result.success(serialized.trim().ifEmpty { null })
+        },
+    )
+}
+
+internal fun optionalInt(
+    key: String,
+    displayName: String,
+): CheckoutPlaygroundSettingDefinition.Value<Int?> {
+    val minimum = 1
+    return value(
+        key = key,
+        displayName = displayName,
+        defaultValue = null,
+        input = CheckoutPlaygroundSettingDefinition.Value.Input.Integer,
+        encode = { it?.toString().orEmpty() },
+        decode = { serialized ->
+            if (serialized.isBlank()) {
+                Result.success(null)
+            } else {
+                val number = serialized.toIntOrNull() ?: return@value invalid(message = "Enter a whole number")
+                if (number < minimum) invalid(message = "Must be at least $minimum") else Result.success(number)
+            }
+        },
+    )
+}
+
+internal fun decimal(
+    key: String,
+    displayName: String,
+    defaultValue: Float,
+    minimum: Float,
+    minimumExclusive: Boolean = false,
+): CheckoutPlaygroundSettingDefinition.Value<Float> {
+    return value(
+        key = key,
+        displayName = displayName,
+        defaultValue = defaultValue,
+        input = CheckoutPlaygroundSettingDefinition.Value.Input.Decimal,
+        encode = ::formatFloat,
+        decode = { serialized ->
+            decodeFloat(
+                value = serialized,
+                minimum = minimum,
+                minimumExclusive = minimumExclusive,
+            )
+        },
+    )
+}
+
+internal fun optionalFloat(
+    key: String,
+    displayName: String,
+    minimum: Float,
+    minimumExclusive: Boolean = false,
+): CheckoutPlaygroundSettingDefinition.Value<Float?> {
+    return value(
+        key = key,
+        displayName = displayName,
+        defaultValue = null,
+        input = CheckoutPlaygroundSettingDefinition.Value.Input.Decimal,
+        encode = { it?.let(::formatFloat).orEmpty() },
+        decode = { serialized ->
+            if (serialized.isBlank()) {
+                Result.success(null)
+            } else {
+                decodeFloat(
+                    value = serialized,
+                    minimum = minimum,
+                    minimumExclusive = minimumExclusive,
+                )
+            }
+        },
+    )
+}
+
+internal fun optionalColor(
+    key: String,
+    displayName: String,
+): CheckoutPlaygroundSettingDefinition.Value<Color?> {
+    return optionalColor(key, displayName, defaultValue = null)
+}
+
+@Suppress("MagicNumber")
+internal fun optionalColor(
+    key: String,
+    displayName: String,
+    defaultValue: Color?,
+): CheckoutPlaygroundSettingDefinition.Value<Color?> {
+    return value(
+        key = key,
+        displayName = displayName,
+        defaultValue = defaultValue,
+        input = CheckoutPlaygroundSettingDefinition.Value.Input.Color,
+        encode = { color ->
+            color?.toArgb()?.toLong()?.and(0xffffffffL)?.toString(16)?.padStart(8, '0')?.uppercase()
+                ?.let { "#$it" }
+                .orEmpty()
+        },
+        decode = { serialized ->
+            if (serialized.isBlank()) Result.success(null) else parseColor(value = serialized)
+        },
+    )
+}
+
+internal fun font(
+    key: String,
+) = choice(
+    key = key,
+    displayName = "Font",
+    defaultValue = CheckoutFont.Default,
+    options = listOf(
+        "Default" to CheckoutFont.Default,
+        "Cursive" to CheckoutFont.Cursive,
+        "Open Sans" to CheckoutFont.OpenSans,
+    ),
+    serialize = CheckoutFont::serializedValue,
+)
+
+internal fun stringCsv(
+    key: String,
+    displayName: String,
+): CheckoutPlaygroundSettingDefinition.Value<List<String>> {
+    return csv(
+        key = key,
+        displayName = displayName,
+        decodeItem = { Result.success(it) },
+        encodeItem = { it },
+    )
+}
+
+internal fun <T> csv(
+    key: String,
+    displayName: String,
+    decodeItem: (String) -> Result<T>,
+    encodeItem: (T) -> String,
+): CheckoutPlaygroundSettingDefinition.Value<List<T>> {
+    return value(
+        key = key,
+        displayName = displayName,
+        defaultValue = emptyList(),
+        encode = { values -> values.joinToString(", ", transform = encodeItem) },
+        decode = { serialized ->
+            val decoded = serialized
+                .split(',')
+                .map(String::trim)
+                .filter(String::isNotEmpty)
+                .distinct()
+                .map(decodeItem)
+            decoded.firstOrNull { it.isFailure }?.let { failure ->
+                Result.failure(requireNotNull(failure.exceptionOrNull()))
+            } ?: Result.success(decoded.map { it.getOrThrow() })
+        },
+    )
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
@@ -1,0 +1,94 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.paymentsheet.example.playground.settings.Currency as PlaygroundCurrency
+
+internal object CheckoutSessionDefinitions {
+    val backendUrl = optionalText(
+        key = "session.backend_url",
+        displayName = "Backend URL",
+        validate = { value ->
+            when {
+                value.isBlank() -> null
+                !value.startsWith("http://") && !value.startsWith("https://") -> "Must be a valid URL"
+                !value.endsWith("/") -> "Must end with /"
+                else -> null
+            }
+        },
+    )
+    val customer = choice(
+        key = "session.customer",
+        displayName = "Customer",
+        defaultValue = "guest",
+        options = listOf(
+            "Guest" to "guest",
+            "New" to "new",
+            "Returning" to "returning",
+        ),
+        serialize = { it },
+    )
+    val customerEmail = text(
+        key = "session.customer_email",
+        displayName = "Customer email",
+        defaultValue = "email@example.com",
+        validate = optionalEmail,
+    )
+    val currency = choice(
+        key = "session.currency",
+        displayName = "Currency",
+        defaultValue = PlaygroundCurrency.USD,
+        options = PlaygroundCurrency.entries.map {
+            it.displayName to it
+        },
+        serialize = PlaygroundCurrency::value,
+    )
+    val automaticPaymentMethods = boolean(
+        key = "session.automatic_payment_methods",
+        displayName = "Automatic payment methods",
+        defaultValue = true,
+    )
+    val paymentMethodTypes = value(
+        key = "session.payment_method_types",
+        displayName = "Payment method types (comma separated)",
+        defaultValue = listOf("card"),
+        encode = { values -> values.joinToString(", ") },
+        decode = { serialized ->
+            Result.success(
+                serialized.split(',')
+                    .map(String::trim)
+                    .filter(String::isNotEmpty)
+                    .distinct()
+            )
+        },
+        isVisible = { settings -> !settings.value(automaticPaymentMethods) },
+    )
+    val automaticTax = boolean(
+        key = "session.automatic_tax",
+        displayName = "Automatic tax",
+        defaultValue = false,
+    )
+    val shippingAddressCollection = boolean(
+        key = "session.shipping_address_collection",
+        displayName = "Collect shipping address",
+        defaultValue = false,
+    )
+    val billingAddressCollection = boolean(
+        key = "session.billing_address_collection",
+        displayName = "Collect billing address",
+        defaultValue = false,
+    )
+    val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
+        key = "session",
+        displayName = "Checkout Session",
+        children = arrayOf(
+            backendUrl,
+            customer,
+            customerEmail,
+            currency,
+            automaticPaymentMethods,
+            paymentMethodTypes,
+            automaticTax,
+            shippingAddressCollection,
+            billingAddressCollection,
+        ),
+    )
+}

--- a/paymentsheet-example/src/main/res/values/strings.xml
+++ b/paymentsheet-example/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="playground_title">Playground</string>
     <string name="playground_subtitle">Testing playground for Stripe engineers</string>
     <string name="checkout_controller_example_title">CheckoutController Example</string>
-    <string name="checkout_controller_example_subtitle">Simple CheckoutController integration</string>
+    <string name="checkout_controller_example_subtitle">Configurable CheckoutController playground</string>
     <string name="onramp_title">Onramp Coordinator</string>
     <string name="onramp_subtitle">Test the OnrampCoordinator functionality</string>
     <string name="action_settings">Settings</string>

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleBackendRepositoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleBackendRepositoryTest.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+class CheckoutControllerExampleBackendRepositoryTest {
+    @Test
+    fun `checkout session URL uses default backend URL`() {
+        val result = checkoutSessionUrl(
+            defaultBackendUrl = "https://default.example/",
+            customBackendUrl = null,
+            endpoint = "checkout_session",
+        )
+
+        assertThat(result).isEqualTo("https://default.example/checkout_session")
+    }
+
+    @Test
+    fun `checkout session URL uses custom backend URL`() {
+        val result = checkoutSessionUrl(
+            defaultBackendUrl = "https://default.example/",
+            customBackendUrl = "https://custom.example/",
+            endpoint = "checkout_session",
+        )
+
+        assertThat(result).isEqualTo("https://custom.example/checkout_session")
+    }
+
+    @Test
+    fun `backend error message is preserved`() {
+        val result = parseCheckoutSessionError(
+            json = Json,
+            errorData = """{"error":"Invalid customer"}""".encodeToByteArray(),
+        )
+
+        assertThat(result).isEqualTo("Invalid customer")
+    }
+
+    @Test
+    fun `malformed backend error has no message`() {
+        val result = parseCheckoutSessionError(
+            json = Json,
+            errorData = "Not JSON".encodeToByteArray(),
+        )
+
+        assertThat(result).isNull()
+    }
+}

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.paymentsheet.example.playground.checkout
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions.session
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettings
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -9,74 +12,87 @@ import org.junit.Test
 
 class CheckoutControllerExampleRequestFactoryTest {
     @Test
-    fun `no tax scenario creates expected request`() {
+    fun `defaults create a Checkout Session request`() = runScenario {
         val request = CheckoutControllerExampleRequestFactory.create(
-            CheckoutControllerExampleScenario.NoTax
+            settings = settings.snapshot(),
+            returningCustomerId = null,
         )
 
         assertThat(request.endpoint).isEqualTo("checkout_session")
         assertThat(request.body).isEqualTo(
             buildJsonObject {
-                put("mode", "payment")
                 put("customer", "guest")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
-                put("payment_method_types", commonPaymentMethodTypes)
+                put("automatic_payment_methods", true)
                 put("automatic_tax", false)
                 put("shipping_address_collection", false)
+                put("billing_address_collection", false)
             }
         )
     }
 
     @Test
-    fun `shipping tax scenario creates expected request`() {
+    fun `session settings are included in request`() = runScenario {
+        settings.update(session.customer, "new")
+        settings.update(session.customerEmail, "another@example.com")
+        settings.update(session.currency, Currency.EUR)
+        settings.update(session.automaticTax, true)
+        settings.update(session.shippingAddressCollection, true)
+        settings.update(session.billingAddressCollection, true)
+
         val request = CheckoutControllerExampleRequestFactory.create(
-            CheckoutControllerExampleScenario.ShippingTax
+            settings = settings.snapshot(),
+            returningCustomerId = null,
         )
 
-        assertThat(request.endpoint).isEqualTo("checkout_session")
         assertThat(request.body).isEqualTo(
             buildJsonObject {
-                put("mode", "payment")
-                put("customer", "guest")
-                put("customer_email", "email@example.com")
-                put("currency", "usd")
-                put("payment_method_types", commonPaymentMethodTypes)
+                put("customer", "new")
+                put("customer_email", "another@example.com")
+                put("currency", "eur")
+                put("automatic_payment_methods", true)
                 put("automatic_tax", true)
                 put("shipping_address_collection", true)
+                put("billing_address_collection", true)
             }
         )
     }
 
     @Test
-    fun `billing tax scenario creates expected request`() {
+    fun `returning customer uses saved customer ID`() = runScenario {
+        settings.update(session.customer, "returning")
+
         val request = CheckoutControllerExampleRequestFactory.create(
-            CheckoutControllerExampleScenario.BillingTax
+            settings = settings.snapshot(),
+            returningCustomerId = "cus_123",
         )
 
-        assertThat(request.endpoint).isEqualTo("checkout_session")
-        assertThat(request.body).isEqualTo(
-            buildJsonObject {
-                put("mode", "payment")
-                put("customer", "guest")
-                put("customer_email", "email@example.com")
-                put("currency", "usd")
-                put("payment_method_types", commonPaymentMethodTypes)
-                put("automatic_tax", true)
-                put("shipping_address_collection", false)
-            }
-        )
+        assertThat(request.body["customer"]).isEqualTo(JsonPrimitive("cus_123"))
     }
 
-    private companion object {
-        val commonPaymentMethodTypes = JsonArray(
-            listOf(
-                JsonPrimitive("card"),
-                JsonPrimitive("us_bank_account"),
-                JsonPrimitive("link"),
-                JsonPrimitive("cashapp"),
-                JsonPrimitive("klarna"),
-            )
+    @Test
+    fun `manual payment methods are included in request`() = runScenario {
+        settings.update(session.automaticPaymentMethods, false)
+        settings.update(session.paymentMethodTypes, listOf("card", "klarna"))
+
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings = settings.snapshot(),
+            returningCustomerId = null,
         )
+
+        assertThat(request.body).containsEntry(
+            "payment_method_types",
+            JsonArray(listOf(JsonPrimitive("card"), JsonPrimitive("klarna"))),
+        )
+        assertThat(request.body).doesNotContainKey("automatic_payment_methods")
     }
+
+    private fun runScenario(block: Scenario.() -> Unit) {
+        block(Scenario(CheckoutPlaygroundSettings.createInMemory()))
+    }
+
+    private data class Scenario(
+        val settings: CheckoutPlaygroundSettings,
+    )
 }

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundConfigurationFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundConfigurationFactoryTest.kt
@@ -1,0 +1,39 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import androidx.compose.ui.graphics.Color
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CheckoutPlaygroundConfigurationFactoryTest {
+    @Test
+    fun `default tree builds CheckoutController configuration`() = runScenario {
+        val configuration = settings.snapshot().checkoutControllerConfiguration()
+
+        assertThat(configuration).isNotNull()
+    }
+
+    @Test
+    fun `nested overrides build CheckoutController configuration`() = runScenario {
+        settings.update(CheckoutPlaygroundDefinitions.Controller.defaults.billing.enabled, true)
+        settings.update(CheckoutPlaygroundDefinitions.Controller.defaults.billing.address.enabled, true)
+        settings.update(
+            CheckoutPlaygroundDefinitions.Controller.payment.appearance.lightColors.primary,
+            Color(0xFF112233),
+        )
+        settings.update(CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.cornerRadius, 8f)
+
+        val configuration = settings.snapshot().checkoutControllerConfiguration()
+
+        assertThat(configuration).isNotNull()
+    }
+
+    private fun runScenario(block: Scenario.() -> Unit) {
+        block(Scenario(CheckoutPlaygroundSettings.createInMemory()))
+    }
+
+    private data class Scenario(
+        val settings: CheckoutPlaygroundSettings,
+    )
+}

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
@@ -1,0 +1,130 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import androidx.compose.ui.graphics.Color
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CheckoutPlaygroundSettingsTest {
+    @Test
+    fun `backend URL defaults to configured playground backend`() {
+        val settings = CheckoutPlaygroundSettings.createInMemory(
+            json = null,
+            defaultBackendUrl = "https://default.example/",
+        )
+
+        assertThat(settings.value(CheckoutPlaygroundDefinitions.session.backendUrl))
+            .isEqualTo("https://default.example/")
+    }
+
+    @Test
+    fun `reset restores configured playground backend URL`() {
+        val definition = CheckoutPlaygroundDefinitions.session.backendUrl
+        val settings = CheckoutPlaygroundSettings.createInMemory(
+            json = null,
+            defaultBackendUrl = "https://default.example/",
+        )
+        settings.update(definition, "https://custom.example/")
+
+        settings.reset()
+
+        assertThat(settings.value(definition)).isEqualTo("https://default.example/")
+    }
+
+    @Test
+    fun `nested setting survives JSON round trip`() = runScenario {
+        settings.update(CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.scale, 1.25f)
+
+        val restored = CheckoutPlaygroundSettings.createInMemory(settings.asJsonString())
+
+        assertThat(restored.value(CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.scale))
+            .isEqualTo(1.25f)
+    }
+
+    @Test
+    fun `unknown and invalid persisted values fall back to defaults`() = runScenario(
+        json = """{"unknown":"value","currency.appearance.scale":"not-a-number"}"""
+    ) {
+        assertThat(settings.value(CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.scale))
+            .isEqualTo(1f)
+    }
+
+    @Test
+    fun `reset restores nested defaults`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.Controller.payment.embeddedMandate
+        settings.update(definition, false)
+
+        settings.reset()
+
+        assertThat(settings.value(definition)).isTrue()
+    }
+
+    @Test
+    fun `terms display defaults to automatic`() = runScenario {
+        val definitions = CheckoutPlaygroundDefinitions.Controller.payment.terms.values.values
+
+        assertThat(definitions.map(settings::value).distinct())
+            .containsExactly(CheckoutTermsDisplay.Automatic)
+    }
+
+    @Test
+    fun `payment colors default to effective SDK colors`() = runScenario {
+        val lightColors = CheckoutPlaygroundDefinitions.Controller.payment.appearance.lightColors
+        val darkColors = CheckoutPlaygroundDefinitions.Controller.payment.appearance.darkColors
+
+        assertThat(lightColors.configuration.values().map(settings::serializedValue))
+            .doesNotContain("")
+        assertThat(darkColors.configuration.values().map(settings::serializedValue))
+            .doesNotContain("")
+    }
+
+    @Test
+    fun `invalid color prevents snapshot`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.background
+        settings.updateSerialized(definition, "blue")
+
+        assertThat(settings.validationErrors())
+            .containsKey(definition)
+    }
+
+    @Test
+    fun `typed color survives JSON round trip`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.background
+        settings.update(definition, Color(0xFF112233))
+
+        val restored = CheckoutPlaygroundSettings.createInMemory(settings.asJsonString())
+
+        assertThat(restored.value(definition)).isEqualTo(Color(0xFF112233))
+    }
+
+    @Test
+    fun `new customer is saved as returning customer`() = runScenario {
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
+
+        settings.saveReturningCustomer("cus_123")
+
+        assertThat(settings.returningCustomerId).isEqualTo("cus_123")
+        assertThat(settings.value(CheckoutPlaygroundDefinitions.session.customer)).isEqualTo("returning")
+    }
+
+    @Test
+    fun `reset clears returning customer`() = runScenario {
+        settings.saveReturningCustomer("cus_123")
+        assertThat(settings.returningCustomerId).isEqualTo("cus_123")
+
+        settings.reset()
+
+        assertThat(settings.returningCustomerId).isNull()
+        assertThat(settings.value(CheckoutPlaygroundDefinitions.session.customer)).isEqualTo("guest")
+    }
+
+    private fun runScenario(
+        json: String? = null,
+        block: Scenario.() -> Unit,
+    ) {
+        block(Scenario(CheckoutPlaygroundSettings.createInMemory(json)))
+    }
+
+    private data class Scenario(
+        val settings: CheckoutPlaygroundSettings,
+    )
+}

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
@@ -1,0 +1,141 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CheckoutPlaygroundSettingsUiTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+
+    @Test
+    fun `opening nested configuration shows only its direct children`() = runScenario {
+        page.group(CheckoutPlaygroundDefinitions.Controller.configuration).assertIsDisplayed().performClick()
+
+        page.group(CheckoutPlaygroundDefinitions.Controller.currencySelector.configuration).assertIsDisplayed()
+        page.value(CheckoutPlaygroundDefinitions.Controller.currencySelector.shouldSetConfiguration)
+            .assertDoesNotExist()
+        page.group(CheckoutPlaygroundDefinitions.session.configuration).assertDoesNotExist()
+        page.group(CheckoutPlaygroundDefinitions.Controller.payment.appearance.configuration).assertDoesNotExist()
+
+        page.group(CheckoutPlaygroundDefinitions.Controller.currencySelector.configuration).performClick()
+
+        page.value(CheckoutPlaygroundDefinitions.Controller.currencySelector.shouldSetConfiguration)
+            .assertIsDisplayed()
+        page.group(CheckoutPlaygroundDefinitions.Controller.payment.configuration).assertDoesNotExist()
+
+        openConfiguration(CheckoutPlaygroundDefinitions.Controller.configuration)
+        page.group(CheckoutPlaygroundDefinitions.Controller.payment.configuration).performClick()
+
+        page.value(CheckoutPlaygroundDefinitions.Controller.payment.shouldSetConfiguration)
+            .assertIsDisplayed()
+        page.group(CheckoutPlaygroundDefinitions.Controller.payment.appearance.configuration)
+            .performScrollTo()
+            .assertIsDisplayed()
+        page.value(CheckoutPlaygroundDefinitions.Controller.currencySelector.shouldSetConfiguration)
+            .assertDoesNotExist()
+
+        openConfiguration(CheckoutPlaygroundDefinitions.Controller.express.configuration)
+
+        page.value(CheckoutPlaygroundDefinitions.Controller.express.shouldSetConfiguration)
+            .performScrollTo()
+            .assertIsDisplayed()
+        page.value(CheckoutPlaygroundDefinitions.Controller.payment.shouldSetConfiguration)
+            .assertDoesNotExist()
+    }
+
+    @Test
+    fun `color setting uses color picker`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.Controller.payment.appearance.lightColors.configuration,
+    ) {
+        val definition = CheckoutPlaygroundDefinitions.Controller.payment.appearance.lightColors.primary
+        page.value(definition).performClick()
+
+        composeRule.onNodeWithText("Pick color").assertIsDisplayed().performClick()
+
+        assertThat(settings.serializedValue(definition)).isEqualTo("#FF000000")
+    }
+
+    @Test
+    fun `customer setting toggles between guest and new`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
+    ) {
+        val definition = CheckoutPlaygroundDefinitions.session.customer
+        composeRule.onNodeWithText("Guest").assertIsDisplayed()
+        composeRule.onNodeWithText("New").assertIsDisplayed().performClick()
+
+        assertThat(settings.value(definition)).isEqualTo("new")
+    }
+
+    @Test
+    fun `payment method types are only displayed for manual payment methods`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
+    ) {
+        page.value(CheckoutPlaygroundDefinitions.session.paymentMethodTypes).assertDoesNotExist()
+
+        settings.update(CheckoutPlaygroundDefinitions.session.automaticPaymentMethods, false)
+        composeRule.waitForIdle()
+
+        page.value(CheckoutPlaygroundDefinitions.session.paymentMethodTypes).assertIsDisplayed()
+    }
+
+    private fun runScenario(
+        initialConfiguration: CheckoutPlaygroundSettingDefinition.Configuration = CheckoutPlaygroundDefinitions.root,
+        block: Scenario.() -> Unit,
+    ) {
+        val settings = CheckoutPlaygroundSettings.createInMemory()
+        var current by mutableStateOf(initialConfiguration)
+        composeRule.setContent {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                CheckoutPlaygroundSettingsUi(
+                    configuration = current,
+                    settings = settings,
+                    onOpenConfiguration = { current = it },
+                )
+            }
+        }
+        block(Scenario(Page(composeRule), settings, openConfiguration = { current = it }))
+    }
+
+    private data class Scenario(
+        val page: Page,
+        val settings: CheckoutPlaygroundSettings,
+        val openConfiguration: (CheckoutPlaygroundSettingDefinition.Configuration) -> Unit,
+    )
+
+    private class Page(private val rule: ComposeContentTestRule) {
+        fun group(definition: CheckoutPlaygroundSettingDefinition.Configuration) =
+            rule.onNodeWithTag(checkoutSettingGroupTestTag(definition))
+
+        fun value(definition: CheckoutPlaygroundSettingDefinition.Value<*>) =
+            rule.onNodeWithTag(checkoutSettingValueTestTag(definition))
+    }
+}


### PR DESCRIPTION
# Summary

Rebuilds the internal CheckoutController example as a checkout-only settings playground.

- Introduces a standalone recursive setting-definition, persistence, validation, and UI framework without reusing the existing PaymentSheet playground settings classes.
- Maps nested settings directly into `CheckoutController.Configuration`, Payment Element, Currency Selector Element, and Express Checkout Element configuration trees.
- Replaces the fixed tax-scenario chooser with editable Checkout Session request fields and an explicit create-session action.
- Adds native nested-screen navigation, persisted values, reset support, applicable checkout elements, and safe promotion-code, email, payment-selection, and confirmation controls.
- Omits Shipping Address Element configuration and presentation while that element remains unimplemented.

# Motivation

The previous example only supported three fixed Checkout Session scenarios and the shared playground setting system flattened nested SDK configurations through special-purpose helpers. CheckoutController needs a focused playground that mirrors its configuration hierarchy, supports arbitrary nesting naturally, and excludes PaymentSheet integrations and settings that do not apply to Checkout Sessions.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet-example:testBaseDebugUnitTest --no-daemon`
- `./gradlew :paymentsheet-example:assembleBaseDebug --no-daemon`
- `./gradlew :paymentsheet-example:detekt --no-daemon`
- `./gradlew detekt --no-daemon`

No tests were ignored.

# Screenshots

Not included. The nested setting navigation is covered by a Robolectric Compose test, but this change was not manually verified on a device.

# Changelog

Not applicable. This changes only the internal `paymentsheet-example` application and does not affect the public SDK.

Committed and created by Codex.
