### PR TITLE
Configure Embedded Payment Element API credentials

### DIFF
--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1424,7 +1424,6 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun allowsDelayedPaymentMethods (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun allowsPaymentMethodsRequiringShippingAddress (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun allowsRemovalOfLastSavedPaymentMethod (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
-	public final fun apiConfiguration (Lcom/stripe/android/core/ApiConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun appearance (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun billingDetailsCollectionConfiguration (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun build ()Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1,3 +1,6 @@
+public abstract interface annotation class com/stripe/android/ApiConfigurationPreview : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class com/stripe/android/ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi : java/lang/annotation/Annotation {
 }
 
@@ -707,6 +710,7 @@ public final class com/stripe/android/paymentelement/EmbeddedPaymentElement$Conf
 	public final fun allowsDelayedPaymentMethods (Z)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun allowsPaymentMethodsRequiringShippingAddress (Z)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun allowsRemovalOfLastSavedPaymentMethod (Z)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
+	public final fun apiConfiguration (Lcom/stripe/android/core/ApiConfiguration;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun appearance (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun billingDetailsCollectionConfiguration (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration$Builder;
 	public final fun build ()Lcom/stripe/android/paymentelement/EmbeddedPaymentElement$Configuration;

--- a/paymentsheet/api/paymentsheet.api
+++ b/paymentsheet/api/paymentsheet.api
@@ -1424,6 +1424,7 @@ public final class com/stripe/android/paymentsheet/PaymentSheet$Configuration$Bu
 	public final fun allowsDelayedPaymentMethods (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun allowsPaymentMethodsRequiringShippingAddress (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun allowsRemovalOfLastSavedPaymentMethod (Z)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
+	public final fun apiConfiguration (Lcom/stripe/android/core/ApiConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun appearance (Lcom/stripe/android/paymentsheet/PaymentSheet$Appearance;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun billingDetailsCollectionConfiguration (Lcom/stripe/android/paymentsheet/PaymentSheet$BillingDetailsCollectionConfiguration;)Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration$Builder;
 	public final fun build ()Lcom/stripe/android/paymentsheet/PaymentSheet$Configuration;

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentelement
 import android.net.Uri
 import androidx.test.espresso.Espresso
 import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethod
@@ -20,6 +22,8 @@ import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.paymentsheet.clientAttributionMetadataParamsForDeferredIntent
 import com.stripe.android.paymentsheet.utils.GooglePayRepositoryTestRule
 import com.stripe.android.paymentsheet.utils.TestRules
@@ -32,9 +36,11 @@ import com.stripe.paymentelementtestpages.ManagePage
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalAnalyticEventCallbackApi::class)
+@RunWith(TestParameterInjector::class)
 internal class EmbeddedPaymentElementAnalyticsTest {
     private val networkRule = NetworkRule(
         hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
@@ -54,6 +60,9 @@ internal class EmbeddedPaymentElementAnalyticsTest {
     private val managePage = ManagePage(testRules.compose)
     private val editPage = EditPage(testRules.compose)
 
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    lateinit var apiConfigurationTestType: ApiConfigurationTestType
+
     private val card1 = CardPaymentMethodDetails("pm_12345", "4242")
     private val card2 = CardPaymentMethodDetails("pm_67890", "5544")
 
@@ -65,6 +74,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
     @Test
     fun testSuccessfulCardPayment() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -104,8 +114,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             analyticsPayloadField("payment_method_layout", "vertical")
         )
 
-        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
-        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        validateCardMetadataAnalyticsRequests()
         validateAnalyticsRequest(eventName = "mc_form_interacted")
         validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
@@ -178,6 +187,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
     @Test
     fun testSuccessfulCardPaymentWithConfirmationToken() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         builderInstance = EmbeddedPaymentElement.Builder(
             createIntentCallback = { _ ->
                 CreateIntentResult.Success("pi_example_secret_example")
@@ -204,8 +214,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_cardscan_api_check_failed")
         validateAnalyticsRequest(eventName = "mc_initial_displayed_payment_methods")
 
-        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
-        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        validateCardMetadataAnalyticsRequests()
         validateAnalyticsRequest(eventName = "mc_form_interacted")
         validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
@@ -277,6 +286,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
     @Test
     fun testCheckoutWithSavedCard() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -355,6 +365,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
     @Test
     fun testEditCard() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -416,6 +427,7 @@ internal class EmbeddedPaymentElementAnalyticsTest {
     @Test
     fun testRemoveCard() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -493,5 +505,23 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             requestMatchers = requestMatchers,
             publishableKey = TestApiKeys.PUBLISHABLE,
         )
+    }
+
+    private fun validateCardMetadataAnalyticsRequests() {
+        val paymentConfigurationPublishableKey = apiConfigurationTestType.paymentConfigurationPublishableKey
+        val eventName = if (paymentConfigurationPublishableKey == null) {
+            "stripe_android.card_metadata_pk_unavailable"
+        } else {
+            "stripe_android.card_metadata_pk_available"
+        }
+        val publishableKey = paymentConfigurationPublishableKey ?: ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY
+
+        repeat(2) {
+            networkRule.validateAnalyticsRequest(
+                eventName = eventName,
+                productUsage = setOf("EmbeddedPaymentElement"),
+                publishableKey = publishableKey,
+            )
+        }
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementAnalyticsTest.kt
@@ -114,7 +114,8 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             analyticsPayloadField("payment_method_layout", "vertical")
         )
 
-        validateCardMetadataAnalyticsRequests()
+        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
         validateAnalyticsRequest(eventName = "mc_form_interacted")
         validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
@@ -214,7 +215,8 @@ internal class EmbeddedPaymentElementAnalyticsTest {
         validateAnalyticsRequest(eventName = "mc_cardscan_api_check_failed")
         validateAnalyticsRequest(eventName = "mc_initial_displayed_payment_methods")
 
-        validateCardMetadataAnalyticsRequests()
+        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
+        validateAnalyticsRequest(eventName = "stripe_android.card_metadata_pk_available")
         validateAnalyticsRequest(eventName = "mc_form_interacted")
         validateAnalyticsRequest(eventName = "mc_card_number_completed")
 
@@ -505,23 +507,5 @@ internal class EmbeddedPaymentElementAnalyticsTest {
             requestMatchers = requestMatchers,
             publishableKey = TestApiKeys.PUBLISHABLE,
         )
-    }
-
-    private fun validateCardMetadataAnalyticsRequests() {
-        val paymentConfigurationPublishableKey = apiConfigurationTestType.paymentConfigurationPublishableKey
-        val eventName = if (paymentConfigurationPublishableKey == null) {
-            "stripe_android.card_metadata_pk_unavailable"
-        } else {
-            "stripe_android.card_metadata_pk_available"
-        }
-        val publishableKey = paymentConfigurationPublishableKey ?: ApiRequest.Options.UNDEFINED_PUBLISHABLE_KEY
-
-        repeat(2) {
-            networkRule.validateAnalyticsRequest(
-                eventName = eventName,
-                productUsage = setOf("EmbeddedPaymentElement"),
-                publishableKey = publishableKey,
-            )
-        }
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementBankIncentiveTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementBankIncentiveTest.kt
@@ -1,11 +1,15 @@
 package com.stripe.android.paymentelement
 
 import androidx.test.espresso.intent.rule.IntentsRule
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.UsBankAccountFormTestUtils
 import com.stripe.android.testing.FeatureFlagTestRule
@@ -14,7 +18,9 @@ import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(TestParameterInjector::class)
 internal class EmbeddedPaymentElementBankIncentiveTest {
     private val networkRule = NetworkRule()
 
@@ -28,9 +34,13 @@ internal class EmbeddedPaymentElementBankIncentiveTest {
     private val embeddedFormPage = EmbeddedFormPage(testRules.compose)
     private val formPage = FormPage(testRules.compose)
 
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    lateinit var apiConfigurationTestType: ApiConfigurationTestType
+
     @Test
     fun testIneligibleLinkedBankAccountRemovesHeaderIncentive() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_12345") },
         resultCallback = {},
     ) { testContext ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementImmediateActionRowSelectionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementImmediateActionRowSelectionTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentelement
 import androidx.test.espresso.Espresso
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.host
@@ -13,6 +15,8 @@ import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.paymentelementnetwork.CardPaymentMethodDetails
 import com.stripe.paymentelementnetwork.setupPaymentMethodDetachResponse
@@ -21,7 +25,9 @@ import com.stripe.paymentelementtestpages.EditPage
 import com.stripe.paymentelementtestpages.ManagePage
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(TestParameterInjector::class)
 internal class EmbeddedPaymentElementImmediateActionRowSelectionTest {
     private val networkRule = NetworkRule()
 
@@ -32,6 +38,9 @@ internal class EmbeddedPaymentElementImmediateActionRowSelectionTest {
     private val managePage = ManagePage(testRules.compose)
     private val editPage = EditPage(testRules.compose)
     private val formPage = EmbeddedFormPage(testRules.compose)
+
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    lateinit var apiConfigurationTestType: ApiConfigurationTestType
 
     private val card1 = CardPaymentMethodDetails("pm_12345", "4242")
     private val card2 = CardPaymentMethodDetails("pm_67890", "5544")
@@ -425,6 +434,7 @@ internal class EmbeddedPaymentElementImmediateActionRowSelectionTest {
         val rowSelectionCalls = Turbine<RowSelectionCall>()
         runEmbeddedPaymentElementTest(
             networkRule = networkRule,
+            apiConfigurationTestType = apiConfigurationTestType,
             createIntentCallback = { _, shouldSavePaymentMethod ->
                 assertThat(shouldSavePaymentMethod).isEqualTo(expectedShouldSavePaymentMethodValue)
                 CreateIntentResult.Success("pi_example_secret_12345")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementIndecisiveUserTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementIndecisiveUserTest.kt
@@ -4,6 +4,8 @@ import androidx.test.espresso.Espresso
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
@@ -15,6 +17,8 @@ import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.paymentelementnetwork.CardPaymentMethodDetails
 import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
@@ -23,7 +27,9 @@ import com.stripe.paymentelementtestpages.ManagePage
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(TestParameterInjector::class)
 internal class EmbeddedPaymentElementIndecisiveUserTest {
     private val networkRule = NetworkRule()
 
@@ -34,6 +40,9 @@ internal class EmbeddedPaymentElementIndecisiveUserTest {
     private val managePage = ManagePage(testRules.compose)
     private val editPage = EditPage(testRules.compose)
     private val formPage = EmbeddedFormPage(testRules.compose)
+
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    lateinit var apiConfigurationTestType: ApiConfigurationTestType
 
     private val card1 = CardPaymentMethodDetails("pm_12345", "4242")
     private val card2 = CardPaymentMethodDetails("pm_67890", "5544")
@@ -161,6 +170,7 @@ internal class EmbeddedPaymentElementIndecisiveUserTest {
         val resultCalls = Turbine<EmbeddedPaymentElement.Result>()
         runEmbeddedPaymentElementTest(
             networkRule = networkRule,
+            apiConfigurationTestType = apiConfigurationTestType,
             createIntentCallback = { _, shouldSavePaymentMethod ->
                 assertThat(shouldSavePaymentMethod).isFalse()
                 CreateIntentResult.Success("pi_example_secret_12345")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -15,6 +15,8 @@ import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.paymentelementnetwork.CardPaymentMethodDetails
 import com.stripe.paymentelementnetwork.setupPaymentMethodDetachResponse
@@ -40,8 +42,8 @@ internal class EmbeddedPaymentElementTest {
     private val editPage = EditPage(testRules.compose)
     private val formPage = EmbeddedFormPage(testRules.compose)
 
-    @TestParameter(valuesProvider = EmbeddedPaymentElementApiConfigurationTestTypeProvider::class)
-    lateinit var apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    lateinit var apiConfigurationTestType: ApiConfigurationTestType
 
     private val card1 = CardPaymentMethodDetails("pm_12345", "4242")
     private val card2 = CardPaymentMethodDetails("pm_67890", "5544")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentelement
 
 import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
@@ -24,7 +26,9 @@ import kotlinx.coroutines.withContext
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(TestParameterInjector::class)
 internal class EmbeddedPaymentElementTest {
     private val networkRule = NetworkRule()
 
@@ -35,6 +39,9 @@ internal class EmbeddedPaymentElementTest {
     private val managePage = ManagePage(testRules.compose)
     private val editPage = EditPage(testRules.compose)
     private val formPage = EmbeddedFormPage(testRules.compose)
+
+    @TestParameter(valuesProvider = EmbeddedPaymentElementApiConfigurationTestTypeProvider::class)
+    lateinit var apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType
 
     private val card1 = CardPaymentMethodDetails("pm_12345", "4242")
     private val card2 = CardPaymentMethodDetails("pm_67890", "5544")
@@ -55,6 +62,7 @@ internal class EmbeddedPaymentElementTest {
     @Test
     fun testSuccessfulCardPayment_withFormSheetActionConfirm() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -81,6 +89,7 @@ internal class EmbeddedPaymentElementTest {
     @Test
     fun testSuccessfulCardPayment_withFormSheetActionContinue() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -115,6 +124,7 @@ internal class EmbeddedPaymentElementTest {
     @Test
     fun testCardFormValidation() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -142,6 +152,7 @@ internal class EmbeddedPaymentElementTest {
     @Test
     fun testRemoveCard() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -180,6 +191,7 @@ internal class EmbeddedPaymentElementTest {
     @Test
     fun testRemoveCardPreservesPreviousSelection() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -221,6 +233,7 @@ internal class EmbeddedPaymentElementTest {
         // Instance 1
         runEmbeddedPaymentElementTest(
             networkRule = networkRule,
+            apiConfigurationTestType = apiConfigurationTestType,
             createIntentCallback = { _, shouldSavePaymentMethod ->
                 assertThat(shouldSavePaymentMethod).isFalse()
                 CreateIntentResult.Success("pi_example_secret_12345")
@@ -249,6 +262,7 @@ internal class EmbeddedPaymentElementTest {
         // Instance 2 - no network requests, no configure call -- just a state set.
         runEmbeddedPaymentElementTest(
             networkRule = networkRule,
+            apiConfigurationTestType = apiConfigurationTestType,
             createIntentCallback = { _, shouldSavePaymentMethod ->
                 assertThat(shouldSavePaymentMethod).isFalse()
                 CreateIntentResult.Success("pi_example_secret_12345")
@@ -269,6 +283,7 @@ internal class EmbeddedPaymentElementTest {
     @Test
     fun testEmbeddedPaymentElementDisplaysMandate() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -289,6 +304,7 @@ internal class EmbeddedPaymentElementTest {
     @Test
     fun testEmbeddedPaymentElementWithTermsDisplayNeverDoesNotDisplayMandate() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")
@@ -315,6 +331,7 @@ internal class EmbeddedPaymentElementTest {
     @Test
     fun testOBO_PassedToElementsSessionCall() = runEmbeddedPaymentElementTest(
         networkRule = networkRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = { _, shouldSavePaymentMethod ->
             assertThat(shouldSavePaymentMethod).isFalse()
             CreateIntentResult.Success("pi_example_secret_12345")

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTestRunner.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement
 
-import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
@@ -13,17 +12,14 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
-import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
 import com.stripe.android.ApiConfigurationPreview
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.account.DefaultLinkStore
 import com.stripe.android.networktesting.NetworkRule
-import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -34,7 +30,7 @@ internal class EmbeddedPaymentElementTestRunnerContext(
     val rowSelectionCalls: ReceiveTurbine<RowSelectionCall>,
     val paymentOptionTurbine: ReceiveTurbine<EmbeddedPaymentElement.PaymentOptionDisplayData?>,
     private val countDownLatch: CountDownLatch,
-    private val apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
+    private val apiConfigurationTestType: ApiConfigurationTestType,
 ) {
     suspend fun configure(
         intentConfiguration: PaymentSheet.IntentConfiguration = PaymentSheet.IntentConfiguration(
@@ -76,36 +72,13 @@ internal fun runEmbeddedPaymentElementTest(
     networkRule: NetworkRule,
     createIntentCallback: CreateIntentCallback,
     resultCallback: EmbeddedPaymentElement.ResultCallback,
+    apiConfigurationTestType: ApiConfigurationTestType,
     builder: EmbeddedPaymentElement.Builder.() -> Unit = {},
     successTimeoutSeconds: Long = 5L,
     rowSelectionCalls: ReceiveTurbine<RowSelectionCall> = Turbine(),
     block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
 ) {
-    runEmbeddedPaymentElementTestWithConfigurationType(
-        networkRule = networkRule,
-        builderInstance = EmbeddedPaymentElement.Builder(
-            createIntentCallback = createIntentCallback,
-            resultCallback = resultCallback,
-        ),
-        builder = builder,
-        successTimeoutSeconds = successTimeoutSeconds,
-        rowSelectionCalls = rowSelectionCalls,
-        apiConfigurationTestType = EmbeddedPaymentElementApiConfigurationTestType.PaymentConfigurationOnly,
-        block = block,
-    )
-}
-
-internal fun runEmbeddedPaymentElementTest(
-    networkRule: NetworkRule,
-    createIntentCallback: CreateIntentCallback,
-    resultCallback: EmbeddedPaymentElement.ResultCallback,
-    apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
-    builder: EmbeddedPaymentElement.Builder.() -> Unit = {},
-    successTimeoutSeconds: Long = 5L,
-    rowSelectionCalls: ReceiveTurbine<RowSelectionCall> = Turbine(),
-    block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
-) {
-    runEmbeddedPaymentElementTestWithConfigurationType(
+    runEmbeddedPaymentElementTest(
         networkRule = networkRule,
         builderInstance = EmbeddedPaymentElement.Builder(
             createIntentCallback = createIntentCallback,
@@ -120,54 +93,13 @@ internal fun runEmbeddedPaymentElementTest(
 }
 
 @OptIn(WalletButtonsPreview::class, SharedPaymentTokenSessionPreview::class)
-private fun runEmbeddedPaymentElementTestWithConfigurationType(
-    networkRule: NetworkRule,
-    builderInstance: EmbeddedPaymentElement.Builder,
-    builder: EmbeddedPaymentElement.Builder.() -> Unit,
-    successTimeoutSeconds: Long,
-    rowSelectionCalls: ReceiveTurbine<RowSelectionCall>,
-    apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
-    block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
-) {
-    runEmbeddedPaymentElementTest(
-        networkRule = networkRule,
-        builderInstance = builderInstance,
-        builder = builder,
-        successTimeoutSeconds = successTimeoutSeconds,
-        rowSelectionCalls = rowSelectionCalls,
-        apiConfigurationTestType = apiConfigurationTestType,
-        block = block,
-    )
-}
-
-@OptIn(WalletButtonsPreview::class, SharedPaymentTokenSessionPreview::class)
 internal fun runEmbeddedPaymentElementTest(
     networkRule: NetworkRule,
     builderInstance: EmbeddedPaymentElement.Builder,
+    apiConfigurationTestType: ApiConfigurationTestType,
     builder: EmbeddedPaymentElement.Builder.() -> Unit = {},
     successTimeoutSeconds: Long = 5L,
     rowSelectionCalls: ReceiveTurbine<RowSelectionCall> = Turbine(),
-    block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
-) {
-    runEmbeddedPaymentElementTest(
-        networkRule = networkRule,
-        builderInstance = builderInstance,
-        builder = builder,
-        successTimeoutSeconds = successTimeoutSeconds,
-        rowSelectionCalls = rowSelectionCalls,
-        apiConfigurationTestType = EmbeddedPaymentElementApiConfigurationTestType.PaymentConfigurationOnly,
-        block = block,
-    )
-}
-
-@OptIn(WalletButtonsPreview::class, SharedPaymentTokenSessionPreview::class)
-private fun runEmbeddedPaymentElementTest(
-    networkRule: NetworkRule,
-    builderInstance: EmbeddedPaymentElement.Builder,
-    builder: EmbeddedPaymentElement.Builder.() -> Unit,
-    successTimeoutSeconds: Long,
-    rowSelectionCalls: ReceiveTurbine<RowSelectionCall>,
-    apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
     block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
 ) {
     val countDownLatch = CountDownLatch(1)
@@ -234,20 +166,13 @@ private fun runEmbeddedPaymentElementTestInternal(
     countDownLatchTimeoutSeconds: Long,
     makeEmbeddedPaymentElement: (ComponentActivity) -> EmbeddedPaymentElement,
     rowSelectionCalls: ReceiveTurbine<RowSelectionCall>,
-    apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
+    apiConfigurationTestType: ApiConfigurationTestType,
     block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
 ) {
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
         scenario.moveToState(Lifecycle.State.CREATED)
         scenario.onActivity {
-            PaymentConfiguration.clearInstance()
-            it.getSharedPreferences(
-                PaymentConfiguration::class.java.canonicalName,
-                Context.MODE_PRIVATE,
-            ).edit().clear().commit()
-            apiConfigurationTestType.paymentConfigurationPublishableKey?.let { publishableKey ->
-                PaymentConfiguration.init(it, publishableKey)
-            }
+            apiConfigurationTestType.initializePaymentConfiguration(it)
             DefaultLinkStore(it.applicationContext).clear()
         }
 
@@ -292,33 +217,3 @@ data class RowSelectionCall(
     val paymentMethodType: String?,
     val paymentOptionLabel: String?,
 )
-
-internal sealed class EmbeddedPaymentElementApiConfigurationTestType(
-    val paymentConfigurationPublishableKey: String?,
-    val apiConfiguration: ApiConfiguration?,
-) {
-    data object PaymentConfigurationOnly : EmbeddedPaymentElementApiConfigurationTestType(
-        paymentConfigurationPublishableKey = TestApiKeys.PUBLISHABLE,
-        apiConfiguration = null,
-    )
-
-    data object ApiConfigurationOnly : EmbeddedPaymentElementApiConfigurationTestType(
-        paymentConfigurationPublishableKey = null,
-        apiConfiguration = ApiConfiguration(TestApiKeys.PUBLISHABLE),
-    )
-
-    data object ApiConfigurationOverridesPaymentConfiguration : EmbeddedPaymentElementApiConfigurationTestType(
-        paymentConfigurationPublishableKey = "pk_test_should_not_be_used",
-        apiConfiguration = ApiConfiguration(TestApiKeys.PUBLISHABLE),
-    )
-}
-
-internal object EmbeddedPaymentElementApiConfigurationTestTypeProvider : TestParameterValuesProvider() {
-    override fun provideValues(
-        context: Context?,
-    ): List<EmbeddedPaymentElementApiConfigurationTestType> = listOf(
-        EmbeddedPaymentElementApiConfigurationTestType.PaymentConfigurationOnly,
-        EmbeddedPaymentElementApiConfigurationTestType.ApiConfigurationOnly,
-        EmbeddedPaymentElementApiConfigurationTestType.ApiConfigurationOverridesPaymentConfiguration,
-    )
-}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTestRunner.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement
 
+import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
@@ -12,10 +13,14 @@ import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.account.DefaultLinkStore
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.MainActivity
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -23,11 +28,13 @@ import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+@OptIn(ApiConfigurationPreview::class)
 internal class EmbeddedPaymentElementTestRunnerContext(
     val embeddedPaymentElement: EmbeddedPaymentElement,
     val rowSelectionCalls: ReceiveTurbine<RowSelectionCall>,
     val paymentOptionTurbine: ReceiveTurbine<EmbeddedPaymentElement.PaymentOptionDisplayData?>,
     private val countDownLatch: CountDownLatch,
+    private val apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
 ) {
     suspend fun configure(
         intentConfiguration: PaymentSheet.IntentConfiguration = PaymentSheet.IntentConfiguration(
@@ -35,11 +42,13 @@ internal class EmbeddedPaymentElementTestRunnerContext(
         ),
         configurationMutator: EmbeddedPaymentElement.Configuration.Builder.() -> EmbeddedPaymentElement.Configuration.Builder = { this },
     ) {
+        val configurationBuilder = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+            .configurationMutator()
+        apiConfigurationTestType.apiConfiguration?.let(configurationBuilder::apiConfiguration)
+
         embeddedPaymentElement.configure(
             intentConfiguration = intentConfiguration,
-            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
-                .configurationMutator()
-                .build()
+            configuration = configurationBuilder.build()
         )
     }
 
@@ -72,7 +81,7 @@ internal fun runEmbeddedPaymentElementTest(
     rowSelectionCalls: ReceiveTurbine<RowSelectionCall> = Turbine(),
     block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
 ) {
-    runEmbeddedPaymentElementTest(
+    runEmbeddedPaymentElementTestWithConfigurationType(
         networkRule = networkRule,
         builderInstance = EmbeddedPaymentElement.Builder(
             createIntentCallback = createIntentCallback,
@@ -81,6 +90,52 @@ internal fun runEmbeddedPaymentElementTest(
         builder = builder,
         successTimeoutSeconds = successTimeoutSeconds,
         rowSelectionCalls = rowSelectionCalls,
+        apiConfigurationTestType = EmbeddedPaymentElementApiConfigurationTestType.PaymentConfigurationOnly,
+        block = block,
+    )
+}
+
+internal fun runEmbeddedPaymentElementTest(
+    networkRule: NetworkRule,
+    createIntentCallback: CreateIntentCallback,
+    resultCallback: EmbeddedPaymentElement.ResultCallback,
+    apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
+    builder: EmbeddedPaymentElement.Builder.() -> Unit = {},
+    successTimeoutSeconds: Long = 5L,
+    rowSelectionCalls: ReceiveTurbine<RowSelectionCall> = Turbine(),
+    block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
+) {
+    runEmbeddedPaymentElementTestWithConfigurationType(
+        networkRule = networkRule,
+        builderInstance = EmbeddedPaymentElement.Builder(
+            createIntentCallback = createIntentCallback,
+            resultCallback = resultCallback,
+        ),
+        builder = builder,
+        successTimeoutSeconds = successTimeoutSeconds,
+        rowSelectionCalls = rowSelectionCalls,
+        apiConfigurationTestType = apiConfigurationTestType,
+        block = block,
+    )
+}
+
+@OptIn(WalletButtonsPreview::class, SharedPaymentTokenSessionPreview::class)
+private fun runEmbeddedPaymentElementTestWithConfigurationType(
+    networkRule: NetworkRule,
+    builderInstance: EmbeddedPaymentElement.Builder,
+    builder: EmbeddedPaymentElement.Builder.() -> Unit,
+    successTimeoutSeconds: Long,
+    rowSelectionCalls: ReceiveTurbine<RowSelectionCall>,
+    apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
+    block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
+) {
+    runEmbeddedPaymentElementTest(
+        networkRule = networkRule,
+        builderInstance = builderInstance,
+        builder = builder,
+        successTimeoutSeconds = successTimeoutSeconds,
+        rowSelectionCalls = rowSelectionCalls,
+        apiConfigurationTestType = apiConfigurationTestType,
         block = block,
     )
 }
@@ -92,6 +147,27 @@ internal fun runEmbeddedPaymentElementTest(
     builder: EmbeddedPaymentElement.Builder.() -> Unit = {},
     successTimeoutSeconds: Long = 5L,
     rowSelectionCalls: ReceiveTurbine<RowSelectionCall> = Turbine(),
+    block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
+) {
+    runEmbeddedPaymentElementTest(
+        networkRule = networkRule,
+        builderInstance = builderInstance,
+        builder = builder,
+        successTimeoutSeconds = successTimeoutSeconds,
+        rowSelectionCalls = rowSelectionCalls,
+        apiConfigurationTestType = EmbeddedPaymentElementApiConfigurationTestType.PaymentConfigurationOnly,
+        block = block,
+    )
+}
+
+@OptIn(WalletButtonsPreview::class, SharedPaymentTokenSessionPreview::class)
+private fun runEmbeddedPaymentElementTest(
+    networkRule: NetworkRule,
+    builderInstance: EmbeddedPaymentElement.Builder,
+    builder: EmbeddedPaymentElement.Builder.() -> Unit,
+    successTimeoutSeconds: Long,
+    rowSelectionCalls: ReceiveTurbine<RowSelectionCall>,
+    apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
     block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
 ) {
     val countDownLatch = CountDownLatch(1)
@@ -147,6 +223,7 @@ internal fun runEmbeddedPaymentElementTest(
         countDownLatchTimeoutSeconds = successTimeoutSeconds,
         makeEmbeddedPaymentElement = factory,
         rowSelectionCalls = rowSelectionCalls,
+        apiConfigurationTestType = apiConfigurationTestType,
         block = block,
     )
 }
@@ -157,12 +234,20 @@ private fun runEmbeddedPaymentElementTestInternal(
     countDownLatchTimeoutSeconds: Long,
     makeEmbeddedPaymentElement: (ComponentActivity) -> EmbeddedPaymentElement,
     rowSelectionCalls: ReceiveTurbine<RowSelectionCall>,
+    apiConfigurationTestType: EmbeddedPaymentElementApiConfigurationTestType,
     block: suspend (EmbeddedPaymentElementTestRunnerContext) -> Unit,
 ) {
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
         scenario.moveToState(Lifecycle.State.CREATED)
         scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
+            PaymentConfiguration.clearInstance()
+            it.getSharedPreferences(
+                PaymentConfiguration::class.java.canonicalName,
+                Context.MODE_PRIVATE,
+            ).edit().clear().commit()
+            apiConfigurationTestType.paymentConfigurationPublishableKey?.let { publishableKey ->
+                PaymentConfiguration.init(it, publishableKey)
+            }
             DefaultLinkStore(it.applicationContext).clear()
         }
 
@@ -184,6 +269,7 @@ private fun runEmbeddedPaymentElementTestInternal(
                     rowSelectionCalls = rowSelectionCalls,
                     paymentOptionTurbine = paymentOptionTurbine,
                     countDownLatch = countDownLatch,
+                    apiConfigurationTestType = apiConfigurationTestType,
                 )
                 block(testContext)
 
@@ -206,3 +292,33 @@ data class RowSelectionCall(
     val paymentMethodType: String?,
     val paymentOptionLabel: String?,
 )
+
+internal sealed class EmbeddedPaymentElementApiConfigurationTestType(
+    val paymentConfigurationPublishableKey: String?,
+    val apiConfiguration: ApiConfiguration?,
+) {
+    data object PaymentConfigurationOnly : EmbeddedPaymentElementApiConfigurationTestType(
+        paymentConfigurationPublishableKey = TestApiKeys.PUBLISHABLE,
+        apiConfiguration = null,
+    )
+
+    data object ApiConfigurationOnly : EmbeddedPaymentElementApiConfigurationTestType(
+        paymentConfigurationPublishableKey = null,
+        apiConfiguration = ApiConfiguration(TestApiKeys.PUBLISHABLE),
+    )
+
+    data object ApiConfigurationOverridesPaymentConfiguration : EmbeddedPaymentElementApiConfigurationTestType(
+        paymentConfigurationPublishableKey = "pk_test_should_not_be_used",
+        apiConfiguration = ApiConfiguration(TestApiKeys.PUBLISHABLE),
+    )
+}
+
+internal object EmbeddedPaymentElementApiConfigurationTestTypeProvider : TestParameterValuesProvider() {
+    override fun provideValues(
+        context: Context?,
+    ): List<EmbeddedPaymentElementApiConfigurationTestType> = listOf(
+        EmbeddedPaymentElementApiConfigurationTestType.PaymentConfigurationOnly,
+        EmbeddedPaymentElementApiConfigurationTestType.ApiConfigurationOnly,
+        EmbeddedPaymentElementApiConfigurationTestType.ApiConfigurationOverridesPaymentConfiguration,
+    )
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationTestRunner.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentelement.nfcscan
 import androidx.compose.ui.test.junit4.ComposeTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.assertCompleted as assertEmbeddedCompleted
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
 import com.stripe.android.paymentelement.runEmbeddedPaymentElementTest
 import com.stripe.android.paymentsheet.CreateIntentCallback
 import com.stripe.android.paymentsheet.CreateIntentResult
@@ -14,11 +15,13 @@ internal fun runNfcScanningIntegrationTest(
     networkRule: NetworkRule,
     composeTestRule: ComposeTestRule,
     integrationType: NfcScanningIntegrationType,
+    apiConfigurationTestType: ApiConfigurationTestType,
     block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
 ) {
     integrationType.runner.run(
         networkRule = networkRule,
         composeTestRule = composeTestRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         block = block,
     )
 }
@@ -27,11 +30,13 @@ internal sealed class NfcScanningIntegrationTestRunner {
     fun run(
         networkRule: NetworkRule,
         composeTestRule: ComposeTestRule,
+        apiConfigurationTestType: ApiConfigurationTestType,
         block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
     ) {
         runTest(
             networkRule = networkRule,
             composeTestRule = composeTestRule,
+            apiConfigurationTestType = apiConfigurationTestType,
             block = block,
         )
     }
@@ -39,6 +44,7 @@ internal sealed class NfcScanningIntegrationTestRunner {
     protected abstract fun runTest(
         networkRule: NetworkRule,
         composeTestRule: ComposeTestRule,
+        apiConfigurationTestType: ApiConfigurationTestType,
         block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
     )
 
@@ -46,10 +52,12 @@ internal sealed class NfcScanningIntegrationTestRunner {
         override fun runTest(
             networkRule: NetworkRule,
             composeTestRule: ComposeTestRule,
+            apiConfigurationTestType: ApiConfigurationTestType,
             block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
         ) {
             runPaymentSheetTest(
                 networkRule = networkRule,
+                apiConfigurationTestType = apiConfigurationTestType,
                 builder = {
                     createIntentCallback(NfcScanningIntegrationTestRunner.createIntentCallback)
                 },
@@ -69,10 +77,12 @@ internal sealed class NfcScanningIntegrationTestRunner {
         override fun runTest(
             networkRule: NetworkRule,
             composeTestRule: ComposeTestRule,
+            apiConfigurationTestType: ApiConfigurationTestType,
             block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
         ) {
             runFlowControllerTest(
                 networkRule = networkRule,
+                apiConfigurationTestType = apiConfigurationTestType,
                 builder = {
                     createIntentCallback(NfcScanningIntegrationTestRunner.createIntentCallback)
                 },
@@ -92,10 +102,12 @@ internal sealed class NfcScanningIntegrationTestRunner {
         override fun runTest(
             networkRule: NetworkRule,
             composeTestRule: ComposeTestRule,
+            apiConfigurationTestType: ApiConfigurationTestType,
             block: suspend NfcScanningIntegrationTestRunnerContext.() -> Unit,
         ) {
             runEmbeddedPaymentElementTest(
                 networkRule = networkRule,
+                apiConfigurationTestType = apiConfigurationTestType,
                 createIntentCallback = createIntentCallback,
                 resultCallback = ::assertEmbeddedCompleted,
             ) { context ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningIntegrationTestRunnerContext.kt
@@ -64,7 +64,7 @@ internal sealed class NfcScanningIntegrationTestRunnerContext(
                 context.presentPaymentSheet {
                     presentWithIntentConfiguration(
                         intentConfiguration = intentConfiguration,
-                        configuration = configuration,
+                        configuration = context.apiConfigurationTestType.applyTo(configuration),
                     )
                 }
             }
@@ -82,7 +82,7 @@ internal sealed class NfcScanningIntegrationTestRunnerContext(
                 context.configureFlowController {
                     configureWithIntentConfiguration(
                         intentConfiguration = intentConfiguration,
-                        configuration = configuration,
+                        configuration = context.apiConfigurationTestType.applyTo(configuration),
                         callback = { success, error ->
                             assertThat(success).isTrue()
                             assertThat(error).isNull()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/nfcscan/NfcScanningTest.kt
@@ -11,6 +11,8 @@ import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.testing.FeatureFlagTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -37,8 +39,11 @@ internal class NfcScanningTest {
     fun success(
         @TestParameter(valuesProvider = NfcScanningIntegrationType.Provider::class)
         integrationType: NfcScanningIntegrationType,
+        @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+        apiConfigurationTestType: ApiConfigurationTestType,
     ) = runNfcScanningIntegrationTest(
         integrationType = integrationType,
+        apiConfigurationTestType = apiConfigurationTestType,
         composeTestRule = composeTestRule,
         networkRule = networkRule,
     ) {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunner.kt
@@ -4,6 +4,7 @@ import androidx.compose.ui.test.junit4.ComposeTestRule
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.CreateCardPresentSetupIntentCallback
 import com.stripe.android.paymentelement.EmbeddedPaymentElementTestRunnerContext
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
 import com.stripe.android.paymentelement.TapToAddPreview
 import com.stripe.android.paymentelement.runEmbeddedPaymentElementTest
 import com.stripe.android.paymentsheet.CreateIntentCallback
@@ -15,6 +16,7 @@ internal fun runTapToAddIntegrationTest(
     networkRule: NetworkRule,
     composeTestRule: ComposeTestRule,
     integrationType: TapToAddIntegrationType,
+    apiConfigurationTestType: ApiConfigurationTestType,
     createIntentCallback: CreateIntentCallback,
     createCardPresentCallback: CreateCardPresentSetupIntentCallback,
     resultCallback: TapToAddResultTestCallback,
@@ -23,6 +25,7 @@ internal fun runTapToAddIntegrationTest(
     integrationType.runner.run(
         networkRule = networkRule,
         composeTestRule = composeTestRule,
+        apiConfigurationTestType = apiConfigurationTestType,
         createIntentCallback = createIntentCallback,
         createCardPresentSetupIntentCallback = createCardPresentCallback,
         resultCallback = resultCallback,
@@ -35,6 +38,7 @@ internal sealed class TapToAddIntegrationTestRunner {
     fun run(
         networkRule: NetworkRule,
         composeTestRule: ComposeTestRule,
+        apiConfigurationTestType: ApiConfigurationTestType,
         createIntentCallback: CreateIntentCallback,
         createCardPresentSetupIntentCallback: CreateCardPresentSetupIntentCallback,
         resultCallback: TapToAddResultTestCallback,
@@ -47,6 +51,7 @@ internal sealed class TapToAddIntegrationTestRunner {
         runTest(
             networkRule = networkRule,
             composeTestRule = composeTestRule,
+            apiConfigurationTestType = apiConfigurationTestType,
             integrationBuilder = integrationBuilder,
             resultCallback = resultCallback,
             block = block,
@@ -56,6 +61,7 @@ internal sealed class TapToAddIntegrationTestRunner {
     protected abstract fun runTest(
         networkRule: NetworkRule,
         composeTestRule: ComposeTestRule,
+        apiConfigurationTestType: ApiConfigurationTestType,
         integrationBuilder: TapToAddIntegrationBuilder,
         resultCallback: TapToAddResultTestCallback,
         block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit
@@ -65,12 +71,14 @@ internal sealed class TapToAddIntegrationTestRunner {
         override fun runTest(
             networkRule: NetworkRule,
             composeTestRule: ComposeTestRule,
+            apiConfigurationTestType: ApiConfigurationTestType,
             integrationBuilder: TapToAddIntegrationBuilder,
             resultCallback: TapToAddResultTestCallback,
             block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit
         ) {
             runPaymentSheetTest(
                 networkRule = networkRule,
+                apiConfigurationTestType = apiConfigurationTestType,
                 builder = {
                     integrationBuilder.applyToPaymentSheetBuilder(this)
                 },
@@ -87,12 +95,14 @@ internal sealed class TapToAddIntegrationTestRunner {
         override fun runTest(
             networkRule: NetworkRule,
             composeTestRule: ComposeTestRule,
+            apiConfigurationTestType: ApiConfigurationTestType,
             integrationBuilder: TapToAddIntegrationBuilder,
             resultCallback: TapToAddResultTestCallback,
             block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit
         ) {
             runFlowControllerTest(
                 networkRule = networkRule,
+                apiConfigurationTestType = apiConfigurationTestType,
                 callConfirmOnPaymentOptionCallback = false,
                 builder = {
                     integrationBuilder.applyToFlowControllerBuilder(this)
@@ -117,12 +127,14 @@ internal sealed class TapToAddIntegrationTestRunner {
         override fun runTest(
             networkRule: NetworkRule,
             composeTestRule: ComposeTestRule,
+            apiConfigurationTestType: ApiConfigurationTestType,
             integrationBuilder: TapToAddIntegrationBuilder,
             resultCallback: TapToAddResultTestCallback,
             block: suspend TapToAddIntegrationTestRunnerContext.() -> Unit
         ) {
             runEmbeddedPaymentElementTest(
                 networkRule = networkRule,
+                apiConfigurationTestType = apiConfigurationTestType,
                 builder = {
                     integrationBuilder.applyToEmbeddedBuilder(this)
                 },

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddIntegrationTestRunnerContext.kt
@@ -73,7 +73,7 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
                 context.presentPaymentSheet {
                     presentWithIntentConfiguration(
                         intentConfiguration = intentConfiguration,
-                        configuration = configuration,
+                        configuration = context.apiConfigurationTestType.applyTo(configuration),
                     )
                 }
             }
@@ -95,7 +95,7 @@ internal sealed class TapToAddIntegrationTestRunnerContext(
                 context.configureFlowController {
                     configureWithIntentConfiguration(
                         intentConfiguration = intentConfiguration,
-                        configuration = configuration,
+                        configuration = context.apiConfigurationTestType.applyTo(configuration),
                         callback = { success, error ->
                             assertThat(success).isTrue()
                             assertThat(error).isNull()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/taptoadd/TapToAddTest.kt
@@ -12,6 +12,8 @@ import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.TapToAddPreview
 import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.paymentsheet.utils.TerminalWrapperTestRule
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.tta.testing.TapToAddCardAddedPage
@@ -62,9 +64,12 @@ internal class TapToAddTest {
     @Test
     fun successWithCompleteMode(
         @TestParameter(valuesProvider = TapToAddIntegrationType.Complete.Provider::class)
-        integrationType: TapToAddIntegrationType.Complete
+        integrationType: TapToAddIntegrationType.Complete,
+        @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+        apiConfigurationTestType: ApiConfigurationTestType,
     ) = runTapToAddIntegrationTest(
         integrationType = integrationType,
+        apiConfigurationTestType = apiConfigurationTestType,
         composeTestRule = composeTestRule,
         networkRule = networkRule,
         createIntentCallback = { _, _ ->
@@ -99,9 +104,12 @@ internal class TapToAddTest {
     @Test
     fun successWithContinueMode(
         @TestParameter(valuesProvider = TapToAddIntegrationType.Continue.Provider::class)
-        integrationType: TapToAddIntegrationType.Continue
+        integrationType: TapToAddIntegrationType.Continue,
+        @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+        apiConfigurationTestType: ApiConfigurationTestType,
     ) = runTapToAddIntegrationTest(
         integrationType = integrationType,
+        apiConfigurationTestType = apiConfigurationTestType,
         composeTestRule = composeTestRule,
         networkRule = networkRule,
         createIntentCallback = { _, _ ->
@@ -137,9 +145,12 @@ internal class TapToAddTest {
     @Test
     fun canceledDuringCardCollection(
         @TestParameter(valuesProvider = TapToAddIntegrationType.Provider::class)
-        integrationType: TapToAddIntegrationType
+        integrationType: TapToAddIntegrationType,
+        @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+        apiConfigurationTestType: ApiConfigurationTestType,
     ) = runTapToAddIntegrationTest(
         integrationType = integrationType,
+        apiConfigurationTestType = apiConfigurationTestType,
         composeTestRule = composeTestRule,
         networkRule = networkRule,
         createIntentCallback = { _, _ ->
@@ -181,8 +192,11 @@ internal class TapToAddTest {
     fun successAfterCancelAfterCardCollectedWithCompleteMode(
         @TestParameter(valuesProvider = TapToAddIntegrationType.Complete.Provider::class)
         integrationType: TapToAddIntegrationType.Complete,
+        @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+        apiConfigurationTestType: ApiConfigurationTestType,
     ) = runTapToAddIntegrationTest(
         integrationType = integrationType,
+        apiConfigurationTestType = apiConfigurationTestType,
         composeTestRule = composeTestRule,
         networkRule = networkRule,
         createIntentCallback = { _, _ ->
@@ -225,9 +239,12 @@ internal class TapToAddTest {
     @Test
     fun successAfterCancelAfterCardCollectedWithLink(
         @TestParameter(valuesProvider = TapToAddIntegrationType.Provider::class)
-        integrationType: TapToAddIntegrationType
+        integrationType: TapToAddIntegrationType,
+        @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+        apiConfigurationTestType: ApiConfigurationTestType,
     ) = runTapToAddIntegrationTest(
         integrationType = integrationType,
+        apiConfigurationTestType = apiConfigurationTestType,
         composeTestRule = composeTestRule,
         networkRule = networkRule,
         createIntentCallback = { _, _ ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CardNumberControllerNetworkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CardNumberControllerNetworkTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet
 
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -20,7 +22,10 @@ import kotlin.time.Duration.Companion.seconds
 
 @OptIn(CardFundingFilteringPrivatePreview::class)
 @RunWith(TestParameterInjector::class)
-internal class CardNumberControllerNetworkTest {
+internal class CardNumberControllerNetworkTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     // The card-metadata request happens async during card number input. We want to make sure it happens,
     // but it's okay if it takes a bit to happen.
     private val networkRule = NetworkRule(validationTimeout = 5.seconds)
@@ -37,6 +42,7 @@ internal class CardNumberControllerNetworkTest {
 
     @Test
     fun testNoCardMetadataRequestWhenAllFundingTypesAllowed() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -54,7 +60,7 @@ internal class CardNumberControllerNetworkTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = configuration,
+                configuration = apiConfigurationTestType.applyTo(configuration),
             )
         }
 
@@ -74,6 +80,7 @@ internal class CardNumberControllerNetworkTest {
 
     @Test
     fun testCardMetadataRequestMadeWhenFundingTypesRestricted() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -91,7 +98,7 @@ internal class CardNumberControllerNetworkTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = configuration,
+                configuration = apiConfigurationTestType.applyTo(configuration),
             )
         }
 
@@ -123,6 +130,7 @@ internal class CardNumberControllerNetworkTest {
 
     @Test
     fun testNoWarningForAllowedFundingWithNetworkRequest() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -140,7 +148,7 @@ internal class CardNumberControllerNetworkTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = configuration,
+                configuration = apiConfigurationTestType.applyTo(configuration),
             )
         }
 
@@ -170,6 +178,7 @@ internal class CardNumberControllerNetworkTest {
 
     @Test
     fun testNoCardMetadataRequestWhenServerFlagDisabled() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -197,7 +206,7 @@ internal class CardNumberControllerNetworkTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = configuration,
+                configuration = apiConfigurationTestType.applyTo(configuration),
             )
         }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ConfirmWithAttestationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/ConfirmWithAttestationTest.kt
@@ -1,11 +1,15 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
 import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.attestation.AttestationActivityContract
 import com.stripe.android.attestation.AttestationActivityResult
 
@@ -24,9 +28,14 @@ import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.junit.rules.RuleChain
 
-internal class ConfirmWithAttestationTest {
+@RunWith(TestParameterInjector::class)
+internal class ConfirmWithAttestationTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val testRules: TestRules = TestRules.create()
 
     @get:Rule
@@ -39,6 +48,7 @@ internal class ConfirmWithAttestationTest {
     @Test
     fun newPaymentMethod_withAttestationEnabled_includesAndroidVerificationObjectInConfirmRequest() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = ProductIntegrationType.PaymentSheet,
             resultCallback = ::assertCompleted,
@@ -49,6 +59,7 @@ internal class ConfirmWithAttestationTest {
     @Test
     fun paymentMethodCreation_withAttestationEnabled_includesAndroidVerificationObjectInCreateRequest() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = ProductIntegrationType.PaymentSheet,
             resultCallback = ::assertCompleted,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsAnalyticsTest.kt
@@ -1,9 +1,13 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import android.content.Context
 import android.net.Uri
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.networktesting.AdvancedFraudSignalsTestRule
@@ -24,8 +28,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.time.Duration.Companion.seconds
 
-@RunWith(AndroidJUnit4::class)
-class CustomPaymentMethodsAnalyticsTest {
+@RunWith(TestParameterInjector::class)
+internal class CustomPaymentMethodsAnalyticsTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val networkRule = NetworkRule(
         hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
         validationTimeout = 5.seconds, // Analytics requests happen async.
@@ -42,6 +49,7 @@ class CustomPaymentMethodsAnalyticsTest {
 
     @Test
     fun testSuccessful() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = IntegrationType.Compose,
         builder = {
@@ -76,7 +84,7 @@ class CustomPaymentMethodsAnalyticsTest {
         context.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration.Builder(merchantDisplayName = "Merchant, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(merchantDisplayName = "Merchant, Inc.")
                     .customPaymentMethods(
                         listOf(
                             PaymentSheet.CustomPaymentMethod(
@@ -88,7 +96,7 @@ class CustomPaymentMethodsAnalyticsTest {
                     )
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
                     .paymentMethodOrder(listOf("cpmt_123", "card"))
-                    .build()
+                    .build())
             )
         }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomPaymentMethodsTest.kt
@@ -5,6 +5,8 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
@@ -23,7 +25,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class CustomPaymentMethodsTest {
+internal class CustomPaymentMethodsTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     @get:Rule
     val testRules: TestRules = TestRules.create()
 
@@ -50,6 +55,7 @@ internal class CustomPaymentMethodsTest {
         var confirmedBillingDetails: PaymentMethod.BillingDetails? = null
 
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             builder = {
@@ -107,6 +113,7 @@ internal class CustomPaymentMethodsTest {
         var confirmedBillingDetails: PaymentMethod.BillingDetails? = null
 
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             builder = {
@@ -183,6 +190,7 @@ internal class CustomPaymentMethodsTest {
         var confirmedBillingDetails: PaymentMethod.BillingDetails? = null
 
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             builder = {
@@ -246,6 +254,7 @@ internal class CustomPaymentMethodsTest {
 
         runEmbeddedPaymentElementTest(
             networkRule = networkRule,
+            apiConfigurationTestType = apiConfigurationTestType,
             builder = {
                 confirmCustomPaymentMethodCallback { customPaymentMethod, billingDetails ->
                     calledConfirmCallback = true

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsConfirmationTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentsheet
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.paymentsheet.utils.ConfirmationType
 import com.stripe.android.paymentsheet.utils.ConfirmationTypeProvider
 import com.stripe.android.paymentsheet.utils.DefaultPaymentMethodsUtils
@@ -24,7 +26,10 @@ import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class DefaultPaymentMethodsConfirmationTest {
+internal class DefaultPaymentMethodsConfirmationTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val testRules: TestRules = TestRules.create()
 
     @get:Rule
@@ -49,6 +54,7 @@ internal class DefaultPaymentMethodsConfirmationTest {
 
     @Test
     fun setNewPMAsDefault_withSavedPaymentMethods_sendsSetAsDefaultParamInConfirmCall() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             confirmationType.createIntentCallback?.let {
@@ -102,6 +108,7 @@ internal class DefaultPaymentMethodsConfirmationTest {
     @Test
     fun setNewPMAsDefault_withSavedPaymentMethods_uncheckSetAsDefault_doesNotSendSetAsDefaultParamInConfirmCall() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             builder = {
                 confirmationType.createIntentCallback?.let {
@@ -152,6 +159,7 @@ internal class DefaultPaymentMethodsConfirmationTest {
     @Test
     fun setNewPMAsDefault_withSavedPaymentMethods_uncheckSaveForFuture_doesNotSendSetAsDefaultParamInConfirmCall() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             builder = {
                 confirmationType.createIntentCallback?.let {
@@ -202,6 +210,7 @@ internal class DefaultPaymentMethodsConfirmationTest {
 
     @Test
     fun payWithNewPM_savePM_sendsSetAsDefaultInConfirmCall() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             confirmationType.createIntentCallback?.let {
@@ -246,6 +255,7 @@ internal class DefaultPaymentMethodsConfirmationTest {
 
     @Test
     fun payWithNewPM_doNotSaveCard_doesNotSetAsDefault() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             confirmationType.createIntentCallback?.let {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsDeferredServerSideConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsDeferredServerSideConfirmationTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet
 
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.RequestMatchers
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.utils.DefaultPaymentMethodsUtils
@@ -16,7 +18,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class DefaultPaymentMethodsDeferredServerSideConfirmationTest {
+internal class DefaultPaymentMethodsDeferredServerSideConfirmationTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
 
     @get:Rule
     val testRules: TestRules = TestRules.create()
@@ -32,6 +37,7 @@ internal class DefaultPaymentMethodsDeferredServerSideConfirmationTest {
 
     @Test
     fun setNewCardAsDefault_withSavedPaymentMethods_failsInTestMode() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             createIntentCallback { _, _ ->
@@ -98,6 +104,7 @@ internal class DefaultPaymentMethodsDeferredServerSideConfirmationTest {
 
     @Test
     fun addFirstCardForUser_failsInTestMode() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             createIntentCallback { _, _ ->

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsFlowControllerConfirmationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsFlowControllerConfirmationTest.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.hasTestTag
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TEST_TAG_ACCOUNT_DETAILS
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.TEST_TAG_BILLING_DETAILS
 import com.stripe.android.paymentsheet.utils.ConfirmationType
@@ -23,7 +25,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class DefaultPaymentMethodsFlowControllerConfirmationTest {
+internal class DefaultPaymentMethodsFlowControllerConfirmationTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     @get:Rule
     val testRules: TestRules = TestRules.create {
         around(IntentsRule())
@@ -85,6 +90,7 @@ internal class DefaultPaymentMethodsFlowControllerConfirmationTest {
         secondLaunchBlock: (PaymentSheetPage) -> Unit,
     ) {
         runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             builder = {
                 confirmationType.createIntentCallback?.let {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/DefaultPaymentMethodsTest.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.RequestMatchers
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -21,7 +23,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class DefaultPaymentMethodsTest {
+internal class DefaultPaymentMethodsTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
@@ -39,6 +44,7 @@ internal class DefaultPaymentMethodsTest {
 
     @Test
     fun setDefaultCard_selectsCard() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = {},
@@ -87,6 +93,7 @@ internal class DefaultPaymentMethodsTest {
     @Test
     fun updatePaymentMethodScreen_defaultPaymentMethod_setAsDefaultCheckboxDisplayedAndDisabled() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             resultCallback = {},
@@ -131,6 +138,7 @@ internal class DefaultPaymentMethodsTest {
 
     @Test
     fun defaultPaymentMethod_displayedWithDefaultBadge() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = {},
@@ -159,6 +167,7 @@ internal class DefaultPaymentMethodsTest {
 
     @Test
     fun defaultPaymentMethod_isSelected() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = {},

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerAnalyticsTest.kt
@@ -1,8 +1,12 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethod
@@ -37,8 +41,11 @@ import org.junit.runner.RunWith
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalAnalyticEventCallbackApi::class)
-@RunWith(AndroidJUnit4::class)
-internal class FlowControllerAnalyticsTest {
+@RunWith(TestParameterInjector::class)
+internal class FlowControllerAnalyticsTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val networkRule = NetworkRule(
         hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
         validationTimeout = 5.seconds, // Analytics requests happen async.
@@ -76,6 +83,7 @@ internal class FlowControllerAnalyticsTest {
 
     @Test
     fun testSuccessfulCardPaymentInFlowController() = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             analyticEventCallback(analyticEventRule)
@@ -106,7 +114,7 @@ internal class FlowControllerAnalyticsTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = horizontalModeConfiguration,
+                configuration = apiConfigurationTestType.applyTo(horizontalModeConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -163,6 +171,7 @@ internal class FlowControllerAnalyticsTest {
 
     @Test
     fun testSuccessfulCardPaymentInFlowControllerInVerticalMode() = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             analyticEventCallback(analyticEventRule)
@@ -189,7 +198,7 @@ internal class FlowControllerAnalyticsTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = verticalModeConfiguration,
+                configuration = apiConfigurationTestType.applyTo(verticalModeConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -248,6 +257,7 @@ internal class FlowControllerAnalyticsTest {
 
     @Test
     fun testSuccessfulCardPaymentInFlowControllerWithConfirmationToken() = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             createIntentCallback { _ ->
@@ -287,7 +297,7 @@ internal class FlowControllerAnalyticsTest {
                         currency = "usd"
                     )
                 ),
-                configuration = horizontalModeConfiguration,
+                configuration = apiConfigurationTestType.applyTo(horizontalModeConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -355,6 +365,7 @@ internal class FlowControllerAnalyticsTest {
 
     @Test
     fun testSavedPaymentMethodInFlowController() = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             analyticEventCallback(analyticEventRule)
@@ -381,13 +392,13 @@ internal class FlowControllerAnalyticsTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = horizontalModeConfiguration.newBuilder()
+                configuration = apiConfigurationTestType.applyTo(horizontalModeConfiguration.newBuilder()
                     .customer(
                         PaymentSheet.CustomerConfiguration(
                             id = "cus_1",
                             ephemeralKeySecret = TestApiKeys.EPHEMERAL,
                         )
-                    ).build(),
+                    ).build()),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -17,6 +17,8 @@ import com.google.android.gms.wallet.PaymentsClient
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
 import com.stripe.android.googlepaylauncher.GooglePayRepository
@@ -60,7 +62,10 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @RunWith(TestParameterInjector::class)
-internal class FlowControllerTest {
+internal class FlowControllerTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val networkRule = NetworkRule()
 
     @get:Rule
@@ -84,6 +89,7 @@ internal class FlowControllerTest {
     fun testSuccessfulCardPayment(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -95,7 +101,7 @@ internal class FlowControllerTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -123,6 +129,7 @@ internal class FlowControllerTest {
     fun testSuccessfulCardPaymentWithVerticalMode(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -134,9 +141,9 @@ internal class FlowControllerTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                    .build(),
+                    .build()),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -166,6 +173,7 @@ internal class FlowControllerTest {
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) {
         runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             callConfirmOnPaymentOptionCallback = false,
@@ -178,9 +186,9 @@ internal class FlowControllerTest {
             testContext.configureFlowController {
                 configureWithPaymentIntent(
                     paymentIntentClientSecret = "pi_example_secret_example",
-                    configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                    configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                         .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                        .build(),
+                        .build()),
                     callback = { success, error ->
                         assertThat(success).isTrue()
                         assertThat(error).isNull()
@@ -208,6 +216,7 @@ internal class FlowControllerTest {
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) {
         runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             callConfirmOnPaymentOptionCallback = false,
@@ -220,9 +229,9 @@ internal class FlowControllerTest {
             testContext.configureFlowController {
                 configureWithPaymentIntent(
                     paymentIntentClientSecret = "pi_example_secret_example",
-                    configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                    configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                         .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                        .build(),
+                        .build()),
                     callback = { success, error ->
                         assertThat(success).isTrue()
                         assertThat(error).isNull()
@@ -252,6 +261,7 @@ internal class FlowControllerTest {
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) {
         runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             callConfirmOnPaymentOptionCallback = false,
@@ -275,8 +285,8 @@ internal class FlowControllerTest {
                             setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession
                         )
                     ),
-                    configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
-                        .build(),
+                    configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
+                        .build()),
                     callback = { success, error ->
                         assertThat(success).isTrue()
                         assertThat(error).isNull()
@@ -306,6 +316,7 @@ internal class FlowControllerTest {
     fun testFailedElementsSessionCall(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -324,7 +335,7 @@ internal class FlowControllerTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -378,7 +389,7 @@ internal class FlowControllerTest {
         scenario.onActivity {
             flowController.configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isFalse()
                     assertThat(error).isNotNull()
@@ -395,6 +406,7 @@ internal class FlowControllerTest {
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) {
         runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             resultCallback = ::assertFailed,
@@ -406,7 +418,7 @@ internal class FlowControllerTest {
             testContext.configureFlowController {
                 configureWithPaymentIntent(
                     paymentIntentClientSecret = "pi_example_secret_example",
-                    configuration = defaultConfiguration,
+                    configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                     callback = { success, error ->
                         assertThat(success).isTrue()
                         assertThat(error).isNull()
@@ -467,7 +479,7 @@ internal class FlowControllerTest {
         scenario.onActivity {
             flowController.configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -491,7 +503,7 @@ internal class FlowControllerTest {
         scenario.onActivity {
             flowController.configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -531,7 +543,7 @@ internal class FlowControllerTest {
             scenario.onActivity {
                 flowController.configureWithPaymentIntent(
                     paymentIntentClientSecret = paymentIntentClientSecret,
-                    configuration = defaultConfiguration,
+                    configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                     callback = { success, error ->
                         assertThat(success).isTrue()
                         assertThat(error).isNull()
@@ -562,6 +574,7 @@ internal class FlowControllerTest {
     fun testDeferredIntentCardPayment(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -583,7 +596,7 @@ internal class FlowControllerTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -636,6 +649,7 @@ internal class FlowControllerTest {
         @TestParameter(valuesProvider = MultipleInstancesTestTypeProvider::class)
         testType: MultipleInstancesTestType,
     ) = runMultipleFlowControllerInstancesTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         testType = testType,
         createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_example") },
@@ -653,7 +667,7 @@ internal class FlowControllerTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -695,6 +709,7 @@ internal class FlowControllerTest {
     fun testDeferredIntentFailedCardPayment(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -723,7 +738,7 @@ internal class FlowControllerTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -755,6 +770,7 @@ internal class FlowControllerTest {
     fun testDeferredIntentCardPaymentWithForcedSuccess(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -776,7 +792,7 @@ internal class FlowControllerTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -808,6 +824,7 @@ internal class FlowControllerTest {
     fun testDeferredIntentCardPaymentWithInvalidStripeIntent(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -837,7 +854,7 @@ internal class FlowControllerTest {
                         currency = "cad",
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -875,6 +892,7 @@ internal class FlowControllerTest {
     fun testCvcRecollection(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -898,14 +916,14 @@ internal class FlowControllerTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
                         ephemeralKeySecret = TestApiKeys.EPHEMERAL,
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-                ),
+                )),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -944,6 +962,7 @@ internal class FlowControllerTest {
     fun testSavedCardsInVerticalMode(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         callConfirmOnPaymentOptionCallback = false,
@@ -968,7 +987,7 @@ internal class FlowControllerTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration.Builder(merchantDisplayName = "Merchant, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(merchantDisplayName = "Merchant, Inc.")
                     .customer(
                         PaymentSheet.CustomerConfiguration(
                             id = "cus_1",
@@ -976,7 +995,7 @@ internal class FlowControllerTest {
                         )
                     )
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                    .build(),
+                    .build()),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -1024,6 +1043,7 @@ internal class FlowControllerTest {
     fun testDefaultPaymentMethodOrderWithFailedSession(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -1042,11 +1062,11 @@ internal class FlowControllerTest {
         testContext.configureFlowController {
             configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                     .allowsDelayedPaymentMethods(true)
                     .allowsPaymentMethodsRequiringShippingAddress(true)
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
-                    .build(),
+                    .build()),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -1079,6 +1099,7 @@ internal class FlowControllerTest {
 
     @Test
     fun testWalletButtonsShown() = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         showWalletButtons = true,
         resultCallback = ::assertCompleted,
@@ -1108,7 +1129,7 @@ internal class FlowControllerTest {
 
         testContext.flowController.configureWithPaymentIntent(
             paymentIntentClientSecret = "pi_123_secret_123",
-            configuration = PaymentSheet.Configuration.Builder(
+            configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(
                 merchantDisplayName = "Example, Inc."
             )
                 .customer(
@@ -1123,7 +1144,7 @@ internal class FlowControllerTest {
                         countryCode = "US",
                     )
                 )
-                .build(),
+                .build()),
             callback = { _, _ ->
                 isConfigured.countDown()
             },
@@ -1140,6 +1161,7 @@ internal class FlowControllerTest {
     @OptIn(WalletButtonsPreview::class)
     @Test
     fun testWalletsShownInExpectedScreensWhenFilteringWalletButtons() = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         showWalletButtons = true,
         resultCallback = ::assertCompleted,
@@ -1173,7 +1195,7 @@ internal class FlowControllerTest {
             activityLaunchObserver.prepareForLaunch(it)
             testContext.flowController.configureWithPaymentIntent(
                 paymentIntentClientSecret = "pi_123_secret_123",
-                configuration = PaymentSheet.Configuration.Builder(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(
                     merchantDisplayName = "Example, Inc."
                 )
                     .paymentMethodLayout(PaymentMethodLayout.Vertical)
@@ -1202,7 +1224,7 @@ internal class FlowControllerTest {
                             )
                         )
                     )
-                    .build(),
+                    .build()),
                 callback = { _, _ ->
                     isConfigured.countDown()
                 },
@@ -1227,6 +1249,7 @@ internal class FlowControllerTest {
     fun testFlowControllerConfigurationBuilderWithTermsDisplayNever(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -1249,14 +1272,14 @@ internal class FlowControllerTest {
                         setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession
                     )
                 ),
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                     .termsDisplay(
                         mapOf(
                             com.stripe.android.model.PaymentMethod.Type.Card to PaymentSheet.TermsDisplay.NEVER
                         )
                     )
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
-                    .build(),
+                    .build()),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()
@@ -1273,6 +1296,7 @@ internal class FlowControllerTest {
     fun testOBO_PassedToElementsSessionCall(
         @TestParameter(valuesProvider = IntegrationTypeProvider ::class) integrationType: IntegrationType,
     ) = runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -1299,8 +1323,8 @@ internal class FlowControllerTest {
                     ),
                     onBehalfOf = oboMerchantID
                 ),
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
-                    .build(),
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
+                    .build()),
                 callback = { success, error ->
                     assertThat(success).isTrue()
                     assertThat(error).isNull()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FormValidationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FormValidationTest.kt
@@ -11,6 +11,8 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.ResponseReplacement
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
@@ -27,7 +29,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class FormValidationTest {
+internal class FormValidationTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     @get:Rule
     val testRules: TestRules = TestRules.create {
         around(IntentsRule())
@@ -43,6 +48,7 @@ internal class FormValidationTest {
         @TestParameter(valuesProvider = ProductIntegrationTypeProvider::class)
         integrationType: ProductIntegrationType,
     ) = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::expectNoResult
@@ -65,6 +71,7 @@ internal class FormValidationTest {
         @TestParameter(valuesProvider = ProductIntegrationTypeProvider::class)
         integrationType: ProductIntegrationType,
     ) = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::expectNoResult

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/GooglePayTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/GooglePayTest.kt
@@ -18,6 +18,8 @@ import com.google.android.gms.wallet.PaymentsClient
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.googlepaylauncher.GooglePayAvailabilityClient
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.GooglePayRepository
@@ -46,7 +48,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class GooglePayTest {
+internal class GooglePayTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     @TestParameter(valuesProvider = ProductIntegrationTypeProvider::class)
     lateinit var integrationType: ProductIntegrationType
 
@@ -195,6 +200,7 @@ internal class GooglePayTest {
         enqueueElementsSession(isGooglePayEnabledInElementsSession)
 
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = testRules.networkRule,
             integrationType = integrationType,
             resultCallback = paymentResultCallback,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/HCaptchaTokenTest.kt
@@ -1,7 +1,11 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.intent.rule.IntentsRule
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -18,10 +22,15 @@ import com.stripe.android.paymentsheet.utils.runProductIntegrationTest
 import com.stripe.android.testing.RetryRule
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.junit.rules.RuleChain
 import kotlin.time.Duration.Companion.seconds
 
-internal class HCaptchaTokenTest {
+@RunWith(TestParameterInjector::class)
+internal class HCaptchaTokenTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     // The /v1/consumers/sessions/log_out request is launched async from a GlobalScope. We want to make sure it happens,
     // but it's okay if it takes a bit to happen.
     private val networkRule = NetworkRule(validationTimeout = 5.seconds)
@@ -37,6 +46,7 @@ internal class HCaptchaTokenTest {
 
     @Test
     fun newPaymentMethod_withPassiveCaptchaEnabled_includesHCaptchaTokenInConfirmRequest() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = ProductIntegrationType.PaymentSheet,
         resultCallback = ::assertCompleted,
@@ -47,6 +57,7 @@ internal class HCaptchaTokenTest {
     @Test
     fun paymentMethodCreation_withPassiveCaptchaEnabled_includesHCaptchaTokenInCreateRequest() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = ProductIntegrationType.PaymentSheet,
             resultCallback = ::assertCompleted,
@@ -62,6 +73,7 @@ internal class HCaptchaTokenTest {
     @Test
     fun linkPaymentMethodMode_withPassiveCaptchaEnabled_includesHCaptchaTokenInConfirmRequest() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = ProductIntegrationType.PaymentSheet,
             resultCallback = ::assertCompleted,
@@ -79,6 +91,7 @@ internal class HCaptchaTokenTest {
     @Test
     fun linkPassthroughMode_withPassiveCaptchaEnabled_includesHCaptchaTokenInConfirmRequest() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = ProductIntegrationType.PaymentSheet,
             resultCallback = ::assertCompleted,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/LinkTest.kt
@@ -4,6 +4,8 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.closeSoftKeyboard
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.link.account.DefaultLinkStore
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.TestApiKeys
@@ -31,7 +33,10 @@ import org.junit.runner.RunWith
 import kotlin.time.Duration.Companion.seconds
 
 @RunWith(TestParameterInjector::class)
-internal class LinkTest {
+internal class LinkTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     // The /v1/consumers/sessions/log_out request is launched async from a GlobalScope. We want to make sure it happens,
     // but it's okay if it takes a bit to happen.
     private val networkRule = NetworkRule(validationTimeout = 5.seconds)
@@ -48,6 +53,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUp() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -126,6 +132,7 @@ internal class LinkTest {
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndSaveForFutureUsage() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             resultCallback = ::assertCompleted,
@@ -234,6 +241,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndCardBrandChoice_Selector() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -316,6 +324,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughMode() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -410,6 +419,7 @@ internal class LinkTest {
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpAndLinkPassthroughModeAndSaveForFutureUsage() =
         runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             integrationType = integrationType,
             resultCallback = ::assertCompleted,
@@ -526,6 +536,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpPassthroughModeAndCardBrandChoice_Selector() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -624,6 +635,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpFailure() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -688,6 +700,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpFailureInPassthroughMode() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -752,6 +765,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpShareFailureInPassthroughMode() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -824,6 +838,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithExistingLinkEmailUsed() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -879,6 +894,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkPreviouslyUsed() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -910,6 +926,7 @@ internal class LinkTest {
 
     @Test
     fun testLogoutAfterLinkTransaction() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -979,6 +996,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithLinkSignUpWithAlbaniaPhoneNumber() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -1052,6 +1070,7 @@ internal class LinkTest {
 
     @Test
     fun testSuccessfulCardPaymentWithCustomerSessionInPassthroughMode() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -1166,6 +1185,7 @@ internal class LinkTest {
 
     @Test
     fun testSingleConsumerLookupWithLinkEnabled() = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAddressAutocompleteTest.kt
@@ -1,7 +1,10 @@
 package com.stripe.android.paymentsheet
 
 import android.text.SpannableString
+import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -21,7 +24,10 @@ import org.junit.runner.RunWith
 
 @OptIn(AddressAutocompletePreview::class)
 @RunWith(TestParameterInjector::class)
-class PaymentSheetAddressAutocompleteTest {
+internal class PaymentSheetAddressAutocompleteTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val placesClientProxyTestRule = PlacesClientProxyTestRule()
 
     @get:Rule
@@ -37,6 +43,7 @@ class PaymentSheetAddressAutocompleteTest {
     @Suppress("DEPRECATION")
     @Test
     fun testUnfilled() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { context ->
@@ -47,7 +54,7 @@ class PaymentSheetAddressAutocompleteTest {
         context.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_123_secret_123",
-                configuration = PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
                     .billingDetailsCollectionConfiguration(
                         PaymentSheet.BillingDetailsCollectionConfiguration(
                             address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
@@ -55,7 +62,7 @@ class PaymentSheetAddressAutocompleteTest {
                         ),
                     )
                     .googlePlacesApiKey("gp_123")
-                    .build(),
+                    .build()),
             )
         }
 
@@ -74,6 +81,7 @@ class PaymentSheetAddressAutocompleteTest {
     @Suppress("DEPRECATION")
     @Test
     fun testPrefilled() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { context ->
@@ -84,7 +92,7 @@ class PaymentSheetAddressAutocompleteTest {
         context.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_123_secret_123",
-                configuration = PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
                     .billingDetailsCollectionConfiguration(
                         PaymentSheet.BillingDetailsCollectionConfiguration(
                             address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
@@ -103,7 +111,7 @@ class PaymentSheetAddressAutocompleteTest {
                         )
                     )
                     .googlePlacesApiKey("gp_123")
-                    .build(),
+                    .build()),
             )
         }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetAnalyticsTest.kt
@@ -1,7 +1,11 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.core.networking.AnalyticsRequest
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentMethod
@@ -35,8 +39,11 @@ import org.junit.runner.RunWith
 import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalAnalyticEventCallbackApi::class)
-@RunWith(AndroidJUnit4::class)
-internal class PaymentSheetAnalyticsTest {
+@RunWith(TestParameterInjector::class)
+internal class PaymentSheetAnalyticsTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val networkRule = NetworkRule(
         hostsToTrack = listOf(ApiRequest.API_HOST, AnalyticsRequest.HOST),
         validationTimeout = 5.seconds, // Analytics requests happen async.
@@ -69,6 +76,7 @@ internal class PaymentSheetAnalyticsTest {
 
     @Test
     fun testSuccessfulCardPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             analyticEventCallback(analyticEventRule)
@@ -100,7 +108,7 @@ internal class PaymentSheetAnalyticsTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = horizontalModeConfiguration,
+                configuration = apiConfigurationTestType.applyTo(horizontalModeConfiguration),
             )
         }
 
@@ -149,6 +157,7 @@ internal class PaymentSheetAnalyticsTest {
 
     @Test
     fun testSuccessfulCardPaymentInVerticalMode() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             analyticEventCallback(analyticEventRule)
@@ -177,7 +186,7 @@ internal class PaymentSheetAnalyticsTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = verticalModeConfiguration,
+                configuration = apiConfigurationTestType.applyTo(verticalModeConfiguration),
             )
         }
 
@@ -227,6 +236,7 @@ internal class PaymentSheetAnalyticsTest {
 
     @Test
     fun testSuccessfulCardPaymentWithConfirmationToken() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             createIntentCallback { _ ->
@@ -265,7 +275,7 @@ internal class PaymentSheetAnalyticsTest {
                         currency = "usd"
                     )
                 ),
-                configuration = horizontalModeConfiguration
+                configuration = apiConfigurationTestType.applyTo(horizontalModeConfiguration)
             )
         }
 
@@ -326,6 +336,7 @@ internal class PaymentSheetAnalyticsTest {
 
     @Test
     fun testSavedPaymentMethod() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         builder = {
             analyticEventCallback(analyticEventRule)
@@ -353,14 +364,14 @@ internal class PaymentSheetAnalyticsTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = horizontalModeConfiguration.newBuilder()
+                configuration = apiConfigurationTestType.applyTo(horizontalModeConfiguration.newBuilder()
                     .customer(
                         PaymentSheet.CustomerConfiguration(
                             id = "cus_1",
                             ephemeralKeySecret = TestApiKeys.EPHEMERAL,
                         )
                     )
-                    .build()
+                    .build())
             )
         }
         analyticEventRule.assertMatchesExpectedEvent(AnalyticEvent.PresentedSheet())

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.Lifecycle
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -29,7 +31,10 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 @RunWith(TestParameterInjector::class)
-internal class PaymentSheetBillingConfigurationTest {
+internal class PaymentSheetBillingConfigurationTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val composeTestRule = createAndroidComposeRule<MainActivity>()
     private val page: PaymentSheetPage = PaymentSheetPage(composeTestRule)
 
@@ -60,7 +65,7 @@ internal class PaymentSheetBillingConfigurationTest {
         scenario.onActivity {
             paymentSheet.presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
                     defaultBillingDetails = PaymentSheet.BillingDetails(
                         name = "Jenny Rosen",
@@ -79,7 +84,7 @@ internal class PaymentSheetBillingConfigurationTest {
                         attachDefaultsToPaymentMethod = true,
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-                ),
+                )),
             )
         }
 
@@ -134,7 +139,7 @@ internal class PaymentSheetBillingConfigurationTest {
         scenario.onActivity {
             paymentSheet.presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
                     defaultBillingDetails = PaymentSheet.BillingDetails(
                         name = "Jenny Rosen",
@@ -150,7 +155,7 @@ internal class PaymentSheetBillingConfigurationTest {
                         attachDefaultsToPaymentMethod = false,
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-                ),
+                )),
             )
         }
 
@@ -175,6 +180,7 @@ internal class PaymentSheetBillingConfigurationTest {
 
     @Test
     fun testAddressInputNotReset() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = IntegrationType.Compose,
         resultCallback = ::assertCompleted,
@@ -186,7 +192,7 @@ internal class PaymentSheetBillingConfigurationTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
                     defaultBillingDetails = PaymentSheet.BillingDetails(
                         name = "Jenny Rosen",
@@ -206,7 +212,7 @@ internal class PaymentSheetBillingConfigurationTest {
                         attachDefaultsToPaymentMethod = false,
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-                ),
+                )),
             )
         }
 
@@ -227,6 +233,7 @@ internal class PaymentSheetBillingConfigurationTest {
         @TestParameter(valuesProvider = PaymentSheetLayoutTypeProvider::class)
         layoutType: PaymentSheetLayoutType,
     ) = runProductIntegrationTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
@@ -86,7 +86,7 @@ internal class PaymentSheetConfirmationTokenTest(
         paymentMethodType: PaymentMethodType,
     ) {
         runPaymentSheetTest(
-        apiConfigurationTestType = apiConfigurationTestType,
+            apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             isLiveMode = isLiveMode,
             builder = {
@@ -105,7 +105,7 @@ internal class PaymentSheetConfirmationTokenTest(
     @Test
     fun testSuccessfulSetup() {
         runPaymentSheetTest(
-        apiConfigurationTestType = apiConfigurationTestType,
+            apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             isLiveMode = false,
             builder = {
@@ -169,19 +169,21 @@ internal class PaymentSheetConfirmationTokenTest(
                     },
                     requireCvcRecollection = paymentMethodType == PaymentMethodType.SavedCardWithCvcRecollection
                 ),
-                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
-                    .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
-                    .also {
-                        if (customerType == CustomerType.ReturningCustomer) {
-                            it.customer(
-                                PaymentSheet.CustomerConfiguration(
-                                    "cus_foobar",
-                                    TestApiKeys.EPHEMERAL
+                configuration = testContext.apiConfigurationTestType.applyTo(
+                    PaymentSheet.Configuration.Builder("Example, Inc.")
+                        .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
+                        .also {
+                            if (customerType == CustomerType.ReturningCustomer) {
+                                it.customer(
+                                    PaymentSheet.CustomerConfiguration(
+                                        "cus_foobar",
+                                        TestApiKeys.EPHEMERAL
+                                    )
                                 )
-                            )
+                            }
                         }
-                    }
-                    .build())
+                        .build()
+                )
             )
         }
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetConfirmationTokenTest.kt
@@ -1,5 +1,9 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.RequestMatcher
 import com.stripe.android.networktesting.RequestMatchers
@@ -22,8 +26,13 @@ import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
-internal class PaymentSheetConfirmationTokenTest {
+@RunWith(TestParameterInjector::class)
+internal class PaymentSheetConfirmationTokenTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     @get:Rule
     val testRules: TestRules = TestRules.create()
 
@@ -77,6 +86,7 @@ internal class PaymentSheetConfirmationTokenTest {
         paymentMethodType: PaymentMethodType,
     ) {
         runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             isLiveMode = isLiveMode,
             builder = {
@@ -95,6 +105,7 @@ internal class PaymentSheetConfirmationTokenTest {
     @Test
     fun testSuccessfulSetup() {
         runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             isLiveMode = false,
             builder = {
@@ -158,7 +169,7 @@ internal class PaymentSheetConfirmationTokenTest {
                     },
                     requireCvcRecollection = paymentMethodType == PaymentMethodType.SavedCardWithCvcRecollection
                 ),
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
                     .also {
                         if (customerType == CustomerType.ReturningCustomer) {
@@ -170,7 +181,7 @@ internal class PaymentSheetConfirmationTokenTest {
                             )
                         }
                     }
-                    .build()
+                    .build())
             )
         }
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCustomerSessionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetCustomerSessionTest.kt
@@ -1,5 +1,9 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -12,8 +16,13 @@ import com.stripe.android.paymentsheet.utils.assertCompleted
 import com.stripe.android.paymentsheet.utils.runPaymentSheetTest
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 
-class PaymentSheetCustomerSessionTest {
+@RunWith(TestParameterInjector::class)
+internal class PaymentSheetCustomerSessionTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     @get:Rule
     val testRules: TestRules = TestRules.create()
 
@@ -24,6 +33,7 @@ class PaymentSheetCustomerSessionTest {
 
     @Test
     fun allowRedisplayIsUnspecifiedWhenNotSavingWithPaymentIntent() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -40,6 +50,7 @@ class PaymentSheetCustomerSessionTest {
 
     @Test
     fun allowRedisplayIsAlwaysWhenSavingWithPaymentIntent() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -57,6 +68,7 @@ class PaymentSheetCustomerSessionTest {
 
     @Test
     fun allowRedisplayIsLimitedWhenNotSavingWithSetupIntent() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -73,6 +85,7 @@ class PaymentSheetCustomerSessionTest {
 
     @Test
     fun allowRedisplayIsAlwaysWhenSavingWithSetupIntent() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -90,6 +103,7 @@ class PaymentSheetCustomerSessionTest {
 
     @Test
     fun allowRedisplayIsUnspecifiedWhenSaveIsDisabledWithPaymentIntent() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -108,6 +122,7 @@ class PaymentSheetCustomerSessionTest {
 
     @Test
     fun allowRedisplayIsLimitedWhenSaveIsDisabledWithSetupIntent() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -126,6 +141,7 @@ class PaymentSheetCustomerSessionTest {
 
     @Test
     fun allowRedisplayIsUnspecifiedWhenOverrideIsUnspecifiedWithSetupIntent() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -145,6 +161,7 @@ class PaymentSheetCustomerSessionTest {
 
     @Test
     fun allowRedisplayIsAlwaysWhenOverrideIsAlwaysWithSetupIntent() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
     ) { testContext ->
@@ -219,13 +236,13 @@ class PaymentSheetCustomerSessionTest {
         presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
                         id = "cus_1",
                         clientSecret = "cuss_1",
                     ),
-                ),
+                )),
             )
         }
     }
@@ -234,13 +251,13 @@ class PaymentSheetCustomerSessionTest {
         presentPaymentSheet {
             presentWithSetupIntent(
                 setupIntentClientSecret = "seti_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
                         id = "cus_1",
                         clientSecret = "cuss_1",
                     ),
-                ),
+                )),
             )
         }
     }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentsheet
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.host
@@ -27,7 +29,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class PaymentSheetDeferredTest {
+internal class PaymentSheetDeferredTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     @get:Rule
     val testRules: TestRules = TestRules.create()
 
@@ -45,6 +50,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredIntentCardPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -67,7 +73,7 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -116,6 +122,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredIntentCardPayment_forSetup() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -135,7 +142,7 @@ internal class PaymentSheetDeferredTest {
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Setup()
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -168,6 +175,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredIntentSavedCardPayment_forSetup() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -199,10 +207,10 @@ internal class PaymentSheetDeferredTest {
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Setup()
                 ),
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                     .customer(PaymentSheet.CustomerConfiguration("cus_foobar", TestApiKeys.EPHEMERAL))
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                    .build(),
+                    .build()),
             )
         }
 
@@ -228,6 +236,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredIntentCardPaymentWithCustomer() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -262,10 +271,10 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                     .customer(PaymentSheet.CustomerConfiguration("cus_foobar", TestApiKeys.EPHEMERAL))
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
-                    .build(),
+                    .build()),
             )
         }
 
@@ -313,6 +322,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredIntentWithSavedCard_sendsClientAttributionMetadata() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -347,10 +357,10 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                     .customer(PaymentSheet.CustomerConfiguration("cus_foobar", TestApiKeys.EPHEMERAL))
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Vertical)
-                    .build(),
+                    .build()),
             )
         }
 
@@ -376,6 +386,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredIntentCardPaymentWithSaveFor() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -410,10 +421,10 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc.")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc.")
                     .customer(PaymentSheet.CustomerConfiguration("cus_foobar", TestApiKeys.EPHEMERAL))
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
-                    .build(),
+                    .build()),
             )
         }
 
@@ -460,6 +471,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredIntentFailedCardPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -484,7 +496,7 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -510,6 +522,7 @@ internal class PaymentSheetDeferredTest {
     @OptIn(DelicatePaymentSheetApi::class)
     @Test
     fun testDeferredIntentCardPaymentWithForcedSuccess() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -531,7 +544,7 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -553,6 +566,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredIntentKonbiniPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -575,10 +589,10 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = PaymentSheet.Configuration.Builder("Example, Inc")
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder("Example, Inc")
                     .allowsDelayedPaymentMethods(true)
                     .paymentMethodLayout(PaymentSheet.PaymentMethodLayout.Horizontal)
-                    .build(),
+                    .build()),
             )
         }
 
@@ -631,6 +645,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredPaymentIntent_withElementsSessionFailure() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -653,7 +668,7 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -701,6 +716,7 @@ internal class PaymentSheetDeferredTest {
 
     @Test
     fun testDeferredSetupIntent_withElementsSessionFailure() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -720,7 +736,7 @@ internal class PaymentSheetDeferredTest {
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Setup()
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -755,6 +771,7 @@ internal class PaymentSheetDeferredTest {
         @TestParameter(valuesProvider = MultipleInstancesTestTypeProvider::class)
         testType: MultipleInstancesTestType,
     ) = runMultiplePaymentSheetInstancesTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         testType = testType,
         createIntentCallback = { _, _ ->
@@ -774,7 +791,7 @@ internal class PaymentSheetDeferredTest {
                         currency = "usd"
                     )
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetLoadParallelismTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetLoadParallelismTest.kt
@@ -1,5 +1,9 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -30,8 +34,11 @@ import java.util.concurrent.TimeUnit
  * necessary and intentional, as it will likely lead to an increase in our loading latency.
  *
  */
-@RunWith(JUnit4::class)
-internal class PaymentSheetLoadParallelismTest {
+@RunWith(TestParameterInjector::class)
+internal class PaymentSheetLoadParallelismTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
 
     @get:Rule
     val testRules: TestRules = TestRules.create()
@@ -155,6 +162,7 @@ internal class PaymentSheetLoadParallelismTest {
         defaultEmail: Boolean,
         expectedRequestOrdering: RequestOrdering,
     ) = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::expectNoResult,
         successTimeoutSeconds = 15L,
@@ -168,10 +176,10 @@ internal class PaymentSheetLoadParallelismTest {
             testContext.presentPaymentSheet {
                 presentWithPaymentIntent(
                     paymentIntentClientSecret = "pi_example_secret_example",
-                    configuration = buildConfiguration(
+                    configuration = apiConfigurationTestType.applyTo(buildConfiguration(
                         customerType = customerType,
                         defaultEmail = defaultEmail,
-                    ),
+                    )),
                 )
             }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetNextActionTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetNextActionTest.kt
@@ -1,5 +1,7 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import android.app.Activity
 import android.app.Instrumentation
 import android.content.Intent
@@ -11,6 +13,8 @@ import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
 import androidx.test.espresso.intent.rule.IntentsRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -29,8 +33,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.time.Duration.Companion.seconds
 
-@RunWith(AndroidJUnit4::class)
-internal class PaymentSheetNextActionTest {
+@RunWith(TestParameterInjector::class)
+internal class PaymentSheetNextActionTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     // The retrieve happens after the sheet has already handed back its result, so give
     // validate() a moment to see it.
     private val networkRule = NetworkRule(validationTimeout = 5.seconds)
@@ -66,6 +73,7 @@ internal class PaymentSheetNextActionTest {
         resultCallback: PaymentSheetResultCallback,
         afterConfirm: (PaymentSheetTestRunnerContext) -> Unit = {},
     ) = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         successTimeoutSeconds = 10L,
         resultCallback = resultCallback,
@@ -77,10 +85,10 @@ internal class PaymentSheetNextActionTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Example, Inc.",
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-                ),
+                )),
             )
         }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
@@ -37,7 +39,10 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(TestParameterInjector::class)
-internal class PaymentSheetTest {
+internal class PaymentSheetTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     private val networkRule = NetworkRule()
 
     @get:Rule
@@ -59,6 +64,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSuccessfulCardPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -70,7 +76,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -90,6 +96,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSuccessfulPayByBankPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -101,7 +108,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -121,6 +128,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSuccessfulLpmPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -132,7 +140,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -152,6 +160,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSuccessfulUsBankPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -165,11 +174,11 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Example, Inc.",
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
                     allowsDelayedPaymentMethods = true,
-                ),
+                )),
             )
         }
 
@@ -194,6 +203,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSocketErrorCardPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::expectNoResult,
@@ -205,7 +215,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -226,6 +236,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testInsufficientFundsCardPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::expectNoResult,
@@ -237,7 +248,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -259,6 +270,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSuccessfulDelayedSuccessPayment() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         successTimeoutSeconds = 10L,
@@ -271,7 +283,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -296,6 +308,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testFailureWhenSetupRequestsFail() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertFailed,
@@ -314,13 +327,14 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
     }
 
     @Test
     fun testPaymentIntentWithCardBrandChoiceSuccess_Selector() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -332,7 +346,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -354,6 +368,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testPaymentIntentWithCardBrandChoiceSuccess_PreferredBrands_Deselect() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -365,11 +380,11 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Example, Inc.",
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
                     preferredNetworks = listOf(CardBrand.CartesBancaires)
-                ),
+                )),
             )
         }
 
@@ -388,6 +403,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testPaymentIntentReturnsFailureWhenAlreadySucceeded() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertFailed,
@@ -399,7 +415,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
     }
@@ -408,6 +424,7 @@ internal class PaymentSheetTest {
     fun testCardMetadataQueryExecutedOncePerCardSessionForBin() {
         repeat(2) {
             runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
                 networkRule = networkRule,
                 integrationType = integrationType,
                 resultCallback = ::assertCompleted,
@@ -419,7 +436,7 @@ internal class PaymentSheetTest {
                 testContext.presentPaymentSheet {
                     presentWithPaymentIntent(
                         paymentIntentClientSecret = "pi_example_secret_example",
-                        configuration = defaultConfiguration,
+                        configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
                     )
                 }
 
@@ -450,6 +467,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testPaymentIntentWithCvcRecollection() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -473,14 +491,14 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
                         ephemeralKeySecret = TestApiKeys.EPHEMERAL,
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-                ),
+                )),
             )
         }
 
@@ -498,6 +516,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testDeferredIntentWithCvcRecollection() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         resultCallback = ::assertCompleted,
         builder = {
@@ -538,7 +557,7 @@ internal class PaymentSheetTest {
                     ),
                     requireCvcRecollection = true,
                 ),
-                configuration = defaultConfiguration.newBuilder()
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration.newBuilder()
                     .customer(
                         customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
                             id = "cus_1",
@@ -550,7 +569,7 @@ internal class PaymentSheetTest {
                             .display(PaymentSheet.LinkConfiguration.Display.Never)
                             .build()
                     )
-                    .build(),
+                    .build()),
             )
         }
 
@@ -576,6 +595,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSavedUsBankAccountMandateNotDisplayDuringCardCheckout() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -607,7 +627,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration.Builder(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(
                     merchantDisplayName = "Merchant, Inc."
                 )
                     .customer(
@@ -618,7 +638,7 @@ internal class PaymentSheetTest {
                     )
                     .allowsDelayedPaymentMethods(true)
                     .link(PaymentSheet.LinkConfiguration.Builder().display(PaymentSheet.LinkConfiguration.Display.Never).build())
-                    .build()
+                    .build())
             )
         }
 
@@ -641,6 +661,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSavedUsBankPayment_sendsClientAttributionMetadata() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -672,7 +693,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration.Builder(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(
                     merchantDisplayName = "Merchant, Inc."
                 )
                     .customer(
@@ -683,7 +704,7 @@ internal class PaymentSheetTest {
                     )
                     .allowsDelayedPaymentMethods(true)
                     .link(PaymentSheet.LinkConfiguration.Builder().display(PaymentSheet.LinkConfiguration.Display.Never).build())
-                    .build()
+                    .build())
             )
         }
 
@@ -702,6 +723,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSavedCardPayment_sendsClientAttributionMetadata() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -733,7 +755,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration.Builder(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(
                     merchantDisplayName = "Merchant, Inc."
                 )
                     .customer(
@@ -744,7 +766,7 @@ internal class PaymentSheetTest {
                     )
                     .allowsDelayedPaymentMethods(true)
                     .link(PaymentSheet.LinkConfiguration.Builder().display(PaymentSheet.LinkConfiguration.Display.Never).build())
-                    .build()
+                    .build())
             )
         }
 
@@ -763,6 +785,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testPrimaryButtonAccessibility() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -774,7 +797,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -797,6 +820,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testFocusFirstEditBadgeOnEdit() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -820,14 +844,14 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration(
                     merchantDisplayName = "Merchant, Inc.",
                     customer = PaymentSheet.CustomerConfiguration(
                         id = "cus_1",
                         ephemeralKeySecret = TestApiKeys.EPHEMERAL,
                     ),
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-                ),
+                )),
             )
         }
 
@@ -843,6 +867,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testTermsDisplayNeverHidesMandate() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -876,7 +901,7 @@ internal class PaymentSheetTest {
                         setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OffSession
                     )
                 ),
-                configuration = configurationWithTermsDisplayNever,
+                configuration = apiConfigurationTestType.applyTo(configurationWithTermsDisplayNever),
             )
         }
 
@@ -886,6 +911,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSocketErrorElementsSessions() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertFailed,
@@ -897,13 +923,14 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
     }
 
     @Test
     fun testOBO_PassedToElementsSessionCall() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         builder = {
@@ -930,7 +957,7 @@ internal class PaymentSheetTest {
                     ),
                     onBehalfOf = oboMerchantID
                 ),
-                configuration = defaultConfiguration,
+                configuration = apiConfigurationTestType.applyTo(defaultConfiguration),
             )
         }
 
@@ -941,6 +968,7 @@ internal class PaymentSheetTest {
 
     @Test
     fun testSavedCard_isDisplayedForDashboard() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
         networkRule = networkRule,
         integrationType = integrationType,
         resultCallback = ::assertCompleted,
@@ -972,7 +1000,7 @@ internal class PaymentSheetTest {
         testContext.presentPaymentSheet {
             presentWithPaymentIntent(
                 paymentIntentClientSecret = "pi_example_secret_example",
-                configuration = PaymentSheet.Configuration.Builder(
+                configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(
                     merchantDisplayName = "Merchant, Inc."
                 )
                     .customer(
@@ -982,7 +1010,7 @@ internal class PaymentSheetTest {
                         )
                     )
                     .link(PaymentSheet.LinkConfiguration.Builder().display(PaymentSheet.LinkConfiguration.Display.Never).build())
-                    .build()
+                    .build())
             )
         }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PreparePaymentMethodTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PreparePaymentMethodTest.kt
@@ -1,7 +1,10 @@
 package com.stripe.android.paymentsheet
 
+import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
+import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.checkouttesting.createPaymentMethod
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -28,7 +31,10 @@ import org.junit.runner.RunWith
 
 @OptIn(SharedPaymentTokenSessionPreview::class)
 @RunWith(TestParameterInjector::class)
-internal class PreparePaymentMethodTest {
+internal class PreparePaymentMethodTest(
+    @TestParameter(valuesProvider = ApiConfigurationTestTypeProvider::class)
+    private val apiConfigurationTestType: ApiConfigurationTestType,
+) {
     @get:Rule
     val testRules: TestRules = TestRules.create()
 
@@ -46,6 +52,7 @@ internal class PreparePaymentMethodTest {
         val completableShippingAddress = CompletableDeferred<AddressDetails?>()
 
         runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             builder = {
                 preparePaymentMethodHandler { paymentMethod, shippingAddress ->
@@ -73,9 +80,9 @@ internal class PreparePaymentMethodTest {
                             externalId = "external_123",
                         )
                     ),
-                    configuration = PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
+                    configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
                         .shippingDetails(SHIPPING_ADDRESS)
-                        .build()
+                        .build())
                 )
             }
 
@@ -103,6 +110,7 @@ internal class PreparePaymentMethodTest {
         val completableFlow = CompletableDeferred<Unit>()
 
         runFlowControllerTest(
+        apiConfigurationTestType = apiConfigurationTestType,
             networkRule = networkRule,
             builder = {
                 preparePaymentMethodHandler { paymentMethod, shippingAddress ->
@@ -133,9 +141,9 @@ internal class PreparePaymentMethodTest {
                             externalId = "external_456",
                         )
                     ),
-                    configuration = PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
+                    configuration = apiConfigurationTestType.applyTo(PaymentSheet.Configuration.Builder(merchantDisplayName = "Example, Inc.")
                         .shippingDetails(SHIPPING_ADDRESS)
-                        .build(),
+                        .build()),
                     callback = { success, error ->
                         assertThat(success).isTrue()
                         assertThat(error).isNull()
@@ -179,6 +187,7 @@ internal class PreparePaymentMethodTest {
 
         runEmbeddedPaymentElementTest(
             networkRule = networkRule,
+            apiConfigurationTestType = apiConfigurationTestType,
             builderInstance = EmbeddedPaymentElement.Builder(
                 preparePaymentMethodHandler = { paymentMethod, shippingAddress ->
                     completablePaymentMethod.complete(paymentMethod)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PreparePaymentMethodTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PreparePaymentMethodTest.kt
@@ -201,7 +201,7 @@ internal class PreparePaymentMethodTest(
                 externalId = "external_789",
             )
 
-            context.embeddedPaymentElement.configure(
+            context.configure(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     sharedPaymentTokenSessionWithMode = PaymentSheet.IntentConfiguration.Mode.Payment(
                         amount = 5000L,
@@ -213,11 +213,10 @@ internal class PreparePaymentMethodTest(
                         externalId = "external_789",
                     )
                 ),
-                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
-                    .shippingDetails(SHIPPING_ADDRESS)
+            ) {
+                shippingDetails(SHIPPING_ADDRESS)
                     .formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
-                    .build()
-            )
+            }
 
             embeddedContentPage.clickOnLpm(code = "card")
             embeddedFormPage.fillOutCardDetails()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
@@ -1,0 +1,73 @@
+package com.stripe.android.paymentsheet.utils
+
+import android.content.Context
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.networktesting.TestApiKeys
+import com.stripe.android.ApiConfigurationPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+
+internal sealed class ApiConfigurationTestType(
+    val paymentConfigurationPublishableKey: String?,
+    val apiConfiguration: ApiConfiguration?,
+) {
+    fun initializePaymentConfiguration(context: Context) {
+        PaymentConfiguration.clearInstance()
+        context.getSharedPreferences(
+            PaymentConfiguration::class.java.canonicalName,
+            Context.MODE_PRIVATE,
+        ).edit().clear().commit()
+        paymentConfigurationPublishableKey?.let { publishableKey ->
+            PaymentConfiguration.init(context, publishableKey)
+        }
+    }
+
+    fun withPublishableKey(publishableKey: String): ApiConfigurationTestType {
+        return Configured(
+            paymentConfigurationPublishableKey = paymentConfigurationPublishableKey?.let {
+                if (this is ApiConfigurationOverridesPaymentConfiguration) it else publishableKey
+            },
+            apiConfiguration = apiConfiguration?.let { configuration ->
+                ApiConfiguration(publishableKey).stripeAccountId(configuration.build().stripeAccountId)
+            },
+        )
+    }
+
+    @OptIn(ApiConfigurationPreview::class)
+    fun applyTo(configuration: PaymentSheet.Configuration): PaymentSheet.Configuration {
+        return apiConfiguration?.let { apiConfiguration ->
+            configuration.newBuilder().apiConfiguration(apiConfiguration).build()
+        } ?: configuration
+    }
+
+    data object PaymentConfigurationOnly : ApiConfigurationTestType(
+        paymentConfigurationPublishableKey = TestApiKeys.PUBLISHABLE,
+        apiConfiguration = null,
+    )
+
+    data object ApiConfigurationOnly : ApiConfigurationTestType(
+        paymentConfigurationPublishableKey = null,
+        apiConfiguration = ApiConfiguration(TestApiKeys.PUBLISHABLE),
+    )
+
+    data object ApiConfigurationOverridesPaymentConfiguration : ApiConfigurationTestType(
+        paymentConfigurationPublishableKey = "pk_test_should_not_be_used",
+        apiConfiguration = ApiConfiguration(TestApiKeys.PUBLISHABLE),
+    )
+
+    private class Configured(
+        paymentConfigurationPublishableKey: String?,
+        apiConfiguration: ApiConfiguration?,
+    ) : ApiConfigurationTestType(paymentConfigurationPublishableKey, apiConfiguration)
+}
+
+internal object ApiConfigurationTestTypeProvider : TestParameterValuesProvider() {
+    override fun provideValues(
+        context: Context?,
+    ): List<ApiConfigurationTestType> = listOf(
+        ApiConfigurationTestType.PaymentConfigurationOnly,
+        ApiConfigurationTestType.ApiConfigurationOnly,
+        ApiConfigurationTestType.ApiConfigurationOverridesPaymentConfiguration,
+    )
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/FlowControllerTestRunner.kt
@@ -26,6 +26,7 @@ internal class FlowControllerTestRunnerContext(
     val flowController: PaymentSheet.FlowController,
     val configureCallbackTurbine: Turbine<PaymentOption?>,
     private val countDownLatch: CountDownLatch,
+    val apiConfigurationTestType: ApiConfigurationTestType,
 ) {
 
     fun configureFlowController(
@@ -62,6 +63,7 @@ internal class FlowControllerTestRunnerContext(
 @OptIn(WalletButtonsPreview::class)
 internal fun runFlowControllerTest(
     networkRule: NetworkRule,
+    apiConfigurationTestType: ApiConfigurationTestType,
     integrationType: IntegrationType = IntegrationType.Compose,
     callConfirmOnPaymentOptionCallback: Boolean = true,
     showWalletButtons: Boolean = false,
@@ -86,7 +88,7 @@ internal fun runFlowControllerTest(
         scenario.moveToState(Lifecycle.State.CREATED)
 
         scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
+            apiConfigurationTestType.initializePaymentConfiguration(it)
             DefaultLinkStore(it.applicationContext).clear()
         }
 
@@ -120,6 +122,7 @@ internal fun runFlowControllerTest(
             ),
             configureCallbackTurbine = configureCallbackTurbine,
             countDownLatch = countDownLatch,
+            apiConfigurationTestType = apiConfigurationTestType,
         )
         runTest {
             block(testContext)
@@ -135,6 +138,7 @@ internal fun runFlowControllerTest(
 
 internal fun runMultipleFlowControllerInstancesTest(
     networkRule: NetworkRule,
+    apiConfigurationTestType: ApiConfigurationTestType,
     testType: MultipleInstancesTestType,
     callConfirmOnPaymentOptionCallback: Boolean = true,
     createIntentCallback: CreateIntentCallback,
@@ -198,7 +202,7 @@ internal fun runMultipleFlowControllerInstancesTest(
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
         scenario.moveToState(Lifecycle.State.CREATED)
         scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
+            apiConfigurationTestType.initializePaymentConfiguration(it)
             DefaultLinkStore(it.applicationContext).clear()
         }
 
@@ -225,6 +229,7 @@ internal fun runMultipleFlowControllerInstancesTest(
             flowController = flowController,
             configureCallbackTurbine = configureCallbackTurbine,
             countDownLatch = countDownLatch,
+            apiConfigurationTestType = apiConfigurationTestType,
         )
         runTest {
             block(testContext)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PaymentSheetTestRunner.kt
@@ -20,6 +20,7 @@ internal class PaymentSheetTestRunnerContext(
     private val scenario: ActivityScenario<MainActivity>,
     private val paymentSheet: PaymentSheet,
     private val countDownLatch: CountDownLatch,
+    val apiConfigurationTestType: ApiConfigurationTestType,
 ) {
 
     fun presentPaymentSheet(
@@ -45,6 +46,7 @@ internal class PaymentSheetTestRunnerContext(
 
 internal fun runPaymentSheetTest(
     networkRule: NetworkRule,
+    apiConfigurationTestType: ApiConfigurationTestType,
     isLiveMode: Boolean = false,
     integrationType: IntegrationType = IntegrationType.Compose,
     builder: PaymentSheet.Builder.() -> Unit = {},
@@ -53,6 +55,11 @@ internal fun runPaymentSheetTest(
     block: suspend (PaymentSheetTestRunnerContext) -> Unit,
 ) {
     val countDownLatch = CountDownLatch(1)
+    val effectiveApiConfigurationTestType = if (isLiveMode) {
+        apiConfigurationTestType.withPublishableKey("pk_live_123")
+    } else {
+        apiConfigurationTestType
+    }
 
     val paymentSheetBuilder = PaymentSheet.Builder { result ->
         resultCallback.onPaymentSheetResult(result)
@@ -64,14 +71,7 @@ internal fun runPaymentSheetTest(
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
         scenario.moveToState(Lifecycle.State.CREATED)
         scenario.onActivity {
-            PaymentConfiguration.init(
-                it,
-                if (isLiveMode) {
-                    "pk_live_123"
-                } else {
-                    "pk_test_123"
-                }
-            )
+            effectiveApiConfigurationTestType.initializePaymentConfiguration(it)
             DefaultLinkStore(it.applicationContext).clear()
         }
 
@@ -90,7 +90,12 @@ internal fun runPaymentSheetTest(
 
         scenario.moveToState(Lifecycle.State.RESUMED)
 
-        val testContext = PaymentSheetTestRunnerContext(scenario, paymentSheet, countDownLatch)
+        val testContext = PaymentSheetTestRunnerContext(
+            scenario,
+            paymentSheet,
+            countDownLatch,
+            effectiveApiConfigurationTestType,
+        )
         runTest {
             block(testContext)
         }
@@ -103,6 +108,7 @@ internal fun runPaymentSheetTest(
 
 internal fun runMultiplePaymentSheetInstancesTest(
     networkRule: NetworkRule,
+    apiConfigurationTestType: ApiConfigurationTestType,
     testType: MultipleInstancesTestType,
     createIntentCallback: CreateIntentCallback,
     successTimeoutSeconds: Long = 5L,
@@ -151,7 +157,7 @@ internal fun runMultiplePaymentSheetInstancesTest(
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
         scenario.moveToState(Lifecycle.State.CREATED)
         scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
+            apiConfigurationTestType.initializePaymentConfiguration(it)
             DefaultLinkStore(it.applicationContext).clear()
         }
 
@@ -173,7 +179,12 @@ internal fun runMultiplePaymentSheetInstancesTest(
             secondPaymentSheet
         }
 
-        val testContext = PaymentSheetTestRunnerContext(scenario, paymentSheet, countDownLatch)
+        val testContext = PaymentSheetTestRunnerContext(
+            scenario,
+            paymentSheet,
+            countDownLatch,
+            apiConfigurationTestType,
+        )
         block(testContext)
 
         val didCompleteSuccessfully = countDownLatch.await(successTimeoutSeconds, TimeUnit.SECONDS)

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ProductIntegrationTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ProductIntegrationTestRunner.kt
@@ -10,6 +10,7 @@ import com.stripe.android.paymentsheet.PaymentSheetResultCallback
 internal fun runProductIntegrationTest(
     networkRule: NetworkRule,
     integrationType: ProductIntegrationType,
+    apiConfigurationTestType: ApiConfigurationTestType,
     builder: ProductIntegrationBuilder.() -> Unit = {},
     resultCallback: PaymentSheetResultCallback,
     block: suspend (ProductIntegrationTestRunnerContext) -> Unit,
@@ -22,6 +23,7 @@ internal fun runProductIntegrationTest(
         ProductIntegrationType.PaymentSheet -> {
             runPaymentSheetTest(
                 networkRule = networkRule,
+                apiConfigurationTestType = apiConfigurationTestType,
                 integrationType = IntegrationType.Compose,
                 builder = {
                     integrationBuilder.applyToPaymentSheetBuilder(this)
@@ -35,6 +37,7 @@ internal fun runProductIntegrationTest(
         ProductIntegrationType.FlowController -> {
             runFlowControllerTest(
                 networkRule = networkRule,
+                apiConfigurationTestType = apiConfigurationTestType,
                 integrationType = IntegrationType.Compose,
                 builder = {
                     integrationBuilder.applyToFlowControllerBuilder(this)
@@ -113,12 +116,12 @@ internal sealed interface ProductIntegrationTestRunnerContext {
                                 currency = "usd"
                             )
                         ),
-                        configuration = configuration,
+                        configuration = context.apiConfigurationTestType.applyTo(configuration),
                     )
                 } else {
                     presentWithPaymentIntent(
                         paymentIntentClientSecret = "pi_example_secret_example",
-                        configuration = configuration,
+                        configuration = context.apiConfigurationTestType.applyTo(configuration),
                     )
                 }
             }
@@ -148,7 +151,7 @@ internal sealed interface ProductIntegrationTestRunnerContext {
                                 currency = "usd",
                             )
                         ),
-                        configuration = configuration,
+                        configuration = context.apiConfigurationTestType.applyTo(configuration),
                         callback = { success, error ->
                             assertThat(success).isTrue()
                             assertThat(error).isNull()
@@ -158,7 +161,7 @@ internal sealed interface ProductIntegrationTestRunnerContext {
                 } else {
                     configureWithPaymentIntent(
                         paymentIntentClientSecret = "pi_example_secret_example",
-                        configuration = configuration,
+                        configuration = context.apiConfigurationTestType.applyTo(configuration),
                         callback = { success, error ->
                             assertThat(success).isTrue()
                             assertThat(error).isNull()

--- a/paymentsheet/src/main/java/com/stripe/android/ApiConfigurationPreview.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/ApiConfigurationPreview.kt
@@ -1,0 +1,8 @@
+package com.stripe.android
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message = "This API is under construction. It can be changed or removed at any time (use at your own risk)"
+)
+@Retention(AnnotationRetention.BINARY)
+annotation class ApiConfigurationPreview

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -273,6 +273,7 @@ internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): Commo
     userOverrideCountry = userOverrideCountry,
     appearance = appearance,
     allowedCardFundingTypes = allowedCardFundingTypes,
+    apiConfiguration = apiConfiguration,
 )
 
 internal fun LinkController.Configuration.State.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -248,6 +248,7 @@ internal fun PaymentSheet.Configuration.asCommonConfiguration(): CommonConfigura
     userOverrideCountry = userOverrideCountry,
     appearance = appearance,
     allowedCardFundingTypes = allowedCardFundingTypes,
+    apiConfiguration = apiConfiguration,
 )
 
 internal fun EmbeddedPaymentElement.Configuration.asCommonConfiguration(): CommonConfiguration = CommonConfiguration(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -13,10 +13,12 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.ui.DelegateDrawable
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentIntent
@@ -264,6 +266,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
         internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
         internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically,
         internal val userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry,
+        internal val apiConfiguration: ApiConfiguration.State?,
     ) : Parcelable {
         @Suppress("TooManyFunctions")
         class Builder(
@@ -301,6 +304,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
             private var opensCardScannerAutomatically: Boolean =
                 ConfigurationDefaults.opensCardScannerAutomatically
             private var userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry
+            private var apiConfiguration: ApiConfiguration.State? = null
 
             /**
              * If set, the customer can select a previously saved payment method.
@@ -537,6 +541,17 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 this.userOverrideCountry = userOverrideCountry
             }
 
+            /**
+             * Sets the API credentials to use for this payment element.
+             *
+             * When not set, the payment element uses the credentials initialized through
+             * [com.stripe.android.PaymentConfiguration].
+             */
+            @ApiConfigurationPreview
+            fun apiConfiguration(apiConfiguration: ApiConfiguration) = apply {
+                this.apiConfiguration = apiConfiguration.build()
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -561,6 +576,7 @@ class EmbeddedPaymentElement @Inject internal constructor(
                 termsDisplay = termsDisplay,
                 opensCardScannerAutomatically = opensCardScannerAutomatically,
                 userOverrideCountry = userOverrideCountry,
+                apiConfiguration = apiConfiguration,
             )
         }
 
@@ -592,6 +608,12 @@ class EmbeddedPaymentElement @Inject internal constructor(
             .userOverrideCountry(userOverrideCountry)
             .apply {
                 primaryButtonLabel?.let { primaryButtonLabel(it) }
+                apiConfiguration?.let {
+                    @OptIn(ApiConfigurationPreview::class)
+                    apiConfiguration(
+                        ApiConfiguration(it.publishableKey).stripeAccountId(it.stripeAccountId)
+                    )
+                }
             }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1140,7 +1140,7 @@ class PaymentSheet internal constructor(
              * When not set, the payment element uses the credentials initialized through
              * [com.stripe.android.PaymentConfiguration].
              */
-            @ApiConfigurationPreview
+            @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
             internal fun apiConfiguration(apiConfiguration: ApiConfiguration) = apply {
                 this.apiConfiguration = apiConfiguration.build()
             }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -14,12 +14,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.fragment.app.Fragment
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.CollectMissingLinkBillingDetailsPreview
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.configuration.ConfigurationDefaults
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.reactnative.ReactNativeSdkInternal
 import com.stripe.android.core.reactnative.UnregisterSignal
 import com.stripe.android.core.strings.ResolvableString
@@ -812,6 +814,7 @@ class PaymentSheet internal constructor(
         internal val termsDisplay: Map<PaymentMethod.Type, TermsDisplay> = emptyMap(),
         internal val opensCardScannerAutomatically: Boolean = ConfigurationDefaults.opensCardScannerAutomatically,
         internal val userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry,
+        internal val apiConfiguration: ApiConfiguration.State? = null,
     ) : Parcelable {
 
         @JvmOverloads
@@ -917,6 +920,7 @@ class PaymentSheet internal constructor(
             allowsRemovalOfLastSavedPaymentMethod = ConfigurationDefaults.allowsRemovalOfLastSavedPaymentMethod,
             externalPaymentMethods = ConfigurationDefaults.externalPaymentMethods,
             customPaymentMethods = ConfigurationDefaults.customPaymentMethods,
+            apiConfiguration = null,
         )
 
         /**
@@ -952,6 +956,7 @@ class PaymentSheet internal constructor(
             private var opensCardScannerAutomatically: Boolean =
                 ConfigurationDefaults.opensCardScannerAutomatically
             private var userOverrideCountry: String? = ConfigurationDefaults.userOverrideCountry
+            private var apiConfiguration: ApiConfiguration.State? = null
 
             private var customPaymentMethods: List<CustomPaymentMethod> =
                 ConfigurationDefaults.customPaymentMethods
@@ -1129,6 +1134,17 @@ class PaymentSheet internal constructor(
                 this.userOverrideCountry = userOverrideCountry
             }
 
+            /**
+             * Sets the API credentials to use for PaymentSheet or FlowController.
+             *
+             * When not set, the payment element uses the credentials initialized through
+             * [com.stripe.android.PaymentConfiguration].
+             */
+            @ApiConfigurationPreview
+            internal fun apiConfiguration(apiConfiguration: ApiConfiguration) = apply {
+                this.apiConfiguration = apiConfiguration.build()
+            }
+
             fun build() = Configuration(
                 merchantDisplayName = merchantDisplayName,
                 customer = customer,
@@ -1154,6 +1170,7 @@ class PaymentSheet internal constructor(
                 termsDisplay = termsDisplay,
                 opensCardScannerAutomatically = opensCardScannerAutomatically,
                 userOverrideCountry = userOverrideCountry,
+                apiConfiguration = apiConfiguration,
             )
         }
 
@@ -1196,6 +1213,12 @@ class PaymentSheet internal constructor(
                 @Suppress("DEPRECATION")
                 googlePlacesApiKey?.let { googlePlacesApiKey(it) }
                 userOverrideCountry?.let { userOverrideCountry(it) }
+                apiConfiguration?.let {
+                    @OptIn(ApiConfigurationPreview::class)
+                    apiConfiguration(
+                        ApiConfiguration(it.publishableKey).stripeAccountId(it.stripeAccountId)
+                    )
+                }
             }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -10,10 +10,9 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.lifecycle.ViewModelProvider
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
-import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.ui.BaseSheetActivity
 import com.stripe.android.paymentsheet.ui.PaymentElementTheme
 import com.stripe.android.paymentsheet.ui.PaymentSheetScreen
@@ -48,12 +47,9 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
                 starterArgs.initializationMode.validate()
                 starterArgs.config.asCommonConfiguration().validate(
                     initializationMode = starterArgs.initializationMode,
-                    isLiveMode = PaymentConfiguration.getInstance(this).let {
-                        ApiConfiguration.State(
-                            publishableKey = it.publishableKey,
-                            stripeAccountId = it.stripeAccountId,
-                        )
-                    }.isLiveMode(),
+                    isLiveMode = ApiConfigurationResolver(this)
+                        .resolve(starterArgs.config.apiConfiguration)
+                        .isLiveMode(),
                     callbackIdentifier = starterArgs.paymentElementCallbackIdentifier,
                 )
             } catch (e: IllegalArgumentException) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/EmbeddedPaymentElementConfigurationTest.kt
@@ -2,7 +2,10 @@ package com.stripe.android.paymentelement
 
 import androidx.compose.ui.graphics.Color
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.CardFundingFilteringPrivatePreview
@@ -16,9 +19,25 @@ import org.junit.Test
 
 class EmbeddedPaymentElementConfigurationTest {
 
+    @Test
+    @OptIn(ApiConfigurationPreview::class)
+    fun `api configuration is included in common configuration`() {
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Test Merchant")
+            .apiConfiguration(
+                ApiConfiguration("pk_test_123").stripeAccountId("acct_123")
+            )
+            .build()
+
+        val apiConfiguration = configuration.asCommonConfiguration().apiConfiguration
+
+        assertThat(apiConfiguration?.publishableKey).isEqualTo("pk_test_123")
+        assertThat(apiConfiguration?.stripeAccountId).isEqualTo("acct_123")
+    }
+
     @OptIn(
         ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi::class,
         CardFundingFilteringPrivatePreview::class,
+        ApiConfigurationPreview::class
     )
     @Test
     fun `newBuilder round-trips all properties`() {
@@ -68,6 +87,9 @@ class EmbeddedPaymentElementConfigurationTest {
             .termsDisplay(mapOf(PaymentMethod.Type.Card to TermsDisplay.NEVER))
             .opensCardScannerAutomatically(true)
             .userOverrideCountry("GB")
+            .apiConfiguration(
+                ApiConfiguration("pk_test_123").stripeAccountId("acct_123")
+            )
             .build()
 
         val roundTripped = original.newBuilder().build()
@@ -85,6 +107,6 @@ class EmbeddedPaymentElementConfigurationTest {
         // When a new property is added, this count will change, signaling that:
         // 1. newBuilder() needs to propagate the new property
         // 2. The round-trip test above needs a non-default value for it
-        assertThat(propertyCount).isEqualTo(23)
+        assertThat(propertyCount).isEqualTo(24)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetConfigurationTest.kt
@@ -106,6 +106,6 @@ class PaymentSheetConfigurationTest {
         // When a new property is added, this count will change, signaling that:
         // 1. newBuilder() needs to propagate the new property
         // 2. The round-trip test above needs a non-default value for it
-        assertThat(propertyCount).isEqualTo(24)
+        assertThat(propertyCount).isEqualTo(25)
     }
 }

--- a/stripe-core/api/stripe-core.api
+++ b/stripe-core/api/stripe-core.api
@@ -1,3 +1,8 @@
+public final class com/stripe/android/core/ApiConfiguration {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun stripeAccountId (Ljava/lang/String;)Lcom/stripe/android/core/ApiConfiguration;
+}
+
 public final class com/stripe/android/core/AppInfo : android/os/Parcelable {
 	public static final field CREATOR Landroid/os/Parcelable$Creator;
 	public static final field Companion Lcom/stripe/android/core/AppInfo$Companion;

--- a/stripe-core/src/main/java/com/stripe/android/core/ApiConfiguration.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/ApiConfiguration.kt
@@ -9,7 +9,6 @@ import kotlinx.parcelize.Parcelize
  * payment UI components. When not provided, components fall back to
  * [PaymentConfiguration.getInstance].
  */
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class ApiConfiguration(
     private val publishableKey: String,
 ) {


### PR DESCRIPTION
# Summary
Expose ApiConfiguration as a preview API and add EmbeddedPaymentElement.Configuration.Builder.apiConfiguration() so each embedded payment element can supply its own publishable key and optional Stripe account ID.

Carry the configured state through CommonConfiguration to PaymentElementLoader, while preserving PaymentConfiguration fallback when no per-instance configuration is supplied.

Changed classes and entry points:

- `ApiConfigurationPreview`, `ApiConfiguration`: expose the publishable-key/Stripe-account pair as a preview public configuration API.
- `EmbeddedPaymentElement.Configuration.Builder`, `EmbeddedPaymentElement`: add the per-instance `apiConfiguration()` entry point.
- `PaymentSheet.Configuration`, `PaymentSheet`: carry the same explicit configuration in the shared PaymentSheet configuration model.
- `CommonConfiguration`: stores the public configuration as the internal paired state consumed by loading.
- `PaymentSheetActivity`: preserves explicit configuration when recreating the PaymentSheet Activity.
- `paymentsheet.api`, `stripe-core.api`: record the new preview API surface.

Committed and created by Codex.

# Motivation
Embedded payment elements can coexist with other Stripe integrations in the same process. Reading mutable global PaymentConfiguration during loading can select credentials from a different integration.

A per-instance configuration keeps the publishable key and Stripe account ID paired with the embedded element that owns them. The parameterized instrumentation coverage proves PaymentConfiguration-only compatibility, API-configuration-only operation, and that explicit API configuration overrides a conflicting global key.

# Testing
- [x] Added tests
- [x] Modified tests
- [x] Manually verified — 27 EmbeddedPaymentElementTest parameterized managed-device cases passed across all three credential modes

# Screenshots
Not applicable — configuration API and request wiring only.

# Changelog
Adds a preview API for configuring EmbeddedPaymentElement credentials per instance.