### PR TITLE
Extract form type classification

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
@@ -35,6 +35,27 @@ internal interface FormDefinitionFactory {
     fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormHelper.FormType
 }
 
+internal fun formTypeForCode(
+    paymentMethodCode: PaymentMethodCode,
+    formElements: List<FormElement>,
+): FormHelper.FormType {
+    val userInteractionAllowed = formElements.any { it.allowsUserInteraction }
+    val requiresFormScreen = userInteractionAllowed ||
+        paymentMethodCode == PaymentMethod.Type.USBankAccount.code ||
+        paymentMethodCode == PaymentMethod.Type.Link.code
+
+    return if (requiresFormScreen) {
+        FormHelper.FormType.UserInteractionRequired
+    } else {
+        val mandate = formElements.firstNotNullOfOrNull { it.mandateText }
+        if (mandate == null) {
+            FormHelper.FormType.Empty
+        } else {
+            FormHelper.FormType.MandateOnly(mandate)
+        }
+    }
+}
+
 internal class DefaultFormDefinitionFactory(
     private val coroutineScope: CoroutineScope,
     private val linkInlineHandler: LinkInlineHandler,
@@ -76,23 +97,7 @@ internal class DefaultFormDefinitionFactory(
 
     override fun formTypeForCode(paymentMethodCode: PaymentMethodCode): FormHelper.FormType {
         val formElements = formElementsForCode(paymentMethodCode)
-        return if (requiresFormScreen(paymentMethodCode, formElements)) {
-            FormHelper.FormType.UserInteractionRequired
-        } else {
-            val mandate = formElements.firstNotNullOfOrNull { it.mandateText }
-            if (mandate == null) {
-                FormHelper.FormType.Empty
-            } else {
-                FormHelper.FormType.MandateOnly(mandate)
-            }
-        }
-    }
-
-    private fun requiresFormScreen(paymentMethodCode: String, formElements: List<FormElement>): Boolean {
-        val userInteractionAllowed = formElements.any { it.allowsUserInteraction }
-        return userInteractionAllowed ||
-            paymentMethodCode == PaymentMethod.Type.USBankAccount.code ||
-            paymentMethodCode == PaymentMethod.Type.Link.code
+        return formTypeForCode(paymentMethodCode, formElements)
     }
 
     private fun createArgumentsFactory(code: PaymentMethodCode): UiDefinitionFactory.Arguments.Factory {


### PR DESCRIPTION
# Summary
Extract form-type classification into an internal helper that accepts a payment method code and its form elements. `DefaultFormDefinitionFactory` now delegates to the helper while preserving the special handling for Link and US bank accounts.

# Motivation
Follow-up form-factory removal work needs to classify forms from already-created form elements in multiple embedded factories. Sharing this helper avoids duplicating the classification algorithm or retaining `DefaultFormDefinitionFactory` solely for that decision.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Verified with:
- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.paymentsheet.FormHelperTest`
- `./gradlew detekt`
- `git diff --check`

No tests were ignored.

# Screenshots
Not applicable; this is an internal refactor with no UI changes.

# Changelog
Not applicable; this does not change public behavior or APIs.

Committed and created by Codex.
