### PR TITLE
Complete CustomerSheet API configuration propagation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerAdapter.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.customersheet
 
 import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.customersheet.injection.DaggerStripeCustomerAdapterComponent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -124,6 +126,14 @@ interface CustomerAdapter {
                     customerEphemeralKeyProvider = customerEphemeralKeyProvider,
                     setupIntentClientSecretProvider = setupIntentClientSecretProvider,
                     paymentMethodTypes = paymentMethodTypes,
+                    apiConfigurationProvider = {
+                        PaymentConfiguration.getInstance(context).let {
+                            ApiConfiguration.State(
+                                publishableKey = it.publishableKey,
+                                stripeAccountId = it.stripeAccountId,
+                            )
+                        }
+                    },
                 )
             return component.stripeCustomerAdapter
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheet.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
@@ -604,6 +605,9 @@ class CustomerSheet internal constructor(
                         imageLoader = DefaultStripeImageLoader(application),
                         errorReporter = ErrorReporter.createFallbackInstance(
                             context = application,
+                            publishableKeyProvider = {
+                                PaymentConfiguration.getInstance(application.applicationContext).publishableKey
+                             },
                             productUsage = setOf("CustomerSheet"),
                         ),
                         context = application,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -1,9 +1,9 @@
 package com.stripe.android.customersheet
 
 import android.content.Context
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.model.PaymentMethod
@@ -33,6 +33,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     private val timeProvider: () -> Long,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: (CustomerEphemeralKey) -> PrefsRepository,
+    private val apiConfigurationProvider: () -> ApiConfiguration.State,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerAdapter {
 
@@ -72,7 +73,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 types = requestedTypes,
                 silentlyFail = false,
-                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -90,7 +91,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -108,7 +109,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -128,7 +129,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
                 params = params,
-                stripeAccountId = PaymentConfiguration.getInstance(context).stripeAccountId,
+                stripeAccountId = apiConfigurationProvider().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -12,6 +12,7 @@ import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSourc
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import com.stripe.android.customersheet.injection.CustomerSheetDataCommonModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiConfigurationToNamedModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
@@ -23,6 +24,7 @@ import javax.inject.Singleton
         CustomerAdapterDataSourceModule::class,
         CustomerSheetDataSourceCommonModule::class,
         CustomerSheetDataCommonModule::class,
+        ApiConfigurationToNamedModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -12,6 +12,7 @@ import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSourc
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import com.stripe.android.customersheet.injection.CustomerSheetDataCommonModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiConfigurationToNamedModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
@@ -23,6 +24,7 @@ import javax.inject.Singleton
         CustomerSessionDataSourceModule::class,
         CustomerSheetDataSourceCommonModule::class,
         CustomerSheetDataCommonModule::class,
+        ApiConfigurationToNamedModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSheetDataSourceCommonModule.kt
@@ -2,13 +2,11 @@ package com.stripe.android.customersheet.data.injection
 
 import android.app.Application
 import android.content.Context
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.StripeNetworkClientModule
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
 
 @Module(includes = [StripeNetworkClientModule::class])
 internal interface CustomerSheetDataSourceCommonModule {
@@ -19,11 +17,4 @@ internal interface CustomerSheetDataSourceCommonModule {
 
     @Binds
     fun bindsApplicationContext(application: Application): Context
-
-    companion object {
-        @Provides
-        fun provideApiConfigurationState(
-            apiConfigurationProvider: () -> ApiConfiguration.State
-        ): ApiConfiguration.State = apiConfigurationProvider()
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
@@ -6,8 +6,8 @@ import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
-import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
+import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import dagger.Binds

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetDataCommonModule.kt
@@ -7,7 +7,7 @@ import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.analytics.RealErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
+import com.stripe.android.payments.core.injection.ApiRequestOptionsModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import dagger.Binds
@@ -16,7 +16,7 @@ import dagger.Provides
 import java.util.Calendar
 import javax.inject.Named
 
-@Module(includes = [PaymentConfigurationModule::class])
+@Module(includes = [ApiRequestOptionsModule::class])
 internal interface CustomerSheetDataCommonModule {
     @Binds
     fun bindsCustomerRepository(repository: CustomerApiRepository): CustomerRepository

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.injection
 
 import android.content.Context
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.core.injection.IOContext
@@ -40,6 +41,7 @@ internal interface StripeCustomerAdapterComponent {
             @BindsInstance customerEphemeralKeyProvider: CustomerEphemeralKeyProvider,
             @BindsInstance setupIntentClientSecretProvider: SetupIntentClientSecretProvider?,
             @BindsInstance paymentMethodTypes: List<String>?,
+            @BindsInstance apiConfigurationProvider: () -> ApiConfiguration.State,
         ): StripeCustomerAdapterComponent
     }
 }
@@ -47,6 +49,11 @@ internal interface StripeCustomerAdapterComponent {
 @Module
 internal interface StripeCustomerAdapterModule {
     companion object {
+        @Provides
+        fun provideApiConfigurationState(
+            apiConfigurationProvider: () -> ApiConfiguration.State
+        ): ApiConfiguration.State = apiConfigurationProvider()
+
         @Provides
         fun providePrefsRepositoryFactory(
             appContext: Context,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -50,11 +50,6 @@ internal interface StripeCustomerAdapterComponent {
 internal interface StripeCustomerAdapterModule {
     companion object {
         @Provides
-        fun provideApiConfigurationState(
-            apiConfigurationProvider: () -> ApiConfiguration.State
-        ): ApiConfiguration.State = apiConfigurationProvider()
-
-        @Provides
         fun providePrefsRepositoryFactory(
             appContext: Context,
             @IOContext workContext: CoroutineContext

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -10,7 +10,7 @@ import com.stripe.android.customersheet.CustomerEphemeralKeyProvider
 import com.stripe.android.customersheet.SetupIntentClientSecretProvider
 import com.stripe.android.customersheet.StripeCustomerAdapter
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
-import com.stripe.android.payments.core.injection.ApiConfigurationToNamedModule
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -26,7 +26,7 @@ import kotlin.coroutines.CoroutineContext
     modules = [
         StripeCustomerAdapterModule::class,
         CustomerSheetDataCommonModule::class,
-        ApiConfigurationToNamedModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -10,6 +10,7 @@ import com.stripe.android.customersheet.CustomerEphemeralKeyProvider
 import com.stripe.android.customersheet.SetupIntentClientSecretProvider
 import com.stripe.android.customersheet.StripeCustomerAdapter
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiConfigurationToNamedModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -25,6 +26,7 @@ import kotlin.coroutines.CoroutineContext
     modules = [
         StripeCustomerAdapterModule::class,
         CustomerSheetDataCommonModule::class,
+        ApiConfigurationToNamedModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
@@ -197,6 +198,12 @@ class CustomerAdapterTest {
         val adapter = createAdapter(
             customerRepository = customerRepository,
             paymentMethodTypes = listOf("card"),
+            apiConfigurationProvider = {
+                ApiConfiguration.State(
+                    publishableKey = "pk_123",
+                    stripeAccountId = "acct_123",
+                )
+            },
         )
         adapter.retrievePaymentMethods()
         verify(customerRepository).getPaymentMethods(
@@ -208,7 +215,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
-            stripeAccountId = isNull()
+            stripeAccountId = eq("acct_123")
         )
     }
 
@@ -773,7 +780,7 @@ class CustomerAdapterTest {
         apiConfigurationProvider: () -> ApiConfiguration.State = {
             ApiConfiguration.State(
                 publishableKey = "pk_123",
-                stripeAccountId = "acct_123",
+                stripeAccountId = null,
             )
         },
     ): StripeCustomerAdapter {
@@ -785,6 +792,7 @@ class CustomerAdapterTest {
             timeProvider = timeProvider,
             customerRepository = customerRepository,
             prefsRepositoryFactory = prefsRepositoryFactory,
+            apiConfigurationProvider = apiConfigurationProvider,
             workContext = testDispatcher,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -770,6 +770,12 @@ class CustomerAdapterTest {
             FakePrefsRepository()
         },
         paymentMethodTypes: List<String>? = null,
+        apiConfigurationProvider: () -> ApiConfiguration.State = {
+            ApiConfiguration.State(
+                publishableKey = "pk_123",
+                stripeAccountId = "acct_123",
+            )
+        },
     ): StripeCustomerAdapter {
         return StripeCustomerAdapter(
             context = application,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -30,7 +30,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -192,7 +191,7 @@ class CustomerAdapterTest {
     fun `retrievePaymentMethods filters with paymentMethodTypes`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
-        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), isNull()))
+        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), any()))
             .thenReturn(Result.success(emptyList()))
 
         val adapter = createAdapter(
@@ -261,7 +260,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
-            stripeAccountId = isNull()
+            stripeAccountId = any()
         )
     }
 


### PR DESCRIPTION
# Summary
Complete CustomerSheet API configuration propagation through its loader, data sources, view-model graph, and StripeCustomerAdapter.

Inject paired ApiConfiguration state into the adapter rather than introducing another named Stripe-account binding, while retaining the compatibility bridge for public entry points that still initialize PaymentConfiguration.

Committed and created by Codex.

# Motivation
CustomerSheet and its adapter perform customer operations across multiple independently constructed graphs. Those operations need the same publishable-key and Stripe-account snapshot instead of resolving one value globally inside the repository.

This layer owns the CustomerSheet-specific wiring and keeps it out of the broader PaymentSheet migration. The final cleanup layer removes the compatibility bridge once every CustomerSheet path supplies state directly.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots
Not applicable — internal CustomerSheet wiring only.

# Changelog
Not applicable — no public API or intended user-visible behavior change.