### PR TITLE
Clean up coroutine scopes in payment form tests

### DIFF
--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -19,6 +19,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.model.AccountRange
 import com.stripe.android.model.CardBrand
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.R
@@ -36,10 +37,12 @@ import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.utils.TestUtils.idleLooper
 import com.stripe.android.utils.isInstanceOf
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -48,16 +51,22 @@ class CardDetailsControllerTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    @get:Rule
-    val coroutineTestRule = CoroutineTestRule(testDispatcher)
+    private val coroutineTestRule = CoroutineTestRule(testDispatcher)
 
-    private val coroutineScope = CoroutineScope(testDispatcher)
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    private val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(testDispatcher))
+
+    private val composeTestRule = createComposeRule()
+
+    private val composeCleanupRule = createComposeCleanupRule()
 
     @get:Rule
-    val composeTestRule = createComposeRule()
-
-    @get:Rule
-    val composeCleanupRule = createComposeCleanupRule()
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(composeTestRule)
+        .around(composeCleanupRule)
+        .around(coroutineTestRule)
+        .around(coroutineScopeCleanupRule)
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FieldValidationMessage
@@ -14,10 +15,12 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import com.stripe.android.R as StripeR
@@ -28,12 +31,17 @@ class CardDetailsElementTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    private val coroutineScope = CoroutineScope(testDispatcher)
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    private val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(testDispatcher))
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
+    private val coroutineTestRule = CoroutineTestRule(testDispatcher)
+
     @get:Rule
-    val coroutineTestRule = CoroutineTestRule(testDispatcher)
+    val ruleChain: RuleChain = RuleChain.outerRule(coroutineTestRule)
+        .around(coroutineScopeCleanupRule)
 
     @Test
     fun `test form field values returned and expiration date parsing`() = runTest {

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionControllerTest.kt
@@ -6,13 +6,16 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -21,10 +24,15 @@ class CardDetailsSectionControllerTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
-    @get:Rule
-    val coroutineTestRule = CoroutineTestRule(testDispatcher)
+    private val coroutineTestRule = CoroutineTestRule(testDispatcher)
 
-    private val coroutineScope = CoroutineScope(testDispatcher)
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.outerRule(coroutineTestRule)
+        .around(coroutineScopeCleanupRule)
+
+    private val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(testDispatcher))
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -17,11 +17,15 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.R
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.CardNumber
+import com.stripe.android.cards.DefaultCardAccountRangeService
 import com.stripe.android.cards.StaticCardAccountRangeSource
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.AccountRange
+import com.stripe.android.model.BinRange
 import com.stripe.android.model.CardBrand
+import com.stripe.android.model.CardFunding
 import com.stripe.android.networking.PaymentAnalyticsEvent
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.events.AnalyticsEventReporter
@@ -39,6 +43,8 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakeCardBrandFilter
 import com.stripe.android.utils.TestUtils.idleLooper
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -46,6 +52,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
@@ -61,16 +68,22 @@ import com.stripe.android.uicore.R as StripeUiCoreR
 @Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 internal class CardNumberControllerTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+    private val composeTestRule = createComposeRule()
 
-    @get:Rule
-    val composeCleanupRule = createComposeCleanupRule()
+    private val composeCleanupRule = createComposeCleanupRule()
 
     private val testDispatcher = UnconfinedTestDispatcher()
 
+    private val coroutineTestRule = CoroutineTestRule(testDispatcher)
+
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @get:Rule
-    val coroutineTestRule = CoroutineTestRule(testDispatcher)
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(composeTestRule)
+        .around(composeCleanupRule)
+        .around(coroutineTestRule)
+        .around(coroutineScopeCleanupRule)
 
     @Test
     fun `When invalid card number verify visible error`() = runTest {
@@ -894,6 +907,42 @@ internal class CardNumberControllerTest {
         }
     }
 
+    @Test
+    fun `cancelling parent scope cancels controller collectors and stops account range updates`() = runTest {
+        val parentJob = Job()
+        val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(testDispatcher + parentJob))
+        val accountRangeService = DefaultCardAccountRangeService(
+            cardAccountRangeRepository = FakeCardAccountRangeRepository(),
+            uiContext = testDispatcher,
+            workContext = testDispatcher,
+            staticCardAccountRanges = mock(),
+            coroutineScope = coroutineScope,
+        )
+        val cardNumberController = DefaultCardNumberController(
+            cardTextFieldConfig = CardNumberConfig(
+                isCardBrandChoiceEligible = false,
+                cardBrandFilter = DefaultCardBrandFilter,
+            ),
+            cardAccountRangeRepository = FakeCardAccountRangeRepository(),
+            uiContext = testDispatcher,
+            workContext = testDispatcher,
+            coroutineScope = coroutineScope,
+            initialValue = null,
+            accountRangeService = accountRangeService,
+        )
+        val controllerJobs = parentJob.children.toList()
+        assertThat(controllerJobs).hasSize(4)
+
+        accountRangeService.updateAccountRangesResult(listOf(accountRange(CardBrand.Visa)))
+        assertThat(cardNumberController.cardBrandFlow.value).isEqualTo(CardBrand.Visa)
+
+        coroutineScope.cancel()
+        assertThat(controllerJobs.all { it.isCancelled }).isTrue()
+
+        accountRangeService.updateAccountRangesResult(listOf(accountRange(CardBrand.MasterCard)))
+        assertThat(cardNumberController.cardBrandFlow.value).isEqualTo(CardBrand.Visa)
+    }
+
     private fun createController(
         initialValue: String? = null,
         cardBrandChoiceConfig: CardBrandChoiceConfig = CardBrandChoiceConfig.Ineligible,
@@ -907,7 +956,7 @@ internal class CardNumberControllerTest {
             cardAccountRangeRepository = FakeCardAccountRangeRepository(),
             uiContext = testDispatcher,
             workContext = testDispatcher,
-            coroutineScope = CoroutineScope(testDispatcher),
+            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(testDispatcher)),
             initialValue = initialValue,
             cardBrandChoiceConfig = cardBrandChoiceConfig,
             cardBrandFilter = cardBrandFilter
@@ -934,6 +983,22 @@ internal class CardNumberControllerTest {
         }
 
         override val loading: StateFlow<Boolean> = stateFlowOf(false)
+    }
+
+    private fun accountRange(cardBrand: CardBrand): AccountRange {
+        return AccountRange(
+            binRange = BinRange(
+                low = "4000000000000000",
+                high = "4999999999999999",
+            ),
+            panLength = 16,
+            brandInfo = when (cardBrand) {
+                CardBrand.Visa -> AccountRange.BrandInfo.Visa
+                CardBrand.MasterCard -> AccountRange.BrandInfo.Mastercard
+                else -> error("Unsupported card brand: $cardBrand")
+            },
+            funding = CardFunding.Credit,
+        )
     }
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsActionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCardDetailsActionTest.kt
@@ -7,14 +7,17 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -22,11 +25,17 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
 internal class TapToAddCardDetailsActionTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
+    private val composeTestRule = createComposeRule()
+
+    private val composeCleanupRule = createComposeCleanupRule()
+
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @get:Rule
-    val composeCleanupRule = createComposeCleanupRule()
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(composeTestRule)
+        .around(composeCleanupRule)
+        .around(coroutineScopeCleanupRule)
 
     @Test
     fun `clicking button calls startPaymentMethodCollection`() = runTest {
@@ -112,6 +121,6 @@ internal class TapToAddCardDetailsActionTest {
     private fun fakeController() = CardDetailsSectionController(
         cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
         initialValues = emptyMap(),
-        coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+        coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -44,6 +44,7 @@ import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
@@ -83,6 +84,8 @@ internal class CustomerSheetScreenshotTest {
 
     private val closeInteractorRule = CleanupTestRule(UpdatePaymentMethodInteractor::close)
 
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @get:Rule
     val ruleChain: RuleChain = RuleChain.emptyRuleChain()
         .around(closeInteractorRule)
@@ -91,6 +94,7 @@ internal class CustomerSheetScreenshotTest {
         .around(scopedThemePaparazzi)
         .around(localeRule)
         .around(coroutineRule)
+        .around(coroutineScopeCleanupRule)
 
     private val usBankAccountFormArguments = USBankAccountFormArguments(
         showCheckbox = false,
@@ -146,7 +150,7 @@ internal class CustomerSheetScreenshotTest {
             ).formElementsForCode(
                 code = PaymentMethod.Type.Card.code,
                 uiDefinitionFactoryArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
-                    coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+                    coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
                     cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
                     linkConfigurationCoordinator = null,
                     onLinkInlineSignupStateChanged = {},

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodFormHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodFormHelper.kt
@@ -12,7 +12,9 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.uicore.elements.FormElement
 
-internal class PaymentMethodFormHelper : FormHelper {
+internal class PaymentMethodFormHelper(
+    private val formElements: List<FormElement> = TestFactory.CARD_FORM_ELEMENTS,
+) : FormHelper {
     var paymentMethodCreateParams: PaymentMethodCreateParams? = PaymentMethodCreateParamsFixtures.DEFAULT_CARD
     val getPaymentMethodParamsCalls = arrayListOf<GetPaymentMethodParamsCall>()
 
@@ -43,7 +45,7 @@ internal class PaymentMethodFormHelper : FormHelper {
         require(code == PaymentMethod.Type.Card.code) {
             "$code payment not supported"
         }
-        return TestFactory.CARD_FORM_ELEMENTS
+        return formElements
     }
 
     override fun createFormArguments(paymentMethodCode: PaymentMethodCode): FormArguments {

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenScreenshotTest.kt
@@ -14,40 +14,38 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.forms.FormArgumentsFactory
 import com.stripe.android.paymentsheet.utils.ViewModelStoreOwnerContext
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.testing.CleanupTestRule
+import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FeatureFlagTestRule
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
-import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 internal class PaymentMethodScreenScreenshotTest {
-    @get:Rule
-    val paparazziRule = PaparazziRule()
+    private val paparazziRule = PaparazziRule()
 
-    @get:Rule
-    val enableKlarnaFormRemovalRule = FeatureFlagTestRule(
+    private val enableKlarnaFormRemovalRule = FeatureFlagTestRule(
         featureFlag = FeatureFlags.enableKlarnaFormRemoval,
         isEnabled = false,
     )
 
     private val dispatcher = UnconfinedTestDispatcher()
 
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(dispatcher)
-    }
+    private val coroutineRule = CoroutineTestRule(dispatcher)
 
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(paparazziRule)
+        .around(enableKlarnaFormRemovalRule)
+        .around(coroutineRule)
+        .around(coroutineScopeCleanupRule)
 
     @Test
     fun `form with button disabled`() {
@@ -125,7 +123,7 @@ internal class PaymentMethodScreenScreenshotTest {
             ),
         )
         val uiDefinitionArgumentsFactory = UiDefinitionFactory.Arguments.Factory.Default(
-            coroutineScope = CoroutineScope(dispatcher),
+            coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(dispatcher)),
             cardAccountRangeRepositoryFactory = NullCardAccountRangeRepositoryFactory,
             linkConfigurationCoordinator = null,
             linkInlineHandler = null,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodScreenTest.kt
@@ -31,14 +31,21 @@ import com.stripe.android.link.ui.PrimaryButtonTag
 import com.stripe.android.link.ui.paymentmenthod.PAYMENT_METHOD_ERROR_TAG
 import com.stripe.android.link.ui.paymentmenthod.PaymentMethodScreen
 import com.stripe.android.link.ui.paymentmenthod.PaymentMethodViewModel
+import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
+import com.stripe.android.lpmfoundations.paymentmethod.formElements
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.NoOpCardScanEventsReporter
 import com.stripe.android.ui.core.cardscan.LocalCardScanEventsReporter
 import com.stripe.android.ui.core.elements.events.LocalCardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -59,6 +66,9 @@ internal class PaymentMethodScreenTest {
     @get:Rule
     val viewModelStoreRule = ViewModelStoreTestRule()
 
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @Test
     fun `form fields are displayed correctly`() = runScenario {
         onCardNumber().assertExists()
@@ -74,7 +84,6 @@ internal class PaymentMethodScreenTest {
     @Test
     fun `no error message on successful payment`() = runScenario {
         fillCardDetails()
-        assertThat(formHelper.formFieldValuesChangedCall.awaitItem()).isNotNull()
 
         onPayButton()
             .scrollToAndAssertDisplayed()
@@ -123,11 +132,13 @@ internal class PaymentMethodScreenTest {
             .assert(hasText("oops"))
     }
 
-    private fun fillCardDetails() {
+    private suspend fun Scenario.fillCardDetails() {
         onCardNumber().performTextReplacement("4242424242424242")
         onCvc().performTextReplacement("123")
         onExpiryDate().performTextReplacement("12/34")
         onZipCode().performTextReplacement("12345")
+        assertThat(formHelper.formFieldValuesChangedCall.awaitItem())
+            .isEqualTo(PaymentMethod.Type.Card.code)
     }
 
     private fun screen(viewModel: PaymentMethodViewModel) {
@@ -149,7 +160,11 @@ internal class PaymentMethodScreenTest {
     private fun runScenario(
         linkAccountManager: FakeLinkAccountManager = FakeLinkAccountManager(),
         linkConfirmationHandler: FakeLinkConfirmationHandler = FakeLinkConfirmationHandler(),
-        formHelper: PaymentMethodFormHelper = PaymentMethodFormHelper(),
+        formHelper: PaymentMethodFormHelper = PaymentMethodFormHelper(
+            formElements = CardDefinition.formElements(
+                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
+            ),
+        ),
         dismissalCoordinator: LinkDismissalCoordinator = RealLinkDismissalCoordinator(),
         block: suspend Scenario.() -> Unit
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -20,9 +20,46 @@ import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 
 internal object TestUiDefinitionFactoryArgumentsFactory {
+    private val cancelledCoroutineScope = CoroutineScope(Dispatchers.Unconfined).apply {
+        cancel()
+    }
+
     fun create(
+        paymentMethodCreateParams: PaymentMethodCreateParams? = null,
+        paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+        paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+        initialValues: Map<IdentifierSpec, String?>? = null,
+        linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
+        linkInlineHandler: LinkInlineHandler? = null,
+        autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
+        initialLinkUserInput: UserInput? = null,
+        setAsDefaultMatchesSaveForFutureUse: Boolean = false,
+        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper? = null,
+        tapToAddHelper: TapToAddHelper? = null,
+        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null,
+        isNfcScanningAvailable: IsNfcScanningAvailable? = null,
+    ): UiDefinitionFactory.Arguments.Factory = create(
+        coroutineScope = cancelledCoroutineScope,
+        paymentMethodCreateParams = paymentMethodCreateParams,
+        paymentMethodExtraParams = paymentMethodExtraParams,
+        paymentMethodOptionsParams = paymentMethodOptionsParams,
+        initialValues = initialValues,
+        linkConfigurationCoordinator = linkConfigurationCoordinator,
+        linkInlineHandler = linkInlineHandler,
+        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+        initialLinkUserInput = initialLinkUserInput,
+        setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+        automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+        tapToAddHelper = tapToAddHelper,
+        paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+        isNfcScanningAvailable = isNfcScanningAvailable,
+    )
+
+    fun create(
+        coroutineScope: CoroutineScope,
         paymentMethodCreateParams: PaymentMethodCreateParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
@@ -43,7 +80,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
             null
         }
         val delegate = UiDefinitionFactory.Arguments.Factory.Default(
-            coroutineScope = CoroutineScope(Dispatchers.Unconfined),
+            coroutineScope = coroutineScope,
             cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory(context),
             paymentMethodCreateParams = paymentMethodCreateParams,
             paymentMethodOptionsParams = paymentMethodOptionsParams,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
@@ -12,6 +12,7 @@ import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormData
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.CoroutineScope
 
 internal fun PaymentMethodDefinition.formElements(
     metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
@@ -28,23 +29,109 @@ internal fun PaymentMethodDefinition.formElements(
     isNfcScanningAvailable: IsNfcScanningAvailable? = null,
     paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
 ): List<FormElement> {
+    return formElementsInternal(
+        coroutineScope = null,
+        metadata = metadata,
+        paymentMethodCreateParams = paymentMethodCreateParams,
+        paymentMethodOptionsParams = paymentMethodOptionsParams,
+        paymentMethodExtraParams = paymentMethodExtraParams,
+        initialValues = initialValues,
+        initialLinkUserInput = initialLinkUserInput,
+        linkConfigurationCoordinator = linkConfigurationCoordinator,
+        setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+        automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+        tapToAddHelper = tapToAddHelper,
+        isNfcScanningAvailable = isNfcScanningAvailable,
+        paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+    )
+}
+
+internal fun PaymentMethodDefinition.formElements(
+    coroutineScope: CoroutineScope,
+    metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+    paymentMethodCreateParams: PaymentMethodCreateParams? = null,
+    paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+    paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+    initialValues: Map<IdentifierSpec, String?>? = null,
+    initialLinkUserInput: UserInput? = null,
+    linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
+    setAsDefaultMatchesSaveForFutureUse: Boolean = false,
+    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
+    automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper? = null,
+    tapToAddHelper: TapToAddHelper? = null,
+    isNfcScanningAvailable: IsNfcScanningAvailable? = null,
+    paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper? = null
+): List<FormElement> {
+    return formElementsInternal(
+        coroutineScope = coroutineScope,
+        metadata = metadata,
+        paymentMethodCreateParams = paymentMethodCreateParams,
+        paymentMethodOptionsParams = paymentMethodOptionsParams,
+        paymentMethodExtraParams = paymentMethodExtraParams,
+        initialValues = initialValues,
+        initialLinkUserInput = initialLinkUserInput,
+        linkConfigurationCoordinator = linkConfigurationCoordinator,
+        setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+        autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+        automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+        tapToAddHelper = tapToAddHelper,
+        isNfcScanningAvailable = isNfcScanningAvailable,
+        paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+    )
+}
+
+private fun PaymentMethodDefinition.formElementsInternal(
+    coroutineScope: CoroutineScope?,
+    metadata: PaymentMethodMetadata,
+    paymentMethodCreateParams: PaymentMethodCreateParams?,
+    paymentMethodOptionsParams: PaymentMethodOptionsParams?,
+    paymentMethodExtraParams: PaymentMethodExtraParams?,
+    initialValues: Map<IdentifierSpec, String?>?,
+    initialLinkUserInput: UserInput?,
+    linkConfigurationCoordinator: LinkConfigurationCoordinator?,
+    setAsDefaultMatchesSaveForFutureUse: Boolean,
+    autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+    tapToAddHelper: TapToAddHelper?,
+    isNfcScanningAvailable: IsNfcScanningAvailable?,
+    paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+): List<FormElement> {
     return requireNotNull(
         metadata.formElementsForCode(
             code = type.code,
-            uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(
-                paymentMethodCreateParams = paymentMethodCreateParams,
-                paymentMethodOptionsParams = paymentMethodOptionsParams,
-                paymentMethodExtraParams = paymentMethodExtraParams,
-                initialValues = initialValues,
-                linkConfigurationCoordinator = linkConfigurationCoordinator,
-                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-                initialLinkUserInput = initialLinkUserInput,
-                setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
-                automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
-                tapToAddHelper = tapToAddHelper,
-                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
-                isNfcScanningAvailable = isNfcScanningAvailable,
-            )
+            uiDefinitionFactoryArgumentsFactory = if (coroutineScope == null) {
+                TestUiDefinitionFactoryArgumentsFactory.create(
+                    paymentMethodCreateParams = paymentMethodCreateParams,
+                    paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
+                    initialValues = initialValues,
+                    linkConfigurationCoordinator = linkConfigurationCoordinator,
+                    autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+                    initialLinkUserInput = initialLinkUserInput,
+                    setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+                    automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+                    tapToAddHelper = tapToAddHelper,
+                    paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                    isNfcScanningAvailable = isNfcScanningAvailable,
+                )
+            } else {
+                TestUiDefinitionFactoryArgumentsFactory.create(
+                    coroutineScope = coroutineScope,
+                    paymentMethodCreateParams = paymentMethodCreateParams,
+                    paymentMethodOptionsParams = paymentMethodOptionsParams,
+                    paymentMethodExtraParams = paymentMethodExtraParams,
+                    initialValues = initialValues,
+                    linkConfigurationCoordinator = linkConfigurationCoordinator,
+                    autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+                    initialLinkUserInput = initialLinkUserInput,
+                    setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+                    automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+                    tapToAddHelper = tapToAddHelper,
+                    paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                    isNfcScanningAvailable = isNfcScanningAvailable,
+                )
+            }
         )
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinitionTest.kt
@@ -11,12 +11,12 @@ import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.formElements
 import com.stripe.android.lpmfoundations.paymentmethod.link.LinkFormElement
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntentFixtures
@@ -31,6 +31,7 @@ import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInt
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsAction
@@ -41,6 +42,7 @@ import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SameAsShippingElement
@@ -48,13 +50,25 @@ import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.filterOutHiddenIdentifiers
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import com.stripe.android.lpmfoundations.paymentmethod.formElements as createFormElements
 import com.stripe.android.ui.core.R as PaymentsUiCoreR
 
 @RunWith(RobolectricTestRunner::class)
 class CardDefinitionTest {
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
+    @get:Rule
+    val cleanupRule = coroutineScopeCleanupRule
+
+    private val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined))
+
     @Test
     fun `createFormElements returns minimal set of fields`() {
         val formElements = CardDefinition.formElements(
@@ -842,6 +856,31 @@ class CardDefinitionTest {
     private fun createLinkConfiguration(): LinkConfiguration {
         return TestFactory.LINK_CONFIGURATION.copy(
             stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD
+        )
+    }
+
+    private fun CardDefinition.formElements(
+        metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
+        paymentMethodExtraParams: PaymentMethodExtraParams? = null,
+        linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
+        setAsDefaultMatchesSaveForFutureUse: Boolean = false,
+        autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
+        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper? = null,
+        tapToAddHelper: TapToAddHelper? = null,
+        isNfcScanningAvailable: IsNfcScanningAvailable? = null,
+    ): List<FormElement> {
+        return createFormElements(
+            coroutineScope = coroutineScope,
+            metadata = metadata,
+            paymentMethodOptionsParams = paymentMethodOptionsParams,
+            paymentMethodExtraParams = paymentMethodExtraParams,
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
+            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+            tapToAddHelper = tapToAddHelper,
+            isNfcScanningAvailable = isNfcScanningAvailable,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.screenshottesting.LayoutDirection
 import com.stripe.android.screenshottesting.PaparazziConfigOption
 import com.stripe.android.screenshottesting.PaparazziRule
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
@@ -24,31 +25,42 @@ import com.stripe.android.ui.core.elements.ScannedCardDetails
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance.DefaultAppearance
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 
 class CardUiDefinitionFactoryTest {
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
-    @get:Rule
-    val coroutineTestRule = CoroutineTestRule()
+    private val coroutineTestRule = CoroutineTestRule()
 
-    @get:Rule
-    val paparazziRule = PaparazziRule()
+    private val paparazziRule = PaparazziRule()
 
-    @get:Rule
-    val rightToLeftPaparazziRule = PaparazziRule(
+    private val rightToLeftPaparazziRule = PaparazziRule(
         listOf(LayoutDirection.RightToLeft)
     )
 
-    @get:Rule
-    val customSpacingPaparazziRule = PaparazziRule(
+    private val customSpacingPaparazziRule = PaparazziRule(
         listOf(CustomSpacingAppearance)
     )
 
-    @get:Rule
-    val customTextFieldsPaparazziRule = PaparazziRule(
+    private val customTextFieldsPaparazziRule = PaparazziRule(
         listOf(CustomTextInsetsAppearance)
     )
+
+    @get:Rule
+    val ruleChain: RuleChain = RuleChain.emptyRuleChain()
+        .around(paparazziRule)
+        .around(rightToLeftPaparazziRule)
+        .around(customSpacingPaparazziRule)
+        .around(customTextFieldsPaparazziRule)
+        .around(coroutineTestRule)
+        .around(coroutineScopeCleanupRule)
+
+    private val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined))
 
     private val metadata = PaymentMethodMetadataFactory.create(
         stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
@@ -67,7 +79,7 @@ class CardUiDefinitionFactoryTest {
 
     @Test
     fun testCardWithScannedCardPill() {
-        val formElements = CardDefinition.formElements(metadata = metadata)
+        val formElements = CardDefinition.formElements(coroutineScope = coroutineScope, metadata = metadata)
 
         val cardDetailsSection = formElements.filterIsInstance<CardDetailsSectionElement>().first()
 
@@ -91,7 +103,7 @@ class CardUiDefinitionFactoryTest {
 
     @Test
     fun testCardWithScannedCardPillAndCustomInsets() {
-        val formElements = CardDefinition.formElements(metadata = metadata)
+        val formElements = CardDefinition.formElements(coroutineScope = coroutineScope, metadata = metadata)
         val cardDetailsSection = formElements.filterIsInstance<CardDetailsSectionElement>().first()
 
         cardDetailsSection.controller.onScannedCard(
@@ -207,6 +219,7 @@ class CardUiDefinitionFactoryTest {
     @Test
     fun testCardWithSaveForLaterAndSetAsDefaultShown() {
         val formElements = CardDefinition.formElements(
+            coroutineScope = coroutineScope,
             metadata = metadata.copy(
                 customerMetadata = getDefaultCustomerMetadata(
                     isPaymentMethodSetAsDefaultEnabled = true

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
@@ -16,18 +16,30 @@ import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.uicore.elements.IdentifierSpec
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestParameterInjector
 
 @RunWith(RobolectricTestParameterInjector::class)
 internal class LpmBillingAddressFormValuesToParamsTest {
+    private val viewModelStoreRule = ViewModelStoreTestRule()
+
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @get:Rule
-    val viewModelStoreRule = ViewModelStoreTestRule()
+    val ruleChain: RuleChain = RuleChain.outerRule(viewModelStoreRule)
+        .around(coroutineScopeCleanupRule)
+
+    private val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined))
 
     @Test
     fun `creates the expected form params`(
@@ -99,6 +111,7 @@ internal class LpmBillingAddressFormValuesToParamsTest {
             metadata.formElementsForCode(
                 code = paymentMethodType.code,
                 uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(
+                    coroutineScope = coroutineScope,
                     initialValues = initialValues,
                 ),
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/UiDefinitionTestHelper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.lpmfoundations.paymentmethod.definitions
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.TapToAddHelper
 import com.stripe.android.isInstanceOf
@@ -25,6 +26,7 @@ import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
+import kotlinx.coroutines.Dispatchers
 
 @Composable
 internal fun PaymentMethodDefinition.CreateFormUi(
@@ -37,7 +39,9 @@ internal fun PaymentMethodDefinition.CreateFormUi(
     tapToAddHelper: TapToAddHelper? = null,
     isValidating: Boolean = false,
 ) {
+    val coroutineScope = rememberCoroutineScope { Dispatchers.Unconfined }
     val formElements = formElements(
+        coroutineScope = coroutineScope,
         metadata = metadata,
         paymentMethodCreateParams = paymentMethodCreateParams,
         paymentMethodExtraParams = paymentMethodExtraParams,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures.COMPOSE_FRAGMENT_ARG
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AddressSpec
 import com.stripe.android.ui.core.elements.AffirmHeaderElement
@@ -36,11 +37,15 @@ import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.forms.FormFieldEntry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import com.stripe.android.core.R as CoreR
@@ -51,8 +56,15 @@ import com.stripe.android.uicore.R as UiCoreR
 internal class FormViewModelTest {
     private val emailSection = EmailSpec()
 
+    private val viewModelStoreRule = ViewModelStoreTestRule()
+
+    private val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
+
     @get:Rule
-    val viewModelStoreRule = ViewModelStoreTestRule()
+    val ruleChain: RuleChain = RuleChain.outerRule(viewModelStoreRule)
+        .around(coroutineScopeCleanupRule)
+
+    private val coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined))
 
     @Test
     fun `Verify completeFormValues is not null when no elements exist`() = runTest {
@@ -562,7 +574,9 @@ internal class FormViewModelTest {
 
             val cardFormElements = PaymentMethodMetadataFactory.create().formElementsForCode(
                 code = "card",
-                uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(),
+                uiDefinitionFactoryArgumentsFactory = TestUiDefinitionFactoryArgumentsFactory.create(
+                    coroutineScope = coroutineScope,
+                ),
             )!!
 
             val formViewModel = createViewModel(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUITest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.ViewActionRecorder
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
+import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.NoOpCardScanEventsReporter
 import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.Amount
@@ -31,6 +32,9 @@ import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventR
 import com.stripe.paymentelementtestpages.FormPage
 import com.stripe.paymentelementtestpages.assertHasErrorMessage
 import com.stripe.paymentelementtestpages.assertHasNoErrorMessage
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Rule
@@ -48,6 +52,9 @@ internal class VerticalModeFormUITest {
 
     @get:Rule
     val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     private val formPage = FormPage(composeRule)
 
@@ -206,7 +213,9 @@ internal class VerticalModeFormUITest {
                 hasIntentToSetup = false,
                 paymentMethodSaveConsentBehavior = PaymentMethodSaveConsentBehavior.Legacy,
             ),
-            formElements = CardDefinition.formElements(),
+            formElements = CardDefinition.formElements(
+                coroutineScope = coroutineScopeCleanupRule.track(CoroutineScope(Dispatchers.Unconfined)),
+            ),
             isValidating = false,
             headerInformation = headerInformation,
         )


### PR DESCRIPTION
# Summary
Clean up coroutine scopes created by payment form tests so their child jobs are cancelled after each test. Add coverage that verifies cancelling the parent scope stops card account-range collectors and subsequent updates.

# Motivation
Tests that create form and card controllers can leave coroutine collectors running beyond the test lifecycle. Tracking and cancelling their scopes makes teardown deterministic and prevents leaked work from affecting later tests.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew detekt`

No tests were newly ignored.

# Screenshots
Not applicable: these are test lifecycle changes with no UI changes.

# Changelog
Not applicable: this change only updates tests and has no user-facing behavior change.

Committed and created by Codex.
