### PR TITLE
Add PaymentSheet API configuration resolution foundation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -3,6 +3,7 @@ package com.stripe.android.common.model
 import android.os.Parcelable
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkAppearance
 import com.stripe.android.link.LinkController
 import com.stripe.android.model.CardBrand
@@ -42,6 +43,7 @@ internal data class CommonConfiguration(
     val opensCardScannerAutomatically: Boolean,
     val userOverrideCountry: String?,
     val appearance: PaymentSheet.Appearance,
+    val apiConfiguration: ApiConfiguration.State? = null,
 ) : Parcelable {
 
     fun allowedCardFundingTypes(enabled: Boolean): List<PaymentSheet.CardFundingType> {
@@ -303,6 +305,10 @@ internal fun LinkController.Configuration.State.asCommonConfiguration(): CommonC
     userOverrideCountry = null,
     appearance = PaymentSheet.Appearance(),
     allowedCardFundingTypes = ConfigurationDefaults.allowedCardFundingTypes,
+    apiConfiguration = ApiConfiguration.State(
+        publishableKey = publishableKey,
+        stripeAccountId = stripeAccountId,
+    ),
 )
 
 private fun String.isEKClientSecretValid(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolver.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import javax.inject.Inject
+import javax.inject.Provider
+
+internal class ApiConfigurationResolver @Inject constructor(
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
+) {
+    fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State {
+        if (apiConfiguration != null) return apiConfiguration
+        val config = paymentConfiguration.get()
+        return ApiConfiguration.State(
+            publishableKey = config.publishableKey,
+            stripeAccountId = config.stripeAccountId,
+        )
+    }
+}


### PR DESCRIPTION
# Summary
Add a PaymentSheet-owned API configuration resolver and carry the resolved state on common PaymentSheet configuration.

Committed and created by Codex.

# Motivation
PaymentSheet needs one coherent publishable-key and Stripe-account snapshot before later loading, repository, and UI flows can stop reading process-global configuration independently.

This layer introduces the shared resolution boundary without migrating downstream consumers yet. Keeping that foundation isolated makes the following repository and loader changes independently reviewable.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

# Screenshots
Not applicable — internal configuration plumbing only.

# Changelog
Not applicable — no public API or intended user-visible behavior change.