### PR TITLE
Make CheckoutController.clearPaymentOption suspend

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import android.app.Application
 import android.graphics.drawable.Drawable
+import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.RestrictTo
@@ -283,18 +284,6 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
-    private fun requireMutableState(): kotlin.Result<Unit> {
-        stateHolder.state
-            ?: return kotlin.Result.failure(
-                IllegalStateException("Cannot mutate checkout session before it is configured.")
-            )
-        return if (sheetStateHolder.sheetIsOpen) {
-            integrationLaunchedFailure()
-        } else {
-            kotlin.Result.success(Unit)
-        }
-    }
-
     private fun integrationLaunchedFailure(): kotlin.Result<Nothing> = kotlin.Result.failure(
         IllegalStateException("Cannot mutate checkout session while a payment flow is presented.")
     )
@@ -338,18 +327,20 @@ class CheckoutController @Inject internal constructor(
      * Clears the customer's selected payment option, resetting it to `null`.
      *
      * Returns [kotlin.Result.failure] if the session hasn't been configured yet, a payment flow is
-     * currently presented, or another mutation or confirmation is in progress.
+     * currently presented.
      */
-    fun clearPaymentOption(): kotlin.Result<Unit> {
-        return requireMutableState().fold(
-            onSuccess = {
-                operationCoordinator.runSynchronousMutation {
-                    stateHolder.clearSelection()
-                    kotlin.Result.success(Unit)
-                }
+    suspend fun clearPaymentOption(): kotlin.Result<Unit> {
+        return withCheckoutState(
+            additionalStateMutations = {
+                copy(
+                    paymentSelection = null,
+                    temporarySelection = null,
+                    previousNewSelections = Bundle(),
+                )
             },
-            onFailure = { kotlin.Result.failure(it) },
-        )
+        ) {
+            kotlin.Result.success(checkoutSessionResponse)
+        }
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -85,15 +85,6 @@ internal class CheckoutControllerStateHolder @Inject constructor(
         return previousNewSelections.previousNewSelection(code)
     }
 
-    fun clearSelection() {
-        val current = requireState(operation = "clearSelection") ?: return
-        state = current.copy(
-            paymentSelection = null,
-            temporarySelection = null,
-            previousNewSelections = Bundle(),
-        )
-    }
-
     /**
      * The selection lives on [CheckoutControllerState], so the mutators can only act once
      * [CheckoutStateLoader] has committed a state. A call before then is a programming error (a

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -54,31 +54,6 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
-    fun <T> runSynchronousMutation(
-        block: () -> Result<T>,
-    ): Result<T> {
-        return synchronized(admissionLock) {
-            when {
-                confirmationInFlight -> Result.failure(
-                    IllegalStateException("Cannot mutate checkout session while confirmation is in progress.")
-                )
-                pendingMutations > 0 -> Result.failure(
-                    IllegalStateException("Cannot mutate checkout session while another mutation is in progress.")
-                )
-                else -> {
-                    check(mutex.tryLock()) {
-                        "Checkout operation gate should be available after synchronous mutation admission."
-                    }
-                    try {
-                        block()
-                    } finally {
-                        mutex.unlock()
-                    }
-                }
-            }
-        }
-    }
-
     fun tryBeginConfirmation(
         arguments: () -> ConfirmationHandler.Args?,
     ): ConfirmationHandler.Args? {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -121,30 +121,6 @@ internal class CheckoutControllerStateHolderTest {
         }
 
     @Test
-    fun `clearSelection resets selection, temporarySelection and previousNewSelections`() = testScenario {
-        stateHolder.state = committedState(
-            paymentSelection = PaymentSelection.GooglePay,
-            temporarySelection = "card",
-            previousNewSelections = Bundle().apply {
-                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-            },
-        )
-
-        stateHolder.selection.test {
-            assertThat(awaitItem()).isEqualTo(PaymentSelection.GooglePay)
-            stateHolder.clearSelection()
-            assertThat(awaitItem()).isNull()
-        }
-
-        val clearedState = requireNotNull(stateHolder.state)
-        assertThat(clearedState.paymentSelection).isNull()
-        assertThat(clearedState.temporarySelection).isNull()
-        assertThat(clearedState.previousNewSelections.isEmpty).isTrue()
-        assertThat(stateHolder.temporarySelection.value).isNull()
-        assertThat(stateHolder.getPreviousNewSelection("cashapp")).isNull()
-    }
-
-    @Test
     fun `selection setters no-op before the state is committed`() = testScenario {
         stateHolder.setSelection(PaymentSelection.GooglePay)
         assertSetBeforeLoadError(operation = "setSelection")
@@ -156,9 +132,6 @@ internal class CheckoutControllerStateHolderTest {
             Bundle().apply { putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION) },
         )
         assertSetBeforeLoadError(operation = "setPreviousNewSelections")
-
-        stateHolder.clearSelection()
-        assertSetBeforeLoadError(operation = "clearSelection")
 
         assertThat(stateHolder.state).isNull()
         assertThat(stateHolder.selection.value).isNull()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -399,25 +399,24 @@ internal class CheckoutControllerTest {
     }
 
     @Test
-    fun `clearPaymentOption clears paymentOptionDisplayData`() = runTest {
-        val savedStateHandle = parentHandleWithState(
-            CheckoutControllerStateFactory.create(
-                paymentSelection = PaymentSelection.GooglePay,
-                temporarySelection = "card",
-                previousNewSelections = Bundle().apply {
-                    putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-                },
-            )
-        )
-
-        val controller = createController(savedStateHandle)
+    fun `clearPaymentOption clears payment option state`() = runMutationScenario(
+        paymentSelection = PaymentSelection.GooglePay,
+        temporarySelection = "card",
+        previousNewSelections = Bundle().apply {
+            putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        },
+    ) {
         controller.session.test {
             assertThat(awaitItem()?.paymentOptionDisplayData).isNotNull()
 
-            assertThat(controller.clearPaymentOption().isSuccess).isTrue()
+            controller.clearPaymentOption().getOrThrow()
 
             assertThat(requireNotNull(awaitItem()).paymentOptionDisplayData).isNull()
         }
+        val clearedState = committedState()
+        assertThat(clearedState.paymentSelection).isNull()
+        assertThat(clearedState.temporarySelection).isNull()
+        assertThat(clearedState.previousNewSelections.isEmpty).isTrue()
     }
 
     @Test
@@ -446,7 +445,7 @@ internal class CheckoutControllerTest {
         }
 
     @Test
-    fun `clearPaymentOption returns failure and preserves selection while a mutation is in flight`() =
+    fun `clearPaymentOption waits for an in-flight mutation before clearing the selection`() =
         runMutationScenario(paymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION) {
             val holdResponse = CountDownLatch(1)
             networkRule.checkoutUpdate(
@@ -457,17 +456,15 @@ internal class CheckoutControllerTest {
             }
             val mutation = async { controller.applyPromotionCode("10OFF") }
             testScheduler.advanceUntilIdle()
+            val clearPaymentOption = async { controller.clearPaymentOption() }
+            testScheduler.advanceUntilIdle()
 
-            val result = controller.clearPaymentOption()
-
-            assertThat(result.isFailure).isTrue()
-            assertThat(result.exceptionOrNull()).hasMessageThat()
-                .isEqualTo("Cannot mutate checkout session while another mutation is in progress.")
             assertThat(controller.session.value?.paymentOptionDisplayData).isNotNull()
 
             holdResponse.countDown()
             assertThat(mutation.await().isSuccess).isTrue()
-            assertThat(controller.session.value?.paymentOptionDisplayData).isNotNull()
+            assertThat(clearPaymentOption.await().isSuccess).isTrue()
+            assertThat(controller.session.value?.paymentOptionDisplayData).isNull()
         }
 
     @Test
@@ -1243,6 +1240,8 @@ internal class CheckoutControllerTest {
     private fun runMutationScenario(
         initModifier: (JSONObject) -> Unit = {},
         paymentSelection: PaymentSelection? = null,
+        temporarySelection: String? = null,
+        previousNewSelections: Bundle = Bundle(),
         sheetIsOpen: Boolean = false,
         assertLoadingConsumed: Boolean = false,
         block: suspend MutationScenario.() -> Unit,
@@ -1257,6 +1256,10 @@ internal class CheckoutControllerTest {
         val controller = setup.controller
         controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
         paymentSelection?.let(setup.stateHolder::setSelection)
+        temporarySelection?.let(setup.stateHolder::setTemporarySelection)
+        if (!previousNewSelections.isEmpty) {
+            setup.stateHolder.setPreviousNewSelections(previousNewSelections)
+        }
         setup.sheetStateHolder.sheetIsOpen = sheetIsOpen
 
         turbineScope {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -359,7 +359,7 @@ internal class CheckoutOperationCoordinatorTest {
 
             resultTurbine.expectNoEvents()
             assertThat(coordinator.isUpdating.value).isFalse()
-            assertThat(coordinator.runSynchronousMutation { Result.success(Unit) }.isSuccess).isTrue()
+            assertThat(coordinator.runMutation { Result.success(Unit) }.isSuccess).isTrue()
         }
 
     @Test
@@ -377,7 +377,7 @@ internal class CheckoutOperationCoordinatorTest {
 
         resultTurbine.expectNoEvents()
         assertThat(coordinator.isUpdating.value).isFalse()
-        assertThat(coordinator.runSynchronousMutation { Result.success(Unit) }.isSuccess).isTrue()
+        assertThat(coordinator.runMutation { Result.success(Unit) }.isSuccess).isTrue()
     }
 
     @Test
@@ -731,61 +731,6 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
             assertThat(awaitItem()).isFalse()
         }
-    }
-
-    @Test
-    fun `synchronous mutation fails while confirmation is in flight`() = runScenario {
-        coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
-
-        val result = coordinator.runSynchronousMutation {
-            Result.success(Unit)
-        }
-
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).hasMessageThat()
-            .isEqualTo("Cannot mutate checkout session while confirmation is in progress.")
-    }
-
-    @Test
-    fun `synchronous mutation fails while asynchronous mutation is in flight`() = runScenario {
-        val mutationStarted = CompletableDeferred<Unit>()
-        val finishMutation = CompletableDeferred<Unit>()
-        val mutation = async {
-            coordinator.runMutation {
-                mutationStarted.complete(Unit)
-                finishMutation.await()
-                Result.success(Unit)
-            }
-        }
-        mutationStarted.await()
-        var synchronousMutationInvoked = false
-
-        val result = coordinator.runSynchronousMutation {
-            synchronousMutationInvoked = true
-            Result.success(Unit)
-        }
-
-        assertThat(result.isFailure).isTrue()
-        assertThat(result.exceptionOrNull()).hasMessageThat()
-            .isEqualTo("Cannot mutate checkout session while another mutation is in progress.")
-        assertThat(synchronousMutationInvoked).isFalse()
-
-        finishMutation.complete(Unit)
-        mutation.await()
-    }
-
-    @Test
-    fun `synchronous mutation executes and returns success when confirmation is not in flight`() = runScenario {
-        var invocationCount = 0
-
-        val result = coordinator.runSynchronousMutation {
-            invocationCount += 1
-            Result.success("updated")
-        }
-
-        assertThat(result.getOrThrow()).isEqualTo("updated")
-        assertThat(invocationCount).isEqualTo(1)
-        assertThat(coordinator.isUpdating.value).isFalse()
     }
 
     private fun runScenario(


### PR DESCRIPTION
# Summary
Make `CheckoutController.clearPaymentOption` a suspend function and route it through the standard serialized checkout mutation path. Remove the synchronous-only coordinator and state-holder workarounds that are no longer needed.

# Motivation
As a synchronous API, clearing the payment option needed a special non-suspending admission path and failed when another mutation was in progress. Making it suspend allows it to behave like the other CheckoutController mutations and wait for the operation gate.

https://stripe.slack.com/archives/C09MLFD2KU7/p1787940947549559

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutControllerTest' --tests 'com.stripe.android.checkout.CheckoutControllerStateHolderTest' --tests 'com.stripe.android.checkout.CheckoutOperationCoordinatorTest'`
- `./gradlew detekt`

No tests were newly ignored.

# Screenshots
Not applicable — this is a non-visual API and mutation-flow change.

# Changelog
Not applicable — `CheckoutController` is a preview, library-group API.

Committed and created by Codex.
