### PR TITLE
Propagate embedded sheet product usage

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.networktesting.RequestMatchers.analyticsPayloadField
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedContentPage
+import com.stripe.android.paymentelement.EmbeddedFormPage
 import com.stripe.android.paymentsheet.validateAnalyticsRequest
 import com.stripe.android.paymentsheet.utils.GooglePayRepositoryTestRule
 import com.stripe.android.paymentsheet.utils.TestRules
@@ -35,6 +36,52 @@ internal class CheckoutPaymentElementAnalyticsTest {
     }
 
     private val contentPage = EmbeddedContentPage(testRules.compose)
+    private val formPage = EmbeddedFormPage(testRules.compose)
+
+    @Test
+    fun testSheetAnalyticsUsesCheckoutProductUsage() = runCheckoutPaymentElementTest(
+        networkRule = networkRule,
+        setup = { controller ->
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_load_started",
+                productUsage = setOf("Checkout"),
+            )
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_load_succeeded",
+                productUsage = setOf("Checkout"),
+            )
+            networkRule.validateAnalyticsRequest(
+                eventName = "mc_initial_displayed_payment_methods",
+                productUsage = setOf("Checkout"),
+            )
+            controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+        },
+    ) { context ->
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_carousel_payment_method_tapped",
+            productUsage = setOf("Checkout"),
+        )
+        networkRule.validateAnalyticsRequest(
+            eventName = "stripe_android.card_metadata_pk_available",
+            productUsage = setOf("Checkout"),
+        )
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_form_shown",
+            productUsage = setOf("Checkout"),
+        )
+        networkRule.validateAnalyticsRequest(
+            eventName = "stripe_android.card_metadata_pk_available",
+            productUsage = setOf("Checkout"),
+        )
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_cardscan_api_check_failed",
+            productUsage = setOf("Checkout"),
+        )
+
+        contentPage.clickOnLpm("card")
+        formPage.waitUntilVisible()
+        context.markTestSucceeded()
+    }
 
     @Test
     fun testTotalChangeFailureSendsAnalyticsErrorCode() = runCheckoutPaymentElementTest(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -20,6 +20,7 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -43,6 +44,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private val operationCoordinator: CheckoutOperationCoordinator,
     private val logger: Logger,
     @ViewModelScope private val coroutineScope: CoroutineScope,
+    @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
@@ -167,6 +169,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
+            productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = currentSelection,
@@ -197,6 +200,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
+            productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,
@@ -225,6 +229,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
+            productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
@@ -15,6 +15,7 @@ import kotlinx.parcelize.Parcelize
 internal data class EmbeddedActivityArgs(
     val paymentMethodMetadata: PaymentMethodMetadata,
     val configuration: EmbeddedPaymentElement.Configuration,
+    val productUsage: Set<String>,
     val paymentElementCallbackIdentifier: String,
     val statusBarColor: Int?,
     val selection: PaymentSelection?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -22,7 +22,6 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
-import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.BuildConfig
@@ -104,10 +103,6 @@ internal interface EmbeddedCommonModule {
         fun provideEventReporterMode(): EventReporter.Mode {
             return EventReporter.Mode.Embedded
         }
-
-        @Provides
-        @Named(PRODUCT_USAGE)
-        fun provideProductUsageTokens() = setOf("EmbeddedPaymentElement")
 
         @Provides
         fun provideDurationProvider(): DurationProvider {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateA
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -57,6 +58,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
     private val errorReporter: ErrorReporter,
+    @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val embeddedResultCallbackHelper: EmbeddedResultCallbackHelper,
@@ -182,6 +184,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
+            productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = currentSelection,
@@ -212,6 +215,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
+            productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,
@@ -240,6 +244,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
+            productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
             selection = selection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -24,6 +24,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -197,6 +198,10 @@ internal interface EmbeddedPaymentElementViewModelModule {
 
     @Suppress("TooManyFunctions")
     companion object {
+        @Provides
+        @Named(PRODUCT_USAGE)
+        fun provideProductUsageTokens(): Set<String> = setOf("EmbeddedPaymentElement")
+
         @Provides
         fun providesContext(application: Application): Context {
             return application

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedCommonModule
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedLinkExtrasModule
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
@@ -51,6 +52,9 @@ internal interface EmbeddedSheetComponent {
             @Named(STATUS_BAR_COLOR)
             statusBarColor: Int?,
             @BindsInstance configuration: EmbeddedPaymentElement.Configuration,
+            @BindsInstance
+            @Named(PRODUCT_USAGE)
+            productUsage: Set<String>,
             @BindsInstance
             @PaymentElementCallbackIdentifier
             paymentElementCallbackIdentifier: String,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
@@ -29,6 +29,7 @@ internal class EmbeddedSheetViewModel @Inject constructor(
                 paymentMethodMetadata = args.paymentMethodMetadata,
                 statusBarColor = args.statusBarColor,
                 configuration = args.configuration,
+                productUsage = args.productUsage,
                 paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
                 application = extras.requireApplication(),
                 savedStateHandle = extras.createSavedStateHandle(),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -71,6 +71,7 @@ internal class CheckoutSheetLauncherTest {
         val expectedArgs = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = EmbeddedConfigurationFactory.create(),
+            productUsage = setOf("Checkout"),
             paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
             statusBarColor = null,
             selection = null,
@@ -363,6 +364,7 @@ internal class CheckoutSheetLauncherTest {
         val expectedArgs = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = EmbeddedConfigurationFactory.create(),
+            productUsage = setOf("Checkout"),
             paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
             statusBarColor = null,
             selection = PaymentSelection.GooglePay,
@@ -490,6 +492,7 @@ internal class CheckoutSheetLauncherTest {
         val expectedArgs = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = EmbeddedConfigurationFactory.create(),
+            productUsage = setOf("Checkout"),
             paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
             statusBarColor = null,
             selection = selection,
@@ -749,6 +752,7 @@ internal class CheckoutSheetLauncherTest {
                 operationCoordinator = operationCoordinator,
                 logger = logger,
                 coroutineScope = testScope,
+                productUsage = setOf("Checkout"),
                 statusBarColor = null,
                 paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
                 rowSelectionImmediateActionHandler = { immediateActionInvoked = true },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -74,6 +74,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val expectedArgs = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = EmbeddedConfigurationFactory.create(),
+            productUsage = setOf("EmbeddedPaymentElement"),
             paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
             statusBarColor = null,
             selection = null,
@@ -399,6 +400,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val expectedArgs = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = EmbeddedConfigurationFactory.create(),
+            productUsage = setOf("EmbeddedPaymentElement"),
             paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
             statusBarColor = null,
             selection = PaymentSelection.GooglePay,
@@ -578,6 +580,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val expectedArgs = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = EmbeddedConfigurationFactory.create(),
+            productUsage = setOf("EmbeddedPaymentElement"),
             paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
             statusBarColor = null,
             selection = selection,
@@ -809,6 +812,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 customerStateHolder = customerStateHolder,
                 sheetStateHolder = sheetStateHolder,
                 errorReporter = errorReporter,
+                productUsage = setOf("EmbeddedPaymentElement"),
                 statusBarColor = null,
                 paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
                 embeddedResultCallbackHelper = callbackHelper,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -261,6 +261,7 @@ internal class EmbeddedSheetActivityTest {
                 input = EmbeddedActivityArgs(
                     paymentMethodMetadata = paymentMethodMetadata,
                     configuration = configuration,
+                    productUsage = setOf("EmbeddedPaymentElement"),
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
                     selection = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -266,6 +266,7 @@ internal class EmbeddedSheetActivityTest {
                     paymentMethodMetadata = paymentMethodMetadata,
                     configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
                         .build(),
+                    productUsage = setOf("EmbeddedPaymentElement"),
                     paymentElementCallbackIdentifier = "EmbeddedSheetActivityTestCallbackIdentifier",
                     statusBarColor = null,
                     selection = selection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -333,6 +333,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                 input = EmbeddedActivityArgs(
                     paymentMethodMetadata = paymentMethodMetadata,
                     configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+                    productUsage = setOf("EmbeddedPaymentElement"),
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
                     selection = selection,


### PR DESCRIPTION
# Summary

Propagate the originating product usage through `EmbeddedActivityArgs` into the launched embedded sheet analytics graph. Checkout sheets now retain `Checkout`, while Embedded Payment Element sheets retain `EmbeddedPaymentElement`.

# Motivation

The launched sheet creates a separate Dagger component that previously hardcoded `EmbeddedPaymentElement`. As a result, analytics emitted after Checkout opened the sheet lost their Checkout attribution.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Validated with focused `paymentsheet` launcher and activity unit tests, Checkout analytics instrumentation, existing Embedded Payment Element analytics instrumentation, and `./gradlew detekt`.

# Screenshots

| Before | After |
| --- | --- |
| Not applicable — analytics-only change. | Not applicable — analytics-only change. |

# Changelog

Not applicable — this fixes internal analytics attribution without changing public API or user-facing behavior.

Committed and created by Codex.
