### PR TITLE
Move Tap to Add API configuration earlier

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.common.taptoadd
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.exception.safeAnalyticsMessage
 import com.stripe.android.core.networking.ApiRequest
@@ -59,7 +59,7 @@ internal interface TapToAddCollectionHandler {
             isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
             terminalWrapper: TerminalWrapper,
             stripeRepository: StripeRepository,
-            paymentConfiguration: PaymentConfiguration,
+            apiConfigurationProvider: () -> ApiConfiguration.State,
             connectionManager: TapToAddConnectionManager,
             tapToPayUxConfiguration: TapToPayUxConfiguration,
             userFacingLogger: UserFacingLogger,
@@ -71,7 +71,6 @@ internal interface TapToAddCollectionHandler {
                     terminalWrapper = terminalWrapper,
                     connectionManager = connectionManager,
                     stripeRepository = stripeRepository,
-                    paymentConfiguration = paymentConfiguration,
                     tapToPayUxConfiguration = tapToPayUxConfiguration,
                     userFacingLogger = userFacingLogger,
                     errorReporter = errorReporter,
@@ -88,7 +87,6 @@ internal interface TapToAddCollectionHandler {
 internal class DefaultTapToAddCollectionHandler(
     private val terminalWrapper: TerminalWrapper,
     private val stripeRepository: StripeRepository,
-    private val paymentConfiguration: PaymentConfiguration,
     private val connectionManager: TapToAddConnectionManager,
     private val errorReporter: ErrorReporter,
     private val userFacingLogger: UserFacingLogger,
@@ -116,6 +114,8 @@ internal class DefaultTapToAddCollectionHandler(
         connectionManager.connect(
             config = TapToAddConnectionManager.ConnectionConfig(
                 merchantDisplayName = metadata.merchantName,
+                publishableKey = metadata.apiConfiguration.publishableKey,
+                isLiveMode = metadata.apiConfiguration.isLiveMode(),
             ),
         )
 
@@ -165,7 +165,7 @@ internal class DefaultTapToAddCollectionHandler(
         val setupIntent = retrieveSetupIntent(clientSecret)
         val setupIntentWithAttachedPaymentMethod = collectPaymentMethod(setupIntent)
         val confirmedIntent = confirmSetupIntent(setupIntentWithAttachedPaymentMethod)
-        val paymentMethod = fetchPaymentMethod(confirmedIntent, customerMetadata)
+        val paymentMethod = fetchPaymentMethod(confirmedIntent, customerMetadata, metadata)
         val updatedPaymentMethod = updatePaymentMethod(paymentMethod, customerMetadata, metadata)
 
         return validatePaymentMethod(updatedPaymentMethod, metadata)
@@ -216,7 +216,7 @@ internal class DefaultTapToAddCollectionHandler(
                         address = billingDetails.address?.asAddressModel()
                     )
                 ),
-                options = getApiOptions(customerMetadata),
+                options = getApiOptions(customerMetadata, metadata),
             ).getOrThrow()
         } ?: paymentMethod
     }
@@ -292,6 +292,7 @@ internal class DefaultTapToAddCollectionHandler(
     private suspend fun fetchPaymentMethod(
         intent: SetupIntent,
         customerMetadata: CustomerMetadata,
+        paymentMethodMetadata: PaymentMethodMetadata
     ): PaymentMethod {
         val paymentMethodId = intent.paymentMethodId
             ?: run {
@@ -317,7 +318,7 @@ internal class DefaultTapToAddCollectionHandler(
         return stripeRepository.retrieveSavedPaymentMethodFromCardPresentPaymentMethod(
             cardPresentPaymentMethodId = paymentMethodId,
             customerId = customerId,
-            options = getApiOptions(customerMetadata)
+            options = getApiOptions(customerMetadata, paymentMethodMetadata)
         ).getOrThrow()
     }
 
@@ -345,7 +346,10 @@ internal class DefaultTapToAddCollectionHandler(
         }
     }
 
-    private fun getApiOptions(customerMetadata: CustomerMetadata): ApiRequest.Options {
+    private fun getApiOptions(
+        customerMetadata: CustomerMetadata,
+        paymentMethodMetadata: PaymentMethodMetadata
+    ): ApiRequest.Options {
         val ephemeralKeySecret = when (customerMetadata) {
             is CustomerMetadata.CustomerSession -> customerMetadata.ephemeralKeySecret
             is CustomerMetadata.LegacyEphemeralKey -> customerMetadata.ephemeralKeySecret
@@ -356,7 +360,7 @@ internal class DefaultTapToAddCollectionHandler(
 
         return ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = paymentConfiguration.stripeAccountId,
+            stripeAccount = paymentMethodMetadata.apiConfiguration.stripeAccountId,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
@@ -59,7 +59,7 @@ internal interface TapToAddConnectionManager {
             applicationContext: Context,
             logger: Logger,
             workContext: CoroutineContext,
-            callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
+            hasCreateCardPresentSetupIntentCallback: () -> Boolean,
             isSimulatedProvider: TapToAddIsSimulatedProvider,
         ): TapToAddConnectionManager {
             return if (isStripeTerminalSdkAvailable()) {
@@ -70,7 +70,7 @@ internal interface TapToAddConnectionManager {
                         errorReporter = errorReporter,
                         terminalWrapper = terminalWrapper,
                         logger = logger,
-                        callbackRetriever = callbackRetriever,
+                        hasCreateCardPresentSetupIntentCallback = hasCreateCardPresentSetupIntentCallback,
                         isSimulatedProvider = isSimulatedProvider,
                     ),
                     fatalErrorChecker = DefaultTapToAddFatalErrorChecker(),
@@ -90,7 +90,7 @@ internal class DefaultTapToAddConnectionManager(
     private val errorReporter: ErrorReporter,
     private val terminalWrapper: TerminalWrapper,
     private val logger: Logger,
-    private val callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
+    private val hasCreateCardPresentSetupIntentCallback: () -> Boolean,
     private val isSimulatedProvider: TapToAddIsSimulatedProvider,
 ) : TapToAddConnectionManager, TerminalListener, TapToPayReaderListener {
     private var connectionTask: CompletableDeferred<Unit>? = null
@@ -102,7 +102,7 @@ internal class DefaultTapToAddConnectionManager(
     }
 
     override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean {
-        if (!callbackRetriever.hasCallback()) {
+        if (!hasCreateCardPresentSetupIntentCallback()) {
             return false
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
@@ -2,7 +2,6 @@ package com.stripe.android.common.taptoadd
 
 import android.annotation.SuppressLint
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.ExponentialBackoffRetryDelaySupplier
@@ -30,14 +29,13 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal interface TapToAddConnectionManager {
     /**
      * Indicates if the device has the support required to use the on-device NFC reader
      */
-    val isSupported: Boolean
+    fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean
 
     /**
      * Connects to the NFC reader. Successful completion of this function indicates a successful connection while
@@ -48,7 +46,9 @@ internal interface TapToAddConnectionManager {
     suspend fun connect(config: ConnectionConfig)
 
     data class ConnectionConfig(
-        val merchantDisplayName: String?
+        val merchantDisplayName: String?,
+        val publishableKey: String,
+        val isLiveMode: Boolean,
     )
 
     companion object {
@@ -58,7 +58,6 @@ internal interface TapToAddConnectionManager {
             errorReporter: ErrorReporter,
             applicationContext: Context,
             logger: Logger,
-            paymentConfiguration: Provider<PaymentConfiguration>,
             workContext: CoroutineContext,
             callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
             isSimulatedProvider: TapToAddIsSimulatedProvider,
@@ -68,7 +67,6 @@ internal interface TapToAddConnectionManager {
                     tapToAddConnectionManager = DefaultTapToAddConnectionManager(
                         applicationContext = applicationContext,
                         workContext = workContext,
-                        paymentConfiguration = paymentConfiguration,
                         errorReporter = errorReporter,
                         terminalWrapper = terminalWrapper,
                         logger = logger,
@@ -89,45 +87,43 @@ internal interface TapToAddConnectionManager {
 internal class DefaultTapToAddConnectionManager(
     private val applicationContext: Context,
     private val workContext: CoroutineContext,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val errorReporter: ErrorReporter,
     private val terminalWrapper: TerminalWrapper,
     private val logger: Logger,
     private val callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
-    isSimulatedProvider: TapToAddIsSimulatedProvider,
+    private val isSimulatedProvider: TapToAddIsSimulatedProvider,
 ) : TapToAddConnectionManager, TerminalListener, TapToPayReaderListener {
     private var connectionTask: CompletableDeferred<Unit>? = null
 
-    private val discoveryConfiguration by lazy {
-        DiscoveryConfiguration.TapToPayDiscoveryConfiguration(isSimulatedProvider.get())
-    }
-
     private val connectionTaskLock = Mutex()
 
-    override val isSupported: Boolean
-        get() {
-            if (!callbackRetriever.hasCallback()) {
-                return false
-            }
+    private fun discoveryConfiguration(isLiveMode: Boolean): DiscoveryConfiguration.TapToPayDiscoveryConfiguration {
+        return DiscoveryConfiguration.TapToPayDiscoveryConfiguration(isSimulatedProvider.get(isLiveMode))
+    }
 
-            initializeIfNeeded()
-
-            return terminal().supportsReadersOfType(
-                deviceType = DeviceType.TAP_TO_PAY_DEVICE,
-                discoveryConfiguration = discoveryConfiguration,
-            ).isSupported
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean {
+        if (!callbackRetriever.hasCallback()) {
+            return false
         }
+
+        initializeIfNeeded(publishableKey)
+
+        return terminal().supportsReadersOfType(
+            deviceType = DeviceType.TAP_TO_PAY_DEVICE,
+            discoveryConfiguration = discoveryConfiguration(isLiveMode),
+        ).isSupported
+    }
 
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) = withContext(workContext) {
         runCatching {
-            when (val connectSetupResult = setup()) {
+            when (val connectSetupResult = setup(config.publishableKey, config.isLiveMode)) {
                 is ConnectSetupResult.AlreadyConnected -> Unit
                 is ConnectSetupResult.ExistingTask -> connectSetupResult.task.await()
                 is ConnectSetupResult.NotSupported -> {
                     throw IllegalStateException("Tap to Add is not supported by this device!")
                 }
                 is ConnectSetupResult.CanStart -> {
-                    val discoverReadersResult = discoverReaders()
+                    val discoverReadersResult = discoverReaders(config.isLiveMode)
 
                     if (discoverReadersResult is DiscoverCallResult.CollectedReaders) {
                         connectReader(discoverReadersResult.readers, config)
@@ -152,13 +148,13 @@ internal class DefaultTapToAddConnectionManager(
         )
     }
 
-    private suspend fun setup(): ConnectSetupResult {
+    private suspend fun setup(publishableKey: String, isLiveMode: Boolean): ConnectSetupResult {
         return connectionTaskLock.withLock {
             connectionTask?.let {
                 return@withLock ConnectSetupResult.ExistingTask(it)
             }
 
-            if (!isSupported) {
+            if (!isSupported(publishableKey, isLiveMode)) {
                 return@withLock ConnectSetupResult.NotSupported
             }
 
@@ -173,10 +169,10 @@ internal class DefaultTapToAddConnectionManager(
     }
 
     @SuppressLint("MissingPermission")
-    private suspend fun discoverReaders() = suspendCancellableCoroutine { continuation ->
+    private suspend fun discoverReaders(isLiveMode: Boolean) = suspendCancellableCoroutine { continuation ->
         try {
             val cancellable = terminal().discoverReaders(
-                config = discoveryConfiguration,
+                config = discoveryConfiguration(isLiveMode),
                 discoveryListener = object : DiscoveryListener {
                     override fun onUpdateDiscoveredReaders(readers: List<Reader>) {
                         continuation.resumeWith(Result.success(DiscoverCallResult.CollectedReaders(readers)))
@@ -290,13 +286,13 @@ internal class DefaultTapToAddConnectionManager(
         )
     }
 
-    private fun initializeIfNeeded() {
+    private fun initializeIfNeeded(publishableKey: String) {
         if (!terminalWrapper.isInitialized()) {
             terminalWrapper.initTerminal(
                 context = applicationContext,
                 tokenProvider = object : ConnectionTokenProvider {
                     override fun fetchConnectionToken(callback: ConnectionTokenCallback) {
-                        callback.onSuccess(paymentConfiguration.get().publishableKey)
+                        callback.onSuccess(publishableKey)
                     }
                 },
                 listener = this,
@@ -344,7 +340,7 @@ internal class DefaultTapToAddConnectionManager(
 }
 
 internal class UnsupportedTapToAddConnectionManager : TapToAddConnectionManager {
-    override val isSupported: Boolean = false
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = false
 
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
         // No-op
@@ -355,7 +351,11 @@ internal class TapToAddRetriableConnectionManager(
     private val tapToAddConnectionManager: TapToAddConnectionManager,
     private val fatalErrorChecker: TapToAddFatalErrorChecker,
     private val retryDelaySupplier: RetryDelaySupplier,
-) : TapToAddConnectionManager by tapToAddConnectionManager {
+) : TapToAddConnectionManager {
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean {
+        return tapToAddConnectionManager.isSupported(publishableKey, isLiveMode)
+    }
+
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
         var retriesRemaining = MAX_RETRIES
 

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
@@ -11,6 +11,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 @Module
@@ -60,6 +61,7 @@ internal interface TapToAddConnectionModule {
             return TerminalWrapper.create()
         }
 
+        @OptIn(TapToAddPreview::class)
         @Provides
         fun providesTapToAddConnectionManager(
             isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
@@ -68,7 +70,7 @@ internal interface TapToAddConnectionModule {
             logger: Logger,
             applicationContext: Context,
             @IOContext workContext: CoroutineContext,
-            callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
+            createCardPresentSetupIntentCallbackProvider: Provider<CreateCardPresentSetupIntentCallback?>,
             isSimulatedProvider: TapToAddIsSimulatedProvider,
         ): TapToAddConnectionManager {
             return TapToAddConnectionManager.create(
@@ -78,7 +80,9 @@ internal interface TapToAddConnectionModule {
                 errorReporter = errorReporter,
                 isSimulatedProvider = isSimulatedProvider,
                 logger = logger,
-                callbackRetriever = callbackRetriever,
+                hasCreateCardPresentSetupIntentCallback = {
+                    createCardPresentSetupIntentCallbackProvider.get() != null
+                },
                 workContext = workContext,
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionModule.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.common.taptoadd
 
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
@@ -12,7 +11,6 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 @Module
@@ -69,7 +67,6 @@ internal interface TapToAddConnectionModule {
             errorReporter: ErrorReporter,
             logger: Logger,
             applicationContext: Context,
-            paymentConfiguration: Provider<PaymentConfiguration>,
             @IOContext workContext: CoroutineContext,
             callbackRetriever: CreateCardPresentSetupIntentCallbackRetriever,
             isSimulatedProvider: TapToAddIsSimulatedProvider,
@@ -79,7 +76,6 @@ internal interface TapToAddConnectionModule {
                 isStripeTerminalSdkAvailable = isStripeTerminalSdkAvailable,
                 terminalWrapper = terminalWrapper,
                 errorReporter = errorReporter,
-                paymentConfiguration = paymentConfiguration,
                 isSimulatedProvider = isSimulatedProvider,
                 logger = logger,
                 callbackRetriever = callbackRetriever,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddIsSimulatedProvider.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddIsSimulatedProvider.kt
@@ -2,20 +2,16 @@ package com.stripe.android.common.taptoadd
 
 import android.content.Context
 import android.content.pm.ApplicationInfo
-import com.stripe.android.PaymentConfiguration
 import javax.inject.Inject
-import javax.inject.Provider
 
 internal interface TapToAddIsSimulatedProvider {
-    fun get(): Boolean
+    fun get(isLiveMode: Boolean): Boolean
 }
 
 internal class DefaultTapToAddIsSimulatedProvider @Inject constructor(
     private val applicationContext: Context,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
 ) : TapToAddIsSimulatedProvider {
-    override fun get(): Boolean {
-        val isLiveMode = paymentConfiguration.get().isLiveMode()
+    override fun get(isLiveMode: Boolean): Boolean {
         val isDebuggable = (applicationContext.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
 
         return !isLiveMode && isDebuggable

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddModule.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.common.taptoadd
 
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.utils.UserFacingLogger
 import com.stripe.android.networking.StripeRepository
 import com.stripe.android.paymentelement.TapToAddPreview
@@ -21,7 +21,7 @@ internal class TapToAddModule {
         isStripeTerminalSdkAvailable: IsStripeTerminalSdkAvailable,
         connectionManager: TapToAddConnectionManager,
         stripeRepository: StripeRepository,
-        paymentConfiguration: PaymentConfiguration,
+        apiConfigurationProvider: () -> ApiConfiguration.State,
         terminalWrapper: TerminalWrapper,
         tapToPayUxConfiguration: TapToPayUxConfiguration,
         userFacingLogger: UserFacingLogger,
@@ -33,7 +33,7 @@ internal class TapToAddModule {
             connectionManager = connectionManager,
             terminalWrapper = terminalWrapper,
             stripeRepository = stripeRepository,
-            paymentConfiguration = paymentConfiguration,
+            apiConfigurationProvider = apiConfigurationProvider,
             tapToPayUxConfiguration = tapToPayUxConfiguration,
             errorReporter = errorReporter,
             userFacingLogger = userFacingLogger,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -59,7 +59,6 @@ import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignu
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
@@ -94,7 +93,6 @@ import javax.inject.Singleton
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
         LinkInlineSignupConfirmationModule::class,
-        PaymentConfigurationModule::class,
         ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -59,6 +59,7 @@ import com.stripe.android.paymentelement.confirmation.linkinline.LinkInlineSignu
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
+import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
@@ -93,6 +94,7 @@ import javax.inject.Singleton
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
         LinkInlineSignupConfirmationModule::class,
+        PaymentConfigurationModule::class,
         ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -320,11 +320,14 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             initializationMode = initializationMode,
             isLiveMode = apiConfiguration.isLiveMode(),
             callbackIdentifier = paymentElementCallbackIdentifier,
-            isTapToAddSupported = tapToAddConnectionStarter.isSupported,
+            isTapToAddSupported = tapToAddConnectionStarter.isSupported(
+                apiConfiguration.publishableKey,
+                apiConfiguration.isLiveMode(),
+            ),
         )
 
         eventReporter.onLoadStarted(metadata.initializedViaCompose, apiConfiguration.publishableKey)
-        tapToAddConnectionStarter.start(configuration)
+        tapToAddConnectionStarter.start(configuration, apiConfiguration.publishableKey, apiConfiguration.isLiveMode())
 
         // Give immediately available results a chance to complete before later load work checks isCompleted.
         val isGooglePaySupportedOnDevice = async(start = CoroutineStart.UNDISPATCHED) {
@@ -597,7 +600,12 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             paymentElementCallbacks = PaymentElementCallbackReferences[paymentElementCallbackIdentifier]
         )
 
-        val isTapToAddAvailable = tapToAddAvailabilityFactory.isAvailable(elementsSession, customerMetadata)
+        val isTapToAddAvailable = tapToAddAvailabilityFactory.isAvailable(
+            elementsSession,
+            customerMetadata,
+            apiConfiguration.publishableKey,
+            apiConfiguration.isLiveMode(),
+        )
 
         val analyticsMetadata = analyticsMetadataFactory.create(
             initializationMode = initializationMode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddAvailabilityFactory.kt
@@ -10,6 +10,8 @@ internal interface TapToAddAvailabilityFactory {
     fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ): Boolean
 }
 
@@ -20,8 +22,12 @@ internal class DefaultTapToAddAvailabilityFactory @Inject constructor(
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ): Boolean {
-        return connectionManager.isSupported && elementsSession.isTapToAddEnabled && customerMetadata != null
+        return connectionManager.isSupported(publishableKey, isLiveMode) &&
+            elementsSession.isTapToAddEnabled &&
+            customerMetadata != null
     }
 }
 
@@ -29,5 +35,7 @@ internal class TapToAddAvailabilityFactoryForCustomerSheet @Inject constructor()
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ) = false
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarter.kt
@@ -12,9 +12,9 @@ import javax.inject.Inject
 import kotlin.coroutines.CoroutineContext
 
 internal interface TapToAddConnectionStarter {
-    val isSupported: Boolean
+    fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean
 
-    fun start(config: CommonConfiguration)
+    fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean)
 }
 
 internal class DefaultTapToAddConnectionStarter @Inject constructor(
@@ -22,15 +22,18 @@ internal class DefaultTapToAddConnectionStarter @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
     @IOContext private val coroutineContext: CoroutineContext,
 ) : TapToAddConnectionStarter {
-    override val isSupported: Boolean
-        get() = tapToAddConnectionManager.isSupported
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean {
+        return tapToAddConnectionManager.isSupported(publishableKey, isLiveMode)
+    }
 
-    override fun start(config: CommonConfiguration) {
+    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
         viewModelScope.launch(coroutineContext) {
             runCatching {
                 tapToAddConnectionManager.connect(
                     config = TapToAddConnectionManager.ConnectionConfig(
                         merchantDisplayName = config.merchantDisplayName,
+                        publishableKey = publishableKey,
+                        isLiveMode = isLiveMode,
                     )
                 )
             }
@@ -39,10 +42,9 @@ internal class DefaultTapToAddConnectionStarter @Inject constructor(
 }
 
 internal class NoOpTapToAddConnectionStarter @Inject constructor() : TapToAddConnectionStarter {
-    override val isSupported: Boolean = false
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = false
 
-    @Suppress("UNUSED_PARAMETER")
-    override fun start(config: CommonConfiguration) {
+    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
         // No-op
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
@@ -711,7 +711,7 @@ class DefaultTapToAddConnectionManagerTest {
                         isSimulatedProvider = object : TapToAddIsSimulatedProvider {
                             override fun get(isLiveMode: Boolean): Boolean = isSimulated
                         },
-                        callbackRetriever = callbackRetriever,
+                        hasCreateCardPresentSetupIntentCallback = callbackRetriever::hasCallback,
                     ),
                     terminalInstance = terminalInstance,
                     errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
 import com.stripe.android.paymentelement.TapToAddPreview
@@ -54,7 +53,11 @@ class DefaultTapToAddConnectionManagerTest {
     private val lifecycleOwner = TestLifecycleOwner()
 
     private val testConnectionConfig =
-        TapToAddConnectionManager.ConnectionConfig(merchantDisplayName = "Test Merchant")
+        TapToAddConnectionManager.ConnectionConfig(
+            merchantDisplayName = "Test Merchant",
+            publishableKey = "pk_test_123",
+            isLiveMode = false,
+        )
 
     @Test
     fun `isSupported returns true when terminal supports tap to add`() = test(
@@ -62,7 +65,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
         }
     ) {
-        assertThat(manager.isSupported).isTrue()
+        assertThat(manager.isSupported("pk_test_123", false)).isTrue()
     }
 
     @Test
@@ -72,7 +75,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
         }
     ) {
-        assertThat(manager.isSupported).isTrue()
+        assertThat(manager.isSupported("pk_test_123", false)).isTrue()
 
         verify(terminalInstance).supportsReadersOfType(
             deviceType = DeviceType.TAP_TO_PAY_DEVICE,
@@ -87,7 +90,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
         }
     ) {
-        assertThat(manager.isSupported).isTrue()
+        assertThat(manager.isSupported("pk_test_123", false)).isTrue()
 
         verify(terminalInstance).supportsReadersOfType(
             deviceType = DeviceType.TAP_TO_PAY_DEVICE,
@@ -101,7 +104,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.NotSupported(IllegalStateException("Not supported!")))
         }
     ) {
-        assertThat(manager.isSupported).isFalse()
+        assertThat(manager.isSupported("pk_test_123", false)).isFalse()
     }
 
     @Test
@@ -112,7 +115,7 @@ class DefaultTapToAddConnectionManagerTest {
             mockSupportedReaderResult(ReaderSupportResult.Supported)
         }
     ) {
-        assertThat(manager.isSupported).isFalse()
+        assertThat(manager.isSupported("pk_test_123", false)).isFalse()
 
         wrapperScenario.isInitializedCalls.expectNoEvents()
     }
@@ -706,9 +709,8 @@ class DefaultTapToAddConnectionManagerTest {
                         errorReporter = errorReporter,
                         logger = logger,
                         isSimulatedProvider = object : TapToAddIsSimulatedProvider {
-                            override fun get(): Boolean = isSimulated
+                            override fun get(isLiveMode: Boolean): Boolean = isSimulated
                         },
-                        paymentConfiguration = { PaymentConfiguration(publishableKey = "pk_test") },
                         callbackRetriever = callbackRetriever,
                     ),
                     terminalInstance = terminalInstance,

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddIsSimulatedProviderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddIsSimulatedProviderTest.kt
@@ -3,11 +3,9 @@ package com.stripe.android.common.taptoadd
 import android.content.Context
 import android.content.pm.ApplicationInfo
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import javax.inject.Provider
 
 class DefaultTapToAddIsSimulatedProviderTest {
 
@@ -15,40 +13,36 @@ class DefaultTapToAddIsSimulatedProviderTest {
     fun `get returns true when test mode and application is debuggable`() {
         val provider = DefaultTapToAddIsSimulatedProvider(
             applicationContext = context(debuggable = true),
-            paymentConfiguration = provider { PaymentConfiguration(publishableKey = "pk_test_123") },
         )
 
-        assertThat(provider.get()).isTrue()
+        assertThat(provider.get(isLiveMode = false)).isTrue()
     }
 
     @Test
     fun `get returns false when live mode even if debuggable`() {
         val provider = DefaultTapToAddIsSimulatedProvider(
             applicationContext = context(debuggable = true),
-            paymentConfiguration = provider { PaymentConfiguration(publishableKey = "pk_live_123") },
         )
 
-        assertThat(provider.get()).isFalse()
+        assertThat(provider.get(isLiveMode = true)).isFalse()
     }
 
     @Test
     fun `get returns false when test mode but application is not debuggable`() {
         val provider = DefaultTapToAddIsSimulatedProvider(
             applicationContext = context(debuggable = false),
-            paymentConfiguration = provider { PaymentConfiguration(publishableKey = "pk_test_123") },
         )
 
-        assertThat(provider.get()).isFalse()
+        assertThat(provider.get(isLiveMode = false)).isFalse()
     }
 
     @Test
     fun `get returns false when live mode and not debuggable`() {
         val provider = DefaultTapToAddIsSimulatedProvider(
             applicationContext = context(debuggable = false),
-            paymentConfiguration = provider { PaymentConfiguration(publishableKey = "pk_live_123") },
         )
 
-        assertThat(provider.get()).isFalse()
+        assertThat(provider.get(isLiveMode = true)).isFalse()
     }
 
     private fun context(debuggable: Boolean): Context {
@@ -62,9 +56,5 @@ class DefaultTapToAddIsSimulatedProviderTest {
         whenever(context.applicationInfo).thenReturn(appInfo)
 
         return context
-    }
-
-    private fun provider(block: () -> PaymentConfiguration): Provider<PaymentConfiguration> {
-        return Provider { block() }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddConnectionManager.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/FakeTapToAddConnectionManager.kt
@@ -4,12 +4,14 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 
 internal class FakeTapToAddConnectionManager private constructor(
-    override val isSupported: Boolean,
+    private val isSupported: Boolean,
     connectResults: List<Result<Unit>>,
 ) : TapToAddConnectionManager {
     private val queuedConnectResults = connectResults.toMutableList()
 
     val connectCalls = Turbine<ConnectCall>()
+
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = isSupported
 
     override suspend fun connect(config: TapToAddConnectionManager.ConnectionConfig) {
         connectCalls.add(ConnectCall(config))

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandlerTest.kt
@@ -4,9 +4,9 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.taptoadd.ui.createTapToAddUxConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
@@ -71,7 +71,7 @@ class TapToAddCollectionHandlerTest {
             isStripeTerminalSdkAvailable = { false },
             terminalWrapper = TestTerminalWrapper.noOp(),
             stripeRepository = FakeTapToAddStripeRepository(Result.failure(NotImplementedError())),
-            paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
+            apiConfigurationProvider = { TEST_API_CONFIGURATION },
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
             tapToPayUxConfiguration = tapToPayUxConfiguration,
             userFacingLogger = FakeUserFacingLogger(),
@@ -90,7 +90,7 @@ class TapToAddCollectionHandlerTest {
             isStripeTerminalSdkAvailable = { true },
             terminalWrapper = TestTerminalWrapper.noOp(),
             stripeRepository = FakeTapToAddStripeRepository(),
-            paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
+            apiConfigurationProvider = { TEST_API_CONFIGURATION },
             connectionManager = FakeTapToAddConnectionManager.noOp(isSupported = true),
             tapToPayUxConfiguration = tapToPayUxConfiguration,
             userFacingLogger = FakeUserFacingLogger(),
@@ -312,7 +312,7 @@ class TapToAddCollectionHandlerTest {
             assertThat(updateCall.options).isEqualTo(
                 ApiRequest.Options(
                     apiKey = "ek_123",
-                    stripeAccount = TEST_PAYMENT_CONFIGURATION.stripeAccountId,
+                    stripeAccount = TEST_API_CONFIGURATION.stripeAccountId,
                 )
             )
 
@@ -914,7 +914,6 @@ class TapToAddCollectionHandlerTest {
                         handler = DefaultTapToAddCollectionHandler(
                             terminalWrapper = terminalWrapper,
                             stripeRepository = stripeRepository,
-                            paymentConfiguration = TEST_PAYMENT_CONFIGURATION,
                             connectionManager = managerScenario.tapToAddConnectionManager,
                             errorReporter = errorReporter,
                             userFacingLogger = FakeUserFacingLogger(),
@@ -1222,7 +1221,7 @@ class TapToAddCollectionHandlerTest {
         val DEFAULT_CALLBACK = CreateCardPresentSetupIntentCallback {
             CreateIntentResult.Success("si_123_secret")
         }
-        val TEST_PAYMENT_CONFIGURATION = PaymentConfiguration(publishableKey = "pk_test")
+        val TEST_API_CONFIGURATION = ApiConfiguration.State(publishableKey = "pk_test", stripeAccountId = null)
         val DEFAULT_BILLING_DETAILS = PaymentSheet.BillingDetails(
             name = "Jane Doe",
             email = "jane@example.com",

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddRetriableConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/TapToAddRetriableConnectionManagerTest.kt
@@ -11,16 +11,20 @@ import kotlin.time.Duration
 
 internal class TapToAddRetriableConnectionManagerTest {
     private val testConnectionConfig =
-        TapToAddConnectionManager.ConnectionConfig(merchantDisplayName = "Test Merchant")
+        TapToAddConnectionManager.ConnectionConfig(
+            merchantDisplayName = "Test Merchant",
+            publishableKey = "pk_test_123",
+            isLiveMode = false,
+        )
 
     @Test
     fun `isSupported is true when inner manager's isSupported is true`() = runScenario(isSupported = true) {
-        assertThat(retryConnectionManager.isSupported).isTrue()
+        assertThat(retryConnectionManager.isSupported("pk_test_123", false)).isTrue()
     }
 
     @Test
     fun `isSupported is false when inner manager's isSupported is false`() = runScenario(isSupported = false) {
-        assertThat(retryConnectionManager.isSupported).isFalse()
+        assertThat(retryConnectionManager.isSupported("pk_test_123", false)).isFalse()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
@@ -725,6 +726,7 @@ internal class DefaultPaymentElementLoaderTest {
                 assertThat(startCalls.awaitItem()).isEqualTo(
                     FakeTapToAddConnectionStarter.StartCall(
                         config = config.asCommonConfiguration(),
+                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                     )
                 )
 
@@ -775,6 +777,7 @@ internal class DefaultPaymentElementLoaderTest {
                 assertThat(startCalls.awaitItem()).isEqualTo(
                     FakeTapToAddConnectionStarter.StartCall(
                         config = config.asCommonConfiguration(),
+                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
                     )
                 )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultTapToAddAvailabilityFactoryTest.kt
@@ -29,6 +29,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isTrue()
     }
@@ -47,6 +49,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -65,6 +69,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = DEFAULT_CUSTOMER_METADATA,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }
@@ -83,6 +89,8 @@ internal class DefaultTapToAddAvailabilityFactoryTest {
                     ),
                 ),
                 customerMetadata = null,
+                publishableKey = "pk_test_123",
+                isLiveMode = false,
             )
         ).isFalse()
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddAvailabilityFactory.kt
@@ -9,5 +9,7 @@ internal class FakeTapToAddAvailabilityFactory(
     override fun isAvailable(
         elementsSession: ElementsSession,
         customerMetadata: CustomerMetadata?,
+        publishableKey: String,
+        isLiveMode: Boolean,
     ): Boolean = isAvailableResult
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeTapToAddConnectionStarter.kt
@@ -5,12 +5,14 @@ import app.cash.turbine.Turbine
 import com.stripe.android.common.model.CommonConfiguration
 
 internal class FakeTapToAddConnectionStarter private constructor(
-    override val isSupported: Boolean = false,
+    private val isSupportedValue: Boolean = false,
 ) : TapToAddConnectionStarter {
     private val startCalls: Turbine<StartCall> = Turbine()
 
-    override fun start(config: CommonConfiguration) {
-        startCalls.add(StartCall(config))
+    override fun isSupported(publishableKey: String, isLiveMode: Boolean): Boolean = isSupportedValue
+
+    override fun start(config: CommonConfiguration, publishableKey: String, isLiveMode: Boolean) {
+        startCalls.add(StartCall(config, publishableKey))
     }
 
     fun ensureAllEventsConsumed() {
@@ -18,7 +20,8 @@ internal class FakeTapToAddConnectionStarter private constructor(
     }
 
     data class StartCall(
-        val config: CommonConfiguration
+        val config: CommonConfiguration,
+        val publishableKey: String,
     )
 
     class Scenario(
@@ -45,6 +48,6 @@ internal class FakeTapToAddConnectionStarter private constructor(
 
         fun create(
             isSupported: Boolean = false,
-        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupported = isSupported)
+        ): FakeTapToAddConnectionStarter = FakeTapToAddConnectionStarter(isSupportedValue = isSupported)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/TapToAddConnectionStarterTest.kt
@@ -22,7 +22,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported).isTrue()
+        assertThat(starter.isSupported("pk_test_123", false)).isTrue()
     }
 
     @Test
@@ -34,7 +34,7 @@ internal class TapToAddConnectionStarterTest {
             coroutineContext = testDispatcher,
         )
 
-        assertThat(starter.isSupported).isFalse()
+        assertThat(starter.isSupported("pk_test_123", false)).isFalse()
     }
 
     @Test
@@ -50,13 +50,15 @@ internal class TapToAddConnectionStarterTest {
             merchantDisplayName = "Books & Things",
         )
 
-        starter.start(commonConfiguration)
+        starter.start(commonConfiguration, "pk_test_123", false)
         advanceUntilIdle()
 
         assertThat(manager.connectCalls.awaitItem()).isEqualTo(
             FakeTapToAddConnectionManager.ConnectCall(
                 config = TapToAddConnectionManager.ConnectionConfig(
                     merchantDisplayName = "Books & Things",
+                    publishableKey = "pk_test_123",
+                    isLiveMode = false,
                 ),
             )
         )


### PR DESCRIPTION
# Summary
Move Tap to Add API configuration resolution to the load-owned boundary and pass the resolved values through availability, connection, and collection flows.

Avoid retaining the PaymentSheet view model or callback retriever in Tap to Add connection state while preserving the temporary compatibility bindings needed at this stack layer.

Committed and created by Codex.

# Motivation
Tap to Add work can outlive the UI object that initiated it. Resolving credentials late from a retained view model or callback retriever both risks stale configuration and keeps UI state reachable after the test or Activity completes.

This layer gives Tap to Add the same load-scoped credential snapshot as PaymentSheet and narrows retained objects to the data required by the connection flow. The final cleanup layer removes the temporary compatibility module after all consumers migrate.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified — PaymentSheet leak regression passed with 2 and 50 Shampoo iterations, followed by a normal-rule run

# Screenshots
Not applicable — lifecycle and configuration plumbing only.

# Changelog
Not applicable — no public API or intended user-visible behavior change.