### PR TITLE
Extract reusable Link payment method selection coordination

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethodSelectionCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethodSelectionCoordinator.kt
@@ -1,0 +1,151 @@
+package com.stripe.android.link
+
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.account.updateLinkAccount
+import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.toLoginState
+import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.isLink
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.LinkDisabledState
+import com.stripe.android.paymentsheet.state.LinkState
+import javax.inject.Inject
+
+internal class LinkPaymentMethodSelectionCoordinator @Inject constructor(
+    private val linkAccountHolder: LinkAccountHolder,
+    private val linkGateFactory: LinkGate.Factory,
+) {
+    fun launchIfEligible(
+        launcher: LinkPaymentLauncher,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        selection: PaymentSelection?,
+        hasDeclinedLink2FA: Boolean,
+        statusBarColor: Int?,
+    ): Boolean {
+        val linkConfiguration = paymentMethodMetadata.linkState?.configuration ?: return false
+        val linkSelection = selection as? PaymentSelection.Link ?: return false
+        val linkAccountInfo = linkAccountHolder.linkAccountInfo.value
+        val shouldLaunch = !hasDeclinedLink2FA &&
+            linkAccountInfo.account != null &&
+            linkGateFactory.create(linkConfiguration).showRuxInFlowController
+
+        if (!shouldLaunch) return false
+
+        launcher.present(
+            configuration = linkConfiguration,
+            paymentMethodMetadata = paymentMethodMetadata,
+            linkAccountInfo = linkAccountInfo,
+            launchMode = LinkLaunchMode.PaymentMethodSelection(linkSelection.selectedPayment?.details),
+            linkExpressMode = LinkExpressMode.ENABLED,
+            statusBarColor = statusBarColor,
+        )
+        return true
+    }
+
+    fun handleResult(
+        result: LinkActivityResult,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customer: CustomerState?,
+        selection: PaymentSelection?,
+    ): Outcome {
+        val updatedPaymentMethodMetadata = result.linkAccountUpdate?.let { update ->
+            update.updateLinkAccount(linkAccountHolder)
+            update.updatedPaymentMethodMetadata(paymentMethodMetadata)
+        }
+        val action = when (result) {
+            is LinkActivityResult.PaymentMethodObtained,
+            is LinkActivityResult.Failed -> Action.Dismiss
+            is LinkActivityResult.Canceled -> when (result.reason) {
+                LinkActivityResult.Canceled.Reason.BackPressed -> {
+                    if (selection?.readyToPayWithLink() == false) {
+                        Action.ShowPaymentOptions
+                    } else {
+                        Action.Dismiss
+                    }
+                }
+                LinkActivityResult.Canceled.Reason.LoggedOut -> selectionUpdate(
+                    selection = selection,
+                    linkPaymentMethod = null,
+                    customer = customer,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    reason = SelectionUpdateReason.LoggedOut,
+                )
+                LinkActivityResult.Canceled.Reason.PayAnotherWay -> Action.ShowPaymentOptions
+            }
+            is LinkActivityResult.Completed -> selectionUpdate(
+                selection = selection,
+                linkPaymentMethod = result.selectedPayment,
+                customer = customer,
+                paymentMethodMetadata = paymentMethodMetadata,
+                reason = SelectionUpdateReason.Completed,
+            )
+        }
+        return Outcome(
+            action = action,
+            updatedPaymentMethodMetadata = updatedPaymentMethodMetadata,
+            suppressFutureLinkLaunch = result is LinkActivityResult.Canceled &&
+                result.reason == LinkActivityResult.Canceled.Reason.BackPressed &&
+                linkAccountHolder.linkAccountInfo.value.account?.accountStatus == AccountStatus.VerificationStarted,
+        )
+    }
+
+    private fun selectionUpdate(
+        selection: PaymentSelection?,
+        linkPaymentMethod: LinkPaymentMethod?,
+        customer: CustomerState?,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        reason: SelectionUpdateReason,
+    ): Action {
+        val linkSelection = selection as? PaymentSelection.Link ?: return Action.Dismiss
+        val updatedSelection = if (linkPaymentMethod != null) {
+            linkSelection.copy(selectedPayment = linkPaymentMethod)
+        } else {
+            determineFallbackPaymentSelectionAfterLinkLogout(
+                customer = customer,
+                paymentMethodMetadata = paymentMethodMetadata,
+            )
+        }
+        return Action.UpdateSelection(updatedSelection, reason)
+    }
+
+    private fun PaymentSelection.readyToPayWithLink(): Boolean = when (this) {
+        is PaymentSelection.Link -> selectedPayment != null
+        else -> isLink
+    }
+
+    private fun LinkAccountUpdate.updatedPaymentMethodMetadata(
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): PaymentMethodMetadata? {
+        if (this !is LinkAccountUpdate.Value) return null
+
+        val accountStatus = account?.accountStatus ?: AccountStatus.SignedOut
+        val updatedLinkState = when (val linkState = paymentMethodMetadata.linkStateResult) {
+            is LinkState -> linkState.copy(loginState = accountStatus.toLoginState())
+            is LinkDisabledState, null -> linkState
+        }
+        return paymentMethodMetadata.copy(linkStateResult = updatedLinkState)
+    }
+
+    data class Outcome(
+        val action: Action,
+        val updatedPaymentMethodMetadata: PaymentMethodMetadata?,
+        val suppressFutureLinkLaunch: Boolean,
+    )
+
+    sealed interface Action {
+        data object Dismiss : Action
+        data object ShowPaymentOptions : Action
+        data class UpdateSelection(
+            val selection: PaymentSelection?,
+            val reason: SelectionUpdateReason,
+        ) : Action
+    }
+
+    enum class SelectionUpdateReason {
+        Completed,
+        LoggedOut,
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.link.utils
 
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 
 /**
@@ -10,6 +12,16 @@ import com.stripe.android.paymentsheet.state.PaymentSheetState
  * @return The best fallback payment selection, or null if no suitable fallback exists
  */
 internal fun PaymentSheetState.Full.determineFallbackPaymentSelectionAfterLinkLogout(): PaymentSelection? {
+    return determineFallbackPaymentSelectionAfterLinkLogout(
+        customer = customer,
+        paymentMethodMetadata = paymentMethodMetadata,
+    )
+}
+
+internal fun determineFallbackPaymentSelectionAfterLinkLogout(
+    customer: CustomerState?,
+    paymentMethodMetadata: PaymentMethodMetadata,
+): PaymentSelection? {
     if (customer == null) return null
 
     // Check if default payment method feature is enabled

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -18,6 +19,7 @@ internal interface SheetActivityContinueCoordinator {
 
 internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
     private val taxRegionUpdater: SheetTaxRegionUpdater,
+    private val paymentMethodMetadata: PaymentMethodMetadata,
     private val stateHolder: SheetActivityStateHolder,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
@@ -27,7 +29,7 @@ internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
 
     override fun onContinue() {
         val selection = selectionHolder.selection.value
-        val taxRegionUpdate = taxRegionUpdater.prepareUpdate(selection)
+        val taxRegionUpdate = taxRegionUpdater.prepareUpdate(paymentMethodMetadata, selection)
         if (taxRegionUpdate == null) {
             stateHolder.setResult(createResult(selection, checkoutSessionResponse = null))
             return

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdater.kt
@@ -14,10 +14,12 @@ internal typealias SheetTaxRegionUpdate = suspend () -> Result<CheckoutSessionRe
 
 @OptIn(CheckoutSessionPreview::class)
 internal class SheetTaxRegionUpdater @Inject constructor(
-    private val paymentMethodMetadata: PaymentMethodMetadata,
     private val taxRegionUpdater: CheckoutSessionTaxRegionUpdater,
 ) {
-    fun prepareUpdate(selection: PaymentSelection?): SheetTaxRegionUpdate? {
+    fun prepareUpdate(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        selection: PaymentSelection?,
+    ): SheetTaxRegionUpdate? {
         val checkoutSessionResponse =
             (paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession)
                 ?.checkoutSessionResponse

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -21,15 +21,14 @@ import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
-import com.stripe.android.link.LinkConfiguration
-import com.stripe.android.link.LinkExpressMode
-import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.LinkPaymentMethodSelectionCoordinator
+import com.stripe.android.link.LinkPaymentMethodSelectionCoordinator.Action
+import com.stripe.android.link.LinkPaymentMethodSelectionCoordinator.SelectionUpdateReason
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.effectiveLinkBrand
-import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.toLoginState
 import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
@@ -102,9 +101,9 @@ internal class DefaultFlowController @Inject internal constructor(
     private val eventReporter: EventReporter,
     private val viewModel: FlowControllerViewModel,
     private val confirmationHandler: FlowControllerConfirmationHandler,
-    private val linkGateFactory: LinkGate.Factory,
     private val linkHandler: LinkHandler,
     private val linkAccountHolder: LinkAccountHolder,
+    private val linkPaymentMethodSelectionCoordinator: LinkPaymentMethodSelectionCoordinator,
     @Named(FLOW_CONTROLLER_LINK_LAUNCHER) private val flowControllerLinkLauncher: LinkPaymentLauncher,
     @Named(WALLETS_BUTTON_LINK_LAUNCHER) private val walletsButtonLinkLauncher: LinkPaymentLauncher,
     @Named(ENABLE_LOGGING) private val enableLogging: Boolean,
@@ -296,47 +295,19 @@ internal class DefaultFlowController @Inject internal constructor(
 
     override fun presentPaymentOptions() {
         withCurrentState { state ->
-            val linkConfiguration = state.paymentSheetState.linkConfiguration
             val paymentSelection = viewModel.paymentSelection
-            val linkAccountInfo = linkAccountHolder.linkAccountInfo.value
-
-            val shouldPresentLink = linkConfiguration != null && shouldPresentLinkInsteadOfPaymentOptions(
-                paymentSelection = paymentSelection,
-                linkAccountInfo = linkAccountInfo,
-                linkConfiguration = linkConfiguration
+            val didLaunchLink = linkPaymentMethodSelectionCoordinator.launchIfEligible(
+                launcher = flowControllerLinkLauncher,
+                paymentMethodMetadata = state.paymentSheetState.paymentMethodMetadata,
+                selection = paymentSelection,
+                hasDeclinedLink2FA = state.declinedLink2FA,
+                statusBarColor = viewModel.statusBarColor,
             )
 
-            if (shouldPresentLink) {
-                val paymentMethodMetadata = state.paymentSheetState.paymentMethodMetadata
-                flowControllerLinkLauncher.present(
-                    configuration = linkConfiguration,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    linkAccountInfo = linkAccountInfo,
-                    linkExpressMode = LinkExpressMode.ENABLED,
-                    launchMode = LinkLaunchMode.PaymentMethodSelection(
-                        selectedPayment = (paymentSelection as? Link)?.selectedPayment?.details
-                    ),
-                    statusBarColor = viewModel.statusBarColor,
-                )
-            } else {
+            if (!didLaunchLink) {
                 showPaymentOptionList(state, paymentSelection)
             }
         }
-    }
-
-    private fun shouldPresentLinkInsteadOfPaymentOptions(
-        paymentSelection: PaymentSelection?,
-        linkAccountInfo: LinkAccountUpdate.Value,
-        linkConfiguration: LinkConfiguration
-    ): Boolean {
-        // If the user has declined to use Link in the past, do not show it again.
-        return viewModel.state?.declinedLink2FA != true &&
-            // The current payment selection is Link
-            paymentSelection is Link &&
-            // The current user has a Link account (not necessarily logged in)
-            linkAccountInfo.account != null &&
-            // feature flag and other conditions are met
-            linkGateFactory.create(linkConfiguration).showRuxInFlowController
     }
 
     private fun showPaymentOptionList(
@@ -369,35 +340,38 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     fun onLinkResultFromFlowController(result: LinkActivityResult) {
-        result.linkAccountUpdate?.updateLinkAccount()
-        when (result) {
-            is LinkActivityResult.PaymentMethodObtained,
-            is LinkActivityResult.Failed -> Unit
-            is LinkActivityResult.Canceled -> when (result.reason) {
-                Reason.BackPressed -> withCurrentState {
-                    val accountStatus = linkAccountHolder.linkAccountInfo.value.account?.accountStatus
-                    // The user dismissed the Link 2FA -> prevent from showing it again
-                    if (accountStatus == AccountStatus.VerificationStarted) {
-                        viewModel.updateState { it?.copy(declinedLink2FA = true) }
-                    }
-                    // just show the payment option list if
-                    // the user didn't have any preselected Link payment details
-                    // (preselected Link payment means the user is attempting to change their Link payment method)
-                    if (viewModel.paymentSelection?.readyToPayWithLink() == false) {
-                        showPaymentOptionList(it, viewModel.paymentSelection)
-                    }
-                }
-                Reason.LoggedOut -> {
-                    updateLinkPaymentSelection(linkPaymentMethod = null, canceled = true)
-                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
-                }
-                Reason.PayAnotherWay -> {
-                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
-                }
+        val currentState = viewModel.state ?: run {
+            result.linkAccountUpdate?.updateLinkAccount(linkAccountHolder)
+            return
+        }
+        val outcome = linkPaymentMethodSelectionCoordinator.handleResult(
+            result = result,
+            paymentMethodMetadata = currentState.paymentSheetState.paymentMethodMetadata,
+            customer = currentState.paymentSheetState.customer,
+            selection = viewModel.paymentSelection,
+        )
+        outcome.updatedPaymentMethodMetadata?.let { paymentMethodMetadata ->
+            viewModel.updateState { state ->
+                state?.copyPaymentSheetState(metadata = paymentMethodMetadata)
             }
+        }
+        if (outcome.suppressFutureLinkLaunch) {
+            viewModel.updateState { state -> state?.copy(declinedLink2FA = true) }
+        }
 
-            is LinkActivityResult.Completed -> {
-                updateLinkPaymentSelection(linkPaymentMethod = result.selectedPayment, canceled = false)
+        when (val action = outcome.action) {
+            Action.Dismiss -> Unit
+            Action.ShowPaymentOptions -> withCurrentState {
+                showPaymentOptionList(it, viewModel.paymentSelection)
+            }
+            is Action.UpdateSelection -> {
+                applyLinkPaymentSelection(
+                    selection = action.selection,
+                    canceled = action.reason == SelectionUpdateReason.LoggedOut,
+                )
+                if (action.reason == SelectionUpdateReason.LoggedOut) {
+                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
+                }
             }
         }
     }
@@ -437,11 +411,6 @@ internal class DefaultFlowController @Inject internal constructor(
                 )
             }
         }
-    }
-
-    fun PaymentSelection.readyToPayWithLink(): Boolean = when (this) {
-        is Link -> selectedPayment != null
-        else -> isLink
     }
 
     /**
@@ -487,18 +456,26 @@ internal class DefaultFlowController @Inject internal constructor(
                 // or clear selection if there is no fallback
                 viewModel.state?.paymentSheetState?.determineFallbackPaymentSelectionAfterLinkLogout()
             }
-            viewModel.paymentSelection = newSelection
-            val paymentOption = newSelection?.let {
-                val linkBrand = viewModel.state?.linkConfiguration
-                    ?.effectiveLinkBrand(linkAccountHolder.linkAccountInfo.value.account)
-                createPaymentOption(it, linkBrand)
-            }
-            val result = PaymentOptionResult(
+            applyLinkPaymentSelection(newSelection, canceled)
+        }
+    }
+
+    private fun applyLinkPaymentSelection(
+        selection: PaymentSelection?,
+        canceled: Boolean,
+    ) {
+        viewModel.paymentSelection = selection
+        val paymentOption = selection?.let {
+            val linkBrand = viewModel.state?.linkConfiguration
+                ?.effectiveLinkBrand(linkAccountHolder.linkAccountInfo.value.account)
+            createPaymentOption(it, linkBrand)
+        }
+        paymentOptionResultCallback.onPaymentOptionResult(
+            PaymentOptionResult(
                 paymentOption = paymentOption,
                 didCancel = canceled,
             )
-            paymentOptionResultCallback.onPaymentOptionResult(result)
-        }
+        )
     }
 
     override fun confirm() {

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodSelectionCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodSelectionCoordinatorTest.kt
@@ -1,0 +1,281 @@
+package com.stripe.android.link
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkPaymentMethodSelectionCoordinator.Action
+import com.stripe.android.link.LinkPaymentMethodSelectionCoordinator.SelectionUpdateReason
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.gate.FakeLinkGate
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.createCustomerState
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.utils.RecordingLinkPaymentLauncher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class LinkPaymentMethodSelectionCoordinatorTest {
+
+    @Test
+    fun `launchIfEligible presents Link for an existing Link selection`() = runScenario {
+        val didLaunch = coordinator.launchIfEligible(
+            launcher = linkLauncherScenario.launcher,
+            paymentMethodMetadata = paymentMethodMetadata,
+            selection = LINK_SELECTION,
+            hasDeclinedLink2FA = false,
+            statusBarColor = STATUS_BAR_COLOR,
+        )
+
+        assertThat(didLaunch).isTrue()
+        val call = linkLauncherScenario.presentCalls.awaitItem()
+        assertThat(call.paymentMethodMetadata).isEqualTo(paymentMethodMetadata)
+        assertThat(call.linkAccount).isEqualTo(TestFactory.LINK_ACCOUNT)
+        assertThat(call.linkExpressMode).isEqualTo(LinkExpressMode.ENABLED)
+        assertThat(call.launchMode).isEqualTo(
+            LinkLaunchMode.PaymentMethodSelection(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD)
+        )
+        assertThat(call.statusBarColor).isEqualTo(STATUS_BAR_COLOR)
+    }
+
+    @Test
+    fun `launchIfEligible does not present Link after 2FA is declined`() = runScenario {
+        val didLaunch = coordinator.launchIfEligible(
+            launcher = linkLauncherScenario.launcher,
+            paymentMethodMetadata = paymentMethodMetadata,
+            selection = LINK_SELECTION,
+            hasDeclinedLink2FA = true,
+            statusBarColor = null,
+        )
+
+        assertThat(didLaunch).isFalse()
+        linkLauncherScenario.presentCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `launchIfEligible does not present Link without an account`() = runScenario(
+        linkAccountUpdate = LinkAccountUpdate.Value(null),
+    ) {
+        val didLaunch = coordinator.launchIfEligible(
+            launcher = linkLauncherScenario.launcher,
+            paymentMethodMetadata = paymentMethodMetadata,
+            selection = LINK_SELECTION,
+            hasDeclinedLink2FA = false,
+            statusBarColor = null,
+        )
+
+        assertThat(didLaunch).isFalse()
+        linkLauncherScenario.presentCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `launchIfEligible does not present Link when RUX is disabled`() = runScenario(
+        showRuxInFlowController = false,
+    ) {
+        val didLaunch = coordinator.launchIfEligible(
+            launcher = linkLauncherScenario.launcher,
+            paymentMethodMetadata = paymentMethodMetadata,
+            selection = LINK_SELECTION,
+            hasDeclinedLink2FA = false,
+            statusBarColor = null,
+        )
+
+        assertThat(didLaunch).isFalse()
+        linkLauncherScenario.presentCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `completed result updates Link selection and account metadata`() = runScenario(
+        paymentMethodMetadata = paymentMethodMetadata(LinkState.LoginState.LoggedOut),
+    ) {
+        val updatedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(id = "csmrpd_updated"),
+            collectedCvc = null,
+            billingPhone = null,
+        )
+
+        val outcome = coordinator.handleResult(
+            result = LinkActivityResult.Completed(
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                selectedPayment = updatedPayment,
+            ),
+            paymentMethodMetadata = paymentMethodMetadata,
+            customer = null,
+            selection = LINK_SELECTION,
+        )
+
+        val action = outcome.action as Action.UpdateSelection
+        assertThat((action.selection as PaymentSelection.Link).selectedPayment).isEqualTo(updatedPayment)
+        assertThat(action.reason).isEqualTo(SelectionUpdateReason.Completed)
+        assertThat(outcome.updatedPaymentMethodMetadata?.linkState?.loginState)
+            .isEqualTo(LinkState.LoginState.LoggedIn)
+        assertThat(outcome.suppressFutureLinkLaunch).isFalse()
+    }
+
+    @Test
+    fun `back from Link verification suppresses future launch`() = runScenario(
+        linkAccountUpdate = LinkAccountUpdate.Value(verificationStartedAccount()),
+    ) {
+        val outcome = coordinator.handleResult(
+            result = LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                linkAccountUpdate = LinkAccountUpdate.Value(verificationStartedAccount()),
+            ),
+            paymentMethodMetadata = paymentMethodMetadata,
+            customer = null,
+            selection = LINK_SELECTION,
+        )
+
+        assertThat(outcome.action).isEqualTo(Action.Dismiss)
+        assertThat(outcome.suppressFutureLinkLaunch).isTrue()
+    }
+
+    @Test
+    fun `back without selected Link payment shows payment options`() = runScenario {
+        val outcome = coordinator.handleResult(
+            result = LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+            ),
+            paymentMethodMetadata = paymentMethodMetadata,
+            customer = null,
+            selection = LINK_SELECTION.copy(selectedPayment = null),
+        )
+
+        assertThat(outcome.action).isEqualTo(Action.ShowPaymentOptions)
+    }
+
+    @Test
+    fun `logout result selects the default saved payment method`() = runScenario(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            hasCustomerConfiguration = true,
+            linkState = linkState(),
+        ),
+        customer = createCustomerState(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            defaultPaymentMethodId = PaymentMethodFixtures.CARD_PAYMENT_METHOD.id,
+        ),
+    ) {
+        val outcome = coordinator.handleResult(
+            result = LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.LoggedOut,
+                linkAccountUpdate = LinkAccountUpdate.Value(null),
+            ),
+            paymentMethodMetadata = paymentMethodMetadata,
+            customer = customer,
+            selection = LINK_SELECTION,
+        )
+
+        val action = outcome.action as Action.UpdateSelection
+        assertThat(action.selection).isEqualTo(
+            PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        )
+        assertThat(action.reason).isEqualTo(SelectionUpdateReason.LoggedOut)
+        assertThat(outcome.updatedPaymentMethodMetadata?.linkState?.loginState)
+            .isEqualTo(LinkState.LoginState.LoggedOut)
+    }
+
+    @Test
+    fun `pay another way result shows payment options`() = runScenario {
+        val outcome = coordinator.handleResult(
+            result = LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.PayAnotherWay,
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+            ),
+            paymentMethodMetadata = paymentMethodMetadata,
+            customer = null,
+            selection = LINK_SELECTION,
+        )
+
+        assertThat(outcome.action).isEqualTo(Action.ShowPaymentOptions)
+    }
+
+    @Test
+    fun `failed result dismisses Link`() = runScenario {
+        val outcome = coordinator.handleResult(
+            result = LinkActivityResult.Failed(
+                error = IllegalStateException("Link failed"),
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+            ),
+            paymentMethodMetadata = paymentMethodMetadata,
+            customer = null,
+            selection = LINK_SELECTION,
+        )
+
+        assertThat(outcome.action).isEqualTo(Action.Dismiss)
+    }
+
+    private fun runScenario(
+        paymentMethodMetadata: PaymentMethodMetadata = paymentMethodMetadata(),
+        customer: CustomerState? = null,
+        linkAccountUpdate: LinkAccountUpdate.Value = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+        showRuxInFlowController: Boolean = true,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle()).apply {
+            set(linkAccountUpdate)
+        }
+        val linkGate = FakeLinkGate().apply {
+            setShowRuxInFlowController(showRuxInFlowController)
+        }
+        RecordingLinkPaymentLauncher.test {
+            Scenario(
+                coordinator = LinkPaymentMethodSelectionCoordinator(
+                    linkAccountHolder = linkAccountHolder,
+                    linkGateFactory = FakeLinkGate.Factory(linkGate),
+                ),
+                paymentMethodMetadata = paymentMethodMetadata,
+                customer = customer,
+                linkLauncherScenario = this,
+            ).block()
+        }
+    }
+
+    private data class Scenario(
+        val coordinator: LinkPaymentMethodSelectionCoordinator,
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val customer: CustomerState?,
+        val linkLauncherScenario: RecordingLinkPaymentLauncher.Scenario,
+    )
+
+    private companion object {
+        const val STATUS_BAR_COLOR = 0x123456
+
+        val LINK_SELECTION = PaymentSelection.Link(
+            brand = LinkBrand.Link,
+            selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+                details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = null,
+                billingPhone = null,
+            ),
+        )
+
+        fun paymentMethodMetadata(
+            loginState: LinkState.LoginState = LinkState.LoginState.LoggedIn,
+        ): PaymentMethodMetadata {
+            return PaymentMethodMetadataFactory.create(linkState = linkState(loginState))
+        }
+
+        fun linkState(
+            loginState: LinkState.LoginState = LinkState.LoginState.LoggedIn,
+        ): LinkState {
+            return LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = loginState,
+                signupMode = null,
+            )
+        }
+
+        fun verificationStartedAccount() = TestFactory.LINK_ACCOUNT.copy(
+            consumerSession = TestFactory.CONSUMER_SESSION.copy(
+                verificationSessions = listOf(TestFactory.VERIFICATION_STARTED_SESSION),
+                currentAuthenticationLevel = ConsumerSession.AuthenticationLevel.NotAuthenticated,
+                minimumAuthenticationLevel = ConsumerSession.AuthenticationLevel.OneFactorAuthentication,
+            )
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -107,11 +107,11 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
         val customerStateHolder = FakeCustomerStateHolder()
         val stateHolder = FakeSheetActivityStateHolder()
         val taxRegionUpdater = SheetTaxRegionUpdater(
-            paymentMethodMetadata = paymentMethodMetadata,
             taxRegionUpdater = checkoutSessionTaxRegionUpdater(),
         )
         val continueCoordinator = DefaultSheetActivityContinueCoordinator(
             taxRegionUpdater = taxRegionUpdater,
+            paymentMethodMetadata = paymentMethodMetadata,
             stateHolder = stateHolder,
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
@@ -45,7 +45,7 @@ internal class SheetTaxRegionUpdaterTest {
             )
         )
     ) {
-        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+        val update = updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
 
         assertThat(update).isNull()
     }
@@ -54,7 +54,7 @@ internal class SheetTaxRegionUpdaterTest {
     fun `prepareUpdate returns null for non-checkout session integration`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     ) {
-        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+        val update = updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
 
         assertThat(update).isNull()
     }
@@ -68,7 +68,7 @@ internal class SheetTaxRegionUpdaterTest {
             )
         )
     ) {
-        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+        val update = updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
 
         assertThat(update).isNull()
     }
@@ -86,14 +86,16 @@ internal class SheetTaxRegionUpdaterTest {
             response.testBodyFromFile("checkout-session-init.json")
         }
 
-        val result = requireNotNull(updater.prepareUpdate(selectionWithAddress(ADDRESS))).invoke()
+        val result = requireNotNull(
+            updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
+        ).invoke()
 
         assertThat(result.getOrThrow().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
     }
 
     @Test
     fun `prepareUpdate returns null when selection is null`() = runScenario {
-        val update = updater.prepareUpdate(selection = null)
+        val update = updater.prepareUpdate(paymentMethodMetadata, selection = null)
 
         assertThat(update).isNull()
     }
@@ -106,14 +108,17 @@ internal class SheetTaxRegionUpdaterTest {
             ),
         )
 
-        val update = updater.prepareUpdate(selection)
+        val update = updater.prepareUpdate(paymentMethodMetadata, selection)
 
         assertThat(update).isNull()
     }
 
     @Test
     fun `prepareUpdate returns null when billing address has no country`() = runScenario {
-        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS.copy(country = null)))
+        val update = updater.prepareUpdate(
+            paymentMethodMetadata,
+            selectionWithAddress(ADDRESS.copy(country = null)),
+        )
 
         assertThat(update).isNull()
     }
@@ -125,7 +130,9 @@ internal class SheetTaxRegionUpdaterTest {
             response.setBody("""{"error":{"message":"Invalid tax region"}}""")
         }
 
-        val result = requireNotNull(updater.prepareUpdate(selectionWithAddress(ADDRESS))).invoke()
+        val result = requireNotNull(
+            updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
+        ).invoke()
 
         assertThat(result.exceptionOrNull()?.message).contains("Invalid tax region")
     }
@@ -147,11 +154,13 @@ internal class SheetTaxRegionUpdaterTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val updater = SheetTaxRegionUpdater(
-            paymentMethodMetadata = paymentMethodMetadata,
             taxRegionUpdater = checkoutSessionTaxRegionUpdater(),
         )
 
-        Scenario(updater = updater).block()
+        Scenario(
+            updater = updater,
+            paymentMethodMetadata = paymentMethodMetadata,
+        ).block()
     }
 
     private fun checkoutSessionTaxRegionUpdater(): CheckoutSessionTaxRegionUpdater {
@@ -193,6 +202,7 @@ internal class SheetTaxRegionUpdaterTest {
 
     private data class Scenario(
         val updater: SheetTaxRegionUpdater,
+        val paymentMethodMetadata: PaymentMethodMetadata,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.LinkPaymentMethodSelectionCoordinator
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.CONSUMER_SESSION
 import com.stripe.android.link.TestFactory.VERIFICATION_STARTED_SESSION
@@ -2517,10 +2518,13 @@ internal class DefaultFlowControllerTest {
             linkHandler = linkHandler ?: mock(),
             paymentElementCallbackIdentifier = FLOW_CONTROLLER_CALLBACK_TEST_IDENTIFIER,
             linkAccountHolder = linkAccountHolder,
+            linkPaymentMethodSelectionCoordinator = LinkPaymentMethodSelectionCoordinator(
+                linkAccountHolder = linkAccountHolder,
+                linkGateFactory = FakeLinkGate.Factory(linkGate),
+            ),
             flowControllerLinkLauncher = flowControllerLinkPaymentLauncher,
             walletsButtonLinkLauncher = walletsButtonLinkPaymentLauncher,
             activityResultRegistryOwner = mock(),
-            linkGateFactory = FakeLinkGate.Factory(linkGate),
             confirmationHandler = confirmationHandler ?: FakeFlowControllerConfirmationHandler(),
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(
                 listOf(KLARNA_PROMOTION)

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -3,6 +3,7 @@ package com.stripe.android.utils
 import androidx.activity.result.ActivityResultCaller
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkExpressMode
@@ -58,7 +59,7 @@ internal object RecordingLinkPaymentLauncher {
                     PresentCall(
                         configuration = arguments[0] as LinkConfiguration,
                         paymentMethodMetadata = arguments[1] as PaymentMethodMetadata,
-                        linkAccount = arguments[2] as? LinkAccount,
+                        linkAccountInfo = arguments[2] as LinkAccountUpdate.Value,
                         launchMode = arguments[3] as LinkLaunchMode,
                         linkExpressMode = arguments[4] as LinkExpressMode,
                         statusBarColor = arguments[5] as? Int,
@@ -96,9 +97,12 @@ internal object RecordingLinkPaymentLauncher {
     data class PresentCall(
         val configuration: LinkConfiguration,
         val paymentMethodMetadata: PaymentMethodMetadata,
-        val linkAccount: LinkAccount?,
+        val linkAccountInfo: LinkAccountUpdate.Value,
         val launchMode: LinkLaunchMode,
         val linkExpressMode: LinkExpressMode,
         val statusBarColor: Int?,
-    )
+    ) {
+        val linkAccount: LinkAccount?
+            get() = linkAccountInfo.account
+    }
 }


### PR DESCRIPTION
# Summary

Extracts FlowController's eager Link payment-method selection policy and result handling into a reusable internal coordinator. Also makes the embedded sheet tax-region updater accept payment-method metadata per invocation so callers can use current state.

# Motivation

PaymentElement needs the same eager Link behavior as FlowController. Landing the shared behavior first avoids duplicating eligibility, account synchronization, logout fallback, and Link result handling in the Checkout-specific implementation.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.link.LinkPaymentMethodSelectionCoordinatorTest' --tests 'com.stripe.android.paymentsheet.flowcontroller.DefaultFlowControllerTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.SheetTaxRegionUpdaterTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityContinueCoordinatorTest'`
- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable. This is an internal behavior-preserving refactor with no rendered UI changes.

# Changelog

Not applicable. This refactors internal implementation without changing public behavior or APIs.

Committed and created by Codex.
