### PR TITLE
Select Google Pay callbacks in `GooglePayPaymentMethodLauncher`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallbackRegistry.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentDataUpdateCallbackRegistry.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.googlepaylauncher
 
 import androidx.annotation.MainThread
-import androidx.annotation.RestrictTo
+import kotlinx.coroutines.CoroutineScope
 
-@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-object GooglePayPaymentDataUpdateCallbackRegistry {
+internal object GooglePayPaymentDataUpdateCallbackRegistry {
+    private var selection: Selection? = null
     private val registeredCallbacks = mutableMapOf<String, GooglePayPaymentDataUpdateCallback>()
 
     @MainThread
@@ -17,7 +17,22 @@ object GooglePayPaymentDataUpdateCallbackRegistry {
         registeredCallbacks.remove(key)
     }
 
-    fun get(key: String): GooglePayPaymentDataUpdateCallback? {
-        return registeredCallbacks[key]
+    fun select(key: String, workScope: CoroutineScope) {
+        selection = registeredCallbacks[key]?.let {
+            Selection(callback = it, workScope = workScope)
+        }
     }
+
+    fun deselect() {
+        selection = null
+    }
+
+    fun get(): Selection? {
+        return selection
+    }
+
+    class Selection(
+        val callback: GooglePayPaymentDataUpdateCallback,
+        val workScope: CoroutineScope,
+    )
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherContractV2.kt
@@ -61,6 +61,7 @@ class GooglePayPaymentMethodLauncherContractV2 :
         internal val displayItems: List<GooglePayJsonFactory.DisplayItem> = emptyList(),
         internal val billingEmailOverride: String? = null,
         internal val shippingAddressParameters: GooglePayJsonFactory.ShippingAddressParameters?,
+        internal val dynamicCallbackId: String? = null,
     ) : Parcelable {
         internal fun toBundle() = bundleOf(EXTRA_ARGS to this)
 

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
@@ -17,6 +18,7 @@ import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.exception.InvalidRequestException
+import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.utils.requireApplication
 import com.stripe.android.googlepaylauncher.injection.DaggerGooglePayPaymentMethodLauncherViewModelFactoryComponent
@@ -26,9 +28,11 @@ import com.stripe.android.networking.StripeRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.plus
 import org.json.JSONObject
 import java.util.Locale
 import javax.inject.Inject
+import kotlin.coroutines.CoroutineContext
 
 internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
     private val context: Context,
@@ -38,6 +42,7 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
     private val stripeRepository: StripeRepository,
     private val googlePayJsonFactory: GooglePayJsonFactory,
     private val googlePayRepository: GooglePayRepository,
+    @IOContext private val workContext: CoroutineContext,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
     /**
@@ -51,6 +56,19 @@ internal class GooglePayPaymentMethodLauncherViewModel @Inject constructor(
 
     private val _googleResult = MutableStateFlow<GooglePayPaymentMethodLauncher.Result?>(null)
     internal val googlePayResult = _googleResult.asStateFlow()
+
+    init {
+        args.dynamicCallbackId?.let { dynamicCallbackId ->
+            GooglePayPaymentDataUpdateCallbackRegistry.select(
+                key = dynamicCallbackId,
+                workScope = viewModelScope.plus(workContext),
+            )
+        }
+    }
+
+    override fun onCleared() {
+        GooglePayPaymentDataUpdateCallbackRegistry.deselect()
+    }
 
     fun updateResult(result: GooglePayPaymentMethodLauncher.Result) {
         _googleResult.value = result

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncher.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncher.kt
@@ -83,6 +83,7 @@ class InternalGooglePayPaymentMethodLauncher @AssistedInject internal constructo
     ) {
         activityResultLauncher.launch(
             GooglePayPaymentMethodLauncherContractV2.Args(
+                dynamicCallbackId = instanceId.takeIf { onPaymentDataChangedCallback != null },
                 config = config,
                 currencyCode = currencyCode,
                 amount = amount,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherViewModelTest.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModelStore
 import androidx.test.core.app.ApplicationProvider
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.wallet.PaymentData
@@ -33,6 +34,7 @@ import com.stripe.android.testing.AbsFakeStripeRepository
 import com.stripe.android.testing.ViewModelStoreTestRule
 import com.stripe.android.testing.fakeCreationExtras
 import kotlinx.coroutines.test.runTest
+import org.junit.After
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -40,6 +42,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 
@@ -69,16 +72,46 @@ class GooglePayPaymentMethodLauncherViewModelTest {
         TestFragment()
     }
 
-    private val viewModel = GooglePayPaymentMethodLauncherViewModel(
-        ApplicationProvider.getApplicationContext(),
-        paymentsClient,
-        REQUEST_OPTIONS,
-        ARGS,
-        stripeRepository,
-        googlePayJsonFactory,
-        googlePayRepository,
-        SavedStateHandle()
-    ).also { viewModelStoreRule.track(it) }
+    private val viewModel = createViewModel(ARGS)
+
+    @After
+    fun tearDown() {
+        GooglePayPaymentDataUpdateCallbackRegistry.deselect()
+        GooglePayPaymentDataUpdateCallbackRegistry.deregister(CALLBACK_ID)
+    }
+
+    @Test
+    fun `init selects dynamic callback`() {
+        val callback = GooglePayPaymentDataUpdateCallback {
+            GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null)
+        }
+        GooglePayPaymentDataUpdateCallbackRegistry.register(CALLBACK_ID, callback)
+
+        createViewModel(ARGS.copy(dynamicCallbackId = CALLBACK_ID)).also {
+            viewModelStoreRule.track(it)
+        }
+
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get()?.callback)
+            .isSameInstanceAs(callback)
+    }
+
+    @Test
+    fun `onCleared deselects dynamic callback`() {
+        val callback = GooglePayPaymentDataUpdateCallback {
+            GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null)
+        }
+        GooglePayPaymentDataUpdateCallbackRegistry.register(CALLBACK_ID, callback)
+
+        val viewModelStore = ViewModelStore()
+        viewModelStore.put("view_model", createViewModel(ARGS.copy(dynamicCallbackId = CALLBACK_ID)))
+
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get()?.callback)
+            .isSameInstanceAs(callback)
+
+        viewModelStore.clear()
+
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get()).isNull()
+    }
 
     @Test
     fun `createPaymentMethod() should return expected result`() = runTest {
@@ -129,16 +162,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
 
     @Test
     fun `createPaymentMethod() uses billingEmailOverride when Google Pay has no email`() = runTest {
-        val viewModelWithEmail = GooglePayPaymentMethodLauncherViewModel(
-            ApplicationProvider.getApplicationContext(),
-            paymentsClient,
-            REQUEST_OPTIONS,
-            ARGS.copy(billingEmailOverride = "checkout@example.com"),
-            stripeRepository,
-            googlePayJsonFactory,
-            googlePayRepository,
-            SavedStateHandle()
-        ).also { viewModelStoreRule.track(it) }
+        val viewModelWithEmail = createViewModel(ARGS.copy(billingEmailOverride = "checkout@example.com"))
 
         viewModelWithEmail.createPaymentMethod(
             PaymentData.fromJson(
@@ -152,16 +176,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
 
     @Test
     fun `createPaymentMethod() prefers billingEmailOverride over Google Pay email`() = runTest {
-        val viewModelWithEmail = GooglePayPaymentMethodLauncherViewModel(
-            ApplicationProvider.getApplicationContext(),
-            paymentsClient,
-            REQUEST_OPTIONS,
-            ARGS.copy(billingEmailOverride = "checkout@example.com"),
-            stripeRepository,
-            googlePayJsonFactory,
-            googlePayRepository,
-            SavedStateHandle()
-        ).also { viewModelStoreRule.track(it) }
+        val viewModelWithEmail = createViewModel(ARGS.copy(billingEmailOverride = "checkout@example.com"))
 
         viewModelWithEmail.createPaymentMethod(
             PaymentData.fromJson(
@@ -267,16 +282,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
 
     @Test
     fun `createPaymentDataRequest() with isElements=true should set 'stripe-elements' software id`() {
-        val viewModel = GooglePayPaymentMethodLauncherViewModel(
-            ApplicationProvider.getApplicationContext(),
-            paymentsClient,
-            REQUEST_OPTIONS,
-            ARGS.copy(isElements = true),
-            stripeRepository,
-            googlePayJsonFactory,
-            googlePayRepository,
-            SavedStateHandle()
-        ).also { viewModelStoreRule.track(it) }
+        val viewModel = createViewModel(ARGS.copy(isElements = true))
 
         val paymentDataRequest = viewModel.createPaymentDataRequest()
 
@@ -289,16 +295,7 @@ class GooglePayPaymentMethodLauncherViewModelTest {
 
     @Test
     fun `createPaymentDataRequest() with isElements=false should set 'stripe-launcher' software id`() {
-        val viewModel = GooglePayPaymentMethodLauncherViewModel(
-            ApplicationProvider.getApplicationContext(),
-            paymentsClient,
-            REQUEST_OPTIONS,
-            ARGS.copy(isElements = false),
-            stripeRepository,
-            googlePayJsonFactory,
-            googlePayRepository,
-            SavedStateHandle()
-        ).also { viewModelStoreRule.track(it) }
+        val viewModel = createViewModel(ARGS.copy(isElements = false))
 
         val paymentDataRequest = viewModel.createPaymentDataRequest()
 
@@ -311,22 +308,15 @@ class GooglePayPaymentMethodLauncherViewModelTest {
 
     @Test
     fun `createPaymentDataRequest() should include shipping address parameters`() {
-        val viewModel = GooglePayPaymentMethodLauncherViewModel(
-            ApplicationProvider.getApplicationContext(),
-            paymentsClient,
-            REQUEST_OPTIONS,
-            ARGS.copy(
+        val viewModel = createViewModel(
+            args = ARGS.copy(
                 shippingAddressParameters = GooglePayJsonFactory.ShippingAddressParameters(
                     isRequired = true,
                     allowedCountryCodes = setOf("US", "CA"),
                     phoneNumberRequired = true,
                 ),
             ),
-            stripeRepository,
-            googlePayJsonFactory,
-            googlePayRepository,
-            SavedStateHandle()
-        ).also { viewModelStoreRule.track(it) }
+        )
 
         val paymentDataRequest = viewModel.createPaymentDataRequest()
 
@@ -393,7 +383,26 @@ class GooglePayPaymentMethodLauncherViewModelTest {
         ): View = FrameLayout(inflater.context)
     }
 
+    private fun createViewModel(
+        args: GooglePayPaymentMethodLauncherContractV2.Args,
+    ): GooglePayPaymentMethodLauncherViewModel {
+        return viewModelStoreRule.track(
+            GooglePayPaymentMethodLauncherViewModel(
+                ApplicationProvider.getApplicationContext(),
+                paymentsClient,
+                REQUEST_OPTIONS,
+                args,
+                stripeRepository,
+                googlePayJsonFactory,
+                googlePayRepository,
+                EmptyCoroutineContext,
+                SavedStateHandle(),
+            )
+        )
+    }
+
     private companion object {
+        const val CALLBACK_ID = "callback_id"
         val ARGS = GooglePayPaymentMethodLauncherContractV2.Args(
             GooglePayPaymentMethodLauncher.Config(
                 GooglePayEnvironment.Test,

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/InternalGooglePayPaymentMethodLauncherTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.FakeActivityResultLauncher
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -19,25 +20,28 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class InternalGooglePayPaymentMethodLauncherTest {
     @Test
-    fun `init registers callback with registry when callback is provided`() {
+    fun `init registers callback with registry when callback is provided`() = runTest {
         val callback = GooglePayPaymentDataUpdateCallback { _ ->
             GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null)
         }
 
         createLauncher(instanceId = "instanceId", onPaymentDataChangedCallback = callback)
+        GooglePayPaymentDataUpdateCallbackRegistry.select("instanceId", this)
 
-        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get("instanceId")).isSameInstanceAs(callback)
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get()?.callback).isSameInstanceAs(callback)
+        GooglePayPaymentDataUpdateCallbackRegistry.deselect()
     }
 
     @Test
-    fun `init does not register anything when callback is null`() {
+    fun `init does not register anything when callback is null`() = runTest {
         createLauncher(instanceId = "instanceId", onPaymentDataChangedCallback = null)
+        GooglePayPaymentDataUpdateCallbackRegistry.select("instanceId", this)
 
-        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get("instanceId")).isNull()
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get()).isNull()
     }
 
     @Test
-    fun `callback is deregistered when lifecycle owner is destroyed`() {
+    fun `callback is deregistered when lifecycle owner is destroyed`() = runTest {
         val lifecycleOwner = TestLifecycleOwner(initialState = Lifecycle.State.CREATED)
         val callback = GooglePayPaymentDataUpdateCallback { _ ->
             GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null)
@@ -49,11 +53,10 @@ class InternalGooglePayPaymentMethodLauncherTest {
             onPaymentDataChangedCallback = callback,
         )
 
-        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get("instanceId")).isSameInstanceAs(callback)
-
         lifecycleOwner.currentState = Lifecycle.State.DESTROYED
+        GooglePayPaymentDataUpdateCallbackRegistry.select("instanceId", this)
 
-        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get("instanceId")).isNull()
+        assertThat(GooglePayPaymentDataUpdateCallbackRegistry.get()).isNull()
     }
 
     @Test
@@ -97,8 +100,40 @@ class InternalGooglePayPaymentMethodLauncherTest {
                 displayItems = emptyList(),
                 billingEmailOverride = null,
                 shippingAddressParameters = null,
+                dynamicCallbackId = null,
             )
         )
+    }
+
+    @Test
+    fun `present includes dynamic callback id when callback is provided`() {
+        val activityResultLauncher = FakeActivityResultLauncher(GooglePayPaymentMethodLauncherContractV2())
+        val callback = GooglePayPaymentDataUpdateCallback {
+            GooglePayPaymentDataUpdateResponse(newTransactionInfo = null, error = null)
+        }
+        val launcher = createLauncher(
+            instanceId = "instanceId",
+            activityResultLauncher = activityResultLauncher,
+            onPaymentDataChangedCallback = callback,
+        )
+
+        launcher.present(
+            currencyCode = "usd",
+            amount = 1000L,
+            config = CONFIG,
+            cardBrandFilter = DefaultCardBrandFilter,
+            cardFundingFilter = DefaultCardFundingFilter,
+            clientAttributionMetadata = null,
+            transactionId = null,
+            label = null,
+            isElements = true,
+            publishableKey = null,
+            displayItems = emptyList(),
+            billingEmailOverride = null,
+            shippingAddressParameters = null,
+        )
+
+        assertThat(activityResultLauncher.launchArgs.single().dynamicCallbackId).isEqualTo("instanceId")
     }
 
     private fun createLauncher(
@@ -120,6 +155,14 @@ class InternalGooglePayPaymentMethodLauncherTest {
                 publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
             ),
             analyticsRequestExecutor = analyticsRequestExecutor,
+        )
+    }
+
+    private companion object {
+        val CONFIG = GooglePayPaymentMethodLauncher.Config(
+            environment = GooglePayEnvironment.Test,
+            merchantCountryCode = "US",
+            merchantName = "Widget Store",
         )
     }
 }


### PR DESCRIPTION
# Summary
Selects the registered Google Pay payment-data callback for the active launcher and passes its identifier through the launcher contract. Configures the Checkout example to request shipping addresses for the shipping-tax scenario.

# Motivation
Support for Google callbacks

# Testing

- [x] Modified tests
- [x] `./gradlew :payments-core:testDebugUnitTest :paymentsheet:testDebugUnitTest :paymentsheet-example:compileBaseDebugKotlin`

# Changelog
No user-facing changelog entry; this is internal plumbing for the upper PR.

Committed and created by Codex.