### PR TITLE
Add PaymentSheet configuration foundation and update customer repository

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -3,6 +3,7 @@ package com.stripe.android.common.model
 import android.os.Parcelable
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkAppearance
 import com.stripe.android.link.LinkController
 import com.stripe.android.model.CardBrand
@@ -42,6 +43,7 @@ internal data class CommonConfiguration(
     val opensCardScannerAutomatically: Boolean,
     val userOverrideCountry: String?,
     val appearance: PaymentSheet.Appearance,
+    val apiConfiguration: ApiConfiguration.State? = null,
 ) : Parcelable {
 
     fun allowedCardFundingTypes(enabled: Boolean): List<PaymentSheet.CardFundingType> {
@@ -303,6 +305,10 @@ internal fun LinkController.Configuration.State.asCommonConfiguration(): CommonC
     userOverrideCountry = null,
     appearance = PaymentSheet.Appearance(),
     allowedCardFundingTypes = ConfigurationDefaults.allowedCardFundingTypes,
+    apiConfiguration = ApiConfiguration.State(
+        publishableKey = publishableKey,
+        stripeAccountId = stripeAccountId,
+    ),
 )
 
 private fun String.isEKClientSecretValid(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet
 
 import android.content.Context
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.exception.stripeErrorMessage
 import com.stripe.android.core.injection.IOContext
@@ -14,6 +15,7 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -32,6 +34,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     private val timeProvider: () -> Long,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: (CustomerEphemeralKey) -> PrefsRepository,
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerAdapter {
 
@@ -71,6 +74,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 types = requestedTypes,
                 silentlyFail = false,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -88,6 +92,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -105,6 +110,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -124,6 +130,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -9,11 +10,13 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetPaymentMethodDataSource {
@@ -42,6 +45,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     paymentMethodId = paymentMethodId,
                     params = params,
+                    stripeAccountId = paymentConfiguration.get().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }
@@ -66,6 +70,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
                     paymentMethodId = paymentMethodId,
+                    stripeAccountId = paymentConfiguration.get().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -11,11 +12,13 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val prefsRepositoryFactory: PrefsRepository.Factory,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetSavedSelectionDataSource {
@@ -101,6 +104,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
             customerId = ephemeralKey.customerId,
             ephemeralKeySecret = ephemeralKey.ephemeralKey,
             paymentMethodId = paymentMethodId,
+            stripeAccountId = paymentConfiguration.get().stripeAccountId,
         ).getOrThrow()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolver.kt
@@ -1,0 +1,19 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import javax.inject.Inject
+import javax.inject.Provider
+
+internal class ApiConfigurationResolver @Inject constructor(
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
+) {
+    fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State {
+        if (apiConfiguration != null) return apiConfiguration
+        val config = paymentConfiguration.get()
+        return ApiConfiguration.State(
+            publishableKey = config.publishableKey,
+            stripeAccountId = config.stripeAccountId,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.repositories
 
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
@@ -19,7 +18,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -29,7 +27,6 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 internal class CustomerApiRepository @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     private val logger: Logger,
     private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
@@ -39,13 +36,14 @@ internal class CustomerApiRepository @Inject constructor(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer? {
         return stripeRepository.retrieveCustomer(
             customerId,
             productUsageTokens,
             ApiRequest.Options(
                 ephemeralKeySecret,
-                lazyPaymentConfig.get().stripeAccountId
+                stripeAccountId
             )
         ).getOrNull()
     }
@@ -55,6 +53,7 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>> = withContext(workContext) {
         val requests = types.filter { paymentMethodType ->
             paymentMethodType in setOf(
@@ -73,7 +72,7 @@ internal class CustomerApiRepository @Inject constructor(
                     productUsageTokens = productUsageTokens,
                     requestOptions = ApiRequest.Options(
                         apiKey = ephemeralKeySecret,
-                        stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                        stripeAccount = stripeAccountId,
                     ),
                 ).onFailure {
                     logger.error("Failed to retrieve payment methods.", it)
@@ -108,13 +107,14 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         return stripeRepository.detachPaymentMethod(
             productUsageTokens = productUsageTokens,
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             ),
         ).onFailure {
             logger.error("Failed to detach payment method $paymentMethodId.", it)
@@ -133,10 +133,11 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = with(CoroutineScope(workContext)) {
         val requestOptions = ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+            stripeAccount = stripeAccountId,
         )
 
         val detachOne: suspend (String) -> Result<PaymentMethod> = { pmId ->
@@ -154,6 +155,7 @@ internal class CustomerApiRepository @Inject constructor(
             // We only support removing duplicate cards.
             types = listOf(PaymentMethod.Type.Card),
             silentlyFail = false,
+            stripeAccountId = stripeAccountId,
         ).getOrElse {
             return Result.failure(it)
         }
@@ -212,6 +214,7 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.attachPaymentMethod(
             customerId = customerId,
@@ -219,7 +222,7 @@ internal class CustomerApiRepository @Inject constructor(
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             )
         ).onFailure {
             logger.error("Failed to attach payment method $paymentMethodId.", it)
@@ -230,13 +233,14 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.updatePaymentMethod(
             paymentMethodId = paymentMethodId,
             paymentMethodUpdateParams = params,
             options = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             )
         ).onFailure {
             logger.error("Failed to update payment method $paymentMethodId.", it)
@@ -246,12 +250,13 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer> = stripeRepository.setDefaultPaymentMethod(
         paymentMethodId = paymentMethodId,
         customerId = customerId,
         options = ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+            stripeAccount = stripeAccountId,
         )
     )
 
@@ -259,6 +264,7 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.retrieveCustomerPaymentMethod(
             customerId = customerId,
@@ -266,7 +272,7 @@ internal class CustomerApiRepository @Inject constructor(
             productUsageTokens = productUsageTokens,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             ),
         ).onFailure {
             logger.error("Failed to retrieve payment method $paymentMethodId.", it)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -14,6 +14,7 @@ internal interface CustomerRepository {
     suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer?
 
     /**
@@ -26,6 +27,7 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>>
 
     /**
@@ -37,6 +39,7 @@ internal interface CustomerRepository {
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     /**
@@ -48,6 +51,7 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     /**
@@ -57,6 +61,7 @@ internal interface CustomerRepository {
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     suspend fun updatePaymentMethod(
@@ -64,17 +69,20 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     suspend fun setDefaultPaymentMethod(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer>
 
     suspend fun retrievePaymentMethod(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.paymentsheet.repositories
 
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * Repository for managing saved payment methods. This abstracts over the underlying
@@ -37,6 +39,7 @@ internal interface SavedPaymentMethodRepository {
 internal class DefaultSavedPaymentMethodRepository @Inject constructor(
     private val customerRepository: CustomerRepository,
     private val checkoutSessionRepository: CheckoutSessionRepository,
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
 ) : SavedPaymentMethodRepository {
 
     override suspend fun detachPaymentMethod(
@@ -57,6 +60,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 customerSessionClientSecret = customerMetadata.customerSessionClientSecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -64,6 +68,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             )
         }
     }
@@ -89,6 +94,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -97,6 +103,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             )
         }
     }
@@ -113,6 +120,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -120,6 +128,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             )
         }
     }
@@ -138,6 +147,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -145,6 +155,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = paymentConfiguration.get().stripeAccountId,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -498,6 +498,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                         PaymentMethod.Type.USBankAccount,
                     ), // These are the only payment method types we support as saved payment methods.
                     silentlyFail = paymentConfiguration.get().isLiveMode(),
+                    stripeAccountId = paymentConfiguration.get().stripeAccountId,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.paymentsheet.state
 
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * Retrieves the customer email from any of the available sources.
@@ -25,6 +27,7 @@ internal interface RetrieveCustomerEmail {
 internal class DefaultRetrieveCustomerEmail @Inject constructor(
     private val customerRepository: CustomerRepository,
     private val durationProvider: DurationProvider,
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
 ) : RetrieveCustomerEmail {
 
     override suspend operator fun invoke(
@@ -59,6 +62,7 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
         return customerRepository.retrieveCustomer(
             customerId = customerId,
             ephemeralKeySecret = ephemeralKeySecret,
+            stripeAccountId = paymentConfiguration.get().stripeAccountId,
         )?.email
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.common.analytics.experiment
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHoldback.EmailRecognitionSource
 import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.link.TestFactory
@@ -64,6 +65,7 @@ class LogLinkGlobalHoldbackExposureTest {
         retrieveCustomerEmail = DefaultRetrieveCustomerEmail(
             customerRepository,
             FakeDurationProvider(),
+            { PaymentConfiguration("pk_test") },
         )
         linkConfigurationCoordinator = FakeLinkConfigurationCoordinator()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -30,6 +30,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -191,7 +192,7 @@ class CustomerAdapterTest {
     fun `retrievePaymentMethods filters with paymentMethodTypes`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
-        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any()))
+        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), any()))
             .thenReturn(Result.success(emptyList()))
 
         val adapter = createAdapter(
@@ -208,6 +209,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
+            stripeAccountId = isNull(),
         )
     }
 
@@ -259,6 +261,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
+            stripeAccountId = isNull(),
         )
     }
 
@@ -777,6 +780,7 @@ class CustomerAdapterTest {
             timeProvider = timeProvider,
             customerRepository = customerRepository,
             prefsRepositoryFactory = prefsRepositoryFactory,
+            paymentConfiguration = { PaymentConfiguration("pk_test") },
             workContext = testDispatcher
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -266,6 +267,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
             elementsSessionManager = elementsSessionManager,
             customerRepository = customerRepository,
             errorReporter = errorReporter,
+            paymentConfiguration = { PaymentConfiguration("pk_test") },
             workContext = coroutineContext,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethodFixtures
@@ -241,6 +242,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
             prefsRepositoryFactory = {
                 prefsRepository
             },
+            paymentConfiguration = { PaymentConfiguration("pk_test") },
             workContext = coroutineContext
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -1,8 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.ListPaymentMethodsParams
@@ -40,7 +38,6 @@ internal class CustomerRepositoryTest {
 
     private val repository = CustomerApiRepository(
         stripeRepository,
-        { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, "acct_123") },
         Logger.getInstance(false),
         workContext = testDispatcher,
         errorReporter = errorReporter
@@ -63,6 +60,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
+                stripeAccountId = null
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -92,6 +90,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.PayPal),
                 true,
+                stripeAccountId = null
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -165,6 +164,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
+                stripeAccountId = null
             ).getOrThrow()
 
             assertThat(result).hasSize(1)
@@ -222,6 +222,7 @@ internal class CustomerRepositoryTest {
             ephemeralKeySecret = "ephemeral_key",
             listOf(PaymentMethod.Type.Card),
             true,
+            stripeAccountId = null
         ).getOrThrow()
 
         assertThat(result).hasSize(2)
@@ -241,6 +242,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = true,
+                stripeAccountId = null
             )
 
             assertThat(result.getOrNull()).isEmpty()
@@ -260,6 +262,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = false,
+                stripeAccountId = null
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -274,7 +277,6 @@ internal class CustomerRepositoryTest {
             val errorReporter = FakeErrorReporter()
             val repository = CustomerApiRepository(
                 failsOnceStripeRepository(),
-                { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                 Logger.getInstance(false),
                 workContext = testDispatcher,
                 errorReporter = errorReporter
@@ -286,6 +288,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = true,
+                stripeAccountId = null
             )
 
             assertThat(result.getOrNull()).containsExactly(
@@ -307,7 +310,6 @@ internal class CustomerRepositoryTest {
             val errorReporter = FakeErrorReporter()
             val repository = CustomerApiRepository(
                 failsOnceStripeRepository(),
-                { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                 Logger.getInstance(false),
                 workContext = testDispatcher,
                 errorReporter = errorReporter
@@ -319,6 +321,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = false,
+                stripeAccountId = null
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -345,6 +348,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -361,6 +365,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result.isFailure).isTrue()
@@ -383,6 +388,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 customerSessionClientSecret = "cuss_123",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -408,6 +414,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethodToRemove.id,
+                stripeAccountId = null
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(paymentMethodsToRemove)
@@ -434,6 +441,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = usBankAccount.id,
+                stripeAccountId = null
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(listOf(usBankAccount))
@@ -458,6 +466,7 @@ internal class CustomerRepositoryTest {
                 customerId = FAKE_CUSTOMER_ID,
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = paymentMethodToRemove.id,
+                stripeAccountId = null
             )
 
             val duplicates = paymentMethods.filter { paymentMethod ->
@@ -488,6 +497,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethods.first().id,
+                stripeAccountId = null
             )
 
             assertThat(result.isFailure).isTrue()
@@ -516,6 +526,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result).isEqualTo(
@@ -533,6 +544,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = null
             )
 
             assertThat(result).isEqualTo(error)
@@ -548,7 +560,8 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                params = PaymentMethodUpdateParams.createCard()
+                params = PaymentMethodUpdateParams.createCard(),
+                stripeAccountId = null
             )
 
             assertThat(result).isEqualTo(success)
@@ -564,7 +577,8 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                params = PaymentMethodUpdateParams.createCard()
+                params = PaymentMethodUpdateParams.createCard(),
+                stripeAccountId = null
             )
 
             assertThat(result).isEqualTo(error)
@@ -577,7 +591,6 @@ internal class CustomerRepositoryTest {
             workContext = coroutineContext,
             errorReporter = errorReporter,
             stripeRepository = stripeRepository,
-            lazyPaymentConfig = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, "acct_123") },
             logger = Logger.getInstance(false),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.repositories
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
@@ -334,6 +335,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         val repository = DefaultSavedPaymentMethodRepository(
             customerRepository = customerRepository,
             checkoutSessionRepository = checkoutSessionRepository,
+            paymentConfiguration = { PaymentConfiguration("pk_test") },
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.isInstanceOf
@@ -171,6 +172,7 @@ internal class DefaultCreateLinkStateTest {
         retrieveCustomerEmail: RetrieveCustomerEmail = DefaultRetrieveCustomerEmail(
             FakeCustomerRepository(),
             FakeDurationProvider(),
+            { PaymentConfiguration("pk_test") },
         ),
     ): DefaultCreateLinkState {
         return DefaultCreateLinkState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1054,6 +1054,7 @@ internal class DefaultPaymentElementLoaderTest {
                     ephemeralKeySecret: String,
                     types: List<PaymentMethod.Type>,
                     silentlyFail: Boolean,
+                    stripeAccountId: String?,
                 ): Result<List<PaymentMethod>> {
                     requestPaymentMethodTypes = types
                     return Result.success(
@@ -5013,6 +5014,7 @@ internal class DefaultPaymentElementLoaderTest {
         val retrieveCustomerEmailImpl = DefaultRetrieveCustomerEmail(
             customerRepo,
             durationProvider,
+            { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
         )
         val createLinkState = DefaultCreateLinkState(
             accountStatusProvider = { linkAccountState },

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
@@ -94,6 +95,7 @@ internal class DefaultRetrieveCustomerEmailTest {
         val retrieveEmail = DefaultRetrieveCustomerEmail(
             customerRepository,
             FakeDurationProvider(),
+            { PaymentConfiguration("pk_test") },
         )
 
         val result = retrieveEmail(
@@ -127,6 +129,7 @@ internal class DefaultRetrieveCustomerEmailTest {
         override suspend fun retrieveCustomer(
             customerId: String,
             ephemeralKeySecret: String,
+            stripeAccountId: String?
         ) = null.also {
             retrieveCalls.add(RetrieveCall(customerId, ephemeralKeySecret))
         }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -60,6 +60,7 @@ internal open class FakeCustomerRepository(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer? {
         _retrieveCustomerRequests.add(
             RetrieveCustomerRequest(
@@ -76,6 +77,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>> {
         _getPaymentMethodsRequests.add(
             GetPaymentMethodsRequest(
@@ -93,6 +95,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -110,6 +113,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -127,6 +131,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = onAttachPaymentMethod()
 
     override suspend fun updatePaymentMethod(
@@ -134,6 +139,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _updateRequests.add(
             UpdateRequest(
@@ -151,6 +157,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer> {
         _setDefaultPaymentMethodRequests.add(
             SetDefaultRequest(
@@ -167,6 +174,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = onRetrievePaymentMethod(paymentMethodId)
 
     data class RetrieveCustomerRequest(


### PR DESCRIPTION
# Summary
Add a PaymentSheet-owned API configuration resolver, carry the resolved state on common PaymentSheet configuration, and pass the optional Stripe account ID explicitly through CustomerRepository operations.

Remove the repository dependency on PaymentConfiguration while existing callers temporarily resolve the account ID at their owning boundary. Tests and fakes exercise the new explicit repository contract.

Committed and created by Codex.

# Motivation
PaymentSheet needs one coherent publishable-key and Stripe-account snapshot before later loading, repository, and UI flows can stop reading process-global configuration independently. Customer requests must then use the Stripe account paired with that snapshot rather than resolving global configuration inside CustomerApiRepository.

Combining the resolution foundation with its first consumer avoids merging unused infrastructure. Later stack layers replace the temporary caller-side compatibility reads with the resolved ApiConfiguration state and propagate it through loading and UI flows.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
Not applicable — internal configuration and repository wiring only.

# Changelog
Not applicable — no public API or intended user-visible behavior change.