### PR TITLE
Reuse Checkout Controller playground customers

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.Button
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -37,6 +38,7 @@ import com.stripe.android.checkout.CheckoutPresenter
 import com.stripe.android.elements.PaymentElement
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
+import com.stripe.android.paymentsheet.example.playground.settings.RadioButtonSetting
 import com.stripe.android.uicore.format.CurrencyFormatter
 import kotlinx.coroutines.launch
 
@@ -51,15 +53,26 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
         val presenter = viewModel.controller.createPresenter(this)
         val paymentElement = presenter.paymentElement()
 
+        observeSessionCompletion()
+        setCheckoutContent(presenter, paymentElement)
+    }
+
+    private fun observeSessionCompletion() {
         lifecycleScope.launch {
             viewModel.sessionComplete.collect {
                 Toast.makeText(this@CheckoutControllerExampleActivity, "Payment complete!", Toast.LENGTH_LONG).show()
                 finish()
             }
         }
+    }
 
+    private fun setCheckoutContent(
+        presenter: CheckoutPresenter,
+        paymentElement: PaymentElement,
+    ) {
         setContent {
             val status by viewModel.status.collectAsState()
+            val settings by viewModel.settings.collectAsState()
             val confirmationResult by viewModel.confirmationResult.collectAsState()
 
             PlaygroundTheme(
@@ -68,21 +81,33 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                         status = status,
                         presenter = presenter,
                         paymentElement = paymentElement,
-                        onScenarioSelected = viewModel::start,
+                        settings = settings,
+                        onSettingChanged = viewModel::updateSetting,
                     )
                 },
                 bottomBarContent = {
-                    val configured = status as? CheckoutControllerExampleViewModel.Status.Configured
-                    if (configured != null) {
-                        ConfirmationControls(
-                            paymentOption = configured.session?.paymentOptionDisplayData,
-                            confirmationResult = confirmationResult,
-                            onSelectPaymentMethod = paymentElement::present,
-                            onConfirm = {
-                                viewModel.clearConfirmationResult()
-                                presenter.confirm()
-                            },
-                        )
+                    when (status) {
+                        is CheckoutControllerExampleViewModel.Status.ChooseSettings -> {
+                            Button(
+                                onClick = viewModel::start,
+                                modifier = Modifier.fillMaxWidth(),
+                            ) {
+                                Text("Create session")
+                            }
+                        }
+                        is CheckoutControllerExampleViewModel.Status.Configured -> {
+                            val configured = status as CheckoutControllerExampleViewModel.Status.Configured
+                            ConfirmationControls(
+                                paymentOption = configured.session?.paymentOptionDisplayData,
+                                confirmationResult = confirmationResult,
+                                onSelectPaymentMethod = paymentElement::present,
+                                onConfirm = {
+                                    viewModel.clearConfirmationResult()
+                                    presenter.confirm()
+                                },
+                            )
+                        }
+                        else -> Unit
                     }
                 },
             )
@@ -95,21 +120,22 @@ private fun CheckoutContent(
     status: CheckoutControllerExampleViewModel.Status,
     presenter: CheckoutPresenter,
     paymentElement: PaymentElement,
-    onScenarioSelected: (CheckoutControllerExampleScenario) -> Unit,
+    settings: CheckoutControllerExampleSettings,
+    onSettingChanged: (CheckoutControllerExampleSettingDefinition<Any>, Any) -> Unit,
 ) {
     when (status) {
-        is CheckoutControllerExampleViewModel.Status.ChooseScenario -> {
-            ScenarioChooser(onScenarioSelected)
+        is CheckoutControllerExampleViewModel.Status.ChooseSettings -> {
+            SettingsChooser(settings, onSettingChanged)
         }
         is CheckoutControllerExampleViewModel.Status.Loading -> {
-            LoadingContent(status.scenario)
+            LoadingContent(status.settings)
         }
         is CheckoutControllerExampleViewModel.Status.Error -> {
-            ErrorContent(status.scenario, status.message)
+            ErrorContent(status.settings, status.message)
         }
         is CheckoutControllerExampleViewModel.Status.Configured -> {
             status.session?.let { session ->
-                ScenarioSummary(status.scenario, session.tax.status)
+                SettingsSummary(status.settings, session.tax.status)
                 LineItemsSection(session)
                 TotalSummarySection(session)
                 if (session.availableExpressCheckoutPaymentMethods.isNotEmpty()) {
@@ -122,35 +148,62 @@ private fun CheckoutContent(
 }
 
 @Composable
-private fun ScenarioChooser(
-    onScenarioSelected: (CheckoutControllerExampleScenario) -> Unit,
+private fun SettingsChooser(
+    settings: CheckoutControllerExampleSettings,
+    onSettingChanged: (CheckoutControllerExampleSettingDefinition<Any>, Any) -> Unit,
 ) {
-    Text(text = "Choose a session scenario", style = MaterialTheme.typography.h6)
-    Spacer(modifier = Modifier.height(16.dp))
-    CheckoutControllerExampleScenario.entries.forEach { scenario ->
-        Button(
-            onClick = { onScenarioSelected(scenario) },
-            modifier = Modifier.fillMaxWidth(),
-        ) {
-            Text(scenario.displayName)
+    Column(
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        settings.activeSettings().forEach { setting ->
+            CheckoutControllerSetting(
+                setting = setting,
+                settings = settings,
+                onSettingChanged = onSettingChanged,
+            )
         }
-        Spacer(modifier = Modifier.height(8.dp))
     }
-    Text(
-        text = "Relaunch this activity to choose another scenario.",
-        style = MaterialTheme.typography.body2,
-        color = Color.Gray,
-    )
 }
 
 @Composable
-private fun LoadingContent(scenario: CheckoutControllerExampleScenario) {
+private fun CheckoutControllerSetting(
+    setting: CheckoutControllerExampleSettings.ActiveSetting,
+    settings: CheckoutControllerExampleSettings,
+    onSettingChanged: (CheckoutControllerExampleSettingDefinition<Any>, Any) -> Unit,
+) {
+    @Suppress("UNCHECKED_CAST")
+    val definition = setting.definition as CheckoutControllerExampleSettingDefinition<Any>
+    val value = setting.value as Any
+
+    Column(modifier = Modifier.padding(start = (setting.indentation * 16).dp)) {
+        RadioButtonSetting(
+            name = definition.displayName,
+            options = definition.options(settings),
+            value = value,
+            onOptionChanged = { updatedValue ->
+                onSettingChanged(definition, updatedValue)
+            },
+        )
+        setting.displayDetails.forEach { detail ->
+            OutlinedTextField(
+                value = detail.value,
+                onValueChange = {},
+                label = { Text(detail.name) },
+                readOnly = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingContent(settings: CheckoutControllerExampleSettings.Snapshot) {
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(text = "Scenario: ${scenario.displayName}")
+            SettingsSummary(settings)
             Spacer(modifier = Modifier.height(12.dp))
             CircularProgressIndicator()
         }
@@ -159,7 +212,7 @@ private fun LoadingContent(scenario: CheckoutControllerExampleScenario) {
 
 @Composable
 private fun ErrorContent(
-    scenario: CheckoutControllerExampleScenario,
+    settings: CheckoutControllerExampleSettings.Snapshot,
     message: String,
 ) {
     Column(
@@ -167,7 +220,7 @@ private fun ErrorContent(
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = "Scenario: ${scenario.displayName}")
+        SettingsSummary(settings)
         Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = "Error",
@@ -180,12 +233,16 @@ private fun ErrorContent(
 }
 
 @Composable
-private fun ScenarioSummary(
-    scenario: CheckoutControllerExampleScenario,
-    taxStatus: Session.Tax.Status,
+private fun SettingsSummary(
+    settings: CheckoutControllerExampleSettings.Snapshot,
+    taxStatus: Session.Tax.Status? = null,
 ) {
-    Text(text = "Scenario: ${scenario.displayName}", style = MaterialTheme.typography.h6)
-    Text(text = "Tax status: $taxStatus", style = MaterialTheme.typography.body1)
+    settings.summaryLines().forEach { summaryLine ->
+        Text(text = summaryLine, style = MaterialTheme.typography.h6)
+    }
+    taxStatus?.let { status ->
+        Text(text = "Tax status: $status", style = MaterialTheme.typography.body1)
+    }
     Spacer(modifier = Modifier.height(16.dp))
 }
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleBackendRepository.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleBackendRepository.kt
@@ -19,10 +19,10 @@ internal class CheckoutControllerExampleBackendRepository(
     private val json = Json { ignoreUnknownKeys = true }
     private val backendUrl = Settings(applicationContext).playgroundBackendUrl
 
-    suspend fun fetchCheckoutSessionClientSecret(
-        scenario: CheckoutControllerExampleScenario,
-    ): kotlin.Result<String> {
-        val request = CheckoutControllerExampleRequestFactory.create(scenario)
+    suspend fun fetchCheckoutSession(
+        settings: CheckoutControllerExampleSettings.Snapshot,
+    ): kotlin.Result<CheckoutResponse> {
+        val request = CheckoutControllerExampleRequestFactory.create(settings)
 
         val apiResponse = withContext(Dispatchers.IO) {
             Fuel.post(backendUrl + request.endpoint)
@@ -42,12 +42,13 @@ internal class CheckoutControllerExampleBackendRepository(
                     PaymentConfiguration.init(applicationContext, response.publishableKey)
                 }
 
-                val clientSecret = response.checkoutSessionClientSecret
-                    ?: return kotlin.Result.failure(
+                if (response.checkoutSessionClientSecret == null) {
+                    return kotlin.Result.failure(
                         IllegalStateException("No checkout session client secret in response")
                     )
+                }
 
-                kotlin.Result.success(clientSecret)
+                kotlin.Result.success(response)
             }
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleCustomerStore.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleCustomerStore.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import android.content.Context
+
+internal class CheckoutControllerExampleCustomerStore(
+    context: Context,
+) {
+    private val sharedPreferences = context.getSharedPreferences(
+        PREFERENCES_NAME,
+        Context.MODE_PRIVATE,
+    )
+
+    fun getCustomerId(): String? {
+        return sharedPreferences.getString(CUSTOMER_ID_KEY, null)
+    }
+
+    fun saveCustomerId(customerId: String) {
+        sharedPreferences.edit().putString(CUSTOMER_ID_KEY, customerId).apply()
+    }
+
+    private companion object {
+        const val PREFERENCES_NAME = "CheckoutControllerExample"
+        const val CUSTOMER_ID_KEY = "customer_id"
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
@@ -6,26 +6,17 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 
-internal enum class CheckoutControllerExampleScenario(
-    val displayName: String,
-) {
-    NoTax("No tax"),
-    ShippingTax("Shipping tax"),
-    BillingTax("Billing tax w/ auto collection"),
-}
-
 internal data class CheckoutControllerExampleRequest(
     val endpoint: String,
     val body: JsonObject,
 )
 
 internal object CheckoutControllerExampleRequestFactory {
-    fun create(scenario: CheckoutControllerExampleScenario): CheckoutControllerExampleRequest {
+    fun create(settings: CheckoutControllerExampleSettings.Snapshot): CheckoutControllerExampleRequest {
         return CheckoutControllerExampleRequest(
             endpoint = "checkout_session",
             body = buildJsonObject {
                 put("mode", "payment")
-                put("customer", "guest")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
                 put(
@@ -40,8 +31,7 @@ internal object CheckoutControllerExampleRequestFactory {
                         )
                     )
                 )
-                put("automatic_tax", scenario != CheckoutControllerExampleScenario.NoTax)
-                put("shipping_address_collection", scenario == CheckoutControllerExampleScenario.ShippingTax)
+                settings.applyTo(this)
             },
         )
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleSettings.kt
@@ -1,0 +1,414 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettingDefinition.Displayable.Option
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.put
+
+internal interface CheckoutControllerExampleSettingDefinition<T : Any> {
+    val key: CheckoutControllerExampleSettingKey
+    val displayName: String
+    val defaultValue: T
+
+    fun options(settings: CheckoutControllerExampleSettings): List<Option<T>>
+
+    fun encode(value: T): String
+
+    fun decode(value: String): T?
+
+    fun apply(value: T, requestBuilder: JsonObjectBuilder)
+
+    fun displayValue(value: T): String
+
+    fun displayDetails(value: T): List<CheckoutControllerExampleSettingDetail> = emptyList()
+
+    val childDefinitions: List<CheckoutControllerExampleSettingDefinition<*>>
+        get() = emptyList()
+
+    fun activeChildDefinitions(value: T): List<CheckoutControllerExampleSettingDefinition<*>> {
+        return childDefinitions
+    }
+}
+
+internal enum class CheckoutControllerExampleSettingKey(
+    val savedStateKey: String,
+) {
+    Customer("customer"),
+    AutomaticTax("automatic_tax"),
+    ShippingAddressCollection("shipping_address_collection"),
+    BillingAddressCollection("billing_address_collection"),
+}
+
+internal data class CheckoutControllerExampleSettingDetail(
+    val name: String,
+    val value: String,
+)
+
+internal sealed interface CheckoutControllerExampleCustomer {
+    val displayName: String
+
+    data object Guest : CheckoutControllerExampleCustomer {
+        override val displayName = "Guest"
+    }
+
+    data object New : CheckoutControllerExampleCustomer {
+        override val displayName = "New customer"
+    }
+
+    data class Existing(
+        val customerId: String,
+    ) : CheckoutControllerExampleCustomer {
+        override val displayName = "Existing customer"
+    }
+}
+
+internal object CheckoutControllerExampleSettingsDefinition {
+    val rootDefinitions: List<CheckoutControllerExampleSettingDefinition<*>> = listOf(
+        Customer,
+        AutomaticTax,
+    )
+
+    object Customer : CheckoutControllerExampleSettingDefinition<CheckoutControllerExampleCustomer> {
+        override val key = CheckoutControllerExampleSettingKey.Customer
+        override val displayName = "Customer"
+        override val defaultValue = CheckoutControllerExampleCustomer.Guest
+
+        override fun options(
+            settings: CheckoutControllerExampleSettings,
+        ): List<Option<CheckoutControllerExampleCustomer>> {
+            return buildList {
+                add(
+                    Option(
+                        CheckoutControllerExampleCustomer.Guest.displayName,
+                        CheckoutControllerExampleCustomer.Guest,
+                    )
+                )
+                add(
+                    Option(
+                        CheckoutControllerExampleCustomer.New.displayName,
+                        CheckoutControllerExampleCustomer.New,
+                    )
+                )
+                settings.storedCustomerId?.let { customerId ->
+                    add(
+                        Option(
+                            CheckoutControllerExampleCustomer.Existing(customerId).displayName,
+                            CheckoutControllerExampleCustomer.Existing(customerId),
+                        )
+                    )
+                }
+            }
+        }
+
+        override fun encode(value: CheckoutControllerExampleCustomer): String {
+            return when (value) {
+                CheckoutControllerExampleCustomer.Guest -> "guest"
+                CheckoutControllerExampleCustomer.New -> "new"
+                is CheckoutControllerExampleCustomer.Existing -> "existing:${value.customerId}"
+            }
+        }
+
+        override fun decode(value: String): CheckoutControllerExampleCustomer? {
+            return when (value) {
+                "guest" -> CheckoutControllerExampleCustomer.Guest
+                "new" -> CheckoutControllerExampleCustomer.New
+                else -> value.removePrefix("existing:")
+                    .takeIf { value.startsWith("existing:") && it.isNotBlank() }
+                    ?.let(CheckoutControllerExampleCustomer::Existing)
+            }
+        }
+
+        override fun apply(
+            value: CheckoutControllerExampleCustomer,
+            requestBuilder: JsonObjectBuilder,
+        ) {
+            val customer = when (value) {
+                CheckoutControllerExampleCustomer.Guest -> "guest"
+                CheckoutControllerExampleCustomer.New -> "new"
+                is CheckoutControllerExampleCustomer.Existing -> require(value.customerId.isNotBlank()) {
+                    "No customer ID available for existing customer"
+                }.let { value.customerId }
+            }
+            requestBuilder.put("customer", customer)
+            if (
+                value == CheckoutControllerExampleCustomer.New ||
+                value is CheckoutControllerExampleCustomer.Existing
+            ) {
+                requestBuilder.put("checkout_session_payment_method_save", "enabled")
+            }
+        }
+
+        override fun displayValue(value: CheckoutControllerExampleCustomer): String {
+            return value.displayName
+        }
+
+        override fun displayDetails(
+            value: CheckoutControllerExampleCustomer,
+        ): List<CheckoutControllerExampleSettingDetail> {
+            return (value as? CheckoutControllerExampleCustomer.Existing)?.let { customer ->
+                listOf(CheckoutControllerExampleSettingDetail("Customer ID", customer.customerId))
+            }.orEmpty()
+        }
+    }
+
+    object AutomaticTax : CheckoutControllerExampleSettingDefinition<Boolean> {
+        override val key = CheckoutControllerExampleSettingKey.AutomaticTax
+        override val displayName = "Automatic tax"
+        override val defaultValue = false
+        override val childDefinitions = listOf(ShippingAddressCollection, BillingAddressCollection)
+
+        override fun options(settings: CheckoutControllerExampleSettings): List<Option<Boolean>> {
+            return listOf(
+                Option("On", true),
+                Option("Off", false),
+            )
+        }
+
+        override fun encode(value: Boolean): String = value.toString()
+
+        override fun decode(value: String): Boolean? = value.toBooleanStrictOrNull()
+
+        override fun apply(value: Boolean, requestBuilder: JsonObjectBuilder) {
+            requestBuilder.put("automatic_tax", value)
+        }
+
+        override fun displayValue(value: Boolean): String = if (value) "On" else "Off"
+
+        override fun activeChildDefinitions(
+            value: Boolean,
+        ): List<CheckoutControllerExampleSettingDefinition<*>> {
+            return if (value) childDefinitions else emptyList()
+        }
+    }
+
+    object ShippingAddressCollection : CheckoutControllerExampleSettingDefinition<Boolean> {
+        override val key = CheckoutControllerExampleSettingKey.ShippingAddressCollection
+        override val displayName = "Shipping"
+        override val defaultValue = true
+
+        override fun options(settings: CheckoutControllerExampleSettings): List<Option<Boolean>> {
+            return listOf(
+                Option("On", true),
+                Option("Off", false),
+            )
+        }
+
+        override fun encode(value: Boolean): String = value.toString()
+
+        override fun decode(value: String): Boolean? = value.toBooleanStrictOrNull()
+
+        override fun apply(value: Boolean, requestBuilder: JsonObjectBuilder) {
+            requestBuilder.put("shipping_address_collection", value)
+        }
+
+        override fun displayValue(value: Boolean): String = if (value) "On" else "Off"
+    }
+
+    object BillingAddressCollection : CheckoutControllerExampleSettingDefinition<Boolean> {
+        override val key = CheckoutControllerExampleSettingKey.BillingAddressCollection
+        override val displayName = "Billing"
+        override val defaultValue = false
+
+        override fun options(settings: CheckoutControllerExampleSettings): List<Option<Boolean>> {
+            return listOf(
+                Option("On", true),
+                Option("Off", false),
+            )
+        }
+
+        override fun encode(value: Boolean): String = value.toString()
+
+        override fun decode(value: String): Boolean? = value.toBooleanStrictOrNull()
+
+        override fun apply(value: Boolean, requestBuilder: JsonObjectBuilder) {
+            if (value) {
+                requestBuilder.put("billing_address_collection", true)
+            }
+        }
+
+        override fun displayValue(value: Boolean): String = if (value) "On" else "Off"
+    }
+}
+
+internal class CheckoutControllerExampleSettings private constructor(
+    private val values: Map<CheckoutControllerExampleSettingDefinition<*>, Any>,
+    val storedCustomerId: String?,
+) {
+    fun <T : Any> withValue(
+        definition: CheckoutControllerExampleSettingDefinition<T>,
+        value: T,
+    ): CheckoutControllerExampleSettings {
+        return CheckoutControllerExampleSettings(
+            values = values + (definition to value),
+            storedCustomerId = storedCustomerId,
+        )
+    }
+
+    fun withStoredCustomerId(customerId: String): CheckoutControllerExampleSettings {
+        return CheckoutControllerExampleSettings(
+            values = values,
+            storedCustomerId = customerId,
+        )
+    }
+
+    fun snapshot(): Snapshot {
+        return Snapshot(values)
+    }
+
+    fun encodedValues(): Map<String, String> {
+        return allDefinitions.associate { definition ->
+            definition.key.savedStateKey to definition.encodeValue(values.getValue(definition))
+        }
+    }
+
+    fun activeSettings(): List<ActiveSetting> {
+        return activeSettings(CheckoutControllerExampleSettingsDefinition.rootDefinitions, indentation = 0)
+    }
+
+    operator fun <T : Any> get(definition: CheckoutControllerExampleSettingDefinition<T>): T {
+        return values.valueFor(definition)
+    }
+
+    private fun activeSettings(
+        definitions: List<CheckoutControllerExampleSettingDefinition<*>>,
+        indentation: Int,
+    ): List<ActiveSetting> {
+        return definitions.flatMap { definition ->
+            activeSettings(definition, indentation)
+        }
+    }
+
+    private fun <T : Any> activeSettings(
+        definition: CheckoutControllerExampleSettingDefinition<T>,
+        indentation: Int,
+    ): List<ActiveSetting> {
+        val value = values.valueFor(definition)
+        return listOf(
+            ActiveSetting(
+                definition = definition,
+                value = value,
+                indentation = indentation,
+                displayDetails = definition.displayDetails(value),
+            )
+        ) + activeSettings(definition.activeChildDefinitions(value), indentation + 1)
+    }
+
+    internal data class ActiveSetting(
+        val definition: CheckoutControllerExampleSettingDefinition<*>,
+        val value: Any,
+        val indentation: Int,
+        val displayDetails: List<CheckoutControllerExampleSettingDetail>,
+    )
+
+    internal class Snapshot internal constructor(
+        private val values: Map<CheckoutControllerExampleSettingDefinition<*>, Any>,
+    ) {
+        fun applyTo(requestBuilder: JsonObjectBuilder) {
+            activeSettings().forEach { setting ->
+                setting.definition.applyValue(setting.value, requestBuilder)
+            }
+        }
+
+        fun summaryLines(): List<String> {
+            return activeSettings().map { setting ->
+                "${setting.definition.displayName}: ${setting.definition.displayValueFor(setting.value)}"
+            }
+        }
+
+        operator fun <T : Any> get(definition: CheckoutControllerExampleSettingDefinition<T>): T {
+            return values.valueFor(definition)
+        }
+
+        private fun activeSettings(): List<ActiveSetting> {
+            return activeSettings(CheckoutControllerExampleSettingsDefinition.rootDefinitions)
+        }
+
+        private fun activeSettings(
+            definitions: List<CheckoutControllerExampleSettingDefinition<*>>,
+        ): List<ActiveSetting> {
+            return definitions.flatMap { definition ->
+                activeSettings(definition)
+            }
+        }
+
+        private fun <T : Any> activeSettings(
+            definition: CheckoutControllerExampleSettingDefinition<T>,
+        ): List<ActiveSetting> {
+            val value = values.valueFor(definition)
+            return listOf(
+                ActiveSetting(
+                    definition = definition,
+                    value = value,
+                    indentation = 0,
+                    displayDetails = definition.displayDetails(value),
+                )
+            ) + activeSettings(definition.activeChildDefinitions(value))
+        }
+    }
+
+    companion object {
+        fun create(
+            persistedValues: Map<String, String>?,
+            storedCustomerId: String?,
+        ): CheckoutControllerExampleSettings {
+            val customerId = storedCustomerId?.takeIf(String::isNotBlank)
+            val values = allDefinitions.associateWith { definition ->
+                val savedValue = persistedValues?.get(definition.key.savedStateKey)
+                when {
+                    savedValue != null -> definition.decodeValue(savedValue) ?: definition.defaultValueValue
+                    definition == CheckoutControllerExampleSettingsDefinition.Customer && customerId != null -> {
+                        CheckoutControllerExampleCustomer.Existing(customerId)
+                    }
+                    else -> definition.defaultValueValue
+                }
+            }
+            return CheckoutControllerExampleSettings(values, customerId)
+        }
+
+        private val allDefinitions: List<CheckoutControllerExampleSettingDefinition<*>> =
+            allDefinitions(CheckoutControllerExampleSettingsDefinition.rootDefinitions)
+
+        private fun allDefinitions(
+            definitions: List<CheckoutControllerExampleSettingDefinition<*>>,
+        ): List<CheckoutControllerExampleSettingDefinition<*>> {
+            return definitions.flatMap { definition ->
+                listOf(definition) + allDefinitions(definition.childDefinitions)
+            }
+        }
+    }
+}
+
+private fun <T : Any> Map<CheckoutControllerExampleSettingDefinition<*>, Any>.valueFor(
+    definition: CheckoutControllerExampleSettingDefinition<T>,
+): T {
+    @Suppress("UNCHECKED_CAST")
+    return getValue(definition) as T
+}
+
+private fun CheckoutControllerExampleSettingDefinition<*>.encodeValue(value: Any): String {
+    @Suppress("UNCHECKED_CAST")
+    return (this as CheckoutControllerExampleSettingDefinition<Any>).encode(value)
+}
+
+private fun CheckoutControllerExampleSettingDefinition<*>.applyValue(
+    value: Any,
+    requestBuilder: JsonObjectBuilder,
+) {
+    @Suppress("UNCHECKED_CAST")
+    (this as CheckoutControllerExampleSettingDefinition<Any>).apply(value, requestBuilder)
+}
+
+private fun CheckoutControllerExampleSettingDefinition<*>.displayValueFor(value: Any): String {
+    @Suppress("UNCHECKED_CAST")
+    return (this as CheckoutControllerExampleSettingDefinition<Any>).displayValue(value)
+}
+
+private fun CheckoutControllerExampleSettingDefinition<*>.decodeValue(value: String): Any? {
+    @Suppress("UNCHECKED_CAST")
+    return (this as CheckoutControllerExampleSettingDefinition<Any>).decode(value)
+}
+
+private val CheckoutControllerExampleSettingDefinition<*>.defaultValueValue: Any
+    get() {
+        @Suppress("UNCHECKED_CAST")
+        return (this as CheckoutControllerExampleSettingDefinition<Any>).defaultValue
+    }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -14,6 +14,8 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.example.playground.checkout.CheckoutControllerExampleSettings.Snapshot
+import com.stripe.android.paymentsheet.example.playground.model.CheckoutResponse
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -25,15 +27,26 @@ import kotlinx.coroutines.launch
 internal class CheckoutControllerExampleViewModel(
     private val repository: CheckoutControllerExampleBackendRepository,
     private val savedStateHandle: SavedStateHandle,
-    application: Application,
+    private val application: Application,
 ) : ViewModel() {
 
-    private val selectedScenario = savedStateHandle.get<String>(SCENARIO_KEY)?.let(
-        CheckoutControllerExampleScenario::valueOf
+    private val customerStore = CheckoutControllerExampleCustomerStore(application)
+    private val _settings = MutableStateFlow(
+        CheckoutControllerExampleSettings.create(
+            persistedValues = savedStateHandle.get<Map<String, String>>(SETTINGS_KEY),
+            storedCustomerId = customerStore.getCustomerId(),
+        )
     )
+    val settings: StateFlow<CheckoutControllerExampleSettings> = _settings.asStateFlow()
+
+    private val restoredSessionSettings = if (savedStateHandle.get<Boolean>(SESSION_STARTED_KEY) == true) {
+        settings.value.snapshot()
+    } else {
+        null
+    }
 
     private val _status = MutableStateFlow<Status>(
-        selectedScenario?.let(Status::Loading) ?: Status.ChooseScenario
+        restoredSessionSettings?.let(Status::Loading) ?: Status.ChooseSettings
     )
     val status: StateFlow<Status> = _status.asStateFlow()
 
@@ -49,7 +62,7 @@ internal class CheckoutControllerExampleViewModel(
     ).resultCallback(::onConfirmationResult).build()
 
     init {
-        selectedScenario?.let(::fetchAndConfigure)
+        restoredSessionSettings?.let(::fetchAndConfigure)
         viewModelScope.launch {
             controller.session.collect { session ->
                 updateConfiguredState { it.copy(session = session) }
@@ -57,14 +70,23 @@ internal class CheckoutControllerExampleViewModel(
         }
     }
 
-    fun start(scenario: CheckoutControllerExampleScenario) {
-        if (savedStateHandle.get<String>(SCENARIO_KEY) != null) {
+    fun updateSetting(
+        definition: CheckoutControllerExampleSettingDefinition<Any>,
+        value: Any,
+    ) {
+        updateSettings(_settings.value.withValue(definition, value))
+    }
+
+    fun start() {
+        if (savedStateHandle.get<Boolean>(SESSION_STARTED_KEY) == true) {
             return
         }
 
-        savedStateHandle[SCENARIO_KEY] = scenario.name
-        _status.value = Status.Loading(scenario)
-        fetchAndConfigure(scenario)
+        val sessionSettings = settings.value.snapshot()
+        persistSettings(settings.value)
+        savedStateHandle[SESSION_STARTED_KEY] = true
+        _status.value = Status.Loading(sessionSettings)
+        fetchAndConfigure(sessionSettings)
     }
 
     fun clearConfirmationResult() {
@@ -92,37 +114,75 @@ internal class CheckoutControllerExampleViewModel(
         }
     }
 
-    private fun fetchAndConfigure(scenario: CheckoutControllerExampleScenario) {
+    private fun updateSettings(updatedSettings: CheckoutControllerExampleSettings) {
+        _settings.value = updatedSettings
+        persistSettings(updatedSettings)
+    }
+
+    private fun persistSettings(settings: CheckoutControllerExampleSettings) {
+        savedStateHandle[SETTINGS_KEY] = settings.encodedValues()
+    }
+
+    private fun fetchAndConfigure(settings: Snapshot) {
         viewModelScope.launch {
-            repository.fetchCheckoutSessionClientSecret(scenario).fold(
-                onSuccess = { clientSecret ->
-                    controller.configure(
-                        clientSecret = clientSecret,
-                    ).fold(
-                        onSuccess = {
-                            _status.value = Status.Configured(
-                                scenario = scenario,
-                                session = controller.session.value,
-                            )
-                        },
-                        onFailure = { error ->
-                            Log.e(TAG, "Failed to configure", error)
-                            _status.value = Status.Error(
-                                scenario = scenario,
-                                message = error.message ?: "Configure failed",
-                            )
-                        },
+            val result = runCatching {
+                repository.fetchCheckoutSession(settings)
+            }.getOrElse { error -> kotlin.Result.failure(error) }
+            val response = result.getOrNull()
+            if (response == null) {
+                val error = result.exceptionOrNull()
+                Log.e(TAG, "Failed to fetch checkout session", error)
+                _status.value = Status.Error(
+                    settings = settings,
+                    message = error?.message ?: "Unknown error",
+                )
+                return@launch
+            }
+            configure(settings, response)
+        }
+    }
+
+    private suspend fun configure(
+        settings: Snapshot,
+        response: CheckoutResponse,
+    ) {
+        if (settings[CheckoutControllerExampleSettingsDefinition.Customer] == CheckoutControllerExampleCustomer.New) {
+            val customerId = response.customerId?.takeIf(String::isNotBlank)
+            if (customerId == null) {
+                _status.value = Status.Error(
+                    settings = settings,
+                    message = "No customer ID returned for new customer",
+                )
+                return
+            }
+            customerStore.saveCustomerId(customerId)
+            updateSettings(
+                _settings.value
+                    .withStoredCustomerId(customerId)
+                    .withValue(
+                        CheckoutControllerExampleSettingsDefinition.Customer,
+                        CheckoutControllerExampleCustomer.Existing(customerId),
                     )
-                },
-                onFailure = { error ->
-                    Log.e(TAG, "Failed to fetch checkout session", error)
-                    _status.value = Status.Error(
-                        scenario = scenario,
-                        message = error.message ?: "Unknown error",
-                    )
-                },
             )
         }
+
+        controller.configure(
+            clientSecret = response.clientSecret,
+        ).fold(
+            onSuccess = {
+                _status.value = Status.Configured(
+                    settings = settings,
+                    session = controller.session.value,
+                )
+            },
+            onFailure = { error ->
+                Log.e(TAG, "Failed to configure", error)
+                _status.value = Status.Error(
+                    settings = settings,
+                    message = error.message ?: "Configure failed",
+                )
+            },
+        )
     }
 
     override fun onCleared() {
@@ -131,14 +191,14 @@ internal class CheckoutControllerExampleViewModel(
     }
 
     sealed interface Status {
-        data object ChooseScenario : Status
-        data class Loading(val scenario: CheckoutControllerExampleScenario) : Status
+        data object ChooseSettings : Status
+        data class Loading(val settings: Snapshot) : Status
         data class Configured(
-            val scenario: CheckoutControllerExampleScenario,
+            val settings: Snapshot,
             val session: Session?,
         ) : Status
         data class Error(
-            val scenario: CheckoutControllerExampleScenario,
+            val settings: Snapshot,
             val message: String,
         ) : Status
     }
@@ -150,7 +210,8 @@ internal class CheckoutControllerExampleViewModel(
 
     companion object {
         private const val TAG = "CheckoutControllerExample"
-        private const val SCENARIO_KEY = "checkout_controller_example_scenario"
+        private const val SETTINGS_KEY = "checkout_controller_example_settings"
+        private const val SESSION_STARTED_KEY = "checkout_controller_example_session_started"
 
         val factory = viewModelFactory {
             initializer {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -206,7 +206,7 @@ private fun TextSetting(
 }
 
 @Composable
-private fun <T> RadioButtonSetting(
+internal fun <T> RadioButtonSetting(
     name: String,
     options: List<PlaygroundSettingDefinition.Displayable.Option<T>>,
     value: T,

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -9,63 +9,229 @@ import org.junit.Test
 
 class CheckoutControllerExampleRequestFactoryTest {
     @Test
-    fun `no tax scenario creates expected request`() {
-        val request = CheckoutControllerExampleRequestFactory.create(
-            CheckoutControllerExampleScenario.NoTax
-        )
+    fun `default settings omit address collection fields`() {
+        val request = CheckoutControllerExampleRequestFactory.create(settings())
 
         assertThat(request.endpoint).isEqualTo("checkout_session")
         assertThat(request.body).isEqualTo(
-            buildJsonObject {
-                put("mode", "payment")
-                put("customer", "guest")
-                put("customer_email", "email@example.com")
-                put("currency", "usd")
-                put("payment_method_types", commonPaymentMethodTypes)
-                put("automatic_tax", false)
-                put("shipping_address_collection", false)
-            }
+            expectedRequest(
+                customer = "guest",
+                automaticTax = false,
+            )
         )
     }
 
     @Test
-    fun `shipping tax scenario creates expected request`() {
+    fun `automatic tax off omits retained address collection fields`() {
         val request = CheckoutControllerExampleRequestFactory.create(
-            CheckoutControllerExampleScenario.ShippingTax
+            settings(
+                automaticTax = false,
+                shippingAddressCollection = false,
+                billingAddressCollection = true,
+            )
         )
 
-        assertThat(request.endpoint).isEqualTo("checkout_session")
         assertThat(request.body).isEqualTo(
-            buildJsonObject {
-                put("mode", "payment")
-                put("customer", "guest")
-                put("customer_email", "email@example.com")
-                put("currency", "usd")
-                put("payment_method_types", commonPaymentMethodTypes)
-                put("automatic_tax", true)
-                put("shipping_address_collection", true)
-            }
+            expectedRequest(
+                customer = "guest",
+                automaticTax = false,
+            )
         )
     }
 
     @Test
-    fun `billing tax scenario creates expected request`() {
+    fun `shipping only settings create expected request`() {
         val request = CheckoutControllerExampleRequestFactory.create(
-            CheckoutControllerExampleScenario.BillingTax
+            settings(
+                automaticTax = true,
+                shippingAddressCollection = true,
+                billingAddressCollection = false,
+            )
         )
 
-        assertThat(request.endpoint).isEqualTo("checkout_session")
         assertThat(request.body).isEqualTo(
-            buildJsonObject {
-                put("mode", "payment")
-                put("customer", "guest")
-                put("customer_email", "email@example.com")
-                put("currency", "usd")
-                put("payment_method_types", commonPaymentMethodTypes)
-                put("automatic_tax", true)
-                put("shipping_address_collection", false)
-            }
+            expectedRequest(
+                customer = "guest",
+                automaticTax = true,
+                shippingAddressCollection = true,
+            )
         )
+    }
+
+    @Test
+    fun `billing only settings create expected request`() {
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings(
+                automaticTax = true,
+                shippingAddressCollection = false,
+                billingAddressCollection = true,
+            )
+        )
+
+        assertThat(request.body).isEqualTo(
+            expectedRequest(
+                customer = "guest",
+                automaticTax = true,
+                shippingAddressCollection = false,
+                billingAddressCollection = true,
+            )
+        )
+    }
+
+    @Test
+    fun `shipping and billing settings create expected request`() {
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings(
+                automaticTax = true,
+                shippingAddressCollection = true,
+                billingAddressCollection = true,
+            )
+        )
+
+        assertThat(request.body).isEqualTo(
+            expectedRequest(
+                customer = "guest",
+                automaticTax = true,
+                shippingAddressCollection = true,
+                billingAddressCollection = true,
+            )
+        )
+    }
+
+    @Test
+    fun `neither address collection setting creates expected request`() {
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings(
+                automaticTax = true,
+                shippingAddressCollection = false,
+                billingAddressCollection = false,
+            )
+        )
+
+        assertThat(request.body).isEqualTo(
+            expectedRequest(
+                customer = "guest",
+                automaticTax = true,
+                shippingAddressCollection = false,
+            )
+        )
+    }
+
+    @Test
+    fun `guest settings ignore a stored customer ID`() {
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings(
+                storedCustomerId = "cus_123",
+                customer = CheckoutControllerExampleCustomer.Guest,
+            )
+        )
+
+        assertThat(request.body).isEqualTo(
+            expectedRequest(
+                customer = "guest",
+                automaticTax = false,
+            )
+        )
+    }
+
+    @Test
+    fun `new customer settings create a customer despite a stored ID`() {
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings(
+                storedCustomerId = "cus_123",
+                customer = CheckoutControllerExampleCustomer.New,
+            )
+        )
+
+        assertThat(request.body).isEqualTo(
+            expectedRequest(
+                customer = "new",
+                automaticTax = false,
+                savesPaymentMethod = true,
+            )
+        )
+    }
+
+    @Test
+    fun `existing customer settings use the stored ID and enable payment method saving`() {
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings(
+                storedCustomerId = "cus_123",
+                customer = CheckoutControllerExampleCustomer.Existing("cus_123"),
+            )
+        )
+
+        assertThat(request.body).isEqualTo(
+            expectedRequest(
+                customer = "cus_123",
+                automaticTax = false,
+                savesPaymentMethod = true,
+            )
+        )
+    }
+
+    @Test
+    fun `existing customer settings fail without a customer ID`() {
+        val failure = runCatching {
+            CheckoutControllerExampleRequestFactory.create(
+                settings(customer = CheckoutControllerExampleCustomer.Existing(""))
+            )
+        }.exceptionOrNull()
+
+        assertThat(failure).hasMessageThat().isEqualTo("No customer ID available for existing customer")
+    }
+
+    private fun settings(
+        storedCustomerId: String? = null,
+        customer: CheckoutControllerExampleCustomer? = null,
+        automaticTax: Boolean = false,
+        shippingAddressCollection: Boolean = true,
+        billingAddressCollection: Boolean = false,
+    ): CheckoutControllerExampleSettings.Snapshot {
+        var settings = CheckoutControllerExampleSettings.create(
+            persistedValues = null,
+            storedCustomerId = storedCustomerId,
+        )
+        customer?.let { value ->
+            settings = settings.withValue(CheckoutControllerExampleSettingsDefinition.Customer, value)
+        }
+        settings = settings.withValue(
+            CheckoutControllerExampleSettingsDefinition.AutomaticTax,
+            automaticTax,
+        )
+        settings = settings.withValue(
+            CheckoutControllerExampleSettingsDefinition.ShippingAddressCollection,
+            shippingAddressCollection,
+        )
+        settings = settings.withValue(
+            CheckoutControllerExampleSettingsDefinition.BillingAddressCollection,
+            billingAddressCollection,
+        )
+        return settings.snapshot()
+    }
+
+    private fun expectedRequest(
+        customer: String,
+        automaticTax: Boolean,
+        shippingAddressCollection: Boolean? = null,
+        billingAddressCollection: Boolean = false,
+        savesPaymentMethod: Boolean = false,
+    ) = buildJsonObject {
+        put("mode", "payment")
+        put("customer_email", "email@example.com")
+        put("currency", "usd")
+        put("payment_method_types", commonPaymentMethodTypes)
+        put("customer", customer)
+        put("automatic_tax", automaticTax)
+        shippingAddressCollection?.let { value ->
+            put("shipping_address_collection", value)
+        }
+        if (billingAddressCollection) {
+            put("billing_address_collection", true)
+        }
+        if (savesPaymentMethod) {
+            put("checkout_session_payment_method_save", "enabled")
+        }
     }
 
     private companion object {

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleSettingsTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleSettingsTest.kt
@@ -1,0 +1,134 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CheckoutControllerExampleSettingsTest {
+    @Test
+    fun `settings list roots in order and adds active children in order`() {
+        val defaultSettings = CheckoutControllerExampleSettings.create(
+            persistedValues = null,
+            storedCustomerId = null,
+        )
+        val automaticTaxSettings = defaultSettings.withValue(
+            CheckoutControllerExampleSettingsDefinition.AutomaticTax,
+            true,
+        )
+
+        assertThat(defaultSettings.activeSettings().map { it.definition.key }).containsExactly(
+            CheckoutControllerExampleSettingKey.Customer,
+            CheckoutControllerExampleSettingKey.AutomaticTax,
+        ).inOrder()
+        assertThat(automaticTaxSettings.activeSettings().map { it.definition.key }).containsExactly(
+            CheckoutControllerExampleSettingKey.Customer,
+            CheckoutControllerExampleSettingKey.AutomaticTax,
+            CheckoutControllerExampleSettingKey.ShippingAddressCollection,
+            CheckoutControllerExampleSettingKey.BillingAddressCollection,
+        ).inOrder()
+    }
+
+    @Test
+    fun `fresh settings select and offer an existing customer when one is stored`() {
+        val settings = CheckoutControllerExampleSettings.create(
+            persistedValues = null,
+            storedCustomerId = "cus_123",
+        )
+
+        assertThat(settings[CheckoutControllerExampleSettingsDefinition.Customer]).isEqualTo(
+            CheckoutControllerExampleCustomer.Existing("cus_123")
+        )
+        assertThat(
+            CheckoutControllerExampleSettingsDefinition.Customer.options(settings).map { it.value }
+        ).containsExactly(
+            CheckoutControllerExampleCustomer.Guest,
+            CheckoutControllerExampleCustomer.New,
+            CheckoutControllerExampleCustomer.Existing("cus_123"),
+        ).inOrder()
+    }
+
+    @Test
+    fun `fresh settings omit the existing customer option when no ID is stored`() {
+        val settings = CheckoutControllerExampleSettings.create(
+            persistedValues = null,
+            storedCustomerId = null,
+        )
+
+        assertThat(settings[CheckoutControllerExampleSettingsDefinition.Customer]).isEqualTo(
+            CheckoutControllerExampleCustomer.Guest
+        )
+        assertThat(
+            CheckoutControllerExampleSettingsDefinition.Customer.options(settings).map { it.value }
+        ).containsExactly(
+            CheckoutControllerExampleCustomer.Guest,
+            CheckoutControllerExampleCustomer.New,
+        ).inOrder()
+    }
+
+    @Test
+    fun `settings encode and restore their typed values`() {
+        val settings = CheckoutControllerExampleSettings.create(
+            persistedValues = null,
+            storedCustomerId = "cus_123",
+        )
+            .withValue(
+                CheckoutControllerExampleSettingsDefinition.Customer,
+                CheckoutControllerExampleCustomer.Existing("cus_456"),
+            )
+            .withValue(CheckoutControllerExampleSettingsDefinition.AutomaticTax, true)
+            .withValue(CheckoutControllerExampleSettingsDefinition.ShippingAddressCollection, false)
+            .withValue(CheckoutControllerExampleSettingsDefinition.BillingAddressCollection, true)
+
+        assertThat(settings.encodedValues()).isEqualTo(
+            mapOf(
+                "customer" to "existing:cus_456",
+                "automatic_tax" to "true",
+                "shipping_address_collection" to "false",
+                "billing_address_collection" to "true",
+            )
+        )
+
+        val restoredSettings = CheckoutControllerExampleSettings.create(
+            persistedValues = settings.encodedValues(),
+            storedCustomerId = "cus_456",
+        )
+
+        assertThat(restoredSettings[CheckoutControllerExampleSettingsDefinition.Customer]).isEqualTo(
+            CheckoutControllerExampleCustomer.Existing("cus_456")
+        )
+        assertThat(restoredSettings[CheckoutControllerExampleSettingsDefinition.AutomaticTax]).isTrue()
+        assertThat(restoredSettings[CheckoutControllerExampleSettingsDefinition.ShippingAddressCollection]).isFalse()
+        assertThat(restoredSettings[CheckoutControllerExampleSettingsDefinition.BillingAddressCollection]).isTrue()
+    }
+
+    @Test
+    fun `automatic tax retains hidden address collection values`() {
+        val settingsWithAutomaticTax = CheckoutControllerExampleSettings.create(
+            persistedValues = null,
+            storedCustomerId = null,
+        )
+            .withValue(CheckoutControllerExampleSettingsDefinition.AutomaticTax, true)
+            .withValue(CheckoutControllerExampleSettingsDefinition.ShippingAddressCollection, false)
+            .withValue(CheckoutControllerExampleSettingsDefinition.BillingAddressCollection, true)
+        val settingsWithoutAutomaticTax = settingsWithAutomaticTax.withValue(
+            CheckoutControllerExampleSettingsDefinition.AutomaticTax,
+            false,
+        )
+        val restoredAutomaticTaxSettings = settingsWithoutAutomaticTax.withValue(
+            CheckoutControllerExampleSettingsDefinition.AutomaticTax,
+            true,
+        )
+
+        assertThat(settingsWithoutAutomaticTax.activeSettings().map { it.definition.key }).containsExactly(
+            CheckoutControllerExampleSettingKey.Customer,
+            CheckoutControllerExampleSettingKey.AutomaticTax,
+        ).inOrder()
+        assertThat(settingsWithoutAutomaticTax[CheckoutControllerExampleSettingsDefinition.ShippingAddressCollection])
+            .isFalse()
+        assertThat(settingsWithoutAutomaticTax[CheckoutControllerExampleSettingsDefinition.BillingAddressCollection])
+            .isTrue()
+        assertThat(restoredAutomaticTaxSettings[CheckoutControllerExampleSettingsDefinition.ShippingAddressCollection])
+            .isFalse()
+        assertThat(restoredAutomaticTaxSettings[CheckoutControllerExampleSettingsDefinition.BillingAddressCollection])
+            .isTrue()
+    }
+}


### PR DESCRIPTION
# Summary

The Checkout Controller playground now lets a tester choose Customer and Automatic Tax behavior independently before creating a session. This replaces the fixed scenarios with one nested settings tree and makes a newly created customer reusable on later launches.

## What changed

- Add Guest, New, and conditional Existing customer options. A stored Customer ID adds and selects Existing on a fresh launch.
- Add independent Shipping and Billing children under Automatic Tax. Their values are retained while Automatic Tax is off, but inactive children are not rendered or applied to requests.
- Use the same ordered setting definitions for UI options, saved-state encoding, status summaries, and request fields.
- Snapshot settings when session creation starts, and persist the encoded settings map separately from the session-started flag.
- Require a non-blank Customer ID from New responses, save it, replace the restorable Customer value with Existing, and enable payment-method saving for New and Existing.

## Architecture

Settings definitions own each option, its serialization, its child activation, and its request fields. The ViewModel owns settings changes and the session lifecycle.

```mermaid
flowchart LR
    UI["Activity<br/>renders settings, session, and results"]
    VM["ViewModel<br/>settings and session lifecycle"]
    SETTINGS["Settings<br/>typed values and active tree"]
    SNAPSHOT["Settings Snapshot<br/>immutable session input"]
    SAVED["SavedStateHandle<br/>encoded map and started flag"]
    STORE["CustomerStore<br/>last created Customer ID"]
    REPO["BackendRepository<br/>request execution"]
    FACTORY["RequestFactory<br/>common fields and active settings"]
    BACKEND["Playground backend<br/>Checkout Session creation"]
    CONTROLLER["CheckoutController<br/>session and confirmation"]

    UI -->|actions| VM
    VM -. settings and status .-> UI
    VM -->|updates| SETTINGS
    SETTINGS -->|snapshot| SNAPSHOT
    VM -->|persist map and flag| SAVED
    SAVED -. restored values .-> VM
    VM -->|read and save ID| STORE
    VM -->|fetch with Snapshot| REPO
    REPO -->|create request| FACTORY
    SNAPSHOT -. active values .-> FACTORY
    REPO -->|POST checkout_session| BACKEND
    BACKEND -. CheckoutResponse .-> REPO
    VM -->|configure and observe| CONTROLLER
    UI -->|present and confirm| CONTROLLER
    CONTROLLER -. Session and Result .-> VM
    SNAPSHOT -. summary lines .-> UI
```

## Runtime flow

```mermaid
flowchart TB
    LAUNCH["Open Checkout Controller"] --> RESTORE["Create Settings from SavedStateHandle<br/>and CustomerStore"]
    RESTORE --> STARTED{"Session-started flag set?"}
    STARTED -->|No| CHOOSE["Render active settings"]
    CHOOSE --> START["start: freeze Snapshot,<br/>persist settings and flag"]
    STARTED -->|Yes| RESUME["Freeze restored Snapshot"]
    START --> FETCH
    RESUME --> FETCH["BackendRepository and RequestFactory<br/>POST checkout_session"]
    FETCH --> RESPONSE{"CheckoutResponse?"}
    RESPONSE -->|Failure| ERROR["Show Error with Snapshot summary"]
    RESPONSE -->|Success| NEW{"Snapshot Customer is New?"}
    NEW -->|No| CONFIGURE
    NEW -->|Yes| ID{"Non-blank customerId?"}
    ID -->|No| ERROR
    ID -->|Yes| SAVE["Save ID and set live Customer to Existing"]
    SAVE --> CONFIGURE["CheckoutController.configure"]
    CONFIGURE -->|Failure| ERROR
    CONFIGURE -->|Success| SESSION["Render session with original Snapshot"]
    SESSION --> CONFIRM["Select payment method and confirm"]
    CONFIRM --> RESULT{"CheckoutController.Result"}
    RESULT -->|Completed| MAIN["finish to Main"]
    RESULT -->|Canceled or Failed| SESSION
```

## What stays the same

- Checkout Controller remains launched from Main and returns there after a successful confirmation.
- With Automatic Tax off, the request omits both address-collection fields so the backend retains its shipping-enabled default.
- Backend PR #1226 remains separate and undeployed.

# Changelog

Not applicable. This changes the internal example playground only.

Committed and created by Codex.