### PR TITLE
Resolve API configuration during PaymentSheet loading

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
@@ -94,18 +94,3 @@ class ApiRequestOptionsModule {
         apiRequestOptionsProvider: () -> ApiRequest.Options
     ): ApiRequest.Options = apiRequestOptionsProvider()
 }
-
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-@Module
-class ApiRequestOptionsOnlyModule {
-    @Provides
-    fun provideApiRequestOptionsProvider(
-        apiConfigurationProvider: () -> ApiConfiguration.State
-    ): () -> ApiRequest.Options = {
-        val state = apiConfigurationProvider()
-        ApiRequest.Options(
-            apiKey = state.publishableKey,
-            stripeAccount = state.stripeAccountId,
-        )
-    }
-}

--- a/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/injection/ApiConfigurationFromPaymentConfigurationModule.kt
@@ -94,3 +94,18 @@ class ApiRequestOptionsModule {
         apiRequestOptionsProvider: () -> ApiRequest.Options
     ): ApiRequest.Options = apiRequestOptionsProvider()
 }
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+@Module
+class ApiRequestOptionsOnlyModule {
+    @Provides
+    fun provideApiRequestOptionsProvider(
+        apiConfigurationProvider: () -> ApiConfiguration.State
+    ): () -> ApiRequest.Options = {
+        val state = apiConfigurationProvider()
+        ApiRequest.Options(
+            apiKey = state.publishableKey,
+            stripeAccount = state.stripeAccountId,
+        )
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -141,6 +141,10 @@ internal class CheckoutPaymentElementAnalyticsTest {
         },
         setup = { controller ->
             networkRule.validateAnalyticsRequest(
+                eventName = "mc_embedded_init",
+                productUsage = setOf("Checkout"),
+            )
+            networkRule.validateAnalyticsRequest(
                 eventName = "mc_load_started",
                 productUsage = setOf("Checkout"),
             )
@@ -173,6 +177,10 @@ internal class CheckoutPaymentElementAnalyticsTest {
             analyticsPayloadField("error_code", "checkout_session_total_changed"),
         )
         // The Checkout Session is refreshed after confirmation fails.
+        networkRule.validateAnalyticsRequest(
+            eventName = "mc_embedded_init",
+            productUsage = setOf("Checkout"),
+        )
         networkRule.validateAnalyticsRequest(
             eventName = "mc_load_started",
             productUsage = setOf("Checkout"),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -43,6 +43,10 @@ internal class CheckoutPaymentElementAnalyticsTest {
         networkRule = networkRule,
         setup = { controller ->
             networkRule.validateAnalyticsRequest(
+                eventName = "mc_embedded_init",
+                productUsage = setOf("Checkout"),
+            )
+            networkRule.validateAnalyticsRequest(
                 eventName = "mc_load_started",
                 productUsage = setOf("Checkout"),
             )

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -50,6 +50,7 @@ import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelecti
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
@@ -117,6 +118,7 @@ import javax.inject.Singleton
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
         NfcScanningAvailabilityModule::class,
         PaymentOptionCardArtModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
     ],
 )
 internal interface CheckoutControllerComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutModule.kt
@@ -2,8 +2,8 @@ package com.stripe.android.checkout.injection
 
 import android.app.Application
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.DisplayDensity
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.core.networking.ApiRequest
@@ -15,7 +15,6 @@ import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Provider
 
 @Module(includes = [PaymentConfigurationModule::class, StripeNetworkClientModule::class])
 internal object CheckoutModule {
@@ -31,12 +30,19 @@ internal object CheckoutModule {
     fun provideProductUsageTokens(): Set<String> = setOf("Checkout")
 
     @Provides
+    fun provideApiRequestOptionsProvider(
+        apiConfigProvider: () -> ApiConfiguration.State
+    ): () -> ApiRequest.Options = {
+        ApiRequest.Options(
+            apiKey = apiConfigProvider().publishableKey,
+            stripeAccount = apiConfigProvider().stripeAccountId,
+        )
+    }
+
+    @Provides
     fun provideApiRequestOptions(
-        paymentConfiguration: Provider<PaymentConfiguration>
-    ): ApiRequest.Options = ApiRequest.Options(
-        apiKey = paymentConfiguration.get().publishableKey,
-        stripeAccount = paymentConfiguration.get().stripeAccountId,
-    )
+        apiRequestOptionsProvider: () -> ApiRequest.Options
+    ): ApiRequest.Options = apiRequestOptionsProvider()
 
     @Provides
     fun provideStripeImageLoader(context: Context): StripeImageLoader = DefaultStripeImageLoader(context)

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
@@ -185,6 +185,7 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
             configuration = config,
             customerMetadata = paymentMethodMetadata.customerMetadata,
             customerEmail = elementsSessionCustomerEmail,
+            stripeAccountId = paymentMethodMetadata.apiConfiguration.stripeAccountId,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -66,6 +66,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -94,6 +95,7 @@ import javax.inject.Singleton
         DefaultIntentConfirmationModule::class,
         LinkInlineSignupConfirmationModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,
         TapToAddModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.customersheet
 
 import com.stripe.android.DefaultCardFundingFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.awaitWithTimeout
 import com.stripe.android.common.validation.isSupportedWithBillingConfig
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.analytics.CustomerSheetEventReporter
@@ -28,12 +26,12 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.validate
 import kotlinx.coroutines.flow.first
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.seconds
 
@@ -50,7 +48,7 @@ internal class DefaultCustomerSheetLoader(
     private val eventReporter: CustomerSheetEventReporter,
     private val errorReporter: ErrorReporter,
     private val workContext: CoroutineContext,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val apiConfigurationResolver: ApiConfigurationResolver,
 ) : CustomerSheetLoader {
 
     @Inject
@@ -61,7 +59,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter: CustomerSheetEventReporter,
         errorReporter: ErrorReporter,
         @IOContext workContext: CoroutineContext,
-        paymentConfiguration: Provider<PaymentConfiguration>,
+        apiConfigurationResolver: ApiConfigurationResolver,
     ) : this(
         googlePayRepositoryFactory = googlePayRepositoryFactory,
         isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
@@ -71,7 +69,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter = eventReporter,
         errorReporter = errorReporter,
         workContext = workContext,
-        paymentConfiguration = paymentConfiguration,
+        apiConfigurationResolver = apiConfigurationResolver,
     )
 
     override suspend fun load(
@@ -159,12 +157,7 @@ internal class DefaultCustomerSheetLoader(
             },
             cardBrandFilter = cardBrandFilter,
             cardFundingFilter = cardFundingFilter,
-            apiConfiguration = paymentConfiguration.get().let {
-                ApiConfiguration.State(
-                    publishableKey = it.publishableKey,
-                    stripeAccountId = it.stripeAccountId,
-                )
-            },
+            apiConfiguration = apiConfigurationResolver.resolve(null),
         ).isReady().first()
         val isGooglePayReadyAndEnabled = configuration.googlePayEnabled && isGooglePaySupportedOnDevice
 
@@ -190,6 +183,7 @@ internal class DefaultCustomerSheetLoader(
                     IntegrationMetadata.CustomerSheet.AttachmentStyle.CreateAttach
                 }
             ),
+            apiConfiguration = apiConfigurationResolver.resolve(null),
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -34,7 +33,6 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     private val timeProvider: () -> Long,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: (CustomerEphemeralKey) -> PrefsRepository,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerAdapter {
 
@@ -74,7 +72,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 types = requestedTypes,
                 silentlyFail = false,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -92,7 +90,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -110,7 +108,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -130,7 +128,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
                 params = params,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter
@@ -29,6 +30,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
     private val elementsSessionRepository: ElementsSessionRepository,
     private val customerAdapter: CustomerAdapter,
     private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetInitializationDataSource,
     CustomerSheetSavedSelectionDataSource,
@@ -132,6 +134,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
             customPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = apiConfigurationProvider(),
         ).onSuccess {
             errorReporter.report(
                 errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerSheet
@@ -34,6 +35,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
     private val prefsRepositoryFactory: PrefsRepository.Factory,
     private val customerSessionProvider: CustomerSheet.CustomerSessionProvider,
     private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
     private val timeProvider: () -> Long,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSessionElementsSessionManager {
@@ -90,6 +92,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                     customPaymentMethods = listOf(),
                     externalPaymentMethods = listOf(),
                     countryOverride = null,
+                    apiConfiguration = apiConfigurationProvider(),
                 ).onSuccess {
                     reportSuccessfulElementsSessionLoad()
                 }.onFailure {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.customersheet.data
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -10,14 +10,13 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val errorReporter: ErrorReporter,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetPaymentMethodDataSource {
     override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
@@ -45,7 +44,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     paymentMethodId = paymentMethodId,
                     params = params,
-                    stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                    stripeAccountId = apiConfigProvider().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }
@@ -70,7 +69,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
                     paymentMethodId = paymentMethodId,
-                    stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                    stripeAccountId = apiConfigProvider().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.customersheet.data
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -12,14 +12,13 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val prefsRepositoryFactory: PrefsRepository.Factory,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetSavedSelectionDataSource {
     override suspend fun retrieveSavedSelection(
@@ -104,7 +103,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
             customerId = ephemeralKey.customerId,
             ephemeralKeySecret = ephemeralKey.ephemeralKey,
             paymentMethodId = paymentMethodId,
-            stripeAccountId = paymentConfiguration.get().stripeAccountId,
+            stripeAccountId = apiConfigProvider().stripeAccountId,
         ).getOrThrow()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerAdapter
@@ -40,6 +41,7 @@ internal interface CustomerAdapterDataSourceComponent {
         fun create(
             @BindsInstance application: Application,
             @BindsInstance adapter: CustomerAdapter,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): CustomerAdapterDataSourceComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.customersheet.CustomerSheet
@@ -40,6 +41,7 @@ internal interface CustomerSessionDataSourceComponent {
         fun create(
             @BindsInstance application: Application,
             @BindsInstance customerSessionProvider: CustomerSheet.CustomerSessionProvider,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): CustomerSessionDataSourceComponent
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
@@ -2,11 +2,13 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import dagger.Binds
 import dagger.Module
+import dagger.Provides
 
 @Module(includes = [StripeNetworkClientModule::class])
 internal interface CustomerSheetDataSourceCommonModule {
@@ -17,4 +19,11 @@ internal interface CustomerSheetDataSourceCommonModule {
 
     @Binds
     fun bindsApplicationContext(application: Application): Context
+
+    companion object {
+        @Provides
+        fun provideApiConfigurationState(
+            apiConfigurationProvider: () -> ApiConfiguration.State
+        ): ApiConfiguration.State = apiConfigurationProvider()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/util/CustomerSheetHacks.kt
@@ -5,8 +5,10 @@ import androidx.activity.ComponentActivity
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.coroutines.asSingle
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.data.CustomerSheetInitializationDataSource
 import com.stripe.android.customersheet.data.CustomerSheetIntentDataSource
@@ -49,6 +51,14 @@ internal object CustomerSheetHacks {
                     .create(
                         application = application,
                         adapter = integration.adapter,
+                        apiConfigurationProvider = {
+                            PaymentConfiguration.getInstance(application).let {
+                                ApiConfiguration.State(
+                                    publishableKey = it.publishableKey,
+                                    stripeAccountId = it.stripeAccountId,
+                                )
+                            }
+                        },
                     )
 
                 _initializationDataSource.value = adapterDataSourceComponent.customerSheetInitializationDataSource
@@ -62,6 +72,14 @@ internal object CustomerSheetHacks {
                     .create(
                         application = application,
                         customerSessionProvider = integration.customerSessionProvider,
+                        apiConfigurationProvider = {
+                            PaymentConfiguration.getInstance(application).let {
+                                ApiConfiguration.State(
+                                    publishableKey = it.publishableKey,
+                                    stripeAccountId = it.stripeAccountId,
+                                )
+                            }
+                        },
                     )
 
                 _initializationDataSource.value =

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkActivityViewModel.kt
@@ -586,8 +586,6 @@ internal class LinkActivityViewModel @Inject constructor(
                     .create(
                         configuration = args.configuration,
                         paymentMethodMetadata = args.paymentMethodMetadata,
-                        publishableKeyProvider = { args.publishableKey },
-                        stripeAccountIdProvider = { args.stripeAccountId },
                         paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
                         context = app,
                         savedStateHandle = handle,

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkConfiguration.kt
@@ -3,6 +3,8 @@ package com.stripe.android.link
 import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.ClientAttributionMetadata
@@ -15,7 +17,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-internal data class LinkConfiguration(
+internal data class LinkConfiguration constructor(
     val stripeIntent: StripeIntent,
     val merchantName: String,
     val sellerBusinessName: String?,
@@ -51,7 +53,14 @@ internal data class LinkConfiguration(
     val linkSupportedPaymentMethodsOnboardingEnabled: List<String>,
     val clientAttributionMetadata: ClientAttributionMetadata,
     val linkBrand: LinkBrand,
+    val apiConfiguration: ApiConfiguration.State,
 ) : Parcelable {
+
+    val requestOptions: ApiRequest.Options
+        get() = ApiRequest.Options(
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
+        )
 
     val customerIdForEceDefaultValues: String?
         get() = if (enableDisplayableDefaultValuesInEce) customerId else null

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton
@@ -14,6 +15,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         LinkControllerModule::class,
+        ApiRequestOptionsOnlyModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import dagger.BindsInstance
 import dagger.Component
@@ -15,7 +15,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         LinkControllerModule::class,
-        ApiRequestOptionsOnlyModule::class,
+        ApiRequestOptionsModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -5,8 +5,8 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import dagger.BindsInstance
 import dagger.Component
 import javax.inject.Singleton

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -2,6 +2,8 @@ package com.stripe.android.link.injection
 
 import android.app.Application
 import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
@@ -30,6 +32,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
 import javax.inject.Singleton
+import javax.inject.Provider
 
 @Module(
     includes = [
@@ -57,6 +60,18 @@ internal interface LinkControllerModule {
     fun bindLinkConfigurationLoader(impl: DefaultLinkConfigurationLoader): LinkConfigurationLoader
 
     companion object {
+        @Provides
+        @Singleton
+        fun provideApiConfigurationProvider(
+            paymentConfiguration: Provider<PaymentConfiguration>,
+        ): () -> ApiConfiguration.State = {
+            val configuration = paymentConfiguration.get()
+            ApiConfiguration.State(
+                publishableKey = configuration.publishableKey,
+                stripeAccountId = configuration.stripeAccountId,
+            )
+        }
+
         @Provides
         @Singleton
         fun provideAppContext(application: Application): Context = application.applicationContext

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerModule.kt
@@ -3,8 +3,8 @@ package com.stripe.android.link.injection
 import android.app.Application
 import android.content.Context
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.ViewModelScope
@@ -31,8 +31,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Named
-import javax.inject.Singleton
 import javax.inject.Provider
+import javax.inject.Singleton
 
 @Module(
     includes = [

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -27,6 +27,7 @@ import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmat
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationToNamedModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
@@ -50,6 +51,7 @@ internal annotation class NativeLinkScope
         DefaultIntentConfirmationModule::class,
         LinkPassthroughConfirmationModule::class,
         ApiRequestOptionsModule::class,
+        ApiConfigurationToNamedModule::class,
     ]
 )
 internal interface NativeLinkComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -6,8 +6,6 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.Logger
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityViewModel
 import com.stripe.android.link.LinkConfiguration
@@ -29,6 +27,7 @@ import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmat
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
 import com.stripe.android.paymentelement.confirmation.link.LinkPassthroughConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -50,6 +49,7 @@ internal annotation class NativeLinkScope
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
         LinkPassthroughConfirmationModule::class,
+        ApiRequestOptionsModule::class,
     ]
 )
 internal interface NativeLinkComponent {
@@ -81,12 +81,6 @@ internal interface NativeLinkComponent {
             configuration: LinkConfiguration,
             @BindsInstance
             paymentMethodMetadata: PaymentMethodMetadata,
-            @BindsInstance
-            @Named(PUBLISHABLE_KEY)
-            publishableKeyProvider: () -> String,
-            @BindsInstance
-            @Named(STRIPE_ACCOUNT_ID)
-            stripeAccountIdProvider: () -> String?,
             @BindsInstance
             @PaymentElementCallbackIdentifier
             paymentElementCallbackIdentifier: String,

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkModule.kt
@@ -8,6 +8,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.Stripe
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.cards.DefaultCardAccountRangeRepositoryFactory
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -37,6 +38,7 @@ import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.repositories.LinkApiRepository
 import com.stripe.android.link.repositories.LinkRepository
 import com.stripe.android.link.ui.oauth.OAuthConsentViewModelComponent
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.paymentelement.AnalyticEventCallback
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
@@ -151,6 +153,11 @@ internal interface NativeLinkModule {
     @SuppressWarnings("TooManyFunctions")
     companion object {
         @Provides
+        fun providePaymentConfiguration(context: Context): PaymentConfiguration {
+            return PaymentConfiguration.getInstance(context)
+        }
+
+        @Provides
         @NativeLinkScope
         fun providesLinkAccountHolder(
             savedStateHandle: SavedStateHandle,
@@ -206,9 +213,10 @@ internal interface NativeLinkModule {
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
 
         @Provides
-        @NativeLinkScope
-        fun providePaymentConfiguration(appContext: Context): PaymentConfiguration {
-            return PaymentConfiguration.getInstance(appContext)
+        fun provideApiConfigurationProvider(
+            paymentMethodMetadata: PaymentMethodMetadata
+        ): () -> ApiConfiguration.State {
+            return { paymentMethodMetadata.apiConfiguration }
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -5,6 +5,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.utils.FeatureFlags.enableNfcScanning
@@ -99,6 +100,7 @@ internal data class PaymentMethodMetadata(
     val cardArts: List<PaymentMethod.Card.CardArt>,
     val shouldUseAutocompleteProxyEndpoints: Boolean,
     private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+    val apiConfiguration: ApiConfiguration.State,
 ) : Parcelable {
 
     val requiresBillingAddressForAutomaticTax: Boolean
@@ -390,6 +392,7 @@ internal data class PaymentMethodMetadata(
             analyticsMetadata: AnalyticsMetadata,
             isTapToAddAvailable: Boolean,
             paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+            apiConfiguration: ApiConfiguration.State,
         ): PaymentMethodMetadata {
             val linkSettings = elementsSession.linkSettings
             val cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty()
@@ -452,6 +455,7 @@ internal data class PaymentMethodMetadata(
                 cardArts = cardArts,
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 paymentMethodLayout = paymentMethodLayout,
+                apiConfiguration = apiConfiguration,
             )
         }
 
@@ -463,6 +467,7 @@ internal data class PaymentMethodMetadata(
             isGooglePayReady: Boolean,
             customerMetadata: CustomerMetadata,
             integrationMetadata: IntegrationMetadata.CustomerSheet,
+            apiConfiguration: ApiConfiguration.State,
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
@@ -523,6 +528,7 @@ internal data class PaymentMethodMetadata(
                 cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty(),
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+                apiConfiguration = apiConfiguration,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -22,7 +22,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
-import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.BuildConfig
@@ -56,7 +56,7 @@ import kotlin.coroutines.CoroutineContext
         PaymentElementRequestSurfaceModule::class,
         PaymentConfigurationModule::class,
         ApiConfigurationModule::class,
-        ApiRequestOptionsOnlyModule::class,
+        ApiRequestOptionsModule::class,
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
         NfcScanningAvailabilityModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -22,8 +22,8 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferen
 import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.CustomerStateHolder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -23,6 +23,7 @@ import com.stripe.android.paymentelement.confirmation.ALLOWS_MANUAL_CONFIRMATION
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PaymentConfigurationModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -31,6 +32,7 @@ import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -53,6 +55,8 @@ import kotlin.coroutines.CoroutineContext
         PaymentsIntegrityModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsOnlyModule::class,
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
         NfcScanningAvailabilityModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.requireApplication
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import javax.inject.Inject
@@ -17,11 +16,7 @@ import kotlin.reflect.KClass
 internal class EmbeddedPaymentElementViewModel @Inject constructor(
     val embeddedPaymentElementSubcomponentFactory: EmbeddedPaymentElementSubcomponent.Factory,
     @ViewModelScope private val customViewModelScope: CoroutineScope,
-    eventReporter: EventReporter,
 ) : ViewModel() {
-    init {
-        eventReporter.onInit()
-    }
 
     override fun onCleared() {
         customViewModelScope.cancel()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -264,7 +264,7 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)
 
-        eventReporter.onInit()
+        // eventReporter.onInit()
 
         viewModelScope.launch(workContext) {
             loadPaymentSheetState()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -264,8 +264,6 @@ internal class PaymentSheetViewModel @Inject internal constructor(
     init {
         SessionSavedStateHandler.attachTo(this, savedStateHandle)
 
-        // eventReporter.onInit()
-
         viewModelScope.launch(workContext) {
             loadPaymentSheetState()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.stripe.android.common.analytics.experiment.LoggableExperiment
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.AnalyticsEvent
+import com.stripe.android.core.networking.AnalyticsFields
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestV2Executor
 import com.stripe.android.core.networking.AnalyticsRequestV2Factory
@@ -52,22 +53,24 @@ internal class DefaultEventReporter @Inject internal constructor(
         origin = ORIGIN,
     )
 
-    override fun onInit() {
+    override fun onInit(publishableKey: String) {
         fireEvent(
             event = PaymentSheetEvent.Init(
                 mode = mode,
             ),
-            paymentMethodMetadata = null, // We won't have a value on init, and using null prevents a stack overflow.
+            paymentMethodMetadata = null,
+            publishableKey = publishableKey,
         )
     }
 
-    override fun onLoadStarted(initializedViaCompose: Boolean) {
+    override fun onLoadStarted(initializedViaCompose: Boolean, publishableKey: String) {
         durationProvider.start(DurationProvider.Key.Loading)
         fireEvent(
             event = PaymentSheetEvent.LoadStarted(
                 initializedViaCompose = initializedViaCompose
             ),
             paymentMethodMetadata = null, // We don't have these details until load is complete.
+            publishableKey = publishableKey,
         )
     }
 
@@ -93,6 +96,7 @@ internal class DefaultEventReporter @Inject internal constructor(
 
     override fun onLoadFailed(
         error: Throwable,
+        publishableKey: String,
     ) {
         val duration = durationProvider.end(DurationProvider.Key.Loading)
         fireEvent(
@@ -102,6 +106,7 @@ internal class DefaultEventReporter @Inject internal constructor(
                 loadTimings = buildLoadTimings(),
             ),
             paymentMethodMetadata = null, // We don't have these details until load is completed successfully.
+            publishableKey = publishableKey,
         )
     }
 
@@ -631,12 +636,15 @@ internal class DefaultEventReporter @Inject internal constructor(
     private fun fireEvent(
         event: PaymentSheetEvent,
         paymentMethodMetadata: PaymentMethodMetadata? = paymentMethodMetadataProvider.get(),
+        publishableKey: String? = null,
     ) {
         CoroutineScope(workContext).launch {
+            val additionalParams = defaultParams(paymentMethodMetadata) + event.params +
+                (publishableKey?.let { mapOf(AnalyticsFields.PUBLISHABLE_KEY to it) } ?: emptyMap())
             analyticsRequestExecutor.executeAsync(
                 paymentAnalyticsRequestFactory.createRequest(
                     event = event,
-                    additionalParams = defaultParams(paymentMethodMetadata) + event.params,
+                    additionalParams = additionalParams,
                 )
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/analytics/EventReporter.kt
@@ -14,9 +14,14 @@ import com.stripe.android.ui.core.cardscan.CardScanEventsReporter
 
 internal interface LoadingEventReporter {
     /**
+     * PaymentSheet or FlowController have been initialized.
+     */
+    fun onInit(publishableKey: String)
+
+    /**
      * PaymentSheet or FlowController have started loading.
      */
-    fun onLoadStarted(initializedViaCompose: Boolean)
+    fun onLoadStarted(initializedViaCompose: Boolean, publishableKey: String)
 
     /**
      * PaymentSheet or FlowController have successfully loaded the information required to be
@@ -30,7 +35,7 @@ internal interface LoadingEventReporter {
     /**
      * PaymentSheet or FlowController have failed to load.
      */
-    fun onLoadFailed(error: Throwable)
+    fun onLoadFailed(error: Throwable, publishableKey: String)
 
     /**
      * PaymentSheet or FlowController have failed to load from the Elements session endpoint.
@@ -45,11 +50,6 @@ internal interface LoadingEventReporter {
 
 @Suppress("TooManyFunctions")
 internal interface EventReporter : CardScanEventsReporter {
-
-    /**
-     * PaymentSheet has been instantiated or FlowController has finished its configuration.
-     */
-    fun onInit()
 
     /**
      * PaymentSheet has been dismissed by pressing the close button.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -17,8 +17,10 @@ import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataU
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.injection.PaymentSheetCommonModule
@@ -40,6 +42,8 @@ import javax.inject.Singleton
         ExtendedPaymentElementConfirmationModule::class,
         TapToAddConnectionStarterModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsOnlyModule::class,
         PaymentElementRequestSurfaceModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -16,7 +16,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
@@ -43,7 +43,7 @@ import javax.inject.Singleton
         TapToAddConnectionStarterModule::class,
         PaymentSheetCommonModule::class,
         ApiConfigurationModule::class,
-        ApiRequestOptionsOnlyModule::class,
+        ApiRequestOptionsModule::class,
         PaymentElementRequestSurfaceModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -16,8 +16,8 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.injection.ApiConfigurationModule

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerViewModel.kt
@@ -69,8 +69,6 @@ internal class FlowControllerViewModel(
     private val restartSession = SessionSavedStateHandler.attachTo(this, handle)
 
     init {
-        flowControllerStateComponent.eventReporter.onInit()
-
         viewModelScope.launch {
             stateFlow.collectLatest { state ->
                 flowControllerStateComponent.linkHandler.setupLink(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import dagger.Module
+import dagger.Provides
+import javax.inject.Provider
+
+@Module
+internal object ApiConfigurationModule {
+    @Provides
+    fun provideApiConfigurationStateProvider(
+        paymentMethodMetadata: Provider<PaymentMethodMetadata?>
+    ): () -> ApiConfiguration.State {
+        return { requireNotNull(paymentMethodMetadata.get()?.apiConfiguration) }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -7,6 +7,7 @@ import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule
@@ -19,6 +20,8 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsOnlyModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentOptionsViewModelModule::class,
         PaymentSheetAutocompleteModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -6,7 +6,7 @@ import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
-import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
@@ -21,7 +21,7 @@ import javax.inject.Singleton
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
         ApiConfigurationModule::class,
-        ApiRequestOptionsOnlyModule::class,
+        ApiRequestOptionsModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentOptionsViewModelModule::class,
         PaymentSheetAutocompleteModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -6,8 +6,8 @@ import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
-import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
 import com.stripe.android.ui.core.forms.resources.injection.ResourceRepositoryModule

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -9,8 +9,8 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
-import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelperModule

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -9,7 +9,7 @@ import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
-import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
@@ -26,7 +26,7 @@ import javax.inject.Singleton
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
         ApiConfigurationModule::class,
-        ApiRequestOptionsOnlyModule::class,
+        ApiRequestOptionsModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -10,6 +10,7 @@ import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsOnlyModule
 import com.stripe.android.paymentsheet.PaymentSheetContract
 import com.stripe.android.paymentsheet.PaymentSheetViewModel
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelperModule
@@ -24,6 +25,8 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
+        ApiRequestOptionsOnlyModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherModule.kt
@@ -14,6 +14,7 @@ import com.stripe.android.uicore.image.StripeImageLoader
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import kotlinx.coroutines.flow.StateFlow
 import javax.inject.Named
 import javax.inject.Singleton
 
@@ -44,8 +45,18 @@ internal abstract class PaymentSheetLauncherModule {
         }
 
         @Provides
-        fun providePaymentMethodMetadata(viewModel: PaymentSheetViewModel): PaymentMethodMetadata? {
-            return viewModel.paymentMethodMetadata.value
+        @Singleton
+        fun providePaymentMethodMetadataFlow(
+            viewModel: PaymentSheetViewModel
+        ): StateFlow<PaymentMethodMetadata?> {
+            return viewModel.paymentMethodMetadata
+        }
+
+        @Provides
+        fun providePaymentMethodMetadata(
+            flow: StateFlow<PaymentMethodMetadata?>
+        ): PaymentMethodMetadata? {
+            return flow.value
         }
 
         @Provides

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepository.kt
@@ -2,9 +2,8 @@ package com.stripe.android.paymentsheet.repositories
 
 import com.stripe.android.Stripe
 import com.stripe.android.checkout.CheckoutController.Address
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.safeAnalyticsMessage
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.ApiRequest
@@ -18,7 +17,6 @@ import com.stripe.android.paymentsheet.analytics.PaymentSheetEvent
 import java.util.TimeZone
 import java.util.UUID
 import javax.inject.Inject
-import javax.inject.Named
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutSessionRepository @Inject constructor(
@@ -26,8 +24,7 @@ internal class CheckoutSessionRepository @Inject constructor(
     private val stripeNetworkClient: StripeNetworkClient,
     private val analyticsRequestExecutor: AnalyticsRequestExecutor,
     private val paymentAnalyticsRequestFactory: PaymentAnalyticsRequestFactory,
-    @Named(PUBLISHABLE_KEY) private val publishableKeyProvider: () -> String,
-    @Named(STRIPE_ACCOUNT_ID) private val stripeAccountIdProvider: () -> String?,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
 ) {
 
     private val apiRequestFactory = ApiRequest.Factory(
@@ -37,16 +34,17 @@ internal class CheckoutSessionRepository @Inject constructor(
     )
     private val stripeErrorJsonParser = StripeErrorJsonParser()
 
-    private fun createOptions(): ApiRequest.Options = ApiRequest.Options(
-        apiKey = publishableKeyProvider(),
-        stripeAccount = stripeAccountIdProvider(),
-    )
+    private val requestOptions: ApiRequest.Options
+        get() = ApiRequest.Options(
+            apiKey = apiConfigurationProvider().publishableKey,
+            stripeAccount = apiConfigurationProvider().stripeAccountId,
+        )
 
     private suspend fun executePost(
         url: String,
         params: Map<String, *>,
     ): Result<CheckoutSessionResponse> {
-        val options = createOptions()
+        val options = requestOptions
         return executeRequestWithResultParser(
             stripeErrorJsonParser = stripeErrorJsonParser,
             stripeNetworkClient = stripeNetworkClient,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -2,9 +2,9 @@ package com.stripe.android.paymentsheet.repositories
 
 import android.app.Application
 import com.stripe.android.DefaultFraudDetectionDataRepository
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.Stripe
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
@@ -28,7 +28,6 @@ import com.stripe.android.paymentsheet.toDeferredIntentParams
 import kotlinx.coroutines.withContext
 import java.util.Calendar
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal interface ElementsSessionRepository {
@@ -39,21 +38,18 @@ internal interface ElementsSessionRepository {
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String> = emptySet(),
     ): Result<ElementsSession>
 }
 
 internal class RealElementsSessionRepository @Inject constructor(
-    application: Application,
+    private val application: Application,
     private val stripeNetworkClient: StripeNetworkClient,
     private val stripeRepository: StripeRepository,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     @IOContext private val workContext: CoroutineContext,
     private val clientParams: ElementsSessionClientParams,
 ) : ElementsSessionRepository {
-
-    private val fraudDetectionDataRepository =
-        DefaultFraudDetectionDataRepository(application, workContext)
 
     private val apiRequestFactory = ApiRequest.Factory(
         appInfo = Stripe.appInfo,
@@ -62,14 +58,6 @@ internal class RealElementsSessionRepository @Inject constructor(
     )
     private val stripeErrorJsonParser = StripeErrorJsonParser()
 
-    // The PaymentConfiguration can change after initialization, so this needs to get a new
-    // request options each time requested.
-    private val requestOptions: ApiRequest.Options
-        get() = ApiRequest.Options(
-            apiKey = lazyPaymentConfig.get().publishableKey,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
-        )
-
     override suspend fun get(
         initializationMode: PaymentElementLoader.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
@@ -77,8 +65,11 @@ internal class RealElementsSessionRepository @Inject constructor(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
+        val fraudDetectionDataRepository =
+            DefaultFraudDetectionDataRepository(application, { apiConfiguration.publishableKey }, workContext)
         fraudDetectionDataRepository.refresh()
 
         val params = initializationMode.toElementsSessionParams(
@@ -91,12 +82,15 @@ internal class RealElementsSessionRepository @Inject constructor(
             linkDisallowedFundingSourceCreation = linkDisallowedFundingSourceCreation,
         )
 
-        val options = requestOptions
+        val options = ApiRequest.Options(
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
+        )
         val elementsSession = retrieveElementsSession(params, options)
 
         return elementsSession.getResultOrElse { elementsSessionFailure ->
             if (shouldFallback(elementsSession)) {
-                fallback(params, elementsSessionFailure)
+                fallback(params, elementsSessionFailure, options)
             } else {
                 elementsSession
             }
@@ -148,6 +142,7 @@ internal class RealElementsSessionRepository @Inject constructor(
     private suspend fun fallback(
         params: ElementsSessionParams,
         elementsSessionFailure: Throwable,
+        requestOptions: ApiRequest.Options,
     ): Result<ElementsSession> = withContext(workContext) {
         val stripeIntent = when (params) {
             is ElementsSessionParams.PaymentIntentType -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
@@ -1,12 +1,11 @@
 package com.stripe.android.paymentsheet.repositories
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * Repository for managing saved payment methods. This abstracts over the underlying
@@ -39,7 +38,7 @@ internal interface SavedPaymentMethodRepository {
 internal class DefaultSavedPaymentMethodRepository @Inject constructor(
     private val customerRepository: CustomerRepository,
     private val checkoutSessionRepository: CheckoutSessionRepository,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val apiConfigProvider: () -> ApiConfiguration.State,
 ) : SavedPaymentMethodRepository {
 
     override suspend fun detachPaymentMethod(
@@ -60,7 +59,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 customerSessionClientSecret = customerMetadata.customerSessionClientSecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -68,7 +67,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
     }
@@ -94,7 +93,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -103,7 +102,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
     }
@@ -120,7 +119,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -128,7 +127,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
     }
@@ -147,7 +146,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -155,7 +154,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                stripeAccountId = apiConfigProvider().stripeAccountId,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.gate.LinkGate
@@ -36,6 +37,7 @@ internal interface CreateLinkState {
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkStateResult
 }
 
@@ -80,6 +82,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkStateResult {
         val linkDisabledReasons = getLinkDisabledReasons(
             elementsSession = elementsSession,
@@ -98,6 +101,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             initializationMode = initializationMode,
             customerMetadata = customerMetadata,
             clientAttributionMetadata = clientAttributionMetadata,
+            apiConfiguration = apiConfiguration,
         )
         val accountStatus = accountStatusProvider(linkConfiguration)
         val loginState = accountStatus.toLoginState()
@@ -224,6 +228,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkConfiguration {
         val cardBrandFilter = getCardBrandFilter(
             elementsSession = elementsSession,
@@ -236,6 +241,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             configuration,
             customerMetadata,
             customerEmail = elementsSession.customer?.email,
+            stripeAccountId = apiConfiguration.stripeAccountId,
         )
         val customerInfo = LinkConfiguration.CustomerInfo(
             name = configuration.defaultBillingDetails?.name,
@@ -254,6 +260,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             cardBrandChoice = cardBrandChoice,
             shippingDetails = shippingDetails,
             clientAttributionMetadata = clientAttributionMetadata,
+            apiConfiguration = apiConfiguration,
         )
     }
 
@@ -266,6 +273,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         cardBrandChoice: LinkConfiguration.CardBrandChoice?,
         shippingDetails: AddressDetails?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ) = LinkConfiguration(
         stripeIntent = elementsSession.stripeIntent,
         merchantName = configuration.merchantDisplayName,
@@ -309,6 +317,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             elementsSession.linkSettings?.linkSupportedPaymentMethodsOnboardingEnabled.orEmpty(),
         clientAttributionMetadata = clientAttributionMetadata,
         linkBrand = elementsSession.linkBrand,
+        apiConfiguration = apiConfiguration,
     )
 
     private fun getCardBrandChoice(elementsSession: ElementsSession): LinkConfiguration.CardBrandChoice? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -31,6 +32,7 @@ internal class ElementsSessionLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         configuration: CommonConfiguration,
         savedPaymentMethodSelection: SavedSelection.PaymentMethod?,
+        apiConfiguration: ApiConfiguration.State,
     ): ElementsSession {
         return elementsSessionRepository.get(
             initializationMode = initializationMode,
@@ -39,6 +41,7 @@ internal class ElementsSessionLoader @Inject constructor(
             customPaymentMethods = configuration.customPaymentMethods,
             savedPaymentMethodSelectionId = savedPaymentMethodSelection?.id,
             countryOverride = configuration.userOverrideCountry,
+            apiConfiguration = apiConfiguration,
             linkDisallowedFundingSourceCreation = configuration.link.disallowFundingSourceCreation,
         ).getOrThrow()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
@@ -43,6 +42,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -62,7 +62,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -275,7 +274,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val userFacingLogger: UserFacingLogger,
     private val integrityRequestManager: IntegrityRequestManager,
     private val tapToAddConnectionStarter: TapToAddConnectionStarter,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val apiConfigurationResolver: ApiConfigurationResolver,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val analyticsMetadataFactory: AnalyticsMetadataFactory,
     private val customerRepository: CustomerRepository,
@@ -309,16 +308,18 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         metadata: PaymentElementLoader.Metadata,
     ): Result<PaymentElementLoader.State> = workContext.runCatching(::reportFailedLoad) {
         val configuration = integrationConfiguration.commonConfiguration
+        val apiConfiguration = apiConfigurationResolver.resolve(configuration.apiConfiguration)
+        eventReporter.onInit(apiConfiguration.publishableKey)
         // Validate configuration before loading
         initializationMode.validate()
         configuration.validate(
             initializationMode = initializationMode,
-            isLiveMode = paymentConfiguration.get().isLiveMode(),
+            isLiveMode = apiConfiguration.isLiveMode(),
             callbackIdentifier = paymentElementCallbackIdentifier,
             isTapToAddSupported = tapToAddConnectionStarter.isSupported,
         )
 
-        eventReporter.onLoadStarted(metadata.initializedViaCompose)
+        eventReporter.onLoadStarted(metadata.initializedViaCompose, apiConfiguration.publishableKey)
         tapToAddConnectionStarter.start(configuration)
 
         // Give immediately available results a chance to complete before later load work checks isCompleted.
@@ -326,24 +327,25 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             durationProvider.measureDuration(
                 DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported
             ) {
-                isGooglePaySupportedOnDevice()
+                isGooglePaySupportedOnDevice(apiConfiguration)
             }
         }
         val isGooglePaySupportedByConfiguration = async {
             durationProvider.measureDuration(
                 DurationProvider.Key.PaymentSheetLoadIsGooglePayReady
             ) {
-                configuration.isGooglePayReady()
+                configuration.isGooglePayReady(apiConfiguration)
             }
         }
 
-        val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration)
+        val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration, apiConfiguration)
 
         val savedPaymentMethodSelection = retrieveSavedPaymentMethodSelection(configuration)
         val elementsSession = loadSession(
             initializationMode = initializationMode,
             configuration = configuration,
             savedPaymentMethodSelection = savedPaymentMethodSelection,
+            apiConfiguration = apiConfiguration,
         )
 
         // Preemptively prepare Integrity asynchronously if needed, as warm up can take
@@ -352,7 +354,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             launch { integrityRequestManager.prepare() }
         }
 
-        fetchPaymentMethodMessaging(elementsSession)
+        fetchPaymentMethodMessaging(elementsSession, apiConfiguration)
 
         val isGooglePayReady = isGooglePayReady(
             configuration = configuration,
@@ -389,6 +391,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }
@@ -410,6 +413,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }
@@ -482,6 +486,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
     private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(
         configuration: CommonConfiguration,
+        apiConfiguration: ApiConfiguration.State,
     ): PrefetchedPaymentMethods? {
         val customer = configuration.customer ?: return null
         val accessType = customer.accessType
@@ -497,8 +502,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                         PaymentMethod.Type.SepaDebit,
                         PaymentMethod.Type.USBankAccount,
                     ), // These are the only payment method types we support as saved payment methods.
-                    silentlyFail = paymentConfiguration.get().isLiveMode(),
-                    stripeAccountId = paymentConfiguration.get().stripeAccountId,
+                    silentlyFail = apiConfiguration.isLiveMode(),
+                    stripeAccountId = apiConfiguration.stripeAccountId,
                 )
             }
         }
@@ -508,6 +513,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         configuration: CommonConfiguration,
         savedPaymentMethodSelection: SavedSelection.PaymentMethod?,
+        apiConfiguration: ApiConfiguration.State,
     ): ElementsSession {
         return durationProvider.measureDuration(
             DurationProvider.Key.PaymentSheetLoadSessionLoad
@@ -519,6 +525,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     configuration = configuration,
                     savedPaymentMethodSelection = savedPaymentMethodSelection,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }
@@ -559,6 +566,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): PaymentMethodMetadata {
         val sharedDataSpecsResult = lpmRepository.getSharedDataSpecs(
             stripeIntent = elementsSession.stripeIntent,
@@ -616,6 +624,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             analyticsMetadata = analyticsMetadata,
             isTapToAddAvailable = isTapToAddAvailable,
             paymentMethodLayout = paymentMethodLayout,
+            apiConfiguration = apiConfiguration,
         )
 
         return paymentMethodMetadata
@@ -697,35 +706,36 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     // Default filters are used here because this only determines the ready state,
     // not what's presented to Google Pay. This check runs async before we fetch the
     // elements session, so using merchant-defined filters would add latency.
-    private suspend fun isGooglePayReadyForEnvironment(environment: GooglePayEnvironment): Boolean {
+    private suspend fun isGooglePayReadyForEnvironment(
+        environment: GooglePayEnvironment,
+        apiConfiguration: ApiConfiguration.State
+    ): Boolean {
         return googlePayRepositoryFactory(
             environment = environment,
             cardFundingFilter = DefaultCardFundingFilter,
             cardBrandFilter = DefaultCardBrandFilter,
-            apiConfiguration = paymentConfiguration.get().let {
-                ApiConfiguration.State(
-                    publishableKey = it.publishableKey,
-                    stripeAccountId = it.stripeAccountId,
-                )
-            },
+            apiConfiguration = apiConfiguration
         ).isReady().first()
     }
 
-    private suspend fun CommonConfiguration.isGooglePayReady(): Boolean {
+    private suspend fun CommonConfiguration.isGooglePayReady(
+        apiConfiguration: ApiConfiguration.State
+    ): Boolean {
         return googlePay?.environment?.let { environment ->
             isGooglePayReadyForEnvironment(
-                when (environment) {
+                environment = when (environment) {
                     PaymentSheet.GooglePayConfiguration.Environment.Production ->
                         GooglePayEnvironment.Production
                     PaymentSheet.GooglePayConfiguration.Environment.Test ->
                         GooglePayEnvironment.Test
-                }
+                },
+                apiConfiguration = apiConfiguration
             )
         } ?: false
     }
 
-    private suspend fun isGooglePaySupportedOnDevice(): Boolean {
-        return isGooglePayReadyForEnvironment(GooglePayEnvironment.Production)
+    private suspend fun isGooglePaySupportedOnDevice(apiConfiguration: ApiConfiguration.State): Boolean {
+        return isGooglePayReadyForEnvironment(GooglePayEnvironment.Production, apiConfiguration)
     }
 
     @Suppress("CyclomaticComplexMethod")
@@ -862,7 +872,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         val treatValidationErrorAsFailure = !state.stripeIntent.isConfirmed || isReloadingAfterProcessDeath
 
         if (state.validationError != null && treatValidationErrorAsFailure) {
-            eventReporter.onLoadFailed(state.validationError)
+            eventReporter.onLoadFailed(state.validationError, paymentMethodMetadata.apiConfiguration.publishableKey)
         } else {
             eventReporter.onLoadSucceeded(
                 paymentSelection = state.paymentSelection,
@@ -875,7 +885,10 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         error: Throwable,
     ) {
         logger.error("Failure loading PaymentSheetState", error)
-        eventReporter.onLoadFailed(error)
+        val publishableKey = runCatching {
+            apiConfigurationResolver.resolve(null).publishableKey
+        }.getOrDefault("")
+        eventReporter.onLoadFailed(error, publishableKey)
     }
 
     private fun logIfMissingExternalPaymentMethods(
@@ -919,13 +932,16 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         }
     }
 
-    private fun fetchPaymentMethodMessaging(elementsSession: ElementsSession) {
+    private fun fetchPaymentMethodMessaging(
+        elementsSession: ElementsSession,
+        apiConfiguration: ApiConfiguration.State,
+    ) {
         val variant = elementsSession.experimentsData?.experimentAssignments[
             ExperimentAssignment.OCS_MOBILE_PAYMENT_METHOD_MESSAGING_PROMOTIONS
         ] ?: return
 
         if (variant == "treatment") {
-            paymentMethodMessagePromotionsHelper.fetchPromotionsAsync(elementsSession.stripeIntent)
+            paymentMethodMessagePromotionsHelper.fetchPromotionsAsync(elementsSession.stripeIntent, apiConfiguration)
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -306,9 +306,13 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         integrationConfiguration: PaymentElementLoader.Configuration,
         metadata: PaymentElementLoader.Metadata,
-    ): Result<PaymentElementLoader.State> = workContext.runCatching(::reportFailedLoad) {
+    ): Result<PaymentElementLoader.State> {
         val configuration = integrationConfiguration.commonConfiguration
         val apiConfiguration = apiConfigurationResolver.resolve(configuration.apiConfiguration)
+
+        return workContext.runCatching(
+            onFailure = { error -> reportFailedLoad(error, apiConfiguration.publishableKey) }
+        ) {
         eventReporter.onInit(apiConfiguration.publishableKey)
         // Validate configuration before loading
         initializationMode.validate()
@@ -481,7 +485,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             paymentMethodMetadata = state.paymentMethodMetadata,
         )
 
-        return@runCatching state
+            return@runCatching state
+        }
     }
 
     private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(
@@ -883,11 +888,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
     private fun reportFailedLoad(
         error: Throwable,
+        publishableKey: String,
     ) {
         logger.error("Failure loading PaymentSheetState", error)
-        val publishableKey = runCatching {
-            apiConfigurationResolver.resolve(null).publishableKey
-        }.getOrDefault("")
         eventReporter.onLoadFailed(error, publishableKey)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodMessagingPromotionsHelper.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.networking.ApiRequest
@@ -22,12 +22,11 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import java.util.Locale
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
 internal interface PaymentMethodMessagePromotionsHelper {
-    fun fetchPromotionsAsync(intent: StripeIntent)
+    fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State)
 
     fun getPromotionIfAvailableForCode(
         code: PaymentMethodCode,
@@ -50,14 +49,13 @@ internal interface PaymentMethodMessagePromotionsHelper {
 @Singleton
 internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     @ViewModelScope private val viewModelScope: CoroutineScope,
     @IOContext private val workContext: CoroutineContext,
     private val eventReporter: EventReporter
 ) : PaymentMethodMessagePromotionsHelper {
     private var promotionsDeferred: Deferred<Result<PaymentMethodMessagePromotionList>>? = null
 
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         eventReporter.onPaymentMethodMessagePromotionsFetchBegin()
         promotionsDeferred?.cancel()
         promotionsDeferred = null
@@ -68,8 +66,8 @@ internal class DefaultPaymentMethodMessagePromotionsHelper @Inject constructor(
                 country = intent.countryCode,
                 locale = Locale.getDefault().language,
                 requestOptions = ApiRequest.Options(
-                    apiKey = lazyPaymentConfig.get().publishableKey,
-                    stripeAccount = lazyPaymentConfig.get().stripeAccountId
+                    apiKey = apiConfiguration.publishableKey,
+                    stripeAccount = apiConfiguration.stripeAccountId
                 )
             )
         }
@@ -124,7 +122,7 @@ internal class PrefetchedPaymentMethodMessagePromotionsHelper(
     private val promotions: List<PaymentMethodMessagePromotion>?,
     private val eventReporter: EventReporter
 ) : PaymentMethodMessagePromotionsHelper {
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         // NO-OP
     }
 
@@ -164,7 +162,7 @@ internal class PrefetchedPaymentMethodMessagePromotionsHelper(
 }
 
 internal class NoOpPromotionsHelper @Inject constructor() : PaymentMethodMessagePromotionsHelper {
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         // NO-OP
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
@@ -1,12 +1,10 @@
 package com.stripe.android.paymentsheet.state
 
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import javax.inject.Inject
-import javax.inject.Provider
 
 /**
  * Retrieves the customer email from any of the available sources.
@@ -21,19 +19,20 @@ internal interface RetrieveCustomerEmail {
         configuration: CommonConfiguration,
         customerMetadata: CustomerMetadata?,
         customerEmail: String?,
+        stripeAccountId: String?
     ): String?
 }
 
 internal class DefaultRetrieveCustomerEmail @Inject constructor(
     private val customerRepository: CustomerRepository,
     private val durationProvider: DurationProvider,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
 ) : RetrieveCustomerEmail {
 
     override suspend operator fun invoke(
         configuration: CommonConfiguration,
         customerMetadata: CustomerMetadata?,
         customerEmail: String?,
+        stripeAccountId: String?
     ): String? {
         return durationProvider.measureDuration(
             DurationProvider.Key.PaymentSheetLoadRetrieveCustomer,
@@ -47,6 +46,7 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
                     defaultEmail ?: retrieveEmailFromApi(
                         customerId = customerMetadata.id,
                         ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
+                        stripeAccountId = stripeAccountId
                     )
                 }
                 is CustomerMetadata.CheckoutSession,
@@ -58,11 +58,12 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
     private suspend fun retrieveEmailFromApi(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?
     ): String? {
         return customerRepository.retrieveCustomer(
             customerId = customerId,
             ephemeralKeySecret = ephemeralKeySecret,
-            stripeAccountId = paymentConfiguration.get().stripeAccountId,
+            stripeAccountId = stripeAccountId,
         )?.email
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutController.Address
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networktesting.NetworkRule
@@ -103,10 +104,14 @@ internal class CheckoutSessionTaxRegionUpdaterTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         val updater = CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
@@ -104,7 +104,7 @@ internal class CheckoutSessionTaxRegionUpdaterTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKeyProvider = { "pk_test_123" },
+                publishableKey = "pk_test_123",
             ),
             apiConfigurationProvider = {
                 ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/analytics/experiment/LogLinkGlobalHoldbackExposureTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.common.analytics.experiment
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.analytics.experiment.LoggableExperiment.LinkHoldback.EmailRecognitionSource
 import com.stripe.android.common.model.CommonConfigurationFactory
 import com.stripe.android.link.TestFactory
@@ -65,7 +64,6 @@ class LogLinkGlobalHoldbackExposureTest {
         retrieveCustomerEmail = DefaultRetrieveCustomerEmail(
             customerRepository,
             FakeDurationProvider(),
-            { PaymentConfiguration("pk_test") },
         )
         linkConfigurationCoordinator = FakeLinkConfigurationCoordinator()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -30,7 +30,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -209,7 +208,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
-            stripeAccountId = isNull(),
+            stripeAccountId = any()
         )
     }
 
@@ -261,7 +260,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
-            stripeAccountId = isNull(),
+            stripeAccountId = any()
         )
     }
 
@@ -780,8 +779,7 @@ class CustomerAdapterTest {
             timeProvider = timeProvider,
             customerRepository = customerRepository,
             prefsRepositoryFactory = prefsRepositoryFactory,
-            paymentConfiguration = { PaymentConfiguration("pk_test") },
-            workContext = testDispatcher
+            workContext = testDispatcher,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -30,6 +30,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -191,7 +192,7 @@ class CustomerAdapterTest {
     fun `retrievePaymentMethods filters with paymentMethodTypes`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
-        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), any()))
+        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), isNull()))
             .thenReturn(Result.success(emptyList()))
 
         val adapter = createAdapter(
@@ -208,7 +209,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
-            stripeAccountId = any()
+            stripeAccountId = isNull()
         )
     }
 
@@ -260,7 +261,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
-            stripeAccountId = any()
+            stripeAccountId = isNull()
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetTest.kt
@@ -11,6 +11,7 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
@@ -33,6 +34,7 @@ class CustomerSheetTest {
     @Before
     fun setup() {
         val appContext = ApplicationProvider.getApplicationContext<Application>()
+        PaymentConfiguration.init(appContext, "pk_test_123")
 
         val activityInfo = ActivityInfo().apply {
             name = TestActivity::class.java.name

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet.data
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetFixtures
@@ -721,6 +722,9 @@ class CustomerAdapterDataSourceTest {
             customerAdapter = adapter,
             elementsSessionRepository = elementsSessionRepository,
             errorReporter = errorReporter,
+            apiConfigurationProvider = {
+                ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+            },
             workContext = coroutineContext,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -267,8 +267,10 @@ class CustomerSessionPaymentMethodDataSourceTest {
             elementsSessionManager = elementsSessionManager,
             customerRepository = customerRepository,
             errorReporter = errorReporter,
-            paymentConfiguration = { PaymentConfiguration("pk_test") },
             workContext = coroutineContext,
+            apiConfigProvider = {
+                ApiConfiguration.State("pk_123", null)
+            }
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethodFixtures
@@ -242,8 +242,10 @@ class CustomerSessionSavedSelectionDataSourceTest {
             prefsRepositoryFactory = {
                 prefsRepository
             },
-            paymentConfiguration = { PaymentConfiguration("pk_test") },
-            workContext = coroutineContext
+            workContext = coroutineContext,
+            apiConfigProvider = {
+                ApiConfiguration.State("pk_123", null)
+            }
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.utils.FakeCustomerSessionProvider
 import com.stripe.android.isInstanceOf
@@ -511,6 +512,9 @@ class DefaultCustomerSessionElementsSessionManagerTest {
                 onIntentConfiguration = onIntentConfiguration,
                 onProvidesCustomerSessionClientSecret = onCustomerSessionClientSecret,
             ),
+            apiConfigurationProvider = {
+                ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+            },
             timeProvider = timeProvider,
             workContext = coroutineContext,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -42,6 +42,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.testing.CoroutineTestRule
@@ -65,6 +66,7 @@ import org.junit.Test
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -454,6 +456,9 @@ internal class DefaultCustomerSheetLoaderTest {
                 workContext = coroutineContext,
                 customerAdapter = FakeCustomerAdapter(),
                 errorReporter = FakeErrorReporter(),
+                apiConfigurationProvider = {
+                    ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+                },
             )
         )
 
@@ -868,11 +873,7 @@ internal class DefaultCustomerSheetLoaderTest {
             eventReporter = eventReporter,
             errorReporter = errorReporter,
             workContext = workContext,
-            paymentConfiguration = {
-                PaymentConfiguration(
-                    publishableKey = "pk_test_123",
-                )
-            },
+            apiConfigurationResolver = ApiConfigurationResolver(Provider { PaymentConfiguration("pk_test_123") })
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetHacksTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.customersheet.CustomerSheetIntegration
 import com.stripe.android.customersheet.FakeCustomerAdapter
@@ -18,6 +19,7 @@ import com.stripe.android.isInstanceOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.junit.After
+import org.junit.Before
 import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.seconds
@@ -25,6 +27,11 @@ import kotlin.time.Duration.Companion.seconds
 @RunWith(AndroidJUnit4::class)
 class CustomerSheetHacksTest {
     private val application = ApplicationProvider.getApplicationContext<Application>()
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(application, "pk_test_123")
+    }
 
     @After
     fun teardown() {

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -83,6 +83,10 @@ internal interface CustomerSheetTestHelper {
             publishableKey = "pk_test_123",
             stripeAccountId = null,
         ),
+        apiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
+            publishableKey = paymentConfiguration.publishableKey,
+            stripeAccountId = paymentConfiguration.stripeAccountId,
+        ),
         configuration: CustomerSheet.Configuration = CustomerSheet.Configuration(
             merchantDisplayName = "Example",
             googlePayEnabled = isGooglePayAvailable,
@@ -128,7 +132,10 @@ internal interface CustomerSheetTestHelper {
             configuration = configuration,
             integrationType = integrationType,
             statusBarColor = null,
-            paymentConfiguration = PaymentConfiguration(if (isLiveMode) "pk_live" else "pk_test"),
+            paymentConfiguration = PaymentConfiguration(
+                publishableKey = if (isLiveMode) "pk_live" else apiConfiguration.publishableKey,
+                stripeAccountId = apiConfiguration.stripeAccountId,
+            ),
             logger = Logger.noop(),
             productUsage = emptySet(),
             confirmationHandlerFactory = confirmationHandler?.let { ConfirmationHandler.Factory { _ -> it } }

--- a/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/TestFactory.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.link
 
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
@@ -306,6 +307,7 @@ internal object TestFactory {
         ),
         cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
         linkBrand = LinkBrand.Link,
+        apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
     )
 
     val LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING = LINK_CONFIGURATION.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/signup/SignUpScreenStateTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.ui.signup
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -118,6 +119,7 @@ class SignUpScreenStateTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.LinkBrand
@@ -83,6 +84,10 @@ internal object PaymentMethodMetadataFactory {
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
         shouldUseAutocompleteProxyEndpoints: Boolean = false,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        apiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
+            publishableKey = "pk_test_123",
+            stripeAccountId = null,
+        ),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -156,6 +161,7 @@ internal object PaymentMethodMetadataFactory {
             cardArts = cardArts,
             shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
             paymentMethodLayout = paymentMethodLayout,
+            apiConfiguration = apiConfiguration,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkConfiguration
@@ -1162,6 +1163,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1236,6 +1241,10 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1298,6 +1307,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         // When flag is false, should use default funding types, not the configured ones
@@ -1337,6 +1350,10 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = true,
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = DEFAULT_CUSTOMER_INTEGRATION_METADATA,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1396,6 +1413,10 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -2116,6 +2137,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata.availableWallets)
@@ -2186,6 +2211,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = true,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata.isTapToAddSupported).isTrue()
@@ -2211,6 +2240,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = true,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata.isTapToAddSupported).isTrue()
@@ -2240,6 +2273,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
 
         assertThat(metadata.isTapToAddSupported).isFalse()
@@ -2381,6 +2418,10 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
     }
 
@@ -2408,6 +2449,10 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = false,
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = DEFAULT_CUSTOMER_INTEGRATION_METADATA,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
     }
 
@@ -2455,6 +2500,7 @@ internal class PaymentMethodMetadataTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElementTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkConfigurationCoordinator
@@ -185,6 +186,7 @@ class LinkFormElementTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State("pk_test_123", null),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationHandlerOptionKtxTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
@@ -770,6 +771,7 @@ class ConfirmationHandlerOptionKtxTest {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = LinkBrand.Link,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -159,10 +159,14 @@ internal suspend fun createIntentConfirmationInterceptor(
                     analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
                     paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                         context = ApplicationProvider.getApplicationContext(),
-                        publishableKey = "pk",
+                        publishableKeyProvider = { "pk" },
                     ),
-                    publishableKeyProvider = { "pk" },
-                    stripeAccountIdProvider = { null },
+                    apiConfigurationProvider = {
+                        ApiConfiguration.State(
+                            publishableKey = "pk",
+                            stripeAccountId = null,
+                        )
+                    },
                 )
                 return CheckoutSessionConfirmationInterceptor(
                     integrationMetadata = integrationMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ConfirmationUtils.kt
@@ -159,7 +159,7 @@ internal suspend fun createIntentConfirmationInterceptor(
                     analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
                     paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                         context = ApplicationProvider.getApplicationContext(),
-                        publishableKeyProvider = { "pk" },
+                        publishableKey = "pk",
                     ),
                     apiConfigurationProvider = {
                         ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.test.core.app.ActivityScenario
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -217,6 +218,16 @@ internal interface ExtendedPaymentElementConfirmationTestModule {
             publishableKey = "pk_123",
             stripeAccountId = null,
         )
+
+        @Provides
+        fun providesApiConfigurationProvider(
+            paymentConfiguration: PaymentConfiguration,
+        ): () -> ApiConfiguration.State = {
+            ApiConfiguration.State(
+                publishableKey = paymentConfiguration.publishableKey,
+                stripeAccountId = paymentConfiguration.stripeAccountId,
+            )
+        }
 
         @Provides
         @Named(PUBLISHABLE_KEY)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -15,6 +15,7 @@ import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.test.core.app.ActivityScenario
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -212,6 +213,16 @@ internal interface PaymentElementConfirmationTestModule {
             publishableKey = "pk_123",
             stripeAccountId = null,
         )
+
+        @Provides
+        fun providesApiConfigurationProvider(
+            paymentConfiguration: PaymentConfiguration,
+        ): () -> ApiConfiguration.State = {
+            ApiConfiguration.State(
+                publishableKey = paymentConfiguration.publishableKey,
+                stripeAccountId = paymentConfiguration.stripeAccountId,
+            )
+        }
 
         @Provides
         @Named(PUBLISHABLE_KEY)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -6,6 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.LocalStripeException
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
@@ -454,10 +455,14 @@ class CheckoutSessionConfirmationInterceptorTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         val interceptor = CheckoutSessionConfirmationInterceptor(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -455,7 +455,7 @@ class CheckoutSessionConfirmationInterceptorTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKeyProvider = { "pk_test_123" },
+                publishableKey = "pk_test_123",
             ),
             apiConfigurationProvider = {
                 ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/linkinline/LinkInlineSignupConfirmationDefinitionTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.LinkConfiguration
@@ -818,6 +819,7 @@ internal class LinkInlineSignupConfirmationDefinitionTest {
                 clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                 cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
                 linkBrand = LinkBrand.Link,
+                apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             ),
             userInput = userInput,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.di.ElementsSessionClientParamsModule
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.core.injection.IOContext
@@ -198,6 +199,16 @@ internal interface LpmNetworkTestModule {
             return PaymentConfiguration(
                 publishableKey = publishableKeyProvider(),
                 stripeAccountId = stripeAccountIdProvider(),
+            )
+        }
+
+        @Provides
+        fun providesApiConfigurationProvider(
+            paymentConfiguration: PaymentConfiguration,
+        ): () -> ApiConfiguration.State = {
+            ApiConfiguration.State(
+                publishableKey = paymentConfiguration.publishableKey,
+                stripeAccountId = paymentConfiguration.stripeAccountId,
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -7,6 +7,7 @@ import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutUpdate
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -143,8 +144,12 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
                 context = ApplicationProvider.getApplicationContext(),
                 publishableKey = "pk_test_123",
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         return CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -166,8 +167,12 @@ internal class SheetTaxRegionUpdaterTest {
                 context = ApplicationProvider.getApplicationContext(),
                 publishableKey = "pk_test_123",
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
 
         return CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -205,10 +205,10 @@ internal class PaymentSheetViewModelTest {
     fun `init should fire analytics event`() {
         val beforeSessionId = AnalyticsRequestFactory.sessionId
         createViewModel()
-        verify(eventReporter).onInit()
+        // verify(eventReporter).onInit()
 
         // Creating the view model should regenerate the analytics sessionId.
-        assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
+        // assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
     }
 
     @Test
@@ -2062,7 +2062,7 @@ internal class PaymentSheetViewModelTest {
     fun `Sends correct analytics event when using normal intent`() = runTest {
         createViewModel()
 
-        verify(eventReporter).onInit()
+        // verify(eventReporter).onInit()
     }
 
     @Test
@@ -2081,7 +2081,7 @@ internal class PaymentSheetViewModelTest {
 
         createViewModelForDeferredIntent()
 
-        verify(eventReporter).onInit()
+        // verify(eventReporter).onInit()
     }
 
     @Test
@@ -2100,7 +2100,7 @@ internal class PaymentSheetViewModelTest {
 
         createViewModelForDeferredIntent()
 
-        verify(eventReporter).onInit()
+        // verify(eventReporter).onInit()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -19,7 +19,6 @@ import com.stripe.android.common.taptoadd.TapToAddNextStep
 import com.stripe.android.core.Logger
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
-import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.isInstanceOf
@@ -60,8 +59,6 @@ import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.model.SetupIntentFixtures
 import com.stripe.android.model.StripeIntent
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
-import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
@@ -78,7 +75,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.ARGS_DEFERRED_INTENT
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.BILLING_DETAILS_FORM_DETAILS
 import com.stripe.android.paymentsheet.PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
-import com.stripe.android.paymentsheet.PaymentSheetFixtures.PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER
 import com.stripe.android.paymentsheet.PaymentSheetViewModel.CheckoutIdentifier
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AutocompleteContract
@@ -199,16 +195,6 @@ internal class PaymentSheetViewModelTest {
     @AfterTest
     fun cleanup() {
         Dispatchers.resetMain()
-    }
-
-    @Test
-    fun `init should fire analytics event`() {
-        val beforeSessionId = AnalyticsRequestFactory.sessionId
-        createViewModel()
-        // verify(eventReporter).onInit()
-
-        // Creating the view model should regenerate the analytics sessionId.
-        // assertThat(beforeSessionId).isNotEqualTo(AnalyticsRequestFactory.sessionId)
     }
 
     @Test
@@ -2056,51 +2042,6 @@ internal class PaymentSheetViewModelTest {
 
             assertThat(awaitItem()).isEqualTo(PaymentSheetViewState.Reset(UserErrorMessage(error.resolvableString)))
         }
-    }
-
-    @Test
-    fun `Sends correct analytics event when using normal intent`() = runTest {
-        createViewModel()
-
-        // verify(eventReporter).onInit()
-    }
-
-    @Test
-    fun `Sends correct analytics event when using deferred intent with client-side confirmation`() = runTest {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
-            .createIntentCallback { _, _ ->
-                error("Should not be called!")
-            }
-            .confirmCustomPaymentMethodCallback { _, _ ->
-                error("Should not be called!")
-            }
-            .externalPaymentMethodConfirmHandler { _, _ ->
-                error("Should not be called!")
-            }
-            .build()
-
-        createViewModelForDeferredIntent()
-
-        // verify(eventReporter).onInit()
-    }
-
-    @Test
-    fun `Sends correct analytics event when using deferred intent with server-side confirmation`() = runTest {
-        PaymentElementCallbackReferences[PAYMENT_SHEET_CALLBACK_TEST_IDENTIFIER] = PaymentElementCallbacks.Builder()
-            .createIntentCallback { _, _ ->
-                error("Should not be called!")
-            }
-            .confirmCustomPaymentMethodCallback { _, _ ->
-                error("Should not be called!")
-            }
-            .externalPaymentMethodConfirmHandler { _, _ ->
-                error("Should not be called!")
-            }
-            .build()
-
-        createViewModelForDeferredIntent()
-
-        // verify(eventReporter).onInit()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -59,7 +59,7 @@ class DefaultEventReporterTest {
 
     @Test
     fun `onInit fires event`() = runScenario {
-        eventReporter.onInit()
+        eventReporter.onInit("pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_complete_init")
@@ -103,11 +103,12 @@ class DefaultEventReporterTest {
                 reset = true,
             )
         )
-        eventReporter.onLoadStarted(initializedViaCompose = true)
+        eventReporter.onLoadStarted(initializedViaCompose = true, publishableKey = "pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_load_started")
         assertThat(request.params).containsEntry("compose", true)
+        assertThat(request.params).containsEntry("publishable_key", "pk_test_123")
     }
 
     @Test
@@ -189,12 +190,13 @@ class DefaultEventReporterTest {
             )
         )
         val error = RuntimeException("Test error")
-        eventReporter.onLoadFailed(error = error)
+        eventReporter.onLoadFailed(error = error, publishableKey = "pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_load_failed")
         assertThat(request.params).containsEntry("duration", 2.0f)
         assertThat(request.params).containsEntry("error_message", "java.lang.RuntimeException")
+        assertThat(request.params).containsEntry("publishable_key", "pk_test_123")
     }
 
     @Test
@@ -267,7 +269,7 @@ class DefaultEventReporterTest {
         durationProvider.completedDurations[DurationProvider.Key.PaymentSheetLoadSessionLoad] = 200.milliseconds
 
         val error = RuntimeException("Test error")
-        eventReporter.onLoadFailed(error = error)
+        eventReporter.onLoadFailed(error = error, publishableKey = "pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_load_failed")
@@ -288,7 +290,7 @@ class DefaultEventReporterTest {
             )
         )
         val error = RuntimeException("Test error")
-        eventReporter.onLoadFailed(error = error)
+        eventReporter.onLoadFailed(error = error, publishableKey = "pk_test_123")
 
         val request = analyticsRequestExecutor.requestTurbine.awaitItem()
         assertThat(request.params).containsEntry("event", "mc_load_failed")
@@ -1520,7 +1522,7 @@ class DefaultEventReporterTest {
         val analyticsRequestV2Executor = FakeAnalyticsRequestV2Executor()
         val paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
             context = context,
-            publishableKey = "pk_test_123",
+            publishableKeyProvider = { "pk_test_123" },
             defaultProductUsageTokens = setOf(""),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/DefaultEventReporterTest.kt
@@ -1522,7 +1522,7 @@ class DefaultEventReporterTest {
         val analyticsRequestV2Executor = FakeAnalyticsRequestV2Executor()
         val paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
             context = context,
-            publishableKeyProvider = { "pk_test_123" },
+            publishableKey = "pk_test_123",
             defaultProductUsageTokens = setOf(""),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeEventReporter.kt
@@ -140,9 +140,6 @@ internal class FakeEventReporter : EventReporter {
         _pmmPromotionsDisplayed.ensureAllEventsConsumed()
     }
 
-    override fun onInit() {
-    }
-
     override fun onDismiss() {
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLoadingEventReporter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/analytics/FakeLoadingEventReporter.kt
@@ -6,6 +6,9 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.PaymentSelection
 
 internal class FakeLoadingEventReporter : LoadingEventReporter {
+    private val _initTurbine = Turbine<InitCall>()
+    val initTurbine: ReceiveTurbine<InitCall> = _initTurbine
+
     private val _loadStartedTurbine = Turbine<LoadStartedCall>()
     val loadStartedTurbine: ReceiveTurbine<LoadStartedCall> = _loadStartedTurbine
 
@@ -23,6 +26,7 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
     val lpmSpecFailureTurbine: ReceiveTurbine<LpmSpecFailureCall> = _lpmSpecFailureTurbine
 
     fun validate() {
+        _initTurbine.ensureAllEventsConsumed()
         _loadStartedTurbine.ensureAllEventsConsumed()
         _loadSucceededTurbine.ensureAllEventsConsumed()
         _loadFailedTurbine.ensureAllEventsConsumed()
@@ -30,7 +34,11 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
         _lpmSpecFailureTurbine.ensureAllEventsConsumed()
     }
 
-    override fun onLoadStarted(initializedViaCompose: Boolean) {
+    override fun onInit(publishableKey: String) {
+        _initTurbine.add(InitCall(publishableKey))
+    }
+
+    override fun onLoadStarted(initializedViaCompose: Boolean, publishableKey: String) {
         _loadStartedTurbine.add(
             LoadStartedCall(
                 initializedViaCompose = initializedViaCompose,
@@ -50,7 +58,7 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
         )
     }
 
-    override fun onLoadFailed(error: Throwable) {
+    override fun onLoadFailed(error: Throwable, publishableKey: String) {
         _loadFailedTurbine.add(
             LoadFailedCall(
                 error = error,
@@ -73,6 +81,10 @@ internal class FakeLoadingEventReporter : LoadingEventReporter {
             )
         )
     }
+
+    class InitCall(
+        val publishableKey: String,
+    )
 
     class LoadStartedCall(
         val initializedViaCompose: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -5,6 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.checkouttesting.checkoutUpdate
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
@@ -37,10 +38,14 @@ class CheckoutSessionRepositoryTest {
         analyticsRequestExecutor = analyticsRequestExecutor,
         paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
             context = ApplicationProvider.getApplicationContext(),
-            publishableKey = "pk_test_123",
+            publishableKeyProvider = { "pk_test_123" },
         ),
-        publishableKeyProvider = { "pk_test_123" },
-        stripeAccountIdProvider = { null },
+        apiConfigurationProvider = {
+            ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            )
+        },
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -38,7 +38,7 @@ class CheckoutSessionRepositoryTest {
         analyticsRequestExecutor = analyticsRequestExecutor,
         paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
             context = ApplicationProvider.getApplicationContext(),
-            publishableKeyProvider = { "pk_test_123" },
+            publishableKey = "pk_test_123",
         ),
         apiConfigurationProvider = {
             ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -2,8 +2,8 @@ package com.stripe.android.paymentsheet.repositories
 
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -327,15 +327,19 @@ class DefaultSavedPaymentMethodRepositoryTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKey = "pk_test_123",
+                publishableKeyProvider = { "pk_test_123" },
             ),
-            publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_test_123",
+                    stripeAccountId = null,
+                )
+            },
         )
         val repository = DefaultSavedPaymentMethodRepository(
             customerRepository = customerRepository,
             checkoutSessionRepository = checkoutSessionRepository,
-            paymentConfiguration = { PaymentConfiguration("pk_test") },
+            apiConfigProvider = { ApiConfiguration.State("pk_123", null) }
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -327,7 +327,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
             analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
             paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
                 context = ApplicationProvider.getApplicationContext(),
-                publishableKeyProvider = { "pk_test_123" },
+                publishableKey = "pk_test_123",
             ),
             apiConfigurationProvider = {
                 ApiConfiguration.State(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -3,10 +3,9 @@ package com.stripe.android.paymentsheet.repositories
 import androidx.core.os.LocaleListCompat
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.networking.StripeNetworkClient
@@ -58,6 +57,7 @@ internal class ElementsSessionRepositoryTest {
                 customPaymentMethods = emptyList(),
                 savedPaymentMethodSelectionId = null,
                 countryOverride = null,
+                apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             ).getOrThrow()
         }
 
@@ -91,6 +91,7 @@ internal class ElementsSessionRepositoryTest {
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
                     countryOverride = null,
+                    apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
                 ).getOrThrow()
             }
 
@@ -119,6 +120,7 @@ internal class ElementsSessionRepositoryTest {
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
                     countryOverride = null,
+                    apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
                 ).getOrThrow()
             }
 
@@ -137,7 +139,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -149,6 +150,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -172,7 +174,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -189,6 +190,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -210,6 +212,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(any())
@@ -231,6 +234,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(any())
@@ -248,7 +252,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -266,6 +269,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -282,7 +286,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -299,6 +302,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -317,7 +321,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -334,6 +337,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -352,7 +356,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -366,6 +369,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -384,7 +388,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -414,6 +417,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -433,7 +437,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -455,6 +458,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -476,7 +480,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -506,6 +509,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -546,6 +550,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -593,6 +598,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -629,6 +635,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -657,6 +664,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             linkDisallowedFundingSourceCreation = setOf("somethingThatsNotAllowed"),
         )
 
@@ -681,6 +689,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -703,6 +712,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -730,6 +740,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -763,6 +774,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -793,6 +805,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -816,6 +829,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -839,6 +853,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -862,6 +877,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -890,6 +906,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -914,6 +931,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -928,7 +946,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "client_secret",
             ),
@@ -937,6 +955,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "uk_12345", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -954,7 +973,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.DEFERRED_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
                 clientSecret = "client_secret",
             ),
@@ -963,6 +982,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "uk_12345", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -980,7 +1000,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.DEFERRED_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
@@ -995,6 +1015,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "uk_12345", stripeAccountId = null),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -1005,13 +1026,10 @@ internal class ElementsSessionRepositoryTest {
         assertThat(params["mobile_app_id"]).isEqualTo(APP_ID)
     }
 
-    private fun createRepository(
-        publishableKey: String = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
-    ) = RealElementsSessionRepository(
+    private fun createRepository() = RealElementsSessionRepository(
         ApplicationProvider.getApplicationContext(),
         stripeNetworkClient,
         stripeRepository,
-        { PaymentConfiguration(publishableKey) },
         testDispatcher,
         clientParams = TEST_CLIENT_PARAMS,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.ui.inline.LinkSignupMode
@@ -946,6 +947,7 @@ class DefaultAnalyticsMetadataFactoryTest {
                 clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
                 cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
                 linkBrand = LinkBrand.Link,
+                apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
             ),
             loginState = LinkState.LoginState.LoggedOut,
             signupModeResult = signupModeResult,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardFundingFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.ApiConfiguration
@@ -177,7 +176,6 @@ internal class DefaultCreateLinkStateTest {
         retrieveCustomerEmail: RetrieveCustomerEmail = DefaultRetrieveCustomerEmail(
             FakeCustomerRepository(),
             FakeDurationProvider(),
-            { PaymentConfiguration("pk_test") },
         ),
     ): DefaultCreateLinkState {
         return DefaultCreateLinkState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -5,6 +5,7 @@ import com.stripe.android.CardFundingFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.model.AccountStatus
@@ -45,6 +46,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            apiConfiguration = DEFAULT_API_CONFIGURATION,
         )
 
         assertThat(retrieveCustomerEmail.invokedWith?.customerEmail).isEqualTo(customerWithEmail.email)
@@ -103,6 +105,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = initializationMode,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            apiConfiguration = DEFAULT_API_CONFIGURATION,
         )
 
         assertThat(result).isInstanceOf<LinkDisabledState>()
@@ -125,6 +128,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            apiConfiguration = DEFAULT_API_CONFIGURATION,
         )
 
         assertThat(linkStateResult).isInstanceOf<LinkState>()
@@ -162,6 +166,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            apiConfiguration = DEFAULT_API_CONFIGURATION,
         )
 
         assertThat(cardFundingFilterFactory.invokedWith).isEqualTo(expectedFundingTypes)
@@ -244,6 +249,7 @@ internal class DefaultCreateLinkStateTest {
             configuration: CommonConfiguration,
             customerMetadata: CustomerMetadata?,
             customerEmail: String?,
+            stripeAccountId: String?,
         ): String? {
             invokedWith = Invocation(
                 configuration = configuration,
@@ -270,6 +276,11 @@ internal class DefaultCreateLinkStateTest {
             paymentIntentCreationFlow = PaymentIntentCreationFlow.Standard,
             paymentMethodSelectionFlow = PaymentMethodSelectionFlow.MerchantSpecified,
             checkoutSessionId = null,
+        )
+
+        val DEFAULT_API_CONFIGURATION = ApiConfiguration.State(
+            publishableKey = "pk_test_123",
+            stripeAccountId = null,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
@@ -726,7 +725,6 @@ internal class DefaultPaymentElementLoaderTest {
                 assertThat(startCalls.awaitItem()).isEqualTo(
                     FakeTapToAddConnectionStarter.StartCall(
                         config = config.asCommonConfiguration(),
-                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                     )
                 )
 
@@ -777,7 +775,6 @@ internal class DefaultPaymentElementLoaderTest {
                 assertThat(startCalls.awaitItem()).isEqualTo(
                     FakeTapToAddConnectionStarter.StartCall(
                         config = config.asCommonConfiguration(),
-                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                     )
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
@@ -78,6 +79,7 @@ import com.stripe.android.paymentsheet.analytics.FakeLoadingEventReporter
 import com.stripe.android.paymentsheet.analytics.FakeLogFcLiteExperiment
 import com.stripe.android.paymentsheet.analytics.FakeLogLinkHoldbackExperiment
 import com.stripe.android.paymentsheet.analytics.FakePaymentMethodMessagePromotionsExperimentHandler
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.toSavedSelection
@@ -182,6 +184,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -203,6 +206,7 @@ internal class DefaultPaymentElementLoaderTest {
             "When a Configuration is passed to PaymentSheet, the Merchant display name cannot be an empty string."
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -223,6 +227,7 @@ internal class DefaultPaymentElementLoaderTest {
             "The PaymentIntent client_secret cannot be an empty string."
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -249,6 +254,7 @@ internal class DefaultPaymentElementLoaderTest {
             "When a CustomerConfiguration is passed to PaymentSheet, the Customer ID cannot be an empty string."
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -276,6 +282,7 @@ internal class DefaultPaymentElementLoaderTest {
             "Conflicting ephemeralKeySecrets between CustomerConfiguration and CustomerConfiguration.customerAccessType"
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -304,6 +311,7 @@ internal class DefaultPaymentElementLoaderTest {
                 "Customer information is provided by the checkout session."
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
 
@@ -324,6 +332,7 @@ internal class DefaultPaymentElementLoaderTest {
         ).getOrThrow()
         assertThat(result.paymentMethodMetadata.customerMetadata).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -354,6 +363,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -396,6 +406,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -471,6 +482,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -500,6 +512,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -527,6 +540,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -554,7 +568,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isEqualTo(PaymentSelection.GooglePay)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -581,7 +596,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -608,7 +624,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -642,7 +659,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -673,6 +691,7 @@ internal class DefaultPaymentElementLoaderTest {
 
                 assertThat(result.paymentMethodMetadata.isTapToAddSupported).isFalse()
 
+                assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
             }
@@ -705,11 +724,15 @@ internal class DefaultPaymentElementLoaderTest {
                 ).getOrThrow()
 
                 assertThat(startCalls.awaitItem()).isEqualTo(
-                    FakeTapToAddConnectionStarter.StartCall(config = config.asCommonConfiguration())
+                    FakeTapToAddConnectionStarter.StartCall(
+                        config = config.asCommonConfiguration(),
+                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    )
                 )
 
                 assertThat(result.paymentMethodMetadata.isTapToAddSupported).isTrue()
 
+                assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
             }
@@ -752,11 +775,15 @@ internal class DefaultPaymentElementLoaderTest {
                 ).getOrThrow()
 
                 assertThat(startCalls.awaitItem()).isEqualTo(
-                    FakeTapToAddConnectionStarter.StartCall(config = config.asCommonConfiguration())
+                    FakeTapToAddConnectionStarter.StartCall(
+                        config = config.asCommonConfiguration(),
+                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                    )
                 )
 
                 assertThat(result.paymentMethodMetadata.isTapToAddSupported).isFalse()
 
+                assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
                 assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
             }
@@ -792,7 +819,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -826,7 +854,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -857,7 +886,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(userFacingLogger.getLoggedMessages())
                 .containsExactlyElementsIn(listOf("GooglePayConfiguration is not set."))
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -885,7 +915,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentSelection).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -921,7 +952,8 @@ internal class DefaultPaymentElementLoaderTest {
                 PaymentMethod.Type.USBankAccount
             )
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -951,7 +983,8 @@ internal class DefaultPaymentElementLoaderTest {
             val request = customerRepository.getPaymentMethodsRequests.awaitItem()
             assertThat(request.types).doesNotContain(PaymentMethod.Type.AuBecsDebit)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -981,7 +1014,8 @@ internal class DefaultPaymentElementLoaderTest {
             val actualException = loadResult.exceptionOrNull()
             assertThat(actualException?.cause).isEqualTo(expectedException)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
         }
 
@@ -1008,7 +1042,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(result.customer?.paymentMethods)
                 .containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -1040,7 +1075,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(result.customer?.paymentMethods)
                 .containsExactly(PaymentMethodFixtures.CARD_PAYMENT_METHOD, cardWithAmexWallet)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -1054,7 +1090,7 @@ internal class DefaultPaymentElementLoaderTest {
                     ephemeralKeySecret: String,
                     types: List<PaymentMethod.Type>,
                     silentlyFail: Boolean,
-                    stripeAccountId: String?,
+                    stripeAccountId: String?
                 ): Result<List<PaymentMethod>> {
                     requestPaymentMethodTypes = types
                     return Result.success(
@@ -1092,6 +1128,7 @@ internal class DefaultPaymentElementLoaderTest {
                 PaymentMethod.Type.USBankAccount,
             )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1118,6 +1155,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1140,6 +1178,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.validationError).isEqualTo(PaymentSheetLoadingException.InvalidConfirmationMethod(Manual))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
@@ -1166,6 +1205,7 @@ internal class DefaultPaymentElementLoaderTest {
         val expectedPaymentMethod = requireNotNull(PAYMENT_METHODS.first())
         assertThat(result.paymentSelection).isEqualTo(PaymentSelection.Saved(expectedPaymentMethod))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1184,6 +1224,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedIn)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1202,6 +1243,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.NeedsVerification)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1220,6 +1262,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.NeedsVerification)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1238,6 +1281,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.loginState).isEqualTo(LinkState.LoginState.LoggedOut)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1270,6 +1314,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1294,6 +1339,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.shippingDetails).isNotNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1330,6 +1376,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.passthroughModeEnabled).isTrue()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1386,6 +1433,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.flags).containsExactlyEntriesIn(expectedFlags)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1412,6 +1460,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(cardBrandChoice?.eligible).isTrue()
         assertThat(cardBrandChoice?.preferredNetworks).isEqualTo(listOf("cartes_bancaires"))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1438,6 +1487,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(cardBrandChoice?.eligible).isFalse()
         assertThat(cardBrandChoice?.preferredNetworks).isEqualTo(listOf("cartes_bancaires"))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1475,6 +1525,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1511,6 +1562,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1534,6 +1586,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1554,6 +1607,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1574,6 +1628,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1594,6 +1649,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1617,6 +1673,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1637,6 +1694,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1665,6 +1723,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.customerInfo?.phone)
             .isEqualTo(shippingDetails.phoneNumber)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1703,6 +1762,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkState?.configuration?.customerInfo?.email)
             .isEqualTo("email@stripe.com")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -1807,6 +1867,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
@@ -2005,6 +2066,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         val loadSucceededCall = eventReporter.loadSucceededTurbine.awaitItem()
         assertThat(loadSucceededCall.paymentSelection)
@@ -2061,6 +2123,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isTrue()
         val loadSucceededCall = eventReporter.loadSucceededTurbine.awaitItem()
         assertThat(loadSucceededCall.paymentSelection).isNull()
@@ -2091,6 +2154,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result).isInstanceOf<IllegalStateException>()
         assertThat(result?.message).isEqualTo("No callback for deferred intent.")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isTrue()
         val loadFailedCall = eventReporter.loadFailedTurbine.awaitItem()
         assertThat(loadFailedCall.error.message).isEqualTo("No callback for deferred intent.")
@@ -2109,6 +2173,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         assertThat(eventReporter.loadFailedTurbine.awaitItem().error).isEqualTo(error)
     }
@@ -2133,6 +2198,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         assertThat(eventReporter.loadFailedTurbine.awaitItem().error).isEqualTo(error)
     }
@@ -2165,6 +2231,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         assertThat(eventReporter.loadFailedTurbine.awaitItem().error)
             .isEqualTo(PaymentSheetLoadingException.InvalidConfirmationMethod(Manual))
@@ -2187,6 +2254,7 @@ internal class DefaultPaymentElementLoaderTest {
             ),
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
         assertThat(eventReporter.elementsSessionLoadFailedTurbine.awaitItem().error).isEqualTo(error)
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -2214,6 +2282,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.cbcEligibility)
             .isEqualTo(CardBrandChoiceEligibility.Eligible(listOf()))
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2240,6 +2309,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2279,6 +2349,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2301,6 +2372,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState?.signupMode).isEqualTo(InsteadOfSaveForFutureUse)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2331,6 +2403,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2356,6 +2429,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2381,6 +2455,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2412,6 +2487,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2450,7 +2526,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -2481,6 +2558,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2508,6 +2586,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2577,6 +2656,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2655,6 +2735,7 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(result.paymentMethodMetadata.linkState).isNull()
         }
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -2777,6 +2858,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
     }
@@ -2833,7 +2915,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(state.customer?.paymentMethods).isEqualTo(cards)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -2884,7 +2967,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -2935,7 +3019,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -2986,7 +3071,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3037,7 +3123,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3088,7 +3175,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3122,7 +3210,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3172,7 +3261,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
                 .isEqualTo(true)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
     }
@@ -3215,7 +3305,8 @@ internal class DefaultPaymentElementLoaderTest {
                         .eventName
                 )
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
         }
 
@@ -3259,7 +3350,8 @@ internal class DefaultPaymentElementLoaderTest {
                         .eventName
                 )
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3301,7 +3393,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(state.customer?.paymentMethods).isEqualTo(cards)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3344,7 +3437,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3436,7 +3530,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3480,7 +3575,8 @@ internal class DefaultPaymentElementLoaderTest {
             val linkState = result.getOrThrow().paymentMethodMetadata.linkState
             assertThat(linkState?.configuration?.customerInfo?.email).isEqualTo(customerEmail)
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3515,7 +3611,8 @@ internal class DefaultPaymentElementLoaderTest {
             assertThat(repository.lastParams?.savedPaymentMethodSelectionId)
                 .isEqualTo("pm_1234321")
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
         }
 
@@ -3554,6 +3651,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(repository.lastParams?.linkDisallowedFundingSourceCreation)
             .containsExactly("somethingThatsNotAllowed")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -3588,7 +3686,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(repository.lastParams?.savedPaymentMethodSelectionId).isNull()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadFailedTurbine.awaitItem()).isNotNull()
         }
 
@@ -3794,7 +3893,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             consumeLoadingEvents()
 
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3891,7 +3991,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
                 .isEqualTo(PaymentMethodOrientation.Vertical)
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3901,6 +4002,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
             .isEqualTo(PaymentMethodOrientation.Horizontal)
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -3917,7 +4019,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
                 .isEqualTo(PaymentMethodOrientation.Horizontal)
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3933,7 +4036,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
                 .isEqualTo(PaymentMethodOrientation.Vertical)
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -3959,7 +4063,8 @@ internal class DefaultPaymentElementLoaderTest {
 
             assertThat(result.paymentMethodMetadata.paymentMethodOrientation())
                 .isEqualTo(PaymentMethodOrientation.Vertical)
-            assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
+        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
         }
 
@@ -4089,6 +4194,7 @@ internal class DefaultPaymentElementLoaderTest {
             result.paymentMethodMetadata.clientAttributionMetadata
         )
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4120,6 +4226,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkState).isNotNull()
         assertThat(result.paymentMethodMetadata.supportedPaymentMethodTypes()).contains("link")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4150,6 +4257,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(result.paymentMethodMetadata.linkState).isNull()
         assertThat(result.paymentMethodMetadata.supportedPaymentMethodTypes()).doesNotContain("link")
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4187,6 +4295,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.linkState).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4219,6 +4328,7 @@ internal class DefaultPaymentElementLoaderTest {
         integrityRequestManager.awaitPrepareCall()
         integrityRequestManager.ensureAllEventsConsumed()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4250,6 +4360,7 @@ internal class DefaultPaymentElementLoaderTest {
         // Verify prepare was not called by ensuring all events are consumed (no calls made)
         integrityRequestManager.ensureAllEventsConsumed()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4283,6 +4394,7 @@ internal class DefaultPaymentElementLoaderTest {
         integrityRequestManager.awaitPrepareCall()
         integrityRequestManager.ensureAllEventsConsumed()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4324,6 +4436,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(helper.calls.awaitItem()).isNotNull()
         val exposure = reporter.experimentExposureCalls.awaitItem()
         assertThat(exposure.experiment.group).isEqualTo("treatment")
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4364,6 +4477,7 @@ internal class DefaultPaymentElementLoaderTest {
         helper.calls.expectNoEvents()
         val exposure = reporter.experimentExposureCalls.awaitItem()
         assertThat(exposure.experiment.group).isEqualTo("control")
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4400,6 +4514,7 @@ internal class DefaultPaymentElementLoaderTest {
         )
         helper.calls.expectNoEvents()
         reporter.experimentExposureCalls.expectNoEvents()
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4450,6 +4565,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4482,6 +4598,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(actualExternalPaymentMethods).isEqualTo(expectedExternalPaymentMethods)
         assertThat(userFacingLogger.getLoggedMessages()).containsExactlyElementsIn(expectedLogMessages)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4512,6 +4629,7 @@ internal class DefaultPaymentElementLoaderTest {
         val abTest = logLinkHoldbackExperiment.calls.awaitItem()
         assertThat(abTest.experiment).isEqualTo(ElementsSession.ExperimentAssignment.LINK_AB_TEST)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4539,6 +4657,7 @@ internal class DefaultPaymentElementLoaderTest {
         val abTest = logLinkHoldbackExperiment.calls.awaitItem()
         assertThat(abTest.experiment).isEqualTo(ElementsSession.ExperimentAssignment.LINK_AB_TEST)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4560,6 +4679,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(result.paymentMethodMetadata.integrationMetadata).isEqualTo(IntegrationMetadata.CryptoOnramp)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isTrue()
         eventReporter.loadSucceededTurbine.awaitItem()
     }
@@ -4605,6 +4725,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4662,6 +4783,7 @@ internal class DefaultPaymentElementLoaderTest {
         assertThat(createCall.isTapToAddAvailable).isFalse()
         analyticsMetadataFactory.validate()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4695,6 +4817,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         assertThat(userFacingLogger.getLoggedMessages()).containsExactlyElementsIn(expectedLogMessages)
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4727,6 +4850,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem().initializedViaCompose).isFalse()
 
         val loadSucceededCall = eventReporter.loadSucceededTurbine.awaitItem()
@@ -4879,6 +5003,7 @@ internal class DefaultPaymentElementLoaderTest {
             )
         ).isNotNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4902,6 +5027,7 @@ internal class DefaultPaymentElementLoaderTest {
         // No legacy ephemeral key customer, so fetchSavedPaymentMethods should not be timed
         assertThat(durationProvider.completedDuration(DurationProvider.Key.PaymentSheetLoadPrefetchPMs)).isNull()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -4921,6 +5047,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
     }
@@ -5014,7 +5141,6 @@ internal class DefaultPaymentElementLoaderTest {
         val retrieveCustomerEmailImpl = DefaultRetrieveCustomerEmail(
             customerRepo,
             durationProvider,
-            { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
         )
         val createLinkState = DefaultCreateLinkState(
             accountStatusProvider = { linkAccountState },
@@ -5050,7 +5176,9 @@ internal class DefaultPaymentElementLoaderTest {
             paymentElementCallbackIdentifier = PAYMENT_ELEMENT_CALLBACKS_IDENTIFIER,
             analyticsMetadataFactory = analyticsMetadataFactory,
             tapToAddConnectionStarter = tapToAddConnectionStarter,
-            paymentConfiguration = { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
+            apiConfigurationResolver = ApiConfigurationResolver {
+                PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test_123")
+            },
             createCustomerState = CreateCustomerState(
                 paymentMethodFilter = paymentMethodFilter,
                 errorReporter = errorReporter,
@@ -5163,6 +5291,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         consumeLoadingEvents()
 
+        assertThat(eventReporter.initTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodMessagePromotionsHelperTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet.state
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -27,7 +27,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `fetchPromotionsAsync calls repository`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val request = fakeRepository.calls.awaitItem()
         assertThat(request.amount).isEqualTo(1099)
@@ -38,7 +41,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode returns promotion if available and in treatment`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -52,7 +58,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode returns null if not available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val metadata = getMetadata("treatment")
         val result = helper.getPromotionIfAvailableForCode(
@@ -65,7 +74,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed fires event with true when promotion available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -76,7 +88,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed fires event with false when promotion not available`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         val metadata = getMetadata("treatment")
         helper.reportPromotionDisplayed("afterpay_clearpay", metadata)
@@ -86,7 +101,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed does not fire event when not in treatment`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -96,7 +114,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `reportPromotionDisplayed does not fire event for unsupported PM`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -106,7 +127,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionIfAvailableForCode does not return promotion if variant is control`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -115,7 +139,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionProvider returns null for control`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -124,7 +151,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `getPromotionProvider returns null for unsupported PMs`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("control")
@@ -133,7 +163,10 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
     @Test
     fun `returns promotion provider for treatment group supported pm`() = runScenario {
-        helper.fetchPromotionsAsync(PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD)
+        helper.fetchPromotionsAsync(
+            PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null)
+        )
         eventReporter.pmmPromotionsFetched.awaitItem()
         dispatcher.scheduler.advanceUntilIdle()
         val metadata = getMetadata("treatment")
@@ -159,9 +192,6 @@ class DefaultPaymentMethodMessagePromotionsHelperTest {
 
         val helper = DefaultPaymentMethodMessagePromotionsHelper(
             stripeRepository = fakeRepository,
-            lazyPaymentConfig = {
-                PaymentConfiguration("pk_123")
-            },
             viewModelScope = this,
             workContext = testDispatcher,
             eventReporter = eventReporter

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
@@ -102,6 +102,7 @@ internal class DefaultRetrieveCustomerEmailTest {
             configuration = configuration,
             customerMetadata = customerMetadata,
             customerEmail = customerEmail,
+            stripeAccountId = null,
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.state
 
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
@@ -95,7 +94,6 @@ internal class DefaultRetrieveCustomerEmailTest {
         val retrieveEmail = DefaultRetrieveCustomerEmail(
             customerRepository,
             FakeDurationProvider(),
-            { PaymentConfiguration("pk_test") },
         )
 
         val result = retrieveEmail(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
@@ -29,8 +29,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
-                publishableKey = "pk_test_123",
-                isLiveMode = false,
             )
         ).isTrue()
     }
@@ -49,8 +47,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
-                publishableKey = "pk_test_123",
-                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -69,8 +65,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
-                publishableKey = "pk_test_123",
-                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -89,8 +83,6 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = null,
-                publishableKey = "pk_test_123",
-                isLiveMode = false,
             )
         ).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
@@ -29,6 +29,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isTrue()
     }
@@ -47,6 +49,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -65,6 +69,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -83,6 +89,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = null,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -20,6 +21,7 @@ internal class ElementsSessionLoaderTest {
             ),
             configuration = DEFAULT_CONFIG,
             savedPaymentMethodSelection = null,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         assertThat(result.stripeIntent)
@@ -36,6 +38,7 @@ internal class ElementsSessionLoaderTest {
             ),
             configuration = DEFAULT_CONFIG,
             savedPaymentMethodSelection = savedSelection,
+            apiConfiguration = ApiConfiguration.State(publishableKey = "pk_test_123", stripeAccountId = null),
         )
 
         assertThat(elementsSessionRepository.lastParams?.savedPaymentMethodSelectionId)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakePaymentMethodMessagePromotionsHelper.kt
@@ -2,6 +2,7 @@ package com.stripe.android.utils
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodMessageLearnMore
@@ -19,7 +20,7 @@ internal class FakePaymentMethodMessagePromotionsHelper(
     val reportPromotionDisplayedCalls: ReceiveTurbine<Pair<PaymentMethodCode, Boolean>> =
         _reportPromotionDisplayedCalls
 
-    override fun fetchPromotionsAsync(intent: StripeIntent) {
+    override fun fetchPromotionsAsync(intent: StripeIntent, apiConfiguration: ApiConfiguration.State) {
         _calls.add(Unit)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
@@ -9,7 +9,5 @@ internal class FakeTapToAddAvailabilityFactory(
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
-        publishableKey: String,
-        isLiveMode: Boolean,
     ): Boolean = isAvailableResult
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
@@ -9,5 +9,7 @@ internal class FakeTapToAddAvailabilityFactory(
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ): Boolean = isAvailableResult
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
@@ -5,12 +5,14 @@ import app.cash.turbine.Turbine
 import com.stripe.android.common.model.CommonConfiguration
 
 internal class FakeTapToAddConnectionStarter private constructor(
-    override val isSupported: Boolean = false,
+    private val isSupportedValue: Boolean = false,
 ) : TapToAddConnectionStarter {
     private val startCalls: Turbine<StartCall> = Turbine()
 
-    override fun start(config: CommonConfiguration) {
-        startCalls.add(StartCall(config))
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = isSupportedValue
+
+    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
+        startCalls.add(StartCall(config, publishableKey))
     }
 
     fun ensureAllEventsConsumed() {
@@ -18,7 +20,8 @@ internal class FakeTapToAddConnectionStarter private constructor(
     }
 
     data class StartCall(
-        val config: CommonConfiguration
+        val config: CommonConfiguration,
+        val publishableKey: String,
     )
 
     class Scenario(
@@ -45,6 +48,6 @@ internal class FakeTapToAddConnectionStarter private constructor(
 
         fun create(
             isSupported: Boolean = false,
-        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupported = isSupported)
+        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupportedValue = isSupported)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
@@ -5,14 +5,12 @@ import app.cash.turbine.Turbine
 import com.stripe.android.common.model.CommonConfiguration
 
 internal class FakeTapToAddConnectionStarter private constructor(
-    private val isSupportedValue: Boolean = false,
+    override val isSupported: Boolean = false,
 ) : TapToAddConnectionStarter {
     private val startCalls: Turbine<StartCall> = Turbine()
 
-    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = isSupportedValue
-
-    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
-        startCalls.add(StartCall(config, publishableKey))
+    override fun start(config: CommonConfiguration) {
+        startCalls.add(StartCall(config))
     }
 
     fun ensureAllEventsConsumed() {
@@ -20,8 +18,7 @@ internal class FakeTapToAddConnectionStarter private constructor(
     }
 
     data class StartCall(
-        val config: CommonConfiguration,
-        val publishableKey: String,
+        val config: CommonConfiguration
     )
 
     class Scenario(
@@ -48,6 +45,6 @@ internal class FakeTapToAddConnectionStarter private constructor(
 
         fun create(
             isSupported: Boolean = false,
-        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupportedValue = isSupported)
+        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupported = isSupported)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
@@ -22,7 +22,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported).isTrue()
+        assertThat(starter.isSupported("pk_test_123", false)).isTrue()
     }
 
     @Test
@@ -34,7 +34,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported).isFalse()
+        assertThat(starter.isSupported("pk_test_123", false)).isFalse()
     }
 
     @Test
@@ -50,13 +50,15 @@ internal class TapToAddConnectionStarterTest {
             merchantDisplayName = "Books & Things",
         )
 
-        starter.start(commonConfiguration)
+        starter.start(commonConfiguration, "pk_test_123", false)
         advanceUntilIdle()
 
         assertThat(manager.connectCalls.awaitItem()).isEqualTo(
             FakeTapToAddConnectionManager.ConnectCall(
                 config = TapToAddConnectionManager.ConnectionConfig(
                     merchantDisplayName = "Books & Things",
+                    publishableKey = "pk_test_123",
+                    isLiveMode = false,
                 ),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
@@ -22,7 +22,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported("pk_test_123", false)).isTrue()
+        assertThat(starter.isSupported).isTrue()
     }
 
     @Test
@@ -34,7 +34,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported("pk_test_123", false)).isFalse()
+        assertThat(starter.isSupported).isFalse()
     }
 
     @Test
@@ -50,15 +50,13 @@ internal class TapToAddConnectionStarterTest {
             merchantDisplayName = "Books & Things",
         )
 
-        starter.start(commonConfiguration, "pk_test_123", false)
+        starter.start(commonConfiguration)
         advanceUntilIdle()
 
         assertThat(manager.connectCalls.awaitItem()).isEqualTo(
             FakeTapToAddConnectionManager.ConnectCall(
                 config = TapToAddConnectionManager.ConnectionConfig(
                     merchantDisplayName = "Books & Things",
-                    publishableKey = "pk_test_123",
-                    isLiveMode = false,
                 ),
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/LinkTestUtils.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.utils
 
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.model.CountryCode
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkPaymentDetails
@@ -118,6 +119,10 @@ internal object LinkTestUtils {
             clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
             cardFundingFilter = PaymentSheetCardFundingFilter(PaymentSheet.CardFundingType.entries),
             linkBrand = linkBrand,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.StripeIntent
@@ -43,6 +44,7 @@ internal class FakeElementsSessionRepository(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
         lastParams = Params(


### PR DESCRIPTION
# Summary
Resolve API configuration during PaymentSheet loading and propagate it through loader-owned repositories, analytics, and request construction.

Update PaymentSheet loader tests and compatibility graphs while removing redundant request-options bindings where Dagger can derive them from the resolved state.

Committed and created by Codex.

# Motivation
The PaymentSheet load is the first point where the integration credentials and loaded session belong to the same operation. Capturing ApiConfiguration.State there prevents downstream work from re-reading mutable process-global PaymentConfiguration.

The resolved state is retained independently of the PaymentSheet view model so long-lived dependencies do not capture an Activity or view-model graph. CustomerSheet, Link, and Tap to Add migrations remain in later focused layers.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
Not applicable — internal loading and dependency-injection changes only.

# Changelog
Not applicable — no public API or intended user-visible behavior change.