### PR TITLE
Stabilize Address Element instrumentation tests

### DIFF
--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/addresselement/AddressElementTest.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/addresselement/AddressElementTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.addresselement
 
+import android.content.Intent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
@@ -7,8 +8,11 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.stripe.android.paymentsheet.example.samples.ui.addresselement.AddressElementExampleActivity
+import com.stripe.android.paymentsheet.example.samples.ui.addresselement.DISABLE_GOOGLE_PLACES_AUTOCOMPLETE_EXTRA
+import com.stripe.android.paymentsheet.example.samples.ui.addresselement.PUBLISHABLE_KEY_OVERRIDE_EXTRA
 import com.stripe.android.paymentsheet.example.samples.ui.addresselement.SELECT_ADDRESS_BUTTON
 import com.stripe.android.test.core.ui.ComposeButton
 import com.stripe.android.utils.TestRules
@@ -18,7 +22,16 @@ import org.junit.Test
 internal class AddressElementTest {
     @get:Rule
     val rules = TestRules.create {
-        around(ActivityScenarioRule(AddressElementExampleActivity::class.java))
+        around(
+            ActivityScenarioRule<AddressElementExampleActivity>(
+                Intent(
+                    ApplicationProvider.getApplicationContext(),
+                    AddressElementExampleActivity::class.java,
+                )
+                    .putExtra(PUBLISHABLE_KEY_OVERRIDE_EXTRA, "pk_test_123")
+                    .putExtra(DISABLE_GOOGLE_PLACES_AUTOCOMPLETE_EXTRA, true),
+            )
+        )
     }
 
     @Test

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleActivity.kt
@@ -36,14 +36,24 @@ class AddressElementExampleActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         supportActionBar?.title = getString(R.string.address_element_title)
         val viewModel by viewModels<AddressElementExampleViewModel>()
+        val disableGooglePlacesAutocomplete = intent.getBooleanExtra(
+            DISABLE_GOOGLE_PLACES_AUTOCOMPLETE_EXTRA,
+            false,
+        )
         setContent {
-            AddressElementExampleScreen(viewModel)
+            AddressElementExampleScreen(
+                viewModel = viewModel,
+                disableGooglePlacesAutocomplete = disableGooglePlacesAutocomplete,
+            )
         }
     }
 }
 
 @Composable
-private fun AddressElementExampleScreen(viewModel: AddressElementExampleViewModel) {
+private fun AddressElementExampleScreen(
+    viewModel: AddressElementExampleViewModel,
+    disableGooglePlacesAutocomplete: Boolean,
+) {
     val viewState by viewModel.state.collectAsState()
     val addressLauncher = rememberAddressLauncher(
         callback = viewModel::handleResult,
@@ -72,7 +82,11 @@ private fun AddressElementExampleScreen(viewModel: AddressElementExampleViewMode
                     onClick = {
                         val config = AddressLauncher.Configuration.Builder()
                             // Provide your Google Places API key to enable autocomplete
-                            .googlePlacesApiKey(Settings(context).googlePlacesApiKey)
+                            .googlePlacesApiKey(
+                                Settings(context).googlePlacesApiKey.takeUnless {
+                                    disableGooglePlacesAutocomplete
+                                },
+                            )
                             .build()
                         addressLauncher.present(
                             publishableKey = state.publishableKey,
@@ -128,3 +142,4 @@ private fun Address(addressDetails: AddressDetails) {
 }
 
 internal const val SELECT_ADDRESS_BUTTON = "SELECT_ADDRESS_BUTTON"
+internal const val DISABLE_GOOGLE_PLACES_AUTOCOMPLETE_EXTRA = "disable_google_places_autocomplete"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/samples/ui/addresselement/AddressElementExampleViewModel.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.example.samples.ui.addresselement
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.requests.suspendable
@@ -18,16 +19,28 @@ import kotlinx.coroutines.launch
 
 internal class AddressElementExampleViewModel(
     application: Application,
+    savedStateHandle: SavedStateHandle,
 ) : AndroidViewModel(application) {
 
+    private val publishableKeyOverride = savedStateHandle.get<String>(PUBLISHABLE_KEY_OVERRIDE_EXTRA)
+
     private val _state = MutableStateFlow<AddressElementExampleViewState>(
-        value = AddressElementExampleViewState.Loading,
+        value = publishableKeyOverride?.let {
+            AddressElementExampleViewState.Content(publishableKey = it)
+        } ?: AddressElementExampleViewState.Loading,
     )
     val state: StateFlow<AddressElementExampleViewState> = _state
 
     init {
-        viewModelScope.launch(Dispatchers.IO) {
-            loadPublishableKey()
+        if (publishableKeyOverride != null) {
+            PaymentConfiguration.init(
+                context = application,
+                publishableKey = publishableKeyOverride,
+            )
+        } else {
+            viewModelScope.launch(Dispatchers.IO) {
+                loadPublishableKey()
+            }
         }
     }
 
@@ -77,3 +90,5 @@ internal class AddressElementExampleViewModel(
         const val backendUrl = "https://stripe-mobile-payment-sheet.stripedemos.com"
     }
 }
+
+internal const val PUBLISHABLE_KEY_OVERRIDE_EXTRA = "publishable_key_override"

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AutocompleteScreenTest.kt
@@ -62,23 +62,26 @@ class AutocompleteScreenTest {
 
     private fun setContent(
         mockClient: FakeGooglePlacesClient = FakeGooglePlacesClient()
-    ) =
+    ) {
+        val viewModel = AutocompleteViewModel(
+            mockClient,
+            AutocompleteViewModel.Args(
+                "US"
+            ),
+            eventReporter,
+            application
+        )
+
         composeTestRule.setContent {
             DefaultStripeTheme {
                 AutocompleteScreenUI(
-                    viewModel = AutocompleteViewModel(
-                        mockClient,
-                        AutocompleteViewModel.Args(
-                            "US"
-                        ),
-                        eventReporter,
-                        application
-                    ),
+                    viewModel = viewModel,
                     navigator = NavHostAddressElementNavigator(),
                     attributionDrawable = null,
                 )
             }
         }
+    }
 
     private fun onAddressOptionsAppBar() = composeTestRule.onNodeWithContentDescription("Back")
     private fun onQueryField() = composeTestRule.onNodeWithText("Address")


### PR DESCRIPTION
# Summary

Stabilizes the Address Element instrumentation coverage by injecting a test publishable key and disabling Google Places through activity extras. Also constructs `AutocompleteViewModel` before entering Compose content.

This is the unrelated test-stability subset currently embedded in #14100, split into an independent PR against `master`.

# Motivation

The Address Element example test currently waits on a live backend for a publishable key and inherits local Google Places configuration, making the test sensitive to external availability. Supplying deterministic launch inputs keeps the test focused on address entry and result rendering while preserving the example's normal runtime behavior when no overrides are present.

Constructing `AutocompleteViewModel` outside composition avoids the `ViewModelConstructorInComposable` lint issue and prevents recomposition from owning object construction.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet-example:compileBaseDebugAndroidTestKotlin :paymentsheet:compileDebugAndroidTestKotlin :paymentsheet:lintDebug`
- `AddressElementTest#testAddressElement`: 2 diagnostic Shampoo iterations passed, then 50/50 diagnostic iterations passed, followed by a passing normal-rule run.
- `AutocompleteScreenTest`: both managed-device tests passed under the normal Compose rule.
- `./gradlew detekt`

Shampoo was diagnostic-only and is absent from the submitted diff. No tests were ignored.

# Screenshots

Not applicable — this changes only test inputs and test object construction, with no visual changes.

# Changelog

Not applicable — this is an internal test and example-harness stabilization with no public API or user-visible behavior change.

Committed and created by Codex.
