### PR TITLE
Create integration-neutral sheet test tags

### DIFF
--- a/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/VerticalModePage.kt
+++ b/payment-element-test-pages/src/main/java/com/stripe/paymentelementtestpages/VerticalModePage.kt
@@ -11,8 +11,8 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_MANDATE_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_ICON_FROM_RES
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_EDIT_SAVED_CARD
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
@@ -63,19 +63,19 @@ class VerticalModePage(
 
     fun assertPrimaryButton(matcher: SemanticsMatcher) {
         composeTestRule
-            .onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).and(matcher))
+            .onNode(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG).and(matcher))
             .assertExists()
     }
 
     fun assertMandateExists() {
         composeTestRule
-            .onNode(hasTestTag(PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG))
+            .onNode(hasTestTag(SHEET_MANDATE_TEST_TAG))
             .assertExists()
     }
 
     fun assertMandateDoesNotExists() {
         composeTestRule
-            .onNode(hasTestTag(PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG))
+            .onNode(hasTestTag(SHEET_MANDATE_TEST_TAG))
             .assertDoesNotExist()
     }
 

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestCashApp.kt
@@ -16,7 +16,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.Initializatio
 import com.stripe.android.paymentsheet.example.playground.settings.InitializationTypeSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.SupportedPaymentMethodsSettingsDefinition
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_ERROR_TEXT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_ERROR_TEST_TAG
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.TestParameters
 import org.junit.Test
@@ -61,7 +61,7 @@ internal class TestCashApp : BasePlaygroundTest() {
                 authorizationAction = AuthorizeAction.Cancel,
             ),
             afterAuthorization = {
-                it.composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG))
+                it.composeTestRule.onNode(hasTestTag(SHEET_ERROR_TEST_TAG))
                     .assertDoesNotExist()
             }
         )

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/lpm/TestUSBankAccount.kt
@@ -23,7 +23,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.DelayedPaymen
 import com.stripe.android.paymentsheet.example.playground.settings.FeatureFlagSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PaymentMethodOptionsSetupFutureUsageOverrideSettingsDefinition
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TEST_TAG_ACCOUNT_DETAILS
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.test.core.AuthorizeAction
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
@@ -241,7 +241,7 @@ internal class TestUSBankAccount : BasePlaygroundTest() {
                 .isNotEmpty()
         }
 
-        ComposeButton(rules.compose, hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+        ComposeButton(rules.compose, hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
             .waitFor(isEnabled())
     }
 }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/PlaygroundTestDriver.kt
@@ -39,7 +39,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TAG
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.playground.PaymentSheetPlaygroundActivity
 import com.stripe.android.paymentsheet.example.playground.PlaygroundState
@@ -58,7 +57,8 @@ import com.stripe.android.paymentsheet.example.playground.settings.MerchantSetti
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundConfigurationData
 import com.stripe.android.paymentsheet.example.playground.settings.RequireCvcRecollectionDefinition
 import com.stripe.android.paymentsheet.example.samples.ui.shared.CHECKOUT_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_ERROR_TEXT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_ERROR_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TAB_LAYOUT_TEST_TAG
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
@@ -800,7 +800,7 @@ internal class PlaygroundTestDriver(
 
         composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
-                .onAllNodes(hasTestTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG).and(hasText(FawryActivity.FAILED_DISPLAY_MESSAGE)))
+                .onAllNodes(hasTestTag(SHEET_ERROR_TEST_TAG).and(hasText(FawryActivity.FAILED_DISPLAY_MESSAGE)))
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isNotEmpty()
         }
@@ -855,7 +855,7 @@ internal class PlaygroundTestDriver(
         composeTestRule.waitUntil(timeoutMillis = DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
             composeTestRule
                 .onAllNodes(
-                    hasTestTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG)
+                    hasTestTag(SHEET_ERROR_TEST_TAG)
                         .and(hasText(CustomPaymentMethodActivity.FAILED_DISPLAY_MESSAGE))
                 )
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
@@ -1139,7 +1139,7 @@ internal class PlaygroundTestDriver(
 
     private fun waitUntilPrimaryButtonIsCompleted() {
         composeTestRule.waitUntil(DEFAULT_UI_TIMEOUT.inWholeMilliseconds) {
-            composeTestRule.onAllNodesWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+            composeTestRule.onAllNodesWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isEmpty()
         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/BuyButton.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.test.core.DEFAULT_UI_TIMEOUT
 import kotlin.time.Duration
 
@@ -16,28 +16,28 @@ class BuyButton(
 ) {
 
     fun click() {
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+        composeTestRule.onNode(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
             .performScrollTo()
             .performClick()
     }
 
     fun checkEnabled(): Boolean = runCatching {
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+        composeTestRule.onNode(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
             .assertIsEnabled()
     }.isSuccess
 
     fun isEnabled() {
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+        composeTestRule.onNode(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
             .assertIsEnabled()
     }
 
     fun isDisplayed() {
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+        composeTestRule.onNode(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
             .assertIsDisplayed()
     }
 
     fun scrollTo() {
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+        composeTestRule.onNode(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
             .performScrollTo()
     }
 
@@ -45,7 +45,7 @@ class BuyButton(
         composeTestRule.waitUntil(timeoutMillis = processingCompleteTimeout.inWholeMilliseconds) {
             runCatching {
                 composeTestRule.onNode(
-                    hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                    hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
                 ).assertIsDisplayed()
             }.isSuccess && checkEnabled()
         }

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/test/core/ui/Selectors.kt
@@ -23,7 +23,7 @@ import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_CONFIRM_BUTTON_TEST_TA
 import com.stripe.android.customersheet.ui.CUSTOMER_SHEET_SAVE_BUTTON_TEST_TAG
 import com.stripe.android.model.PaymentMethod.Type.Blik
 import com.stripe.android.model.PaymentMethod.Type.CashAppPay
-import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.example.playground.RELOAD_TEST_TAG
 import com.stripe.android.paymentsheet.example.playground.activity.CustomPaymentMethodActivity
 import com.stripe.android.paymentsheet.example.playground.activity.FawryActivity
@@ -58,7 +58,7 @@ internal class Selectors(
     val continueButton = BuyButton(composeTestRule)
     val complete = ComposeButton(composeTestRule, hasTestTag(CHECKOUT_TEST_TAG))
     val reload = ComposeButton(composeTestRule, hasTestTag(RELOAD_TEST_TAG))
-    val embeddedFormBuyButton = ComposeButton(composeTestRule, hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON))
+    val embeddedFormBuyButton = ComposeButton(composeTestRule, hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
     val multiStepSelect = ComposeButton(
         composeTestRule,
         hasTestTag(PAYMENT_METHOD_SELECTOR_TEST_TAG)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -23,7 +23,7 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedContentPage
 import com.stripe.android.paymentelement.EmbeddedFormPage
-import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.utils.TestRules
@@ -318,10 +318,10 @@ internal class CheckoutPaymentElementTest {
     private fun clickPaymentOptionsPrimaryButton() {
         testRules.compose.waitUntil(timeoutMillis = 5_000) {
             testRules.compose.onAllNodes(
-                hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON).and(isEnabled())
+                hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG).and(isEnabled())
             ).fetchSemanticsNodes(atLeastOneRootRequired = false).isNotEmpty()
         }
-        testRules.compose.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+        testRules.compose.onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
             .performScrollTo()
             .performClick()
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -18,10 +18,11 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.performTextReplacement
 import androidx.compose.ui.test.performTouchInput
-import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
 import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
-import com.stripe.android.ui.core.elements.MANDATE_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_ERROR_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_MANDATE_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import kotlin.time.Duration.Companion.seconds
 
 internal class EmbeddedFormPage(
@@ -86,7 +87,7 @@ internal class EmbeddedFormPage(
         clickPrimaryButtonWithoutWaitingForDismissal()
 
         composeTestRule.waitUntil(5.seconds.inWholeMilliseconds) {
-            composeTestRule.onAllNodesWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+            composeTestRule.onAllNodesWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isEmpty()
         }
@@ -102,11 +103,11 @@ internal class EmbeddedFormPage(
             timeoutMillis = 5.seconds.inWholeMilliseconds,
         ) {
             composeTestRule.onAllNodes(
-                hasTestTag(PRIMARY_BUTTON_TEST_TAG).and(isNotEnabled())
+                hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG).and(isNotEnabled())
             ).fetchSemanticsNodes().isNotEmpty()
         }
 
-        composeTestRule.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+        composeTestRule.onNodeWithTag(SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG)
             .performScrollTo()
             .performTouchInput { click() }
 
@@ -142,11 +143,11 @@ internal class EmbeddedFormPage(
 
     fun assertErrorIsShown(message: String) {
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
-            composeTestRule.onAllNodes(hasText(message))
+            composeTestRule.onAllNodes(hasTestTag(SHEET_ERROR_TEST_TAG).and(hasText(message)))
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isNotEmpty()
         }
-        composeTestRule.onNode(hasText(message))
+        composeTestRule.onNode(hasTestTag(SHEET_ERROR_TEST_TAG).and(hasText(message)))
             .performScrollTo()
             .assertIsDisplayed()
     }
@@ -154,26 +155,26 @@ internal class EmbeddedFormPage(
     fun assertMandateIsShown() {
         waitUntilVisible()
 
-        composeTestRule.onNodeWithTag(MANDATE_TEST_TAG)
+        composeTestRule.onNodeWithTag(SHEET_MANDATE_TEST_TAG)
             .assertExists()
     }
 
     fun assertMandateIsMissing() {
         waitUntilVisible()
 
-        composeTestRule.onNodeWithTag(MANDATE_TEST_TAG)
+        composeTestRule.onNodeWithTag(SHEET_MANDATE_TEST_TAG)
             .assertDoesNotExist()
     }
 
     private fun waitUntilPrimaryButtonIsEnabled() {
         composeTestRule.waitUntil {
-            composeTestRule.onAllNodes(hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON).and(isEnabled()))
+            composeTestRule.onAllNodes(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG).and(isEnabled()))
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isNotEmpty()
         }
     }
 
     private fun primaryButton(): SemanticsNodeInteraction {
-        return composeTestRule.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+        return composeTestRule.onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
@@ -10,7 +10,7 @@ import com.stripe.android.paymentelement.EmbeddedContentPage
 import com.stripe.android.paymentelement.EmbeddedFormPage
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.EmbeddedPaymentElementTestRunnerContext
-import com.stripe.android.paymentelement.embedded.form.EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.PaymentSheet as StripePaymentSheet
@@ -147,7 +147,7 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
         }
 
         override fun clickPrimaryButton() {
-            composeTestRule.onNodeWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+            composeTestRule.onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
                 .performScrollTo()
                 .performClick()
 
@@ -175,7 +175,7 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
         }
 
         protected fun hasPrimaryButton(): Boolean {
-            return composeTestRule.onAllNodesWithTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)
+            return composeTestRule.onAllNodesWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isNotEmpty()
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FormValidationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FormValidationTest.kt
@@ -15,8 +15,8 @@ import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.payments.bankaccount.ui.CollectBankAccountActivity
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.utils.ProductIntegrationType
 import com.stripe.android.paymentsheet.utils.ProductIntegrationTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
@@ -130,17 +130,17 @@ internal class FormValidationTest {
     private fun clickPrimaryButton() {
         composeTestRule.waitUntil(5_000) {
             composeTestRule
-                .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).and(isNotEnabled()))
+                .onAllNodes(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG).and(isNotEnabled()))
                 .fetchSemanticsNodes().isNotEmpty()
         }
 
         composeTestRule.waitUntil(5_000) {
             composeTestRule
-                .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG))
+                .onAllNodes(hasTestTag(SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG))
                 .fetchSemanticsNodes().isNotEmpty()
         }
 
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG))
+        composeTestRule.onNode(hasTestTag(SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG))
             .performScrollTo()
             .performClick()
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetPage.kt
@@ -30,9 +30,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withId
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
 import com.stripe.android.paymentsheet.ui.GOOGLE_PAY_BUTTON_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_ERROR_TEXT_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_ERROR_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_MANDATE_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_OPTION_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
@@ -226,11 +226,11 @@ internal class PaymentSheetPage(
     fun clickPrimaryButton() {
         composeTestRule.waitUntil(5_000) {
             composeTestRule
-                .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).and(isEnabled()))
+                .onAllNodes(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG).and(isEnabled()))
                 .fetchSemanticsNodes().isNotEmpty()
         }
 
-        composeTestRule.onNode(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+        composeTestRule.onNode(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
             .performScrollTo()
             .performClick()
 
@@ -255,12 +255,12 @@ internal class PaymentSheetPage(
     fun assertErrorMessageShown() {
         composeTestRule.waitUntil(timeoutMillis = 5_000) {
             composeTestRule
-                .onAllNodesWithTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG)
+                .onAllNodesWithTag(SHEET_ERROR_TEST_TAG)
                 .fetchSemanticsNodes()
                 .isNotEmpty()
         }
 
-        composeTestRule.onNodeWithTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(SHEET_ERROR_TEST_TAG).assertIsDisplayed()
     }
 
     fun fillCvcRecollection(cvc: String) {
@@ -428,7 +428,7 @@ internal class PaymentSheetPage(
     fun waitUntilVisible() {
         composeTestRule.waitUntil(5000) {
             composeTestRule
-                .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+                .onAllNodes(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isNotEmpty()
         }
@@ -437,7 +437,7 @@ internal class PaymentSheetPage(
     fun waitUntilMissing() {
         composeTestRule.waitUntil(5000) {
             composeTestRule
-                .onAllNodes(hasTestTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG))
+                .onAllNodes(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG))
                 .fetchSemanticsNodes(atLeastOneRootRequired = false)
                 .isEmpty()
         }
@@ -536,7 +536,7 @@ internal class PaymentSheetPage(
         composeTestRule.onNodeWithTag(MANDATE_TEST_TAG)
             .assertDoesNotExist()
 
-        composeTestRule.onNodeWithTag(PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG)
+        composeTestRule.onNodeWithTag(SHEET_MANDATE_TEST_TAG)
             .assertDoesNotExist()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/FormActivityUI.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.embedded.form
 
-import androidx.annotation.RestrictTo
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -12,10 +11,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentelement.embedded.sheet.SheetActivityStateHolder
 import com.stripe.android.paymentsheet.ui.ErrorMessage
 import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.paymentsheet.ui.SHEET_ERROR_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_MANDATE_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.utils.DismissKeyboardOnProcessing
 import com.stripe.android.paymentsheet.utils.PaymentSheetContentPadding
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor
@@ -61,6 +66,7 @@ internal fun USBankAccountMandate(
             modifier = Modifier
                 .padding(vertical = 8.dp)
                 .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
+                .testTag(SHEET_MANDATE_TEST_TAG)
         )
     }
 }
@@ -75,6 +81,7 @@ internal fun FormActivityError(
             modifier = Modifier
                 .padding(vertical = 8.dp)
                 .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
+                .testTag(SHEET_ERROR_TEST_TAG)
         )
     }
 }
@@ -90,7 +97,13 @@ internal fun FormActivityPrimaryButton(
         modifier = Modifier.padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
     ) {
         PrimaryButton(
-            modifier = Modifier.testTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON),
+            modifier = Modifier
+                .testTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
+                .semantics {
+                    if (!state.isEnabled) {
+                        disabled()
+                    }
+                },
             label = state.primaryButtonLabel.resolve(),
             locked = state.shouldDisplayLockIcon,
             enabled = state.isEnabled,
@@ -101,6 +114,7 @@ internal fun FormActivityPrimaryButton(
         if (!state.isEnabled && !state.isProcessing) {
             Box(
                 modifier = Modifier
+                    .testTag(SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG)
                     .matchParentSize()
                     .pointerInput(Unit) {
                         detectTapGestures { onDisabledClick() }
@@ -109,6 +123,3 @@ internal fun FormActivityPrimaryButton(
         }
     }
 }
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON = "EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -380,7 +380,7 @@ private fun PaymentSheetContent(
                 modifier = Modifier
                     .padding(horizontalPadding)
                     .padding(bottom = 8.dp)
-                    .testTag(PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG),
+                    .testTag(SHEET_MANDATE_TEST_TAG),
             )
         }
 
@@ -390,7 +390,7 @@ private fun PaymentSheetContent(
                 modifier = Modifier
                     .padding(horizontalPadding)
                     .padding(top = 2.dp, bottom = 8.dp)
-                    .testTag(PAYMENT_SHEET_ERROR_TEXT_TEST_TAG),
+                    .testTag(SHEET_ERROR_TEST_TAG),
             )
         }
     }
@@ -404,7 +404,7 @@ private fun PaymentSheetContent(
                 modifier = Modifier
                     .padding(top = 8.dp)
                     .padding(horizontalPadding)
-                    .testTag(PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG),
+                    .testTag(SHEET_MANDATE_TEST_TAG),
             )
         }
     }
@@ -501,7 +501,7 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
 
     val modifier = Modifier
         .padding(MaterialTheme.stripeFormInsets.getOuterFormInsets())
-        .testTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+        .testTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
         .semantics {
             role = Role.Button
 
@@ -547,7 +547,7 @@ private fun PrimaryButton(viewModel: BaseSheetViewModel) {
         if (uiState?.canClickWhileDisabled == true && uiState?.enabled != true) {
             Box(
                 Modifier
-                    .testTag(PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG)
+                    .testTag(SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG)
                     .matchParentSize()
                     .pointerInput(Unit) {
                         detectTapGestures { uiState?.onDisabledClick?.invoke() }
@@ -577,10 +577,4 @@ internal fun PaymentSheetViewState.convert(): PrimaryButton.State {
     }
 }
 
-const val PAYMENT_SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG = "PRIMARY_BUTTON_DISABLED_OVERLAY"
-const val PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG = "PRIMARY_BUTTON"
-const val PAYMENT_SHEET_ERROR_TEXT_TEST_TAG = "PAYMENT_SHEET_ERROR"
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-const val PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG = "PAYMENT_SHEET_MANDATE_TEXT_TEST_TAG"
 private const val POST_SUCCESS_ANIMATION_DELAY = 1500L

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SheetTestTags.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SheetTestTags.kt
@@ -1,0 +1,11 @@
+@file:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+
+package com.stripe.android.paymentsheet.ui
+
+import androidx.annotation.RestrictTo
+import com.stripe.android.ui.core.elements.MANDATE_TEST_TAG
+
+const val SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG = "PRIMARY_BUTTON_DISABLED_OVERLAY"
+const val SHEET_PRIMARY_BUTTON_TEST_TAG = "PRIMARY_BUTTON"
+const val SHEET_ERROR_TEST_TAG = "PAYMENT_SHEET_ERROR"
+const val SHEET_MANDATE_TEST_TAG = MANDATE_TEST_TAG

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -40,6 +40,7 @@ import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.paymentelementtestpages.BillingDetailsPage
 import com.stripe.paymentelementtestpages.FormPage
@@ -60,7 +61,7 @@ internal class EmbeddedSheetActivityTest {
     private val billingDetailsPage = BillingDetailsPage(composeTestRule)
     private val primaryButton = composeTestRule.onNode(
         hasTestTag(PRIMARY_BUTTON_TEST_TAG)
-            .and(hasParent(hasTestTag(EMBEDDED_FORM_ACTIVITY_PRIMARY_BUTTON)))
+            .and(hasParent(hasTestTag(SHEET_PRIMARY_BUTTON_TEST_TAG)))
     )
 
     @get:Rule

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -44,9 +44,9 @@ import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLaunc
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.databinding.StripeAndroidPrimaryButtonBinding
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.getLabel
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
@@ -398,7 +398,7 @@ internal class PaymentOptionsActivityTest {
                 val text = "some text"
                 val mandateNode = composeTestRule.onNode(hasText(text))
                 val primaryButtonNode = composeTestRule
-                    .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                    .onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
 
                 viewModel.mandateHandler.updateMandateText(text.resolvableString, false)
                 mandateNode.assertIsDisplayed()
@@ -424,7 +424,7 @@ internal class PaymentOptionsActivityTest {
                 val text = "some text"
                 val mandateNode = composeTestRule.onNode(hasText(text))
                 val primaryButtonNode = composeTestRule
-                    .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                    .onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
 
                 viewModel.mandateHandler.updateMandateText(text.resolvableString, true)
                 mandateNode.assertIsDisplayed()
@@ -453,7 +453,7 @@ internal class PaymentOptionsActivityTest {
                 val text = "some text"
                 val mandateNode = composeTestRule.onNode(hasText(text))
                 val primaryButtonNode = composeTestRule
-                    .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                    .onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
 
                 viewModel.mandateHandler.updateMandateText(text.resolvableString, false)
                 mandateNode.performScrollTo()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -90,10 +90,10 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.ui.GOOGLE_PAY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_EDIT_BUTTON_TEST_TAG
-import com.stripe.android.paymentsheet.ui.PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.ui.SAVED_PAYMENT_METHOD_CARD_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SHEET_NAVIGATION_BUTTON_TAG
+import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.ui.TEST_TAG_MODIFY_BADGE
 import com.stripe.android.paymentsheet.ui.UPDATE_PM_REMOVE_BUTTON_TEST_TAG
@@ -958,7 +958,7 @@ internal class PaymentSheetActivityTest {
             val text = "some text"
             val mandateNode = composeTestRule.onNode(hasText(text))
             val primaryButtonNode = composeTestRule
-                .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                .onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
 
             viewModel.mandateHandler.updateMandateText(text.resolvableString, false)
             mandateNode.assertIsDisplayed()
@@ -981,7 +981,7 @@ internal class PaymentSheetActivityTest {
             val text = "some text"
             val mandateNode = composeTestRule.onNode(hasText(text))
             val primaryButtonNode = composeTestRule
-                .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                .onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
 
             viewModel.mandateHandler.updateMandateText(text.resolvableString, true)
             mandateNode.assertIsDisplayed()
@@ -1009,7 +1009,7 @@ internal class PaymentSheetActivityTest {
             val text = "some text"
             val mandateNode = composeTestRule.onNode(hasText(text))
             val primaryButtonNode = composeTestRule
-                .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                .onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
 
             viewModel.mandateHandler.updateMandateText(text.resolvableString, false)
             mandateNode.performScrollTo()
@@ -1162,7 +1162,7 @@ internal class PaymentSheetActivityTest {
 
         scenario.launch(intent).onActivity {
             composeTestRule
-                .onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG)
+                .onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG)
                 .performClick()
 
             composeTestRule.waitForIdle()
@@ -1193,7 +1193,7 @@ internal class PaymentSheetActivityTest {
             scenario.onActivity {
                 composeTestRule.waitForIdle()
                 assertThat(viewModel.selection.value).isEqualTo(initialSelection)
-                composeTestRule.onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).assertIsEnabled()
+                composeTestRule.onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG).assertIsEnabled()
                 assertThat(viewModel.navigationHandler.currentScreen.value)
                     .isInstanceOf<SelectSavedPaymentMethods>()
 
@@ -1202,13 +1202,13 @@ internal class PaymentSheetActivityTest {
 
                 composeTestRule.waitForIdle()
                 assertThat(viewModel.selection.value).isEqualTo(newSelection)
-                composeTestRule.onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).assertIsEnabled()
+                composeTestRule.onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG).assertIsEnabled()
 
                 viewModel.transitionToAddPaymentScreen()
 
                 composeTestRule.waitForIdle()
                 assertThat(viewModel.selection.value).isNull()
-                composeTestRule.onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).assertIsNotEnabled()
+                composeTestRule.onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG).assertIsNotEnabled()
                 assertThat(viewModel.navigationHandler.currentScreen.value)
                     .isInstanceOf<AddAnotherPaymentMethod>()
 
@@ -1216,7 +1216,7 @@ internal class PaymentSheetActivityTest {
 
                 composeTestRule.waitForIdle()
                 assertThat(viewModel.selection.value).isEqualTo(newSelection)
-                composeTestRule.onNodeWithTag(PAYMENT_SHEET_PRIMARY_BUTTON_TEST_TAG).assertIsEnabled()
+                composeTestRule.onNodeWithTag(SHEET_PRIMARY_BUTTON_TEST_TAG).assertIsEnabled()
                 assertThat(viewModel.navigationHandler.currentScreen.value)
                     .isInstanceOf<SelectSavedPaymentMethods>()
             }


### PR DESCRIPTION
# Summary

Creates integration-neutral test tags for the sheet primary button, disabled overlay, mandate, and error. Both the legacy PaymentSheet screen and Embedded Sheet now expose the same tags, and existing page objects and test consumers use the shared selectors.

Committed and created by Codex.

# Motivation

PaymentSheet tests currently depend on tags owned by the legacy screen, while Embedded Sheet uses separate selectors. Sharing sheet-level tags lets the existing page objects work with either implementation and prepares the tests for the upcoming activity migration without changing their behavior at migration time.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Validation performed:

- `./gradlew detekt`
- `./gradlew :paymentsheet:testDebugUnitTest --rerun-tasks`
- `./gradlew :paymentsheet:compileDebugAndroidTestKotlin`
- `./gradlew :paymentsheet-example:compileBaseDebugAndroidTestKotlin`
- `./gradlew :paymentsheet-example:compileCardScanDebugAndroidTestKotlin`
- `./gradlew :paymentsheet-example:compileTapToAddDebugAndroidTestKotlin`

Ignored tests: None.

# Screenshots

Not applicable — this changes test selectors and semantics without changing rendered UI.

# Changelog

Not applicable — this is an internal test-infrastructure change with no user-facing behavior or public API changes.
