### PR TITLE
Add common payment methods to Checkout playground

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
@@ -25,10 +25,7 @@ internal object CheckoutControllerExampleRequestFactory {
             endpoint = "checkout_session",
             body = buildJsonObject {
                 put("mode", "payment")
-                put(
-                    "customer",
-                    if (scenario == CheckoutControllerExampleScenario.BillingTax) "guest" else "new"
-                )
+                put("customer", "guest")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
                 put(
@@ -45,9 +42,6 @@ internal object CheckoutControllerExampleRequestFactory {
                 )
                 put("automatic_tax", scenario != CheckoutControllerExampleScenario.NoTax)
                 put("shipping_address_collection", scenario == CheckoutControllerExampleScenario.ShippingTax)
-                if (scenario != CheckoutControllerExampleScenario.BillingTax) {
-                    put("billing_address_collection", false)
-                }
             },
         )
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.example.playground.checkout
 
+import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
@@ -9,7 +11,7 @@ internal enum class CheckoutControllerExampleScenario(
 ) {
     NoTax("No tax"),
     ShippingTax("Shipping tax"),
-    BillingTax("Billing tax"),
+    BillingTax("Billing tax w/ auto collection"),
 }
 
 internal data class CheckoutControllerExampleRequest(
@@ -23,12 +25,29 @@ internal object CheckoutControllerExampleRequestFactory {
             endpoint = "checkout_session",
             body = buildJsonObject {
                 put("mode", "payment")
-                put("customer", "new")
+                put(
+                    "customer",
+                    if (scenario == CheckoutControllerExampleScenario.BillingTax) "guest" else "new"
+                )
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
+                put(
+                    "payment_method_types",
+                    JsonArray(
+                        listOf(
+                            JsonPrimitive("card"),
+                            JsonPrimitive("us_bank_account"),
+                            JsonPrimitive("link"),
+                            JsonPrimitive("cashapp"),
+                            JsonPrimitive("klarna"),
+                        )
+                    )
+                )
                 put("automatic_tax", scenario != CheckoutControllerExampleScenario.NoTax)
                 put("shipping_address_collection", scenario == CheckoutControllerExampleScenario.ShippingTax)
-                put("billing_address_collection", scenario == CheckoutControllerExampleScenario.BillingTax)
+                if (scenario != CheckoutControllerExampleScenario.BillingTax) {
+                    put("billing_address_collection", false)
+                }
             },
         )
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
@@ -11,7 +11,7 @@ internal enum class CheckoutControllerExampleScenario(
 ) {
     NoTax("No tax"),
     ShippingTax("Shipping tax"),
-    BillingTax("Billing tax"),
+    BillingTax("Billing tax w/ auto collection"),
 }
 
 internal data class CheckoutControllerExampleRequest(
@@ -45,7 +45,9 @@ internal object CheckoutControllerExampleRequestFactory {
                 )
                 put("automatic_tax", scenario != CheckoutControllerExampleScenario.NoTax)
                 put("shipping_address_collection", scenario == CheckoutControllerExampleScenario.ShippingTax)
-                put("billing_address_collection", scenario == CheckoutControllerExampleScenario.BillingTax)
+                if (scenario != CheckoutControllerExampleScenario.BillingTax) {
+                    put("billing_address_collection", false)
+                }
             },
         )
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
@@ -11,7 +11,7 @@ internal enum class CheckoutControllerExampleScenario(
 ) {
     NoTax("No tax"),
     ShippingTax("Shipping tax"),
-    BillingTax("Billing tax w/ auto collection"),
+    BillingTax("Billing tax"),
 }
 
 internal data class CheckoutControllerExampleRequest(
@@ -45,9 +45,7 @@ internal object CheckoutControllerExampleRequestFactory {
                 )
                 put("automatic_tax", scenario != CheckoutControllerExampleScenario.NoTax)
                 put("shipping_address_collection", scenario == CheckoutControllerExampleScenario.ShippingTax)
-                if (scenario != CheckoutControllerExampleScenario.BillingTax) {
-                    put("billing_address_collection", false)
-                }
+                put("billing_address_collection", scenario == CheckoutControllerExampleScenario.BillingTax)
             },
         )
     }

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -66,7 +66,6 @@ class CheckoutControllerExampleRequestFactoryTest {
                 put("payment_method_types", commonPaymentMethodTypes)
                 put("automatic_tax", true)
                 put("shipping_address_collection", false)
-                put("billing_address_collection", true)
             }
         )
     }

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -18,13 +18,12 @@ class CheckoutControllerExampleRequestFactoryTest {
         assertThat(request.body).isEqualTo(
             buildJsonObject {
                 put("mode", "payment")
-                put("customer", "new")
+                put("customer", "guest")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
                 put("payment_method_types", commonPaymentMethodTypes)
                 put("automatic_tax", false)
                 put("shipping_address_collection", false)
-                put("billing_address_collection", false)
             }
         )
     }
@@ -39,13 +38,12 @@ class CheckoutControllerExampleRequestFactoryTest {
         assertThat(request.body).isEqualTo(
             buildJsonObject {
                 put("mode", "payment")
-                put("customer", "new")
+                put("customer", "guest")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
                 put("payment_method_types", commonPaymentMethodTypes)
                 put("automatic_tax", true)
                 put("shipping_address_collection", true)
-                put("billing_address_collection", false)
             }
         )
     }

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -66,6 +66,7 @@ class CheckoutControllerExampleRequestFactoryTest {
                 put("payment_method_types", commonPaymentMethodTypes)
                 put("automatic_tax", true)
                 put("shipping_address_collection", false)
+                put("billing_address_collection", true)
             }
         )
     }

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.example.playground.checkout
 
 import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.junit.Test
@@ -19,6 +21,7 @@ class CheckoutControllerExampleRequestFactoryTest {
                 put("customer", "new")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
+                put("payment_method_types", commonPaymentMethodTypes)
                 put("automatic_tax", false)
                 put("shipping_address_collection", false)
                 put("billing_address_collection", false)
@@ -39,6 +42,7 @@ class CheckoutControllerExampleRequestFactoryTest {
                 put("customer", "new")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
+                put("payment_method_types", commonPaymentMethodTypes)
                 put("automatic_tax", true)
                 put("shipping_address_collection", true)
                 put("billing_address_collection", false)
@@ -56,13 +60,25 @@ class CheckoutControllerExampleRequestFactoryTest {
         assertThat(request.body).isEqualTo(
             buildJsonObject {
                 put("mode", "payment")
-                put("customer", "new")
+                put("customer", "guest")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
+                put("payment_method_types", commonPaymentMethodTypes)
                 put("automatic_tax", true)
                 put("shipping_address_collection", false)
-                put("billing_address_collection", true)
             }
+        )
+    }
+
+    private companion object {
+        val commonPaymentMethodTypes = JsonArray(
+            listOf(
+                JsonPrimitive("card"),
+                JsonPrimitive("us_bank_account"),
+                JsonPrimitive("link"),
+                JsonPrimitive("cashapp"),
+                JsonPrimitive("klarna"),
+            )
         )
     }
 }


### PR DESCRIPTION
# Summary

The three Checkout playground tax scenarios now request Card, US bank account, Link, Cash App Pay, and Klarna explicitly. They use guest Checkout Sessions without an explicit billing-address-collection setting, so Billing Tax exercises Checkout's default automatic billing-address collection.

## What changed

- Sends the same five explicit payment method types for No Tax, Shipping Tax, and Billing Tax.
- Uses `customer: "guest"` for every scenario. The backend does not create or retrieve a Customer; it passes `customer_email` directly to the Session.
- Omits `billing_address_collection` for every scenario. The backend leaves Checkout's billing collection setting unset, so Checkout uses its `auto` behavior.
- Keeps automatic payment methods absent. Shipping Tax alone sends `shipping_address_collection: true`; No Tax and Billing Tax explicitly send `false`.

## What stays the same

- No Tax keeps automatic tax off and shipping collection `false`.
- Shipping Tax keeps automatic tax and shipping collection on.
- Billing Tax keeps automatic tax on and shipping collection `false`.
- Currency, backend-provided line items, `customer_email`, and scenario routing remain unchanged.
- This changes only the example app. It does not change the SDK API or require a backend deployment.

## Coverage

- Three exact request-factory tests assert the complete body for each scenario, including the guest customer mode, tax and shipping flags, absence of the billing collection key, and the five payment methods.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- Focused request-factory unit tests passed: 3 tests.
- The path-aware pre-push check passed: `:paymentsheet-example:detekt`.
- CI will run against the latest parent head.

# Notes

- The omitted billing flag intentionally exercises Checkout's default `auto` collection behavior. Taxability still depends on an active test-mode tax registration for the entered jurisdiction.

Committed and created by Codex.
