### PR TITLE
Deduplicate PaymentSheet form analytics

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -52,6 +52,8 @@ internal class DefaultEventReporter @Inject internal constructor(
         origin = ORIGIN,
     )
 
+    private var interactedPaymentMethodCode: PaymentMethodCode? = null
+
     override fun onInit() {
         fireEvent(
             event = PaymentSheetEvent.Init(
@@ -218,6 +220,7 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     override fun onPaymentMethodFormShown(code: PaymentMethodCode) {
+        interactedPaymentMethodCode = null
         durationProvider.start(DurationProvider.Key.ConfirmButtonClicked)
 
         fireAnalyticEvent(AnalyticEvent.DisplayedPaymentMethodForm(code))
@@ -229,6 +232,11 @@ internal class DefaultEventReporter @Inject internal constructor(
     }
 
     override fun onPaymentMethodFormInteraction(code: PaymentMethodCode) {
+        if (interactedPaymentMethodCode == code) {
+            return
+        }
+
+        interactedPaymentMethodCode = code
         fireAnalyticEvent(AnalyticEvent.StartedInteractionWithPaymentMethodForm(code))
         fireEvent(
             PaymentSheetEvent.PaymentOptionFormInteraction(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListener.kt
@@ -86,7 +86,7 @@ internal class PaymentSheetAnalyticsListener(
                 reportPaymentOptions(false)
             }
             is AddFirstPaymentMethod, is AddAnotherPaymentMethod -> {
-                reportFormShown(currentPaymentMethodTypeProvider())
+                reportFormShownIfNecessary(currentPaymentMethodTypeProvider())
                 reportPaymentOptions(false)
             }
         }
@@ -114,15 +114,20 @@ internal class PaymentSheetAnalyticsListener(
         }
     }
 
-    private fun reportFormShown(code: String) {
+    fun reportFormShown(code: PaymentMethodCode) {
+        previouslyShownForm = code
+        previouslyInteractedForm = null
+        eventReporter.onPaymentMethodFormShown(code)
+    }
+
+    private fun reportFormShownIfNecessary(code: PaymentMethodCode) {
         /*
          * Prevents this event from being reported multiple times on the same payment form after process death. We
          * should only trigger a form shown event when initially shown in the add payment method screen or the user
          * navigates to a different form.
          */
         if (previouslyShownForm != code) {
-            eventReporter.onPaymentMethodFormShown(code)
-            previouslyShownForm = code
+            reportFormShown(code)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodVerticalLayoutInteractor.kt
@@ -196,7 +196,7 @@ internal class DefaultPaymentMethodVerticalLayoutInteractor(
                 canChangeCbc = viewModel.customerStateHolder.canChangeCbc,
                 isCurrentScreen = isCurrentScreen,
                 reportPaymentMethodTypeSelected = viewModel.eventReporter::onSelectPaymentMethod,
-                reportFormShown = viewModel.eventReporter::onPaymentMethodFormShown,
+                reportFormShown = viewModel.analyticsListener::reportFormShown,
                 shouldUpdateVerticalModeSelection = { paymentMethodCode ->
                     val requiresFormScreen = paymentMethodCode != null &&
                         formHelper.formTypeForCode(paymentMethodCode) == FormType.UserInteractionRequired

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -433,6 +433,49 @@ class DefaultEventReporterTest {
     }
 
     @Test
+    fun `onPaymentMethodFormInteraction fires event once for repeated interactions`() = runScenario {
+        paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+
+        eventReporter.onPaymentMethodFormInteraction(code = "card")
+        eventReporter.onPaymentMethodFormInteraction(code = "card")
+
+        assertThat(analyticsEventTurbine.awaitItem())
+            .isEqualTo(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
+        val request = analyticsRequestExecutor.requestTurbine.awaitItem()
+        assertThat(request.params).containsEntry("event", "mc_form_interacted")
+    }
+
+    @Test
+    fun `onPaymentMethodFormShown allows form interaction to fire again`() = runScenario {
+        repeat(3) {
+            paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
+        }
+        durationProvider.startCalls.push(
+            FakeDurationProvider.StartCall(
+                key = DurationProvider.Key.ConfirmButtonClicked,
+                reset = true,
+            )
+        )
+
+        eventReporter.onPaymentMethodFormInteraction(code = "card")
+        eventReporter.onPaymentMethodFormShown(code = "card")
+        eventReporter.onPaymentMethodFormInteraction(code = "card")
+
+        assertThat(analyticsEventTurbine.awaitItem())
+            .isEqualTo(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
+        assertThat(analyticsEventTurbine.awaitItem())
+            .isEqualTo(AnalyticEvent.DisplayedPaymentMethodForm("card"))
+        assertThat(analyticsEventTurbine.awaitItem())
+            .isEqualTo(AnalyticEvent.StartedInteractionWithPaymentMethodForm("card"))
+        assertThat(analyticsRequestExecutor.requestTurbine.awaitItem().params)
+            .containsEntry("event", "mc_form_interacted")
+        assertThat(analyticsRequestExecutor.requestTurbine.awaitItem().params)
+            .containsEntry("event", "mc_form_shown")
+        assertThat(analyticsRequestExecutor.requestTurbine.awaitItem().params)
+            .containsEntry("event", "mc_form_interacted")
+    }
+
+    @Test
     fun `onPaymentMethodFormCompleted fires event`() = runScenario {
         paymentMethodMetadataStack.push(paymentMethodMetadataWithTestAnalyticsMetadata)
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/PaymentSheetAnalyticsListenerTest.kt
@@ -50,6 +50,18 @@ class PaymentSheetAnalyticsListenerTest {
     }
 
     @Test
+    fun `reporting form shown allows interaction to be reported again`() = runScenario {
+        analyticsListener.reportFormShown("card")
+        analyticsListener.reportFieldInteraction("card")
+        analyticsListener.reportFieldInteraction("card")
+        analyticsListener.reportFormShown("card")
+        analyticsListener.reportFieldInteraction("card")
+
+        verify(eventReporter, times(2)).onPaymentMethodFormShown("card")
+        verify(eventReporter, times(2)).onPaymentMethodFormInteraction("card")
+    }
+
+    @Test
     fun `reportPaymentSheetHidden reports for UpdatePaymentMethod`() = runScenario {
         analyticsListener.reportPaymentSheetHidden(mock<PaymentSheetScreen.UpdatePaymentMethod>())
 


### PR DESCRIPTION
# Summary

Deduplicates PaymentSheet payment-method form interaction analytics within each form display.

This is layer 2 of 2 in the stack. It routes vertical-mode form-shown reporting through `PaymentSheetAnalyticsListener`, resets interaction tracking when a form is shown, and prevents repeated interaction events for the same displayed form. The change is independent of layer 1; the dependency is only for stack ordering.

# Motivation

A displayed payment-method form can emit repeated field interactions, which previously produced duplicate interaction analytics. A newly displayed form should still be able to report a fresh interaction, so the deduplication state must reset at the form-shown boundary.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew detekt`

No tests were newly ignored.

# Screenshots

Not applicable; this PR changes analytics behavior without visual changes.

# Changelog

Not applicable; this is an internal analytics correction with no public API impact.

Committed and created by Codex.
