### PR TITLE
Move embedded sheet ViewModel construction out of Dagger

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityModule.kt
@@ -66,8 +66,6 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Named
 import javax.inject.Singleton
@@ -142,13 +140,6 @@ internal interface EmbeddedActivityModule {
         @Provides
         fun providesContext(application: Application): Context {
             return application
-        }
-
-        @Provides
-        @Singleton
-        @ViewModelScope
-        fun provideViewModelScope(): CoroutineScope {
-            return CoroutineScope(SupervisorJob() + Dispatchers.Main)
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.embedded.sheet
 import android.app.Application
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
@@ -22,6 +23,7 @@ import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsE
 import com.stripe.android.paymentsheet.injection.PaymentSheetAutocompleteModule
 import dagger.BindsInstance
 import dagger.Component
+import kotlinx.coroutines.CoroutineScope
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -40,7 +42,6 @@ import javax.inject.Singleton
 )
 @Singleton
 internal interface EmbeddedSheetComponent {
-    val viewModel: EmbeddedSheetViewModel
     val selectionHolder: EmbeddedSelectionHolder
     val customerStateHolder: CustomerStateHolder
 
@@ -64,6 +65,9 @@ internal interface EmbeddedSheetComponent {
             @BindsInstance savedStateHandle: SavedStateHandle,
             @BindsInstance promotion: PaymentMethodMessagePromotion?,
             @BindsInstance launchMode: EmbeddedLaunchMode,
+            @BindsInstance
+            @ViewModelScope
+            viewModelScope: CoroutineScope,
         ): EmbeddedSheetComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
@@ -8,10 +8,11 @@ import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import javax.inject.Inject
 
-internal class EmbeddedSheetViewModel @Inject constructor(
+internal class EmbeddedSheetViewModel(
     val component: EmbeddedSheetComponent,
     @ViewModelScope private val customViewModelScope: CoroutineScope,
 ) : ViewModel() {
@@ -25,6 +26,7 @@ internal class EmbeddedSheetViewModel @Inject constructor(
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val args = argsSupplier()
+            val customViewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
             val component = DaggerEmbeddedSheetComponent.factory().build(
                 paymentMethodMetadata = args.paymentMethodMetadata,
                 statusBarColor = args.statusBarColor,
@@ -35,13 +37,17 @@ internal class EmbeddedSheetViewModel @Inject constructor(
                 savedStateHandle = extras.createSavedStateHandle(),
                 promotion = args.promotion,
                 launchMode = args.launchMode,
+                viewModelScope = customViewModelScope,
             )
 
             component.customerStateHolder.setCustomerState(args.customerState)
             component.selectionHolder.setPreviousNewSelections(args.previousNewSelections)
             component.selectionHolder.setSelection(args.selection)
 
-            return component.viewModel as T
+            return EmbeddedSheetViewModel(
+                component = component,
+                customViewModelScope = customViewModelScope,
+            ) as T
         }
     }
 }


### PR DESCRIPTION
# Summary

Moves `EmbeddedSheetViewModel` construction and coroutine-scope ownership into its existing `Factory`. The factory binds the same lifecycle scope into `EmbeddedSheetComponent` and directly constructs the ViewModel after initializing the component state holders.

Committed and created by Codex.

# Motivation

Decoupling the ViewModel from Dagger makes its lifecycle ownership explicit and removes ViewModel construction from the component graph. This is independently useful and leaves the follow-up activity migration responsible only for loading states.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Validation performed:

- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew detekt`

Ignored tests: None.

# Screenshots

Not applicable — this is an internal dependency-injection refactor with no visual changes.

# Changelog

Not applicable — there are no public API or user-visible behavior changes.
