### PR TITLE
Extract reusable wallet header rendering

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/InitialPaymentOptionsScreenFactory.kt
@@ -218,7 +218,7 @@ internal class InitialPaymentOptionsScreenFactory @Inject constructor(
         return !requiresFormScreen
     }
 
-    private fun walletsState(): WalletsState? {
+    internal fun walletsState(): WalletsState? {
         val linkAccount = linkAccountHolder.linkAccountInfo.value.account
         return WalletsState.create(
             isLinkAvailable = paymentMethodMetadata.shouldShowLinkButton,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetWalletsHeader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/SheetWalletsHeader.kt
@@ -1,0 +1,51 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentsheet.ui.WalletsHeader
+import javax.inject.Inject
+
+internal class SheetWalletsHeader @Inject constructor(
+    private val launchMode: EmbeddedLaunchMode,
+    private val navigator: EmbeddedNavigator,
+    private val initialPaymentOptionsScreenFactory: InitialPaymentOptionsScreenFactory,
+) {
+    @Composable
+    operator fun invoke(screen: EmbeddedNavigator.Screen) {
+        if (!shouldShow(screen)) return
+
+        initialPaymentOptionsScreenFactory.walletsState()?.let { state ->
+            WalletsHeader(
+                state = state,
+                onGooglePayPressed = state.onGooglePayPressed,
+                onLinkPressed = state.onLinkPressed,
+                dividerSpacing = if (screen is EmbeddedNavigator.Screen.VerticalPaymentOptions) {
+                    24.dp
+                } else {
+                    16.dp
+                },
+                modifier = Modifier,
+                cardBrandFilter = state.cardBrandFilter,
+                cardFundingFilter = state.cardFundingFilter,
+                additionalContent = {},
+            )
+        }
+    }
+
+    private fun shouldShow(screen: EmbeddedNavigator.Screen): Boolean {
+        return when (launchMode) {
+            is EmbeddedLaunchMode.PaymentOptions -> when (screen) {
+                is EmbeddedNavigator.Screen.Form -> !navigator.canGoBack
+                is EmbeddedNavigator.Screen.HorizontalPaymentOptions -> !navigator.canGoBack
+                is EmbeddedNavigator.Screen.VerticalPaymentOptions -> true
+                is EmbeddedNavigator.Screen.ManageAll,
+                is EmbeddedNavigator.Screen.ManageUpdate,
+                is EmbeddedNavigator.Screen.SavedPaymentMethodConfirm -> false
+            }
+            is EmbeddedLaunchMode.Form,
+            is EmbeddedLaunchMode.Manage -> false
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentSheetScreen.kt
@@ -14,11 +14,9 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -46,7 +44,6 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.role
@@ -58,7 +55,6 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.ui.BottomSheetScaffold
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.link.ui.LinkButton
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
@@ -67,7 +63,6 @@ import com.stripe.android.paymentsheet.databinding.StripeFragmentPrimaryButtonCo
 import com.stripe.android.paymentsheet.model.MandateText
 import com.stripe.android.paymentsheet.model.PaymentSheetViewState
 import com.stripe.android.paymentsheet.navigation.PaymentSheetScreen
-import com.stripe.android.paymentsheet.state.WalletLocation
 import com.stripe.android.paymentsheet.state.WalletsProcessingState
 import com.stripe.android.paymentsheet.state.WalletsState
 import com.stripe.android.paymentsheet.ui.PaymentSheetFlowType.Complete
@@ -421,78 +416,26 @@ internal fun Wallet(
     cardBrandFilter: CardBrandFilter,
     cardFundingFilter: CardFundingFilter
 ) {
-    val padding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
-
-    Column(modifier = modifier.padding(padding)) {
-        WalletHeader(
-            state = state,
-            onGooglePayPressed = onGooglePayPressed,
-            onLinkPressed = onLinkPressed,
-            cardBrandFilter = cardBrandFilter,
-            cardFundingFilter = cardFundingFilter
-        )
-
-        when (processingState) {
-            is WalletsProcessingState.Idle -> processingState.error?.let { error ->
-                ErrorMessage(
-                    error = error.resolve(),
-                    modifier = Modifier.padding(vertical = 3.dp, horizontal = 1.dp),
-                )
-            }
-            else -> Unit
-        }
-
-        if (state.walletsInHeader) {
-            Spacer(modifier = Modifier.requiredHeight(dividerSpacing))
-
-            val text = stringResource(state.dividerTextResource)
-            WalletsDivider(text)
-        }
-    }
-}
-
-@Composable
-private fun WalletHeader(
-    state: WalletsState,
-    onGooglePayPressed: () -> Unit,
-    onLinkPressed: () -> Unit,
-    cardBrandFilter: CardBrandFilter,
-    cardFundingFilter: CardFundingFilter
-) {
-    val walletItems = remember(state) {
-        // Only show wallet if allowed in header
-        state.wallets(WalletLocation.HEADER)
-    }
-
-    Column(
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        for (wallet in walletItems) {
-            when (wallet) {
-                is WalletsState.GooglePay -> {
-                    GooglePayButton(
-                        state = PrimaryButton.State.Ready,
-                        allowCreditCards = wallet.allowCreditCards,
-                        buttonType = wallet.buttonType,
-                        billingAddressParameters = wallet.billingAddressParameters,
-                        isEnabled = state.buttonsEnabled,
-                        onPressed = onGooglePayPressed,
-                        cardBrandFilter = cardBrandFilter,
-                        cardFundingFilter = cardFundingFilter,
-                        additionalEnabledNetworks = wallet.additionalEnabledNetworks
+    WalletsHeader(
+        state = state,
+        onGooglePayPressed = onGooglePayPressed,
+        onLinkPressed = onLinkPressed,
+        dividerSpacing = dividerSpacing,
+        modifier = modifier,
+        cardBrandFilter = cardBrandFilter,
+        cardFundingFilter = cardFundingFilter,
+        additionalContent = {
+            when (processingState) {
+                is WalletsProcessingState.Idle -> processingState.error?.let { error ->
+                    ErrorMessage(
+                        error = error.resolve(),
+                        modifier = Modifier.padding(vertical = 3.dp, horizontal = 1.dp),
                     )
                 }
-                is WalletsState.Link -> {
-                    LinkButton(
-                        state = wallet.state,
-                        enabled = state.buttonsEnabled,
-                        linkBrand = wallet.linkBrand,
-                        onClick = onLinkPressed,
-                    )
-                }
+                else -> Unit
             }
-        }
-    }
+        },
+    )
 }
 
 @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletsHeader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletsHeader.kt
@@ -1,0 +1,71 @@
+package com.stripe.android.paymentsheet.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.stripe.android.CardBrandFilter
+import com.stripe.android.CardFundingFilter
+import com.stripe.android.link.ui.LinkButton
+import com.stripe.android.paymentsheet.state.WalletLocation
+import com.stripe.android.paymentsheet.state.WalletsState
+import com.stripe.android.uicore.getOuterFormInsets
+import com.stripe.android.uicore.stripeFormInsets
+
+@Composable
+internal fun WalletsHeader(
+    state: WalletsState,
+    onGooglePayPressed: () -> Unit,
+    onLinkPressed: () -> Unit,
+    dividerSpacing: Dp,
+    modifier: Modifier,
+    cardBrandFilter: CardBrandFilter,
+    cardFundingFilter: CardFundingFilter,
+    additionalContent: @Composable () -> Unit,
+) {
+    val walletItems = remember(state) {
+        state.wallets(WalletLocation.HEADER)
+    }
+    if (walletItems.isEmpty()) return
+
+    val padding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
+    Column(modifier = modifier.padding(padding)) {
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            walletItems.forEach { wallet ->
+                when (wallet) {
+                    is WalletsState.GooglePay -> GooglePayButton(
+                        state = PrimaryButton.State.Ready,
+                        allowCreditCards = wallet.allowCreditCards,
+                        buttonType = wallet.buttonType,
+                        billingAddressParameters = wallet.billingAddressParameters,
+                        isEnabled = state.buttonsEnabled,
+                        onPressed = onGooglePayPressed,
+                        cardBrandFilter = cardBrandFilter,
+                        cardFundingFilter = cardFundingFilter,
+                        additionalEnabledNetworks = wallet.additionalEnabledNetworks,
+                    )
+                    is WalletsState.Link -> LinkButton(
+                        state = wallet.state,
+                        enabled = state.buttonsEnabled,
+                        theme = wallet.theme,
+                        linkBrand = wallet.linkBrand,
+                        onClick = onLinkPressed,
+                    )
+                }
+            }
+        }
+
+        additionalContent()
+
+        Spacer(modifier = Modifier.requiredHeight(dividerSpacing))
+        WalletsDivider(stringResource(state.dividerTextResource))
+    }
+}


### PR DESCRIPTION
# Summary
Extract wallet-header rendering into a reusable composable shared by legacy PaymentSheet and `SheetWalletsHeader`.

The shared renderer handles wallet ordering, Link and Google Pay buttons, spacing, the divider, explicit callbacks and card filters, and the configured Link theme. Legacy processing errors remain in the legacy wrapper.

# Motivation
The embedded sheet needs the same wallet-header UI as legacy PaymentSheet. Sharing the rendering avoids duplicating wallet behavior while keeping screen and launch-mode visibility policy in `SheetWalletsHeader`.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Automated validation:
- `./gradlew :paymentsheet:compileDebugKotlin`
- `./gradlew :paymentsheet:detekt`
- `./gradlew detekt`
- `git diff --check`

No tests were ignored.

# Screenshots
Not applicable — this refactor preserves the existing wallet-header layout and has no intended visual changes.

# Changelog
Not applicable — this is an internal UI-rendering refactor with no public API or user-facing behavior change.

Committed and created by Codex.
