### PR TITLE
Eagerly launch Link from PaymentElement present

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -43,6 +43,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private val sessionRefresher: CheckoutSessionRefresher,
     private val operationCoordinator: CheckoutOperationCoordinator,
     private val logger: Logger,
+    private val checkoutSheetLinkHelper: CheckoutSheetLinkHelper,
     @ViewModelScope private val coroutineScope: CoroutineScope,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
@@ -51,10 +52,16 @@ internal class CheckoutSheetLauncher @Inject constructor(
 ) : EmbeddedSheetLauncher {
 
     init {
+        checkoutSheetLinkHelper.register(
+            activityResultCaller = activityResultCaller,
+            launchPaymentOptions = ::launchPaymentOptionsSheet,
+        )
+
         lifecycleOwner.lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     activityLauncher.unregister()
+                    checkoutSheetLinkHelper.unregister()
                     super.onDestroy(owner)
                 }
             }
@@ -226,6 +233,25 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
+
+        if (checkoutSheetLinkHelper.launchLinkIfEligible(paymentMethodMetadata, selection)) {
+            return
+        }
+
+        launchPaymentOptionsSheet(
+            paymentMethodMetadata = paymentMethodMetadata,
+            customerState = customerState,
+            selection = selection,
+            configuration = configuration,
+        )
+    }
+
+    private fun launchPaymentOptionsSheet(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customerState: CustomerState?,
+        selection: PaymentSelection?,
+        configuration: EmbeddedPaymentElement.Configuration,
+    ) {
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLinkHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLinkHelper.kt
@@ -1,0 +1,263 @@
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultCaller
+import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason
+import com.stripe.android.link.LinkExpressMode
+import com.stripe.android.link.LinkLaunchMode
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.account.updateLinkAccount
+import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.toLoginState
+import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentelement.embedded.sheet.SheetTaxRegionUpdater
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.PaymentSelection.Link
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.LinkDisabledState
+import com.stripe.android.paymentsheet.state.LinkState
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Named
+
+internal const val PAYMENT_ELEMENT_LINK_LAUNCHER = "LinkPaymentLauncher_CheckoutPaymentElement"
+
+internal interface CheckoutSheetLinkHelper {
+    fun register(
+        activityResultCaller: ActivityResultCaller,
+        launchPaymentOptions: LaunchPaymentOptions,
+    )
+
+    fun unregister()
+
+    fun launchLinkIfEligible(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        selection: PaymentSelection?,
+    ): Boolean
+
+    fun interface LaunchPaymentOptions {
+        fun launch(
+            paymentMethodMetadata: PaymentMethodMetadata,
+            customerState: CustomerState?,
+            selection: PaymentSelection?,
+            configuration: EmbeddedPaymentElement.Configuration,
+        )
+    }
+}
+
+@OptIn(CheckoutSessionPreview::class)
+internal class DefaultCheckoutSheetLinkHelper @Inject constructor(
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val sheetStateHolder: SheetStateHolder,
+    private val errorReporter: ErrorReporter,
+    private val sessionRefresher: CheckoutSessionRefresher,
+    private val operationCoordinator: CheckoutOperationCoordinator,
+    private val logger: Logger,
+    private val checkoutControllerStateHolder: CheckoutControllerStateHolder,
+    private val linkAccountHolder: LinkAccountHolder,
+    private val linkGateFactory: LinkGate.Factory,
+    @Named(PAYMENT_ELEMENT_LINK_LAUNCHER) private val paymentElementLinkLauncher: LinkPaymentLauncher,
+    private val taxRegionUpdater: SheetTaxRegionUpdater,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+    @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
+) : CheckoutSheetLinkHelper {
+    override fun register(
+        activityResultCaller: ActivityResultCaller,
+        launchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
+    ) {
+        paymentElementLinkLauncher.register(
+            activityResultCaller = activityResultCaller,
+            callback = { result -> onLinkResult(result, launchPaymentOptions) },
+        )
+    }
+
+    override fun unregister() {
+        paymentElementLinkLauncher.unregister()
+    }
+
+    override fun launchLinkIfEligible(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        selection: PaymentSelection?,
+    ): Boolean {
+        val linkConfiguration = paymentMethodMetadata.linkState?.configuration
+        val linkAccountInfo = linkAccountHolder.linkAccountInfo.value
+        val shouldPresentLink = linkConfiguration != null &&
+            !sheetStateHolder.declinedLink2FA &&
+            selection is Link &&
+            linkAccountInfo.account != null &&
+            linkGateFactory.create(linkConfiguration).showRuxInFlowController
+
+        if (!shouldPresentLink) return false
+
+        paymentElementLinkLauncher.present(
+            configuration = linkConfiguration,
+            paymentMethodMetadata = paymentMethodMetadata,
+            linkAccountInfo = linkAccountInfo,
+            launchMode = LinkLaunchMode.PaymentMethodSelection(selection.selectedPayment?.details),
+            linkExpressMode = LinkExpressMode.ENABLED,
+            statusBarColor = statusBarColor,
+        )
+        return true
+    }
+
+    private fun onLinkResult(
+        result: LinkActivityResult,
+        launchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
+    ) {
+        result.linkAccountUpdate?.let(::updateLinkAccount)
+
+        when (result) {
+            is LinkActivityResult.PaymentMethodObtained,
+            is LinkActivityResult.Failed -> closeLinkPresentation()
+            is LinkActivityResult.Canceled -> when (result.reason) {
+                Reason.BackPressed -> {
+                    val accountStatus = linkAccountHolder.linkAccountInfo.value.account?.accountStatus
+                    if (accountStatus == AccountStatus.VerificationStarted) {
+                        sheetStateHolder.declinedLink2FA = true
+                    }
+                    if ((selectionHolder.selection.value as? Link)?.selectedPayment == null) {
+                        showCurrentPaymentOptions(launchPaymentOptions)
+                    } else {
+                        closeLinkPresentation()
+                    }
+                }
+                Reason.LoggedOut -> {
+                    updateLinkPaymentSelection(linkPaymentMethod = null, apply = true)
+                    showCurrentPaymentOptions(launchPaymentOptions)
+                }
+                Reason.PayAnotherWay -> showCurrentPaymentOptions(launchPaymentOptions)
+            }
+            is LinkActivityResult.Completed -> handleCompletedLinkResult(
+                linkPaymentMethod = result.selectedPayment,
+                launchPaymentOptions = launchPaymentOptions,
+            )
+        }
+    }
+
+    private fun handleCompletedLinkResult(
+        linkPaymentMethod: LinkPaymentMethod?,
+        launchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
+    ) {
+        val newSelection = updateLinkPaymentSelection(linkPaymentMethod, apply = false)
+        if (newSelection == null) {
+            selectionHolder.setSelection(null)
+            closeLinkPresentation()
+            return
+        }
+
+        val state = checkoutControllerStateHolder.state
+        val taxRegionUpdate = state?.let {
+            taxRegionUpdater.prepareUpdate(it.paymentMethodMetadata, newSelection)
+        }
+        if (taxRegionUpdate == null) {
+            selectionHolder.setSelection(newSelection)
+            closeLinkPresentation()
+            return
+        }
+
+        coroutineScope.launch {
+            var taxRegionUpdated = false
+            var paymentOptionsShown = false
+            try {
+                operationCoordinator.runMutation {
+                    taxRegionUpdate().mapCatching { response ->
+                        taxRegionUpdated = true
+                        selectionHolder.setSelection(newSelection)
+                        sessionRefresher.refresh(response)
+                    }
+                }.onFailure { error ->
+                    if (taxRegionUpdated) {
+                        logger.error("Failed to refresh the checkout session after Link selection.", error)
+                    } else {
+                        selectionHolder.setSelection(newSelection)
+                        logger.error("Failed to update the tax region after Link selection.", error)
+                        showCurrentPaymentOptions(launchPaymentOptions)
+                        paymentOptionsShown = true
+                    }
+                }
+            } finally {
+                if (!paymentOptionsShown) {
+                    closeLinkPresentation()
+                }
+            }
+        }
+    }
+
+    private fun updateLinkPaymentSelection(
+        linkPaymentMethod: LinkPaymentMethod?,
+        apply: Boolean,
+    ): PaymentSelection? {
+        val currentSelection = selectionHolder.selection.value as? Link ?: return selectionHolder.selection.value
+        val newSelection = if (linkPaymentMethod != null) {
+            currentSelection.copy(selectedPayment = linkPaymentMethod)
+        } else {
+            val state = checkoutControllerStateHolder.state
+            state?.let {
+                determineFallbackPaymentSelectionAfterLinkLogout(
+                    customer = customerStateHolder.customer.value,
+                    paymentMethodMetadata = it.paymentMethodMetadata,
+                )
+            }
+        }
+        if (apply) {
+            selectionHolder.setSelection(newSelection)
+        }
+        return newSelection
+    }
+
+    private fun updateLinkAccount(update: LinkAccountUpdate) {
+        update.updateLinkAccount(linkAccountHolder)
+        if (update !is LinkAccountUpdate.Value) return
+
+        val state = checkoutControllerStateHolder.state ?: return
+        val metadata = state.paymentMethodMetadata
+        val accountStatus = update.account?.accountStatus ?: AccountStatus.SignedOut
+        val updatedLinkState = when (val linkState = metadata.linkStateResult) {
+            is LinkState -> linkState.copy(loginState = accountStatus.toLoginState())
+            is LinkDisabledState, null -> linkState
+        }
+        checkoutControllerStateHolder.state = state.copy(
+            paymentMethodMetadata = metadata.copy(linkStateResult = updatedLinkState),
+        )
+    }
+
+    private fun showCurrentPaymentOptions(
+        launchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
+    ) {
+        sheetStateHolder.sheetIsOpen = false
+        val state = checkoutControllerStateHolder.state
+        if (state == null) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NOT_CONFIGURED
+            )
+            return
+        }
+        sheetStateHolder.sheetIsOpen = true
+        launchPaymentOptions.launch(
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            customerState = customerStateHolder.customer.value,
+            selection = selectionHolder.selection.value,
+            configuration = state.embeddedConfiguration,
+        )
+    }
+
+    private fun closeLinkPresentation() {
+        sheetStateHolder.sheetIsOpen = false
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -2,8 +2,16 @@ package com.stripe.android.checkout.injection
 
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutSheetLauncher
+import com.stripe.android.checkout.CheckoutSheetLinkHelper
+import com.stripe.android.checkout.DefaultCheckoutSheetLinkHelper
+import com.stripe.android.checkout.PAYMENT_ELEMENT_LINK_LAUNCHER
 import com.stripe.android.elements.PaymentElement
+import com.stripe.android.link.LinkActivityContract
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.account.LinkStore
+import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper
@@ -21,6 +29,7 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Named
 
 @Module
 internal interface PaymentElementModule {
@@ -46,8 +55,27 @@ internal interface PaymentElementModule {
     @Binds
     fun bindsSheetLauncher(launcher: CheckoutSheetLauncher): EmbeddedSheetLauncher
 
+    @Binds
+    fun bindsCheckoutSheetLinkHelper(helper: DefaultCheckoutSheetLinkHelper): CheckoutSheetLinkHelper
+
     @OptIn(CheckoutSessionPreview::class)
     companion object {
+        @Provides
+        @Named(PAYMENT_ELEMENT_LINK_LAUNCHER)
+        fun providePaymentElementLinkLauncher(
+            linkAnalyticsComponentFactory: LinkAnalyticsComponent.Factory,
+            linkActivityContract: LinkActivityContract,
+            @PaymentElementCallbackIdentifier identifier: String,
+            linkStore: LinkStore,
+        ): LinkPaymentLauncher {
+            return LinkPaymentLauncher(
+                linkAnalyticsComponentFactory = linkAnalyticsComponentFactory,
+                paymentElementCallbackIdentifier = identifier,
+                linkActivityContract = linkActivityContract,
+                linkStore = linkStore,
+            )
+        }
+
         @Provides
         fun providePaymentElementConfiguration(
             stateHolder: CheckoutControllerStateHolder,

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.link.utils
 
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentSheetState
 
 /**
@@ -10,6 +12,16 @@ import com.stripe.android.paymentsheet.state.PaymentSheetState
  * @return The best fallback payment selection, or null if no suitable fallback exists
  */
 internal fun PaymentSheetState.Full.determineFallbackPaymentSelectionAfterLinkLogout(): PaymentSelection? {
+    return determineFallbackPaymentSelectionAfterLinkLogout(
+        customer = customer,
+        paymentMethodMetadata = paymentMethodMetadata,
+    )
+}
+
+internal fun determineFallbackPaymentSelectionAfterLinkLogout(
+    customer: CustomerState?,
+    paymentMethodMetadata: PaymentMethodMetadata,
+): PaymentSelection? {
     if (customer == null) return null
 
     // Check if default payment method feature is enabled

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/SheetStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/SheetStateHolder.kt
@@ -14,7 +14,12 @@ internal class SheetStateHolder @Inject constructor(
         get() = savedStateHandle.get<Boolean>(SHEET_IS_OPEN_KEY) == true
         set(value) = savedStateHandle.set(SHEET_IS_OPEN_KEY, value)
 
+    var declinedLink2FA: Boolean
+        get() = savedStateHandle.get<Boolean>(DECLINED_LINK_2FA_KEY) == true
+        set(value) = savedStateHandle.set(DECLINED_LINK_2FA_KEY, value)
+
     companion object {
         private const val SHEET_IS_OPEN_KEY = "SheetStateHolder_SHEET_IS_OPEN_KEY"
+        private const val DECLINED_LINK_2FA_KEY = "SheetStateHolder_DECLINED_LINK_2FA_KEY"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -508,10 +508,48 @@ internal class CheckoutSheetLauncherTest {
             selection = selection,
             configuration = EmbeddedConfigurationFactory.create(),
         )
+        checkoutSheetLinkHelper.launchLinkIfEligibleCalls.awaitItem()
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall()
 
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `launchPaymentOptions does not launch sheet when Link helper launches`() = testScenario {
+        checkoutSheetLinkHelper.launchLinkIfEligibleResult = true
+
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            customerState = null,
+            selection = null,
+            configuration = EmbeddedConfigurationFactory.create(),
+        )
+
+        val call = checkoutSheetLinkHelper.launchLinkIfEligibleCalls.awaitItem()
+        assertThat(call.selection).isNull()
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `Link helper callback launches payment options with supplied state`() = testScenario {
+        val metadata = PaymentMethodMetadataFactory.create()
+        val customerState = createCustomerState()
+        val selection = PaymentSelection.GooglePay
+        val configuration = EmbeddedConfigurationFactory.create()
+
+        linkLaunchPaymentOptions.launch(
+            paymentMethodMetadata = metadata,
+            customerState = customerState,
+            selection = selection,
+            configuration = configuration,
+        )
+
+        val args = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(args.paymentMethodMetadata).isEqualTo(metadata)
+        assertThat(args.customerState).isEqualTo(customerState)
+        assertThat(args.selection).isEqualTo(selection)
+        assertThat(args.configuration).isEqualTo(configuration)
     }
 
     @Test
@@ -525,6 +563,7 @@ internal class CheckoutSheetLauncherTest {
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             configuration = EmbeddedConfigurationFactory.create(),
         )
+        checkoutSheetLinkHelper.launchLinkIfEligibleCalls.awaitItem()
         val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
 
         assertThat(launchCall.previousNewSelections.previousNewSelection("card"))
@@ -706,6 +745,7 @@ internal class CheckoutSheetLauncherTest {
         sheetStateHolder.sheetIsOpen = true
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
         val unregisteredLauncher = dummyActivityResultCallerScenario.awaitNextUnregisteredLauncher()
+        checkoutSheetLinkHelper.unregisterCalls.awaitItem()
 
         assertThat(unregisteredLauncher).isEqualTo(launcher)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
@@ -713,7 +753,7 @@ internal class CheckoutSheetLauncherTest {
 
     @Suppress("LongMethod")
     private fun testScenario(
-        block: suspend Scenario.() -> Unit
+        block: suspend Scenario.() -> Unit,
     ) = runTest {
         var immediateActionInvoked = false
         val testScope = this
@@ -721,6 +761,7 @@ internal class CheckoutSheetLauncherTest {
         val savedStateHandle = SavedStateHandle()
         val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val errorReporter = FakeErrorReporter()
         val customerStateHolder = DefaultCustomerStateHolder(
             savedStateHandle = savedStateHandle,
             selection = selectionHolder.selection,
@@ -728,9 +769,9 @@ internal class CheckoutSheetLauncherTest {
             paymentMethodMetadataFlow = stateFlowOf(null),
         )
         val sheetStateHolder = SheetStateHolder(savedStateHandle)
-        val errorReporter = FakeErrorReporter()
         val sessionRefresher = FakeCheckoutSessionRefresher()
         val logger = FakeLogger()
+        val checkoutSheetLinkHelper = FakeCheckoutSheetLinkHelper()
         val confirmationHandler = FakeConfirmationHandler()
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
@@ -739,7 +780,6 @@ internal class CheckoutSheetLauncherTest {
             logger = logger,
             resultCallback = CheckoutController.ResultCallback {},
         )
-
         DummyActivityResultCaller.test {
             val sheetLauncher = CheckoutSheetLauncher(
                 activityResultCaller = activityResultCaller,
@@ -751,6 +791,7 @@ internal class CheckoutSheetLauncherTest {
                 sessionRefresher = sessionRefresher,
                 operationCoordinator = operationCoordinator,
                 logger = logger,
+                checkoutSheetLinkHelper = checkoutSheetLinkHelper,
                 coroutineScope = testScope,
                 productUsage = setOf("Checkout"),
                 statusBarColor = null,
@@ -759,6 +800,7 @@ internal class CheckoutSheetLauncherTest {
             )
             val registerCall = awaitRegisterCall()
             val launcher = awaitNextRegisteredLauncher()
+            val linkRegisterCall = checkoutSheetLinkHelper.registerCalls.awaitItem()
 
             assertThat(registerCall).isNotNull()
             assertThat(registerCall.contract).isInstanceOf<EmbeddedSheetContract>()
@@ -777,12 +819,15 @@ internal class CheckoutSheetLauncherTest {
                 sessionRefresher = sessionRefresher,
                 logger = logger,
                 operationCoordinator = operationCoordinator,
+                checkoutSheetLinkHelper = checkoutSheetLinkHelper,
+                linkLaunchPaymentOptions = linkRegisterCall.launchPaymentOptions,
                 runCurrent = testScheduler::runCurrent,
             ).block()
         }
 
         confirmationHandler.validate()
         sessionRefresher.ensureAllEventsConsumed()
+        checkoutSheetLinkHelper.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -799,6 +844,8 @@ internal class CheckoutSheetLauncherTest {
         val sessionRefresher: FakeCheckoutSessionRefresher,
         val logger: FakeLogger,
         val operationCoordinator: CheckoutOperationCoordinator,
+        val checkoutSheetLinkHelper: FakeCheckoutSheetLinkHelper,
+        val linkLaunchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
         private val runCurrent: () -> Unit,
     ) {
         fun runCurrent() {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLinkHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLinkHelperTest.kt
@@ -1,0 +1,451 @@
+package com.stripe.android.checkout
+
+import android.app.Application
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkExpressMode
+import com.stripe.android.link.LinkLaunchMode
+import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.TestFactory
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.gate.FakeLinkGate
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.ConsumerSession
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentelement.embedded.sheet.SheetTaxRegionUpdater
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.createCustomerState
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.testing.DummyActivityResultCaller
+import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.testing.FakeLogger
+import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.RecordingLinkPaymentLauncher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(CheckoutSessionPreview::class)
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutSheetLinkHelperTest {
+
+    private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
+
+    @get:Rule
+    val paymentConfigurationTestRule = PaymentConfigurationTestRule(applicationContext)
+
+    @Test
+    fun `launchLinkIfEligible launches Link when selected and RUX is enabled`() = testScenario(
+        initialState = linkCheckoutState(),
+    ) {
+        linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
+        val didLaunch = launchLink()
+
+        assertThat(didLaunch).isTrue()
+        val call = linkLauncherScenario.presentCalls.awaitItem()
+        assertThat(call.configuration).isEqualTo(TestFactory.LINK_CONFIGURATION)
+        assertThat(call.paymentMethodMetadata).isEqualTo(checkoutControllerStateHolder.state?.paymentMethodMetadata)
+        assertThat(call.linkAccount).isEqualTo(TestFactory.LINK_ACCOUNT)
+        assertThat(call.linkExpressMode).isEqualTo(LinkExpressMode.ENABLED)
+        assertThat(call.launchMode).isEqualTo(
+            LinkLaunchMode.PaymentMethodSelection(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD)
+        )
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `launchLinkIfEligible returns false when Link RUX is disabled`() = testScenario(
+        initialState = linkCheckoutState(),
+    ) {
+        linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+        linkGate.setShowRuxInFlowController(false)
+
+        val didLaunch = launchLink()
+
+        assertThat(didLaunch).isFalse()
+        linkLauncherScenario.presentCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `completed Link result updates selection and account state`() = testScenario(
+        initialState = linkCheckoutState(loginState = LinkState.LoginState.LoggedOut),
+    ) {
+        linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+        launchLink()
+        linkLauncherScenario.presentCalls.awaitItem()
+        val updatedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD.copy(id = "csmrpd_updated"),
+            collectedCvc = null,
+            billingPhone = null,
+        )
+
+        linkResultCallback(
+            LinkActivityResult.Completed(
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                selectedPayment = updatedPayment,
+            )
+        )
+
+        val selection = selectionHolder.selection.value as PaymentSelection.Link
+        assertThat(selection.selectedPayment).isEqualTo(updatedPayment)
+        val linkState = checkoutControllerStateHolder.state?.paymentMethodMetadata?.linkState
+        assertThat(linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedIn)
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+    }
+
+    @Test
+    fun `back from Link verification prevents eager relaunch`() = testScenario(
+        initialState = linkCheckoutState(),
+    ) {
+        val verificationAccount = TestFactory.LINK_ACCOUNT.copy(
+            consumerSession = TestFactory.CONSUMER_SESSION.copy(
+                verificationSessions = listOf(TestFactory.VERIFICATION_STARTED_SESSION),
+                currentAuthenticationLevel = ConsumerSession.AuthenticationLevel.NotAuthenticated,
+                minimumAuthenticationLevel = ConsumerSession.AuthenticationLevel.OneFactorAuthentication,
+            )
+        )
+        linkAccountHolder.set(LinkAccountUpdate.Value(verificationAccount))
+        launchLink()
+        linkLauncherScenario.presentCalls.awaitItem()
+
+        linkResultCallback(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                linkAccountUpdate = LinkAccountUpdate.Value(verificationAccount),
+            )
+        )
+
+        assertThat(sheetStateHolder.declinedLink2FA).isTrue()
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(launchLink()).isFalse()
+        linkLauncherScenario.presentCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `pay another way from Link launches current payment options`() = testScenario(
+        initialState = linkCheckoutState(),
+    ) {
+        linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+        launchLink()
+        linkLauncherScenario.presentCalls.awaitItem()
+
+        linkResultCallback(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.PayAnotherWay,
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+            )
+        )
+
+        val call = launchPaymentOptionsCalls.awaitItem()
+        assertThat(call.selection).isEqualTo(selectionHolder.selection.value)
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `logout from Link selects saved fallback and launches payment options`() = testScenario(
+        initialState = linkCheckoutState(hasCustomerConfiguration = true),
+    ) {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        customerStateHolder.setCustomerState(createCustomerState(paymentMethods = listOf(paymentMethod)))
+        linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+        launchLink()
+        linkLauncherScenario.presentCalls.awaitItem()
+
+        linkResultCallback(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.LoggedOut,
+                linkAccountUpdate = LinkAccountUpdate.Value(null),
+            )
+        )
+
+        assertThat(selectionHolder.selection.value).isEqualTo(PaymentSelection.Saved(paymentMethod))
+        assertThat(launchPaymentOptionsCalls.awaitItem().selection).isEqualTo(PaymentSelection.Saved(paymentMethod))
+    }
+
+    @Test
+    fun `completed Link result updates tax region before closing`() {
+        val updatedResponse = CheckoutSessionResponseFactory.create(id = "cs_updated")
+        val checkoutResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
+        testScenario(
+            initialState = linkCheckoutState(checkoutSessionResponse = checkoutResponse),
+            taxRegionUpdateResult = Result.success(updatedResponse),
+        ) {
+            sessionRefresher.enqueueRefreshAction {}
+            linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+            launchLink()
+            linkLauncherScenario.presentCalls.awaitItem()
+            val updatedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+                details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = null,
+                billingPhone = null,
+            )
+
+            linkResultCallback(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                    selectedPayment = updatedPayment,
+                )
+            )
+            runCurrent()
+
+            assertThat(sessionRefresher.calls.awaitItem())
+                .isEqualTo(FakeCheckoutSessionRefresher.Call.Commit(updatedResponse))
+            assertThat((selectionHolder.selection.value as PaymentSelection.Link).selectedPayment)
+                .isEqualTo(updatedPayment)
+            assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        }
+    }
+
+    @Test
+    fun `failed Link tax update reopens payment options with updated selection`() {
+        val error = IllegalStateException("Tax update failed")
+        val checkoutResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
+        testScenario(
+            initialState = linkCheckoutState(checkoutSessionResponse = checkoutResponse),
+            taxRegionUpdateResult = Result.failure(error),
+        ) {
+            linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+            launchLink()
+            linkLauncherScenario.presentCalls.awaitItem()
+            val updatedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+                details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = null,
+                billingPhone = null,
+            )
+
+            linkResultCallback(
+                LinkActivityResult.Completed(
+                    linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+                    selectedPayment = updatedPayment,
+                )
+            )
+            runCurrent()
+
+            val call = launchPaymentOptionsCalls.awaitItem()
+            assertThat((call.selection as PaymentSelection.Link).selectedPayment).isEqualTo(updatedPayment)
+            assertThat(logger.errorLogs).containsExactly(
+                "Failed to update the tax region after Link selection." to error
+            )
+            assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+        }
+    }
+
+    @Test
+    fun `restored pay another way result launches options from persisted state`() = testScenario(
+        initialState = linkCheckoutState(),
+    ) {
+        sheetStateHolder.sheetIsOpen = true
+
+        linkResultCallback(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.PayAnotherWay,
+                linkAccountUpdate = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+            )
+        )
+
+        val call = launchPaymentOptionsCalls.awaitItem()
+        assertThat(call.paymentMethodMetadata)
+            .isEqualTo(checkoutControllerStateHolder.state?.paymentMethodMetadata)
+        assertThat(call.configuration).isEqualTo(checkoutControllerStateHolder.state?.embeddedConfiguration)
+    }
+
+    @Suppress("LongMethod")
+    private fun testScenario(
+        initialState: CheckoutControllerState,
+        taxRegionUpdateResult: Result<CheckoutSessionResponse>? = null,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val testScope = this
+        val savedStateHandle = SavedStateHandle()
+        val errorReporter = FakeErrorReporter()
+        val checkoutControllerStateHolder = CheckoutControllerStateFactory.createStateHolder(
+            savedStateHandle = savedStateHandle,
+            errorReporter = errorReporter,
+        ).apply {
+            state = initialState
+        }
+        val selectionHolder: EmbeddedSelectionHolder = checkoutControllerStateHolder
+        val customerStateHolder = DefaultCustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(initialState.paymentMethodMetadata.customerMetadata),
+            paymentMethodMetadataFlow = stateFlowOf(null),
+        )
+        val sheetStateHolder = SheetStateHolder(savedStateHandle)
+        val sessionRefresher = FakeCheckoutSessionRefresher()
+        val logger = FakeLogger()
+        val linkAccountHolder = LinkAccountHolder(savedStateHandle)
+        val linkGate = FakeLinkGate()
+        val confirmationHandler = FakeConfirmationHandler()
+        val operationCoordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            sheetStateHolder = sheetStateHolder,
+            sessionRefresher = sessionRefresher,
+            logger = logger,
+            resultCallback = CheckoutController.ResultCallback {},
+        )
+        val taxRegionUpdater = SheetTaxRegionUpdater { response, _, _ ->
+            taxRegionUpdateResult ?: Result.success(response)
+        }
+        val launchPaymentOptionsCalls = Turbine<LaunchPaymentOptionsCall>()
+
+        RecordingLinkPaymentLauncher.test {
+            val linkLauncherScenario = this
+            DummyActivityResultCaller.test {
+                val helper = DefaultCheckoutSheetLinkHelper(
+                    selectionHolder = selectionHolder,
+                    customerStateHolder = customerStateHolder,
+                    sheetStateHolder = sheetStateHolder,
+                    errorReporter = errorReporter,
+                    sessionRefresher = sessionRefresher,
+                    operationCoordinator = operationCoordinator,
+                    logger = logger,
+                    checkoutControllerStateHolder = checkoutControllerStateHolder,
+                    linkAccountHolder = linkAccountHolder,
+                    linkGateFactory = FakeLinkGate.Factory(linkGate),
+                    paymentElementLinkLauncher = linkLauncherScenario.launcher,
+                    taxRegionUpdater = taxRegionUpdater,
+                    coroutineScope = testScope,
+                    statusBarColor = null,
+                )
+                helper.register(activityResultCaller) { metadata, customerState, selection, configuration ->
+                    launchPaymentOptionsCalls.add(
+                        LaunchPaymentOptionsCall(
+                            paymentMethodMetadata = metadata,
+                            customerState = customerState,
+                            selection = selection,
+                            configuration = configuration,
+                        )
+                    )
+                }
+                val linkRegisterCall = linkLauncherScenario.registerCalls.awaitItem()
+
+                Scenario(
+                    helper = helper,
+                    selectionHolder = selectionHolder,
+                    checkoutControllerStateHolder = checkoutControllerStateHolder,
+                    customerStateHolder = customerStateHolder,
+                    sheetStateHolder = sheetStateHolder,
+                    sessionRefresher = sessionRefresher,
+                    logger = logger,
+                    linkAccountHolder = linkAccountHolder,
+                    linkGate = linkGate,
+                    linkLauncherScenario = linkLauncherScenario,
+                    linkResultCallback = linkRegisterCall.callback,
+                    launchPaymentOptionsCalls = launchPaymentOptionsCalls,
+                    runCurrent = testScheduler::runCurrent,
+                ).block()
+
+                helper.unregister()
+                linkLauncherScenario.unregisterCalls.awaitItem()
+            }
+        }
+
+        launchPaymentOptionsCalls.ensureAllEventsConsumed()
+        confirmationHandler.validate()
+        sessionRefresher.ensureAllEventsConsumed()
+    }
+
+    private class Scenario(
+        val helper: CheckoutSheetLinkHelper,
+        val selectionHolder: EmbeddedSelectionHolder,
+        val checkoutControllerStateHolder: CheckoutControllerStateHolder,
+        val customerStateHolder: CustomerStateHolder,
+        val sheetStateHolder: SheetStateHolder,
+        val sessionRefresher: FakeCheckoutSessionRefresher,
+        val logger: FakeLogger,
+        val linkAccountHolder: LinkAccountHolder,
+        val linkGate: FakeLinkGate,
+        val linkLauncherScenario: RecordingLinkPaymentLauncher.Scenario,
+        val linkResultCallback: (LinkActivityResult) -> Unit,
+        val launchPaymentOptionsCalls: Turbine<LaunchPaymentOptionsCall>,
+        private val runCurrent: () -> Unit,
+    ) {
+        fun launchLink(): Boolean {
+            sheetStateHolder.sheetIsOpen = true
+            val state = requireNotNull(checkoutControllerStateHolder.state)
+            return helper.launchLinkIfEligible(
+                paymentMethodMetadata = state.paymentMethodMetadata,
+                selection = state.paymentSelection,
+            )
+        }
+
+        fun runCurrent() {
+            runCurrent.invoke()
+        }
+    }
+
+    private data class LaunchPaymentOptionsCall(
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val customerState: CustomerState?,
+        val selection: PaymentSelection?,
+        val configuration: EmbeddedPaymentElement.Configuration,
+    )
+
+    private companion object {
+        val LINK_SELECTION = PaymentSelection.Link(
+            brand = LinkBrand.Link,
+            selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+                details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+                collectedCvc = null,
+                billingPhone = null,
+            ),
+        )
+
+        fun linkCheckoutState(
+            loginState: LinkState.LoginState = LinkState.LoginState.LoggedIn,
+            hasCustomerConfiguration: Boolean = false,
+            checkoutSessionResponse: CheckoutSessionResponse? = null,
+        ): CheckoutControllerState {
+            val response = checkoutSessionResponse ?: CheckoutSessionResponseFactory.create()
+            val integrationMetadata = checkoutSessionResponse?.let {
+                IntegrationMetadata.CheckoutSession(
+                    id = it.id,
+                    instancesKey = "test_instances_key",
+                    checkoutSessionResponse = it,
+                )
+            }
+            return CheckoutControllerStateFactory.create(
+                checkoutSessionResponse = response,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    hasCustomerConfiguration = hasCustomerConfiguration,
+                    linkState = LinkState(
+                        configuration = TestFactory.LINK_CONFIGURATION,
+                        loginState = loginState,
+                        signupMode = null,
+                    ),
+                    integrationMetadata = integrationMetadata
+                        ?: PaymentMethodMetadataFactory.create().integrationMetadata,
+                ),
+                paymentSelection = LINK_SELECTION,
+            )
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSheetLinkHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSheetLinkHelper.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultCaller
+import app.cash.turbine.Turbine
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal class FakeCheckoutSheetLinkHelper(
+    var launchLinkIfEligibleResult: Boolean = false,
+) : CheckoutSheetLinkHelper {
+    val registerCalls = Turbine<RegisterCall>()
+    val unregisterCalls = Turbine<Unit>()
+    val launchLinkIfEligibleCalls = Turbine<LaunchLinkIfEligibleCall>()
+
+    override fun register(
+        activityResultCaller: ActivityResultCaller,
+        launchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
+    ) {
+        registerCalls.add(RegisterCall(activityResultCaller, launchPaymentOptions))
+    }
+
+    override fun unregister() {
+        unregisterCalls.add(Unit)
+    }
+
+    override fun launchLinkIfEligible(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        selection: PaymentSelection?,
+    ): Boolean {
+        launchLinkIfEligibleCalls.add(LaunchLinkIfEligibleCall(paymentMethodMetadata, selection))
+        return launchLinkIfEligibleResult
+    }
+
+    fun ensureAllEventsConsumed() {
+        registerCalls.ensureAllEventsConsumed()
+        unregisterCalls.ensureAllEventsConsumed()
+        launchLinkIfEligibleCalls.ensureAllEventsConsumed()
+    }
+
+    data class RegisterCall(
+        val activityResultCaller: ActivityResultCaller,
+        val launchPaymentOptions: CheckoutSheetLinkHelper.LaunchPaymentOptions,
+    )
+
+    data class LaunchLinkIfEligibleCall(
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val selection: PaymentSelection?,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -3,6 +3,7 @@ package com.stripe.android.utils
 import androidx.activity.result.ActivityResultCaller
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkExpressMode
@@ -58,7 +59,7 @@ internal object RecordingLinkPaymentLauncher {
                     PresentCall(
                         configuration = arguments[0] as LinkConfiguration,
                         paymentMethodMetadata = arguments[1] as PaymentMethodMetadata,
-                        linkAccount = arguments[2] as? LinkAccount,
+                        linkAccountInfo = arguments[2] as LinkAccountUpdate.Value,
                         launchMode = arguments[3] as LinkLaunchMode,
                         linkExpressMode = arguments[4] as LinkExpressMode,
                         statusBarColor = arguments[5] as? Int,
@@ -96,9 +97,12 @@ internal object RecordingLinkPaymentLauncher {
     data class PresentCall(
         val configuration: LinkConfiguration,
         val paymentMethodMetadata: PaymentMethodMetadata,
-        val linkAccount: LinkAccount?,
+        val linkAccountInfo: LinkAccountUpdate.Value,
         val launchMode: LinkLaunchMode,
         val linkExpressMode: LinkExpressMode,
         val statusBarColor: Int?,
-    )
+    ) {
+        val linkAccount: LinkAccount?
+            get() = linkAccountInfo.account
+    }
 }


### PR DESCRIPTION
# Summary

Wires a Checkout Link presentation coordinator into `PaymentElement.present()` so eligible returning Link customers go directly to Link's payment-method picker. The coordinator owns eager-launch eligibility, Link result handling, account and selection synchronization, persisted verification dismissal, payment-options fallbacks, and Checkout Session tax refresh. This is layer 2 of 2 and depends on the tax-region refactor in #14222.

# Motivation

`PaymentElement.present()` currently always opens the embedded payment-options sheet, unlike `DefaultFlowController` and the equivalent iOS Payment Element path. Returning Link customers should go directly to Link while retaining verification, logout, “Pay another way,” and tax-update fallbacks.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutSheetLinkHelperTest' --tests 'com.stripe.android.checkout.CheckoutSheetLauncherTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.DefaultSheetActivityContinueCoordinatorTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.SheetTaxRegionUpdaterTest'`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable. This changes presentation routing and state handling without changing rendered UI.

# Changelog

Not applicable. `PaymentElement` is currently restricted to the Checkout Session preview API.

Committed and created by Codex.
