### PR TITLE
Extract shared analytics state helpers

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementInitializer.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentsheet.analytics.EventReporter
-import com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListener.Companion.PREVIOUSLY_SENT_DEEP_LINK_EVENT
+import com.stripe.android.paymentsheet.analytics.previouslySentDeepLinkEvent
 import javax.inject.Inject
 
 @EmbeddedPaymentElementScope
@@ -18,16 +18,10 @@ internal class EmbeddedPaymentElementInitializer @Inject constructor(
     private val eventReporter: EventReporter,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) {
-    private var previouslySentDeepLinkEvent: Boolean
-        get() = savedStateHandle[PREVIOUSLY_SENT_DEEP_LINK_EVENT] ?: false
-        set(value) {
-            savedStateHandle[PREVIOUSLY_SENT_DEEP_LINK_EVENT] = value
-        }
-
     fun initialize(applicationIsTaskOwner: Boolean) {
-        if (!applicationIsTaskOwner && !previouslySentDeepLinkEvent) {
+        if (!applicationIsTaskOwner && !savedStateHandle.previouslySentDeepLinkEvent) {
             eventReporter.onCannotProperlyReturnFromLinkAndOtherLPMs()
-            previouslySentDeepLinkEvent = true
+            savedStateHandle.previouslySentDeepLinkEvent = true
         }
 
         sheetStateHolder.sheetLauncher = sheetLauncher

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -45,14 +45,14 @@ import com.stripe.android.paymentelement.confirmation.toConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.StripeAutocompleteRepository
 import com.stripe.android.paymentsheet.addresselement.analytics.AddressLauncherEventReporter
-import com.stripe.android.paymentsheet.addresselement.computeBillingEditDistance
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
+import com.stripe.android.paymentsheet.analytics.persistBillingAnalytics
+import com.stripe.android.paymentsheet.analytics.reportBillingAddressCompleted
 import com.stripe.android.paymentsheet.cvcrecollection.CvcRecollectionHandler
 import com.stripe.android.paymentsheet.injection.DaggerPaymentSheetLauncherComponent
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
-import com.stripe.android.paymentsheet.model.billingDetails
 import com.stripe.android.paymentsheet.model.isLink
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
 import com.stripe.android.paymentsheet.paymentdatacollection.cvcrecollection.Args
@@ -581,7 +581,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
             val confirmationOption = withContext(viewModelScope.coroutineContext) {
                 inProgressSelection = paymentSelection
-                persistBillingAnalytics(paymentSelection)
+                savedStateHandle.persistBillingAnalytics(paymentSelection, autocompleteFilledAddress)
 
                 paymentSelectionWithCvcIfEnabled(paymentSelection)
                     ?.toConfirmationOption(
@@ -659,7 +659,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 deferredIntentConfirmationType = deferredIntentConfirmationType,
                 intentId = intentId,
             )
-            reportBillingAddressCompleted(paymentSelection)
+            savedStateHandle.reportBillingAddressCompleted(paymentSelection, eventReporter)
         }
 
         // Log out of Link to invalidate the token
@@ -676,30 +676,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                 _paymentSheetResult.tryEmit(PaymentSheetResult.Completed())
             }
         }
-    }
-
-    private fun persistBillingAnalytics(paymentSelection: PaymentSelection?) {
-        if (paymentSelection !is PaymentSelection.New) return
-        val billingAddress = paymentSelection.billingDetails?.address ?: return
-        val filledAddress = autocompleteFilledAddress
-        savedStateHandle[AUTOCOMPLETE_USED_KEY] = filledAddress != null
-        savedStateHandle[AUTOCOMPLETE_EDIT_DISTANCE_KEY] = filledAddress?.let {
-            computeBillingEditDistance(it, billingAddress)
-        }
-    }
-
-    private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
-        if (paymentSelection !is PaymentSelection.New) return
-        val countryCode = paymentSelection.billingDetails?.address?.country ?: return
-        val autocompleteUsed = savedStateHandle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
-        val editDistance = savedStateHandle.get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
-        savedStateHandle.remove<Boolean>(AUTOCOMPLETE_USED_KEY)
-        savedStateHandle.remove<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
-        eventReporter.onBillingAddressCompleted(
-            addressCountryCode = countryCode,
-            autocompleteResultSelected = autocompleteUsed,
-            editDistance = editDistance,
-        )
     }
 
     private fun processConfirmationResult(result: ConfirmationHandler.Result?) {
@@ -839,8 +815,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
 
     private companion object {
         const val IN_PROGRESS_SELECTION = "IN_PROGRESS_PAYMENT_SELECTION"
-        const val AUTOCOMPLETE_USED_KEY = "BILLING_AUTOCOMPLETE_USED"
-        const val AUTOCOMPLETE_EDIT_DISTANCE_KEY = "BILLING_AUTOCOMPLETE_EDIT_DISTANCE"
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
@@ -17,12 +17,6 @@ internal class PaymentSheetAnalyticsListener(
     coroutineScope: CoroutineScope,
     private val currentPaymentMethodTypeProvider: () -> String
 ) {
-    private var previouslySentDeepLinkEvent: Boolean
-        get() = savedStateHandle[PREVIOUSLY_SENT_DEEP_LINK_EVENT] ?: false
-        set(value) {
-            savedStateHandle[PREVIOUSLY_SENT_DEEP_LINK_EVENT] = value
-        }
-
     private var previouslyPresentedSheet: Boolean
         get() = savedStateHandle[PREVIOUSLY_PRESENTED_SHEET] ?: false
         set(value) {
@@ -50,10 +44,10 @@ internal class PaymentSheetAnalyticsListener(
     }
 
     fun cannotProperlyReturnFromLinkAndOtherLPMs() {
-        if (!previouslySentDeepLinkEvent) {
+        if (!savedStateHandle.previouslySentDeepLinkEvent) {
             eventReporter.onCannotProperlyReturnFromLinkAndOtherLPMs()
 
-            previouslySentDeepLinkEvent = true
+            savedStateHandle.previouslySentDeepLinkEvent = true
         }
     }
 
@@ -135,7 +129,6 @@ internal class PaymentSheetAnalyticsListener(
     companion object {
         internal const val PREVIOUSLY_SHOWN_PAYMENT_FORM = "previously_shown_payment_form"
         internal const val PREVIOUSLY_INTERACTION_PAYMENT_FORM = "previously_interacted_payment_form"
-        internal const val PREVIOUSLY_SENT_DEEP_LINK_EVENT = "previously_sent_deep_link_event"
         internal const val PREVIOUSLY_PRESENTED_SHEET = "previously_presented_sheet"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsState.kt
@@ -1,0 +1,49 @@
+package com.stripe.android.paymentsheet.analytics
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.model.Address
+import com.stripe.android.paymentsheet.addresselement.computeBillingEditDistance
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.billingDetails
+
+private const val PREVIOUSLY_SENT_DEEP_LINK_EVENT = "previously_sent_deep_link_event"
+private const val AUTOCOMPLETE_USED_KEY = "BILLING_AUTOCOMPLETE_USED"
+private const val AUTOCOMPLETE_EDIT_DISTANCE_KEY = "BILLING_AUTOCOMPLETE_EDIT_DISTANCE"
+
+internal var SavedStateHandle.previouslySentDeepLinkEvent: Boolean
+    get() = this[PREVIOUSLY_SENT_DEEP_LINK_EVENT] ?: false
+    set(value) {
+        this[PREVIOUSLY_SENT_DEEP_LINK_EVENT] = value
+    }
+
+internal fun SavedStateHandle.persistBillingAnalytics(
+    paymentSelection: PaymentSelection?,
+    autocompleteFilledAddress: Address?,
+) {
+    if (paymentSelection !is PaymentSelection.New) return
+    val billingAddress = paymentSelection.billingDetails?.address ?: return
+
+    this[AUTOCOMPLETE_USED_KEY] = autocompleteFilledAddress != null
+    this[AUTOCOMPLETE_EDIT_DISTANCE_KEY] = autocompleteFilledAddress?.let {
+        computeBillingEditDistance(it, billingAddress)
+    }
+}
+
+internal fun SavedStateHandle.reportBillingAddressCompleted(
+    paymentSelection: PaymentSelection,
+    eventReporter: EventReporter,
+) {
+    if (paymentSelection !is PaymentSelection.New) return
+    val countryCode = paymentSelection.billingDetails?.address?.country ?: return
+    val autocompleteUsed = get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
+    val editDistance = get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
+
+    remove<Boolean>(AUTOCOMPLETE_USED_KEY)
+    remove<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
+
+    eventReporter.onBillingAddressCompleted(
+        addressCountryCode = countryCode,
+        autocompleteResultSelected = autocompleteUsed,
+        editDistance = editDistance,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -58,14 +58,14 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetResult
 import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
-import com.stripe.android.paymentsheet.addresselement.computeBillingEditDistance
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.PaymentSheetConfirmationError
+import com.stripe.android.paymentsheet.analytics.persistBillingAnalytics
+import com.stripe.android.paymentsheet.analytics.reportBillingAddressCompleted
 import com.stripe.android.paymentsheet.model.PaymentOption
 import com.stripe.android.paymentsheet.model.PaymentOptionFactory
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.PaymentSelection.Link
-import com.stripe.android.paymentsheet.model.billingDetails
 import com.stripe.android.paymentsheet.model.isLink
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.CustomerState
@@ -82,9 +82,6 @@ import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Named
-
-private const val AUTOCOMPLETE_USED_KEY = "BILLING_AUTOCOMPLETE_USED"
-private const val AUTOCOMPLETE_EDIT_DISTANCE_KEY = "BILLING_AUTOCOMPLETE_EDIT_DISTANCE"
 
 @Suppress("LargeClass")
 @OptIn(WalletButtonsPreview::class)
@@ -567,7 +564,7 @@ internal class DefaultFlowController @Inject internal constructor(
         paymentSelection: PaymentSelection?,
         state: PaymentSheetState.Full,
     ) {
-        persistBillingAnalytics(paymentSelection)
+        viewModel.handle.persistBillingAnalytics(paymentSelection, viewModel.autocompleteFilledAddress)
         viewModelScope.launch {
             val confirmationOption = paymentSelection?.toConfirmationOption(
                 configuration = state.config,
@@ -661,7 +658,7 @@ internal class DefaultFlowController @Inject internal constructor(
                         deferredIntentConfirmationType = result.metadata[DeferredIntentConfirmationTypeKey],
                         intentId = result.intent.id,
                     )
-                    reportBillingAddressCompleted(paymentSelection)
+                    viewModel.handle.reportBillingAddressCompleted(paymentSelection, eventReporter)
                 }
 
                 onPaymentResult(
@@ -778,7 +775,7 @@ internal class DefaultFlowController @Inject internal constructor(
                         deferredIntentConfirmationType = deferredIntentConfirmationType,
                         intentId = intentId,
                     )
-                    reportBillingAddressCompleted(paymentSelection)
+                    viewModel.handle.reportBillingAddressCompleted(paymentSelection, eventReporter)
                 }
             }
             is PaymentResult.Failed -> {
@@ -793,30 +790,6 @@ internal class DefaultFlowController @Inject internal constructor(
                 // Nothing to do here
             }
         }
-    }
-
-    private fun persistBillingAnalytics(paymentSelection: PaymentSelection?) {
-        if (paymentSelection !is PaymentSelection.New) return
-        val billingAddress = paymentSelection.billingDetails?.address ?: return
-        val filledAddress = viewModel.autocompleteFilledAddress
-        viewModel.handle[AUTOCOMPLETE_USED_KEY] = filledAddress != null
-        viewModel.handle[AUTOCOMPLETE_EDIT_DISTANCE_KEY] = filledAddress?.let {
-            computeBillingEditDistance(it, billingAddress)
-        }
-    }
-
-    private fun reportBillingAddressCompleted(paymentSelection: PaymentSelection) {
-        if (paymentSelection !is PaymentSelection.New) return
-        val countryCode = paymentSelection.billingDetails?.address?.country ?: return
-        val autocompleteUsed = viewModel.handle.get<Boolean>(AUTOCOMPLETE_USED_KEY) == true
-        val editDistance = viewModel.handle.get<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
-        viewModel.handle.remove<Boolean>(AUTOCOMPLETE_USED_KEY)
-        viewModel.handle.remove<Int>(AUTOCOMPLETE_EDIT_DISTANCE_KEY)
-        eventReporter.onBillingAddressCompleted(
-            addressCountryCode = countryCode,
-            autocompleteResultSelected = autocompleteUsed,
-            editDistance = editDistance,
-        )
     }
 
     private fun PaymentResult.convertToPaymentSheetResult() = when (this) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsStateTest.kt
@@ -1,0 +1,136 @@
+package com.stripe.android.paymentsheet.analytics
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodCreateParamsFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class PaymentSheetAnalyticsStateTest {
+    @Test
+    fun `previouslySentDeepLinkEvent defaults to false and persists updates`() = runScenario {
+        assertThat(savedStateHandle.previouslySentDeepLinkEvent).isFalse()
+
+        savedStateHandle.previouslySentDeepLinkEvent = true
+
+        assertThat(savedStateHandle.previouslySentDeepLinkEvent).isTrue()
+        assertThat(savedStateHandle.get<Boolean>("previously_sent_deep_link_event")).isTrue()
+    }
+
+    @Test
+    fun `reportBillingAddressCompleted reports persisted autocomplete analytics`() = runScenario {
+        savedStateHandle.persistBillingAnalytics(
+            paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            autocompleteFilledAddress = autocompleteAddress,
+        )
+
+        savedStateHandle.reportBillingAddressCompleted(
+            paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            eventReporter = eventReporter,
+        )
+
+        val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+        assertThat(call.addressCountryCode).isEqualTo("US")
+        assertThat(call.autocompleteResultSelected).isTrue()
+        assertThat(call.editDistance).isEqualTo(1)
+    }
+
+    @Test
+    fun `reportBillingAddressCompleted reports when autocomplete was not used`() = runScenario {
+        savedStateHandle.persistBillingAnalytics(
+            paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            autocompleteFilledAddress = null,
+        )
+
+        savedStateHandle.reportBillingAddressCompleted(
+            paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            eventReporter = eventReporter,
+        )
+
+        val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+        assertThat(call.autocompleteResultSelected).isFalse()
+        assertThat(call.editDistance).isNull()
+    }
+
+    @Test
+    fun `reportBillingAddressCompleted clears persisted analytics`() = runScenario {
+        savedStateHandle.persistBillingAnalytics(
+            paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            autocompleteFilledAddress = autocompleteAddress,
+        )
+        savedStateHandle.reportBillingAddressCompleted(
+            paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            eventReporter = eventReporter,
+        )
+        eventReporter.billingAddressCompletedCalls.awaitItem()
+
+        savedStateHandle.reportBillingAddressCompleted(
+            paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
+            eventReporter = eventReporter,
+        )
+
+        val call = eventReporter.billingAddressCompletedCalls.awaitItem()
+        assertThat(call.autocompleteResultSelected).isFalse()
+        assertThat(call.editDistance).isNull()
+    }
+
+    @Test
+    fun `reportBillingAddressCompleted ignores saved payment selections`() = runScenario {
+        savedStateHandle.reportBillingAddressCompleted(
+            paymentSelection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+            eventReporter = eventReporter,
+        )
+
+        eventReporter.billingAddressCompletedCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `reportBillingAddressCompleted ignores selections without a billing address`() = runScenario {
+        val paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION.copy(
+            paymentMethodCreateParams = PaymentMethodCreateParams.create(
+                card = PaymentMethodCreateParamsFixtures.CARD,
+            )
+        )
+        savedStateHandle.persistBillingAnalytics(
+            paymentSelection = paymentSelection,
+            autocompleteFilledAddress = autocompleteAddress,
+        )
+
+        savedStateHandle.reportBillingAddressCompleted(
+            paymentSelection = paymentSelection,
+            eventReporter = eventReporter,
+        )
+
+        eventReporter.billingAddressCompletedCalls.expectNoEvents()
+    }
+
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val eventReporter = FakeEventReporter()
+        Scenario(
+            savedStateHandle = SavedStateHandle(),
+            eventReporter = eventReporter,
+        ).block()
+        eventReporter.validate()
+    }
+
+    private data class Scenario(
+        val savedStateHandle: SavedStateHandle,
+        val eventReporter: FakeEventReporter,
+    )
+
+    private companion object {
+        val autocompleteAddress = Address(
+            line1 = "123 Main St",
+            city = "San Francisco",
+            state = "CA",
+            country = "US",
+            postalCode = "94111",
+        )
+    }
+}


### PR DESCRIPTION
# Summary

Extract shared `SavedStateHandle` helpers for PaymentSheet analytics state.

- Move the deep-link-reporting state key out of `PaymentSheetAnalyticsListener` so PaymentSheet and Embedded Payment Element share a neutral owner.
- Consolidate billing-address autocomplete persistence and completion reporting used by PaymentSheet and FlowController.
- Preserve the existing saved-state keys, process-restoration behavior, analytics timing, and payloads.

# Motivation

PaymentSheet and FlowController duplicated the billing-address analytics state machine, while Embedded Payment Element depended on a key owned by a PaymentSheet-specific listener. Centralizing this state removes the duplicate logic and gives cross-integration analytics state a neutral owner.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsStateTest' --tests 'com.stripe.android.paymentsheet.analytics.PaymentSheetAnalyticsListenerTest' --tests 'com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentElementInitializerTest' --tests 'com.stripe.android.paymentsheet.PaymentSheetViewModelTest' --tests 'com.stripe.android.paymentsheet.flowcontroller.DefaultFlowControllerTest'`
- `./gradlew :paymentsheet:detekt`
- `./gradlew detekt`

Ignored tests: None.

# Screenshots

Not applicable — this is an internal analytics-state refactor with no UI changes.

# Changelog

Not applicable — this refactor does not change public SDK behavior.

Committed and created by Codex.
