### PR TITLE
Extract PaymentOptions result factory

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsResultFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsResultFactory.kt
@@ -1,0 +1,79 @@
+package com.stripe.android.paymentsheet
+
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal object PaymentOptionsResultFactory {
+
+    fun createSucceeded(
+        paymentSelection: PaymentSelection,
+        initialPaymentSelection: PaymentSelection?,
+        paymentMethods: List<PaymentMethod>,
+        linkAccountInfo: LinkAccountUpdate.Value,
+        autocompleteFilledAddress: Address?,
+    ): PaymentOptionsActivityResult.Succeeded {
+        return PaymentOptionsActivityResult.Succeeded(
+            paymentSelection = paymentSelection.withLinkDetails(
+                initialPaymentSelection = initialPaymentSelection,
+                linkAccountInfo = linkAccountInfo,
+            ),
+            linkAccountInfo = linkAccountInfo,
+            paymentMethods = paymentMethods,
+            autocompleteFilledAddress = autocompleteFilledAddress,
+        )
+    }
+
+    fun createCanceled(
+        initialPaymentSelection: PaymentSelection?,
+        paymentMethods: List<PaymentMethod>,
+        linkAccountInfo: LinkAccountUpdate.Value,
+    ): PaymentOptionsActivityResult.Canceled {
+        val restoredSelection = initialPaymentSelection
+            ?.withLinkDetails(
+                initialPaymentSelection = initialPaymentSelection,
+                linkAccountInfo = linkAccountInfo,
+            )
+            ?.rebindSavedPaymentMethod(paymentMethods)
+
+        return PaymentOptionsActivityResult.Canceled(
+            linkAccountInfo = linkAccountInfo,
+            mostRecentError = null,
+            paymentSelection = restoredSelection,
+            paymentMethods = paymentMethods,
+        )
+    }
+
+    /**
+     * - Clears Link payment details when there is no current Link account.
+     * - Restores the previously selected Link payment method when the current selection omits it.
+     */
+    private fun PaymentSelection.withLinkDetails(
+        initialPaymentSelection: PaymentSelection?,
+        linkAccountInfo: LinkAccountUpdate.Value,
+    ): PaymentSelection {
+        return when (this) {
+            is PaymentSelection.Link -> when (linkAccountInfo.account) {
+                null -> copy(selectedPayment = null)
+                else -> copy(
+                    selectedPayment = selectedPayment ?: (initialPaymentSelection as? PaymentSelection.Link)
+                        ?.selectedPayment
+                )
+            }
+            else -> this
+        }
+    }
+
+    private fun PaymentSelection.rebindSavedPaymentMethod(
+        paymentMethods: List<PaymentMethod>,
+    ): PaymentSelection? {
+        if (this !is PaymentSelection.Saved) {
+            return this
+        }
+
+        return paymentMethods.firstOrNull { it.id == paymentMethod.id }?.let { paymentMethod ->
+            copy(paymentMethod = paymentMethod)
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -29,7 +29,6 @@ import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.effectiveLinkBrand
 import com.stripe.android.link.gate.LinkGate
-import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
@@ -323,14 +322,16 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 val linkBrand =
                     linkConfiguration.effectiveLinkBrand(linkAccountHolder.linkAccountInfo.value.account)
                 _paymentOptionsActivityResult.tryEmit(
-                    PaymentOptionsActivityResult.Succeeded(
-                        linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
+                    PaymentOptionsResultFactory.createSucceeded(
                         paymentSelection = Link(
                             brand = linkBrand,
                             selectedPayment = result.selectedPayment,
                             shippingAddress = result.shippingAddress,
                         ),
-                        paymentMethods = customerStateHolder.paymentMethods.value
+                        initialPaymentSelection = args.state.paymentSelection,
+                        linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
+                        paymentMethods = customerStateHolder.paymentMethods.value,
+                        autocompleteFilledAddress = autocompleteFilledAddress,
                     )
                 )
             }
@@ -347,31 +348,12 @@ internal class PaymentOptionsViewModel @Inject constructor(
     override fun onUserCancel() {
         eventReporter.onDismiss()
         _paymentOptionsActivityResult.tryEmit(
-            PaymentOptionsActivityResult.Canceled(
+            PaymentOptionsResultFactory.createCanceled(
+                initialPaymentSelection = args.state.paymentSelection,
                 linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
-                mostRecentError = null,
-                paymentSelection = determinePaymentSelectionUponCancel(),
                 paymentMethods = customerStateHolder.paymentMethods.value,
             )
         )
-    }
-
-    private fun determinePaymentSelectionUponCancel(): PaymentSelection? {
-        val initialSelection = args.state.paymentSelection?.withLinkDetails()
-
-        return if (initialSelection is PaymentSelection.Saved) {
-            initialSelection.takeIfStillValid()
-        } else {
-            initialSelection
-        }
-    }
-
-    private fun PaymentSelection.Saved.takeIfStillValid(): PaymentSelection.Saved? {
-        val paymentMethods = customerStateHolder.paymentMethods.value
-        val paymentMethod = paymentMethods.firstOrNull { it.id == paymentMethod.id }
-        return paymentMethod?.let {
-            this.copy(paymentMethod = it)
-        }
     }
 
     override fun onError(error: ResolvableString?) {
@@ -401,9 +383,10 @@ internal class PaymentOptionsViewModel @Inject constructor(
                 )
             } else {
                 _paymentOptionsActivityResult.tryEmit(
-                    PaymentOptionsActivityResult.Succeeded(
+                    PaymentOptionsResultFactory.createSucceeded(
+                        initialPaymentSelection = args.state.paymentSelection,
                         linkAccountInfo = linkAccountHolder.linkAccountInfo.value,
-                        paymentSelection = paymentSelection.withLinkDetails(),
+                        paymentSelection = paymentSelection,
                         paymentMethods = customerStateHolder.paymentMethods.value,
                         autocompleteFilledAddress = autocompleteFilledAddress,
                     )
@@ -416,24 +399,6 @@ internal class PaymentOptionsViewModel @Inject constructor(
         viewModelScope.launch {
             validationRequested.emit(Unit)
         }
-    }
-
-    /**
-     * - Updates the [PaymentSelection], if Link, to include the current [LinkAccount] if it exists.
-     * - Preserves the previously selected payment method, if any, in case none is selected in this launch.
-     */
-    private fun PaymentSelection.withLinkDetails(): PaymentSelection = when (this) {
-        is Link -> when (linkAccountHolder.linkAccountInfo.value.account) {
-            // If link account is null, clear account status and selected payment from payment selection
-            null -> copy(
-                selectedPayment = null
-            )
-            // If link account exists, include it in the payment selection and keep the previously selected payment.
-            else -> copy(
-                selectedPayment = (selectedPayment ?: (args.state.paymentSelection as? Link)?.selectedPayment)
-            )
-        }
-        else -> this
     }
 
     private fun shouldShowLinkVerification(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsResultFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsResultFactoryTest.kt
@@ -1,0 +1,176 @@
+package com.stripe.android.paymentsheet
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.TestFactory
+import com.stripe.android.model.AddressFixtures
+import com.stripe.android.model.ConsumerPaymentDetails
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import org.junit.Test
+
+internal class PaymentOptionsResultFactoryTest {
+
+    @Test
+    fun `createSucceeded includes current result data`() {
+        val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+        val paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+        val linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+
+        val result = PaymentOptionsResultFactory.createSucceeded(
+            paymentSelection = selection,
+            initialPaymentSelection = null,
+            paymentMethods = paymentMethods,
+            linkAccountInfo = linkAccountInfo,
+            autocompleteFilledAddress = AddressFixtures.ADDRESS,
+        )
+
+        assertThat(result.paymentSelection).isEqualTo(selection)
+        assertThat(result.paymentMethods).isEqualTo(paymentMethods)
+        assertThat(result.linkAccountInfo).isEqualTo(linkAccountInfo)
+        assertThat(result.autocompleteFilledAddress).isEqualTo(AddressFixtures.ADDRESS)
+    }
+
+    @Test
+    fun `createSucceeded clears Link payment method without Link account`() {
+        val selectedPayment = linkPaymentMethod(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD)
+
+        val result = PaymentOptionsResultFactory.createSucceeded(
+            paymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
+                selectedPayment = selectedPayment,
+            ),
+            initialPaymentSelection = null,
+            paymentMethods = emptyList(),
+            linkAccountInfo = LinkAccountUpdate.Value(null),
+            autocompleteFilledAddress = null,
+        )
+
+        val resultSelection = result.paymentSelection as PaymentSelection.Link
+        assertThat(resultSelection.selectedPayment).isNull()
+    }
+
+    @Test
+    fun `createSucceeded restores initial Link payment method`() {
+        val initialSelectedPayment = linkPaymentMethod(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD)
+
+        val result = PaymentOptionsResultFactory.createSucceeded(
+            paymentSelection = PaymentSelection.Link(brand = LinkBrand.Link),
+            initialPaymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
+                selectedPayment = initialSelectedPayment,
+            ),
+            paymentMethods = emptyList(),
+            linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+            autocompleteFilledAddress = null,
+        )
+
+        val resultSelection = result.paymentSelection as PaymentSelection.Link
+        assertThat(resultSelection.selectedPayment).isEqualTo(initialSelectedPayment)
+    }
+
+    @Test
+    fun `createSucceeded prefers current Link payment method`() {
+        val initialSelectedPayment = linkPaymentMethod(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD)
+        val currentSelectedPayment = linkPaymentMethod(
+            details = TestFactory.CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT,
+        )
+
+        val result = PaymentOptionsResultFactory.createSucceeded(
+            paymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
+                selectedPayment = currentSelectedPayment,
+            ),
+            initialPaymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
+                selectedPayment = initialSelectedPayment,
+            ),
+            paymentMethods = emptyList(),
+            linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+            autocompleteFilledAddress = null,
+        )
+
+        val resultSelection = result.paymentSelection as PaymentSelection.Link
+        assertThat(resultSelection.selectedPayment).isEqualTo(currentSelectedPayment)
+    }
+
+    @Test
+    fun `createCanceled rebinds saved selection to current payment method`() {
+        val initialPaymentMethod = PaymentMethodFixtures.CARD_WITH_NETWORKS_PAYMENT_METHOD
+        val currentPaymentMethod = initialPaymentMethod.copy(
+            card = PaymentMethodFixtures.CARD_WITH_NETWORKS.copy(displayBrand = "visa")
+        )
+        val linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+
+        val result = PaymentOptionsResultFactory.createCanceled(
+            initialPaymentSelection = PaymentSelection.Saved(initialPaymentMethod),
+            paymentMethods = listOf(currentPaymentMethod),
+            linkAccountInfo = linkAccountInfo,
+        )
+
+        assertThat(result.paymentSelection).isEqualTo(PaymentSelection.Saved(currentPaymentMethod))
+        assertThat(result.paymentMethods).containsExactly(currentPaymentMethod)
+        assertThat(result.linkAccountInfo).isEqualTo(linkAccountInfo)
+        assertThat(result.mostRecentError).isNull()
+    }
+
+    @Test
+    fun `createCanceled clears removed saved selection`() {
+        val result = PaymentOptionsResultFactory.createCanceled(
+            initialPaymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            paymentMethods = emptyList(),
+            linkAccountInfo = LinkAccountUpdate.Value(null),
+        )
+
+        assertThat(result.paymentSelection).isNull()
+    }
+
+    @Test
+    fun `createCanceled preserves non-saved selection`() {
+        val result = PaymentOptionsResultFactory.createCanceled(
+            initialPaymentSelection = PaymentSelection.GooglePay,
+            paymentMethods = emptyList(),
+            linkAccountInfo = LinkAccountUpdate.Value(null),
+        )
+
+        assertThat(result.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
+    }
+
+    @Test
+    fun `createCanceled clears initial Link payment method without Link account`() {
+        val result = PaymentOptionsResultFactory.createCanceled(
+            initialPaymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
+                selectedPayment = linkPaymentMethod(TestFactory.CONSUMER_PAYMENT_DETAILS_CARD),
+            ),
+            paymentMethods = emptyList(),
+            linkAccountInfo = LinkAccountUpdate.Value(null),
+        )
+
+        val resultSelection = result.paymentSelection as PaymentSelection.Link
+        assertThat(resultSelection.selectedPayment).isNull()
+    }
+
+    @Test
+    fun `createCanceled preserves null selection`() {
+        val result = PaymentOptionsResultFactory.createCanceled(
+            initialPaymentSelection = null,
+            paymentMethods = emptyList(),
+            linkAccountInfo = LinkAccountUpdate.Value(null),
+        )
+
+        assertThat(result.paymentSelection).isNull()
+    }
+
+    private fun linkPaymentMethod(
+        details: ConsumerPaymentDetails.PaymentDetails,
+    ): LinkPaymentMethod {
+        return LinkPaymentMethod.ConsumerPaymentDetails(
+            details = details,
+            collectedCvc = null,
+            billingPhone = null,
+        )
+    }
+}


### PR DESCRIPTION
# Summary

- Extract PaymentOptions success and cancellation result construction into a reusable factory.
- Centralize saved payment method rebinding, Link selection restoration, and autocomplete output.
- Delegate result creation from `PaymentOptionsViewModel` while preserving its orchestration behavior.

# Motivation

PaymentOptions result shaping currently lives in `PaymentOptionsViewModel`, which makes it difficult to reuse from the shared sheet activity. This isolates the behavior behind an internal, stateless factory that the shared activity can adopt in a follow-up change.

Committed and created by Codex.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.PaymentOptionsResultFactoryTest' --tests 'com.stripe.android.paymentsheet.PaymentOptionsViewModelTest'`
- `./gradlew detekt`

No tests were newly ignored.

# Screenshots

| Before | After |
| ------------- | ------------- |
| Not applicable — internal result-construction refactor. | Not applicable — no UI changes. |

# Changelog

Not applicable — this is an internal refactor with no public API or user-facing behavior change.
