### PR TITLE
Decouple embedded tax region updates

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetActivityContinueCoordinator.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -18,6 +19,7 @@ internal interface SheetActivityContinueCoordinator {
 
 internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
     private val taxRegionUpdater: SheetTaxRegionUpdater,
+    private val paymentMethodMetadata: PaymentMethodMetadata,
     private val stateHolder: SheetActivityStateHolder,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
@@ -27,7 +29,7 @@ internal class DefaultSheetActivityContinueCoordinator @Inject constructor(
 
     override fun onContinue() {
         val selection = selectionHolder.selection.value
-        val taxRegionUpdate = taxRegionUpdater.prepareUpdate(selection)
+        val taxRegionUpdate = taxRegionUpdater.prepareUpdate(paymentMethodMetadata, selection)
         if (taxRegionUpdate == null) {
             stateHolder.setResult(createResult(selection, checkoutSessionResponse = null))
             return

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdater.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdater.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkout.toCheckoutAddress
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
@@ -13,11 +14,25 @@ import javax.inject.Inject
 internal typealias SheetTaxRegionUpdate = suspend () -> Result<CheckoutSessionResponse>
 
 @OptIn(CheckoutSessionPreview::class)
-internal class SheetTaxRegionUpdater @Inject constructor(
-    private val paymentMethodMetadata: PaymentMethodMetadata,
-    private val taxRegionUpdater: CheckoutSessionTaxRegionUpdater,
+internal typealias TaxRegionUpdate = suspend (
+    CheckoutSessionResponse,
+    CheckoutSessionResponse.TaxAddressSource,
+    CheckoutController.Address.State,
+) -> Result<CheckoutSessionResponse>
+
+@OptIn(CheckoutSessionPreview::class)
+internal class SheetTaxRegionUpdater internal constructor(
+    private val updateTaxRegion: TaxRegionUpdate,
 ) {
-    fun prepareUpdate(selection: PaymentSelection?): SheetTaxRegionUpdate? {
+    @Inject
+    constructor(taxRegionUpdater: CheckoutSessionTaxRegionUpdater) : this(
+        updateTaxRegion = taxRegionUpdater::updateServerStateIfNeeded,
+    )
+
+    fun prepareUpdate(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        selection: PaymentSelection?,
+    ): SheetTaxRegionUpdate? {
         val checkoutSessionResponse =
             (paymentMethodMetadata.integrationMetadata as? IntegrationMetadata.CheckoutSession)
                 ?.checkoutSessionResponse
@@ -27,10 +42,10 @@ internal class SheetTaxRegionUpdater @Inject constructor(
             ?: return null
 
         return {
-            taxRegionUpdater.updateServerStateIfNeeded(
-                checkoutSessionResponse = checkoutSessionResponse,
-                addressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-                address = address,
+            updateTaxRegion(
+                checkoutSessionResponse,
+                CheckoutSessionResponse.TaxAddressSource.BILLING,
+                address,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -107,11 +107,11 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
         val customerStateHolder = FakeCustomerStateHolder()
         val stateHolder = FakeSheetActivityStateHolder()
         val taxRegionUpdater = SheetTaxRegionUpdater(
-            paymentMethodMetadata = paymentMethodMetadata,
             taxRegionUpdater = checkoutSessionTaxRegionUpdater(),
         )
         val continueCoordinator = DefaultSheetActivityContinueCoordinator(
             taxRegionUpdater = taxRegionUpdater,
+            paymentMethodMetadata = paymentMethodMetadata,
             stateHolder = stateHolder,
             selectionHolder = selectionHolder,
             customerStateHolder = customerStateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
@@ -45,7 +45,7 @@ internal class SheetTaxRegionUpdaterTest {
             )
         )
     ) {
-        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+        val update = updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
 
         assertThat(update).isNull()
     }
@@ -54,7 +54,7 @@ internal class SheetTaxRegionUpdaterTest {
     fun `prepareUpdate returns null for non-checkout session integration`() = runScenario(
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
     ) {
-        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+        val update = updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
 
         assertThat(update).isNull()
     }
@@ -68,7 +68,7 @@ internal class SheetTaxRegionUpdaterTest {
             )
         )
     ) {
-        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS))
+        val update = updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
 
         assertThat(update).isNull()
     }
@@ -86,14 +86,16 @@ internal class SheetTaxRegionUpdaterTest {
             response.testBodyFromFile("checkout-session-init.json")
         }
 
-        val result = requireNotNull(updater.prepareUpdate(selectionWithAddress(ADDRESS))).invoke()
+        val result = requireNotNull(
+            updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
+        ).invoke()
 
         assertThat(result.getOrThrow().id).isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
     }
 
     @Test
     fun `prepareUpdate returns null when selection is null`() = runScenario {
-        val update = updater.prepareUpdate(selection = null)
+        val update = updater.prepareUpdate(paymentMethodMetadata, selection = null)
 
         assertThat(update).isNull()
     }
@@ -106,14 +108,17 @@ internal class SheetTaxRegionUpdaterTest {
             ),
         )
 
-        val update = updater.prepareUpdate(selection)
+        val update = updater.prepareUpdate(paymentMethodMetadata, selection)
 
         assertThat(update).isNull()
     }
 
     @Test
     fun `prepareUpdate returns null when billing address has no country`() = runScenario {
-        val update = updater.prepareUpdate(selectionWithAddress(ADDRESS.copy(country = null)))
+        val update = updater.prepareUpdate(
+            paymentMethodMetadata,
+            selectionWithAddress(ADDRESS.copy(country = null)),
+        )
 
         assertThat(update).isNull()
     }
@@ -125,7 +130,9 @@ internal class SheetTaxRegionUpdaterTest {
             response.setBody("""{"error":{"message":"Invalid tax region"}}""")
         }
 
-        val result = requireNotNull(updater.prepareUpdate(selectionWithAddress(ADDRESS))).invoke()
+        val result = requireNotNull(
+            updater.prepareUpdate(paymentMethodMetadata, selectionWithAddress(ADDRESS))
+        ).invoke()
 
         assertThat(result.exceptionOrNull()?.message).contains("Invalid tax region")
     }
@@ -147,11 +154,13 @@ internal class SheetTaxRegionUpdaterTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val updater = SheetTaxRegionUpdater(
-            paymentMethodMetadata = paymentMethodMetadata,
             taxRegionUpdater = checkoutSessionTaxRegionUpdater(),
         )
 
-        Scenario(updater = updater).block()
+        Scenario(
+            updater = updater,
+            paymentMethodMetadata = paymentMethodMetadata,
+        ).block()
     }
 
     private fun checkoutSessionTaxRegionUpdater(): CheckoutSessionTaxRegionUpdater {
@@ -193,6 +202,7 @@ internal class SheetTaxRegionUpdaterTest {
 
     private data class Scenario(
         val updater: SheetTaxRegionUpdater,
+        val paymentMethodMetadata: PaymentMethodMetadata,
     )
 
     private companion object {


### PR DESCRIPTION
# Summary

Refactors embedded Checkout Session tax-region updates to accept payment-method metadata at the call site. This is layer 1 of 2 in the eager Link presentation stack and has no intended behavior change.

# Motivation

The Checkout Link coordinator needs to prepare tax-region updates from the latest restored Checkout controller state, rather than from metadata captured when the sheet activity graph was created.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityContinueCoordinatorTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.SheetTaxRegionUpdaterTest'`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable. This is an internal refactor with no UI changes.

# Changelog

Not applicable. This is an internal refactor with no public API or behavior changes.

Committed and created by Codex.
