### PR TITLE
Filter tax-incomplete saved payment methods (MOBILESDK-4697)

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementAnalyticsTest.kt
@@ -121,8 +121,11 @@ internal class CheckoutPaymentElementAnalyticsTest {
                                 "type": "card",
                                 "billing_details": {
                                     "address": {
+                                        "line1": "510 Townsend St",
+                                        "city": "San Francisco",
+                                        "state": "CA",
                                         "country": "US",
-                                        "postal_code": "12345"
+                                        "postal_code": "94103"
                                     }
                                 },
                                 "card": {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -65,6 +65,7 @@ internal class CreateCustomerState @Inject constructor(
                     paymentMethods = state.paymentMethods,
                     params = PaymentMethodFilter.FilterParams(
                         billingDetailsCollectionConfiguration = metadata.billingDetailsCollectionConfiguration,
+                        requiresBillingAddressForAutomaticTax = metadata.requiresBillingAddressForAutomaticTax,
                         customerMetadata = customerMetadata,
                         cardBrandFilter = metadata.cardBrandFilter,
                         cardFundingFilter = metadata.cardFundingFilter,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodAutomaticTaxBillingDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodAutomaticTaxBillingDetails.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentsheet.state
+
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.ui.core.elements.automaticTaxRequiredFields
+import com.stripe.android.uicore.elements.IdentifierSpec
+
+internal fun PaymentMethod.hasSufficientBillingDetailsForAutomaticTax(): Boolean {
+    val address = billingDetails?.address ?: return false
+    val countryCode = address.country?.takeUnless { it.isBlank() }?.uppercase() ?: return false
+
+    return automaticTaxRequiredFields(countryCode).all { requiredField ->
+        requiredField.addressValue(address).isNullOrBlank().not()
+    }
+}
+
+private fun IdentifierSpec.addressValue(address: Address): String? {
+    return when (this) {
+        IdentifierSpec.Line1 -> address.line1
+        IdentifierSpec.City -> address.city
+        IdentifierSpec.State -> address.state
+        IdentifierSpec.PostalCode -> address.postalCode
+        else -> null
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodFilter.kt
@@ -21,6 +21,7 @@ internal interface PaymentMethodFilter {
 
     class FilterParams(
         val billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
+        val requiresBillingAddressForAutomaticTax: Boolean,
         val customerMetadata: CustomerMetadata?,
         val remoteDefaultPaymentMethodId: String?,
         val cardBrandFilter: CardBrandFilter,
@@ -45,7 +46,11 @@ internal class DefaultPaymentMethodFilter @Inject constructor() : PaymentMethodF
             } ?: true
             params.cardBrandFilter.isAccepted(paymentMethod) &&
                 fundingAccepted &&
-                paymentMethod.isSupportedWithBillingConfig(params.billingDetailsCollectionConfiguration)
+                paymentMethod.isSupportedWithBillingConfig(params.billingDetailsCollectionConfiguration) &&
+                (
+                    !params.requiresBillingAddressForAutomaticTax ||
+                        paymentMethod.hasSufficientBillingDetailsForAutomaticTax()
+                    )
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/CreateCustomerStateTest.kt
@@ -3,10 +3,13 @@ package com.stripe.android.paymentsheet.state
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.model.Address
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -78,6 +81,92 @@ internal class CreateCustomerStateTest {
         assertThat(result!!.paymentMethods).isEmpty()
         assertThat(result.defaultPaymentMethodId).isNull()
     }
+
+    @Test
+    fun `Checkout session only includes payment methods with sufficient automatic tax billing details`() = runScenario {
+        val insufficientPaymentMethod = paymentMethodWithBillingAddress(
+            id = "pm_insufficient",
+            address = Address(country = "US"),
+        )
+        val sufficientUnitedStatesPaymentMethod = paymentMethodWithBillingAddress(
+            id = "pm_sufficient_us",
+            address = Address(
+                country = "US",
+                line1 = "510 Townsend St",
+                city = "San Francisco",
+                state = "CA",
+                postalCode = "94103",
+            ),
+        )
+        val sufficientGermanyPaymentMethod = paymentMethodWithBillingAddress(
+            id = "pm_sufficient_de",
+            address = Address(country = "DE"),
+        )
+        val checkoutSessionResponse = createAutomaticTaxCheckoutSession(
+            paymentMethods = listOf(
+                insufficientPaymentMethod,
+                sufficientUnitedStatesPaymentMethod,
+                sufficientGermanyPaymentMethod,
+            ),
+        )
+
+        val result = createCustomerState(
+            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+                instancesKey = "instances_key",
+                checkoutSessionResponse = checkoutSessionResponse,
+            ),
+            metadata = createAutomaticTaxCheckoutMetadata(checkoutSessionResponse),
+            paymentMethodFilter = DefaultPaymentMethodFilter(),
+        )
+
+        assertThat(result).isNotNull()
+        assertThat(result!!.paymentMethods).containsExactly(
+            sufficientUnitedStatesPaymentMethod,
+            sufficientGermanyPaymentMethod,
+        ).inOrder()
+    }
+
+    private fun paymentMethodWithBillingAddress(
+        id: String,
+        address: Address,
+    ): PaymentMethod {
+        return PaymentMethodFactory.card(
+            id = id,
+            last4 = "4242",
+            billingDetails = PaymentMethod.BillingDetails(address = address),
+        )
+    }
+
+    private fun createAutomaticTaxCheckoutSession(
+        paymentMethods: List<PaymentMethod>,
+    ): CheckoutSessionResponse {
+        return CheckoutSessionResponseFactory.create(
+            customer = CheckoutSessionResponse.Customer(
+                id = "cus_checkout_automatic_tax",
+                paymentMethods = paymentMethods,
+                canDetachPaymentMethod = false,
+            ),
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
+    }
+
+    private fun createAutomaticTaxCheckoutMetadata(
+        checkoutSessionResponse: CheckoutSessionResponse,
+    ) = PaymentMethodMetadataFactory.create(
+        integrationMetadata = IntegrationMetadata.CheckoutSession(
+            id = checkoutSessionResponse.id,
+            instancesKey = "instances_key",
+            checkoutSessionResponse = checkoutSessionResponse,
+        ),
+    ).copy(
+        customerMetadata = CustomerMetadata.CheckoutSession(
+            sessionId = checkoutSessionResponse.id,
+            customerId = "cus_checkout_automatic_tax",
+            removePaymentMethod = PaymentMethodRemovePermission.None,
+            saveConsent = PaymentMethodSaveConsentBehavior.Disabled(overrideAllowRedisplay = null),
+        ),
+    )
 
     @Test
     fun `Customer session extracts payment methods and default payment method`() = runScenario {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentMethodFilterTest.kt
@@ -103,6 +103,62 @@ class DefaultPaymentMethodFilterTest {
         )
     }
 
+    @Test
+    fun `Filters saved payment methods with insufficient automatic tax billing details`() = runTest {
+        val insufficientPaymentMethod = PaymentMethodFactory.card(
+            id = "pm_insufficient",
+            last4 = "4242",
+        )
+        val sufficientPaymentMethod = PaymentMethodFactory.card(
+            id = "pm_sufficient",
+            last4 = "4243",
+            billingDetails = PaymentMethod.BillingDetails(address = Address(country = "DE")),
+        )
+
+        val result = filter(
+            paymentMethods = listOf(insufficientPaymentMethod, sufficientPaymentMethod),
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        assertThat(result).containsExactly(sufficientPaymentMethod)
+    }
+
+    @Test
+    fun `Does not filter saved payment methods when automatic tax billing details are not required`() = runTest {
+        val paymentMethods = listOf(
+            PaymentMethodFactory.card(
+                id = "pm_card",
+                last4 = "4242",
+            ),
+            PaymentMethodFactory.usBankAccount().copy(id = "pm_us_bank_account"),
+        )
+
+        val result = filter(
+            paymentMethods = paymentMethods,
+            requiresBillingAddressForAutomaticTax = false,
+        )
+
+        assertThat(result).containsExactlyElementsIn(paymentMethods).inOrder()
+    }
+
+    @Test
+    fun `Filters non-card saved payment methods with insufficient automatic tax billing details`() = runTest {
+        val insufficientPaymentMethod = PaymentMethodFactory.usBankAccount().copy(
+            id = "pm_insufficient",
+        )
+        val sufficientPaymentMethod = PaymentMethodFactory.usBankAccount().copy(
+            id = "pm_sufficient",
+            billingDetails = PaymentMethod.BillingDetails(address = Address(country = "DE")),
+        )
+
+        val result = filter(
+            paymentMethods = listOf(insufficientPaymentMethod, sufficientPaymentMethod),
+            requiresBillingAddressForAutomaticTax = true,
+        )
+
+        assertThat(result).containsExactly(sufficientPaymentMethod)
+    }
+
     @OptIn(CardFundingFilteringPrivatePreview::class)
     @Test
     fun `Should filter saved cards with credit funding type only`() = runTest {
@@ -197,6 +253,7 @@ class DefaultPaymentMethodFilterTest {
         isPaymentMethodSetAsDefaultEnabled: Boolean = false,
         remoteDefaultPaymentMethodId: String? = null,
         localSavedSelection: SavedSelection = SavedSelection.None,
+        requiresBillingAddressForAutomaticTax: Boolean = false,
         cardBrandFilter: PaymentSheetCardBrandFilter = PaymentSheetCardBrandFilter(
             cardBrandAcceptance = PaymentSheet.CardBrandAcceptance.all(),
         ),
@@ -208,6 +265,7 @@ class DefaultPaymentMethodFilterTest {
             paymentMethods = paymentMethods,
             params = PaymentMethodFilter.FilterParams(
                 billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration,
+                requiresBillingAddressForAutomaticTax = requiresBillingAddressForAutomaticTax,
                 customerMetadata = CustomerMetadata.CustomerSession(
                     id = "cus_1",
                     ephemeralKeySecret = "ek_123",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/PaymentMethodAutomaticTaxBillingDetailsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/PaymentMethodAutomaticTaxBillingDetailsTest.kt
@@ -1,0 +1,146 @@
+package com.stripe.android.paymentsheet.state
+
+import com.google.common.truth.Truth.assertThat
+import com.google.testing.junit.testparameterinjector.TestParameter
+import com.google.testing.junit.testparameterinjector.TestParameterInjector
+import com.google.testing.junit.testparameterinjector.TestParameterValuesProvider
+import com.stripe.android.model.Address
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.testing.PaymentMethodFactory
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(TestParameterInjector::class)
+internal class PaymentMethodAutomaticTaxBillingDetailsTest {
+    @Test
+    fun `detects sufficient automatic tax billing details`(
+        @TestParameter(valuesProvider = AutomaticTaxBillingDetailsCaseProvider::class)
+        testCase: AutomaticTaxBillingDetailsCase,
+    ) {
+        val paymentMethod = PaymentMethodFactory.card(
+            last4 = "4242",
+            billingDetails = testCase.billingDetails,
+        )
+
+        assertThat(paymentMethod.hasSufficientBillingDetailsForAutomaticTax())
+            .isEqualTo(testCase.isSufficient)
+    }
+}
+
+internal object AutomaticTaxBillingDetailsCaseProvider : TestParameterValuesProvider() {
+    override fun provideValues(
+        context: Context?,
+    ): List<AutomaticTaxBillingDetailsCase> = automaticTaxBillingDetailsCases
+
+    private val automaticTaxBillingDetailsCases = listOf(
+        AutomaticTaxBillingDetailsCase(
+            name = "Missing billing details",
+            billingDetails = null,
+            isSufficient = false,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "Missing address",
+            billingDetails = PaymentMethod.BillingDetails(),
+            isSufficient = false,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "Blank country",
+            billingDetails = PaymentMethod.BillingDetails(address = Address(country = " ")),
+            isSufficient = false,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "Lowercase US",
+            billingDetails = billingDetails(
+                country = "us",
+                line1 = "510 Townsend St",
+                city = "San Francisco",
+                state = "CA",
+                postalCode = "94103",
+            ),
+            isSufficient = true,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "Country only when no additional fields are required",
+            billingDetails = billingDetails(country = "DE"),
+            isSufficient = true,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "Canada without postal code",
+            billingDetails = billingDetails(country = "CA"),
+            isSufficient = false,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "Canada with postal code",
+            billingDetails = billingDetails(country = "CA", postalCode = "M5V 3A8"),
+            isSufficient = true,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "Great Britain with postal code",
+            billingDetails = billingDetails(country = "GB", postalCode = "EC1A 1BB"),
+            isSufficient = true,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "India with postal code",
+            billingDetails = billingDetails(country = "IN", postalCode = "110001"),
+            isSufficient = true,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "Puerto Rico without state",
+            billingDetails = billingDetails(
+                country = "PR",
+                line1 = "151 Calle de Tetuan",
+                city = "San Juan",
+                postalCode = "00901",
+            ),
+            isSufficient = true,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "United States with blank city",
+            billingDetails = billingDetails(
+                country = "US",
+                line1 = "510 Townsend St",
+                city = " ",
+                state = "CA",
+                postalCode = "94103",
+            ),
+            isSufficient = false,
+        ),
+        AutomaticTaxBillingDetailsCase(
+            name = "United States with all required fields",
+            billingDetails = billingDetails(
+                country = "US",
+                line1 = "510 Townsend St",
+                city = "San Francisco",
+                state = "CA",
+                postalCode = "94103",
+            ),
+            isSufficient = true,
+        ),
+    )
+}
+
+internal data class AutomaticTaxBillingDetailsCase(
+    val name: String,
+    val billingDetails: PaymentMethod.BillingDetails?,
+    val isSufficient: Boolean,
+) {
+    override fun toString(): String = name
+}
+
+private fun billingDetails(
+    country: String,
+    line1: String? = null,
+    city: String? = null,
+    state: String? = null,
+    postalCode: String? = null,
+): PaymentMethod.BillingDetails {
+    return PaymentMethod.BillingDetails(
+        address = Address(
+            country = country,
+            line1 = line1,
+            city = city,
+            state = state,
+            postalCode = postalCode,
+        ),
+    )
+}


### PR DESCRIPTION
# Summary

Filters saved payment methods that lack billing details required for automatic tax when a Checkout Session uses `session.billing` as its tax address source.

# Motivation

Checkout can return saved methods whose billing address cannot calculate tax. Selecting those methods leaves the session without a usable tax address.

This change applies only when Checkout automatic tax is enabled with billing as the address source. Other integrations and Checkout shipping-tax sessions keep their existing behavior.

# Testing

- [x] Added parameterized validator coverage for missing, blank, lowercase, country-only, and country-specific addresses.
- [x] Added enabled, disabled, and non-card filter coverage.
- [x] Added Checkout `CreateCustomerState` coverage using the real filter.
- [x] Updated the Checkout analytics fixture with complete US billing details for saved card `pm_12345`, preserving `assertHasSelectedSavedPaymentMethod("pm_12345")` and all analytics assertions.
- [x] Focused managed-device test passed on `pixel2api33_0`: `CheckoutPaymentElementAnalyticsTest#testTotalChangeFailureSendsAnalyticsErrorCode` executed 1 test with 0 failures.
- [ ] Manually verified: N/A, no visual layout change.

Focused unit tests and the repository pre-push hook (`detekt` and `apiCheck`) pass. CI pending.

# Screenshots

N/A. No visual layout change.

# Changelog

N/A. No public API change.

Committed and created by Codex.
