### PR TITLE
Support inline-only address autocomplete interactors

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractor.kt
@@ -6,7 +6,7 @@ import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.CoroutineScope
 
 internal class PaymentElementAutocompleteAddressInteractor(
-    private val launcher: AutocompleteLauncher,
+    private val launcher: AutocompleteLauncher?,
     override val autocompleteConfig: AutocompleteAddressInteractor.Config,
 ) : AutocompleteAddressInteractor, AutocompleteLauncherResultHandler {
     private var eventListener: ((AutocompleteAddressInteractor.Event) -> Unit)? = null
@@ -17,7 +17,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
 
     override fun onAutocomplete(country: String) {
         autocompleteConfig.googlePlacesApiKey?.let { googlePlacesApiKey ->
-            launcher.launch(
+            launcher?.launch(
                 country = country,
                 googlePlacesApiKey = googlePlacesApiKey,
                 resultHandler = this,
@@ -43,7 +43,7 @@ internal class PaymentElementAutocompleteAddressInteractor(
     }
 
     class Factory(
-        private val launcher: AutocompleteLauncher,
+        private val launcher: AutocompleteLauncher?,
         private val autocompleteConfig: AutocompleteAddressInteractor.Config,
         private val placesClient: PlacesClientProxy?,
         private val stripeAutocompleteRepository: StripeAutocompleteRepository?,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -295,7 +295,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
     }
 
     @Test
-    fun `Factory creates inline interactor when proxy flag is on with repository`() = test { scenario ->
+    fun `Factory creates inline interactor without launcher when proxy flag is on with repository`() = test {
         val config = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = null,
             autocompleteCountries = setOf("US"),
@@ -304,7 +304,7 @@ class PaymentElementAutocompleteAddressInteractorTest {
         )
 
         val factory = PaymentElementAutocompleteAddressInteractor.Factory(
-            launcher = scenario.launcher,
+            launcher = null,
             autocompleteConfig = config,
             placesClient = null,
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),


### PR DESCRIPTION
# Summary

- Allow `PaymentElementAutocompleteAddressInteractor` and its factory to operate without an activity launcher.
- Cover Stripe-hosted inline autocomplete with a null launcher in the existing factory test.
- This is the pre-work layer for #14181.

# Motivation

Stripe-hosted inline autocomplete does not launch a separate activity. Making the launcher optional lets inline-only consumers use the existing factory without creating and registering an unused activity-result launcher.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Validation completed:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.addresselement.PaymentElementAutocompleteAddressInteractorTest'`
- `./gradlew detekt`
- `git diff --check`

No tests were newly ignored.

# Screenshots

Not applicable — this is an internal refactor with no UI changes.

# Changelog

Not applicable — this changes no public API or user-visible behavior.

Committed and created by Codex.
