### PR TITLE
Eagerly launch Link from PaymentElement present

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -43,6 +43,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private val sessionRefresher: CheckoutSessionRefresher,
     private val operationCoordinator: CheckoutOperationCoordinator,
     private val logger: Logger,
+    private val checkoutSheetLinkHelper: CheckoutSheetLinkHelper,
     @ViewModelScope private val coroutineScope: CoroutineScope,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
@@ -51,10 +52,16 @@ internal class CheckoutSheetLauncher @Inject constructor(
 ) : EmbeddedSheetLauncher {
 
     init {
+        checkoutSheetLinkHelper.register(
+            activityResultCaller = activityResultCaller,
+            launchPaymentOptions = ::launchPaymentOptionsSheet,
+        )
+
         lifecycleOwner.lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     activityLauncher.unregister()
+                    checkoutSheetLinkHelper.unregister()
                     super.onDestroy(owner)
                 }
             }
@@ -226,6 +233,25 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
+
+        if (checkoutSheetLinkHelper.launchLinkIfEligible(paymentMethodMetadata, selection)) {
+            return
+        }
+
+        launchPaymentOptionsSheet(
+            paymentMethodMetadata = paymentMethodMetadata,
+            customerState = customerState,
+            selection = selection,
+            configuration = configuration,
+        )
+    }
+
+    private fun launchPaymentOptionsSheet(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customerState: CustomerState?,
+        selection: PaymentSelection?,
+        configuration: EmbeddedPaymentElement.Configuration,
+    ) {
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -2,8 +2,16 @@ package com.stripe.android.checkout.injection
 
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutSheetLauncher
+import com.stripe.android.checkout.CheckoutSheetLinkHelper
+import com.stripe.android.checkout.DefaultCheckoutSheetLinkHelper
+import com.stripe.android.checkout.PAYMENT_ELEMENT_LINK_LAUNCHER
 import com.stripe.android.elements.PaymentElement
+import com.stripe.android.link.LinkActivityContract
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.account.LinkStore
+import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper
@@ -21,6 +29,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Named
 
 @Module
 internal interface PaymentElementModule {
@@ -46,8 +55,27 @@ internal interface PaymentElementModule {
     @Binds
     fun bindsSheetLauncher(launcher: CheckoutSheetLauncher): EmbeddedSheetLauncher
 
+    @Binds
+    fun bindsCheckoutSheetLinkHelper(helper: DefaultCheckoutSheetLinkHelper): CheckoutSheetLinkHelper
+
     @OptIn(CheckoutSessionPreview::class)
     companion object {
+        @Provides
+        @Named(PAYMENT_ELEMENT_LINK_LAUNCHER)
+        fun providePaymentElementLinkLauncher(
+            linkAnalyticsComponentFactory: LinkAnalyticsComponent.Factory,
+            linkActivityContract: LinkActivityContract,
+            @PaymentElementCallbackIdentifier identifier: String,
+            linkStore: LinkStore,
+        ): LinkPaymentLauncher {
+            return LinkPaymentLauncher(
+                linkAnalyticsComponentFactory = linkAnalyticsComponentFactory,
+                paymentElementCallbackIdentifier = identifier,
+                linkActivityContract = linkActivityContract,
+                linkStore = linkStore,
+            )
+        }
+
         @Provides
         fun providePaymentElementConfiguration(
             stateHolder: CheckoutControllerStateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -508,10 +508,48 @@ internal class CheckoutSheetLauncherTest {
             selection = selection,
             configuration = EmbeddedConfigurationFactory.create(),
         )
+        checkoutSheetLinkHelper.launchLinkIfEligibleCalls.awaitItem()
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall()
 
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `launchPaymentOptions does not launch sheet when Link helper launches`() = testScenario {
+        checkoutSheetLinkHelper.launchLinkIfEligibleResult = true
+
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            customerState = null,
+            selection = null,
+            configuration = EmbeddedConfigurationFactory.create(),
+        )
+
+        val call = checkoutSheetLinkHelper.launchLinkIfEligibleCalls.awaitItem()
+        assertThat(call.selection).isNull()
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `Link helper callback launches payment options with supplied state`() = testScenario {
+        val metadata = PaymentMethodMetadataFactory.create()
+        val customerState = createCustomerState()
+        val selection = PaymentSelection.GooglePay
+        val configuration = EmbeddedConfigurationFactory.create()
+
+        linkLaunchPaymentOptions.launch(
+            paymentMethodMetadata = metadata,
+            customerState = customerState,
+            selection = selection,
+            configuration = configuration,
+        )
+
+        val args = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(args.paymentMethodMetadata).isEqualTo(metadata)
+        assertThat(args.customerState).isEqualTo(customerState)
+        assertThat(args.selection).isEqualTo(selection)
+        assertThat(args.configuration).isEqualTo(configuration)
     }
 
     @Test
@@ -525,6 +563,7 @@ internal class CheckoutSheetLauncherTest {
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             configuration = EmbeddedConfigurationFactory.create(),
         )
+        checkoutSheetLinkHelper.launchLinkIfEligibleCalls.awaitItem()
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
 
         assertThat(launchCall.previousNewSelections.previousNewSelection("card"))
@@ -706,6 +745,7 @@ internal class CheckoutSheetLauncherTest {
         sheetStateHolder.sheetIsOpen = true
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
         val unregisteredLauncher = dummyActivityResultCallerScenario.awaitNextUnregisteredLauncher()
+        checkoutSheetLinkHelper.unregisterCalls.awaitItem()
 
         assertThat(unregisteredLauncher).isEqualTo(launcher)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
@@ -713,7 +753,7 @@ internal class CheckoutSheetLauncherTest {
 
     @Suppress("LongMethod")
     private fun testScenario(
-        block: suspend Scenario.() -> Unit
+        block: suspend Scenario.() -> Unit,
     ) = runTest {
         var immediateActionInvoked = false
         val testScope = this
@@ -721,6 +761,7 @@ internal class CheckoutSheetLauncherTest {
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val errorReporter = FakeErrorReporter()
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
             selection = selectionHolder.selection,
@@ -728,9 +769,9 @@ internal class CheckoutSheetLauncherTest {
             paymentMethodMetadataFlow = stateFlowOf(null),
         )
         val sheetStateHolder = SheetStateHolder(savedStateHandle)
-        val errorReporter = FakeErrorReporter()
         val sessionRefresher = FakeCheckoutSessionRefresher()
         val logger = FakeLogger()
+        val checkoutSheetLinkHelper = FakeCheckoutSheetLinkHelper()
         val confirmationHandler = FakeConfirmationHandler()
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
@@ -739,7 +780,6 @@ internal class CheckoutSheetLauncherTest {
             logger = logger,
             resultCallback = CheckoutController.ResultCallback {},
         )
-
         DummyActivityResultCaller.test {
             val sheetLauncher = CheckoutSheetLauncher(
                 activityResultCaller = activityResultCaller,
@@ -751,6 +791,7 @@ internal class CheckoutSheetLauncherTest {
                 sessionRefresher = sessionRefresher,
                 operationCoordinator = operationCoordinator,
                 logger = logger,
+                checkoutSheetLinkHelper = checkoutSheetLinkHelper,
                 coroutineScope = testScope,
                 productUsage = setOf("Checkout"),
                 statusBarColor = null,
@@ -759,6 +800,7 @@ internal class CheckoutSheetLauncherTest {
             )
             val registerCall = awaitRegisterCall()
             val launcher = awaitNextRegisteredLauncher()
+            val linkRegisterCall = checkoutSheetLinkHelper.registerCalls.awaitItem()
 
             assertThat(registerCall).isNotNull()
             assertThat(registerCall.contract).isInstanceOf<EmbeddedSheetContract>()
@@ -777,12 +819,15 @@ internal class CheckoutSheetLauncherTest {
                 sessionRefresher = sessionRefresher,
                 logger = logger,
                 operationCoordinator = operationCoordinator,
+                checkoutSheetLinkHelper = checkoutSheetLinkHelper,
+                linkLaunchPaymentOptions = linkRegisterCall.launchPaymentOptions,
                 runCurrent = testScheduler::runCurrent,
             ).block()
         }
 
         confirmationHandler.validate()
         sessionRefresher.ensureAllEventsConsumed()
+        checkoutSheetLinkHelper.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -799,6 +844,8 @@ internal class CheckoutSheetLauncherTest {
         val sessionRefresher: FakeCheckoutSessionRefresher,
         val logger: FakeLogger,
         val operationCoordinator: CheckoutOperationCoordinator,
+        val checkoutSheetLinkHelper: FakeCheckoutSheetLinkHelper,
+        val linkLaunchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
         private val runCurrent: () -> Unit,
     ) {
         fun runCurrent() {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSheetLinkHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSheetLinkHelper.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultCaller
+import app.cash.turbine.Turbine
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal class FakeCheckoutSheetLinkHelper(
+    var launchLinkIfEligibleResult: Boolean = false,
+) : CheckoutSheetLinkHelper {
+    val registerCalls = Turbine<RegisterCall>()
+    val unregisterCalls = Turbine<Unit>()
+    val launchLinkIfEligibleCalls = Turbine<LaunchLinkIfEligibleCall>()
+
+    override fun register(
+        activityResultCaller: ActivityResultCaller,
+        launchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
+    ) {
+        registerCalls.add(RegisterCall(activityResultCaller, launchPaymentOptions))
+    }
+
+    override fun unregister() {
+        unregisterCalls.add(Unit)
+    }
+
+    override fun launchLinkIfEligible(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        selection: PaymentSelection?,
+    ): Boolean {
+        launchLinkIfEligibleCalls.add(LaunchLinkIfEligibleCall(paymentMethodMetadata, selection))
+        return launchLinkIfEligibleResult
+    }
+
+    fun ensureAllEventsConsumed() {
+        registerCalls.ensureAllEventsConsumed()
+        unregisterCalls.ensureAllEventsConsumed()
+        launchLinkIfEligibleCalls.ensureAllEventsConsumed()
+    }
+
+    data class RegisterCall(
+        val activityResultCaller: ActivityResultCaller,
+        val launchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
+    )
+
+    data class LaunchLinkIfEligibleCall(
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val selection: PaymentSelection?,
+    )
+}


### PR DESCRIPTION
# Summary

Wires the Checkout Link coordinator into `PaymentElement.present()` so eligible returning Link customers go directly to Link's payment-method picker. This is layer 3 of 3 and contains only Dagger and launcher integration.

# Motivation

`PaymentElement.present()` currently always opens the embedded payment-options sheet, unlike `DefaultFlowController` and the equivalent iOS Payment Element path. Returning Link customers should go directly to Link while retaining the coordinator's verification, logout, “Pay another way,” and tax-update fallbacks.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable. This changes presentation routing and state handling without changing rendered UI.

# Changelog

Not applicable. `PaymentElement` is currently restricted to the Checkout Session preview API.

Committed and created by Codex.
