### PR TITLE
Propagate controller shipping to Checkout Session confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -73,7 +73,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
                     intent = intent,
                     paymentMethod = paymentMethod,
                     savePaymentMethod = confirmationOption.shouldSave.takeIf { isSaveEnabled },
-                    shippingInformation = null,
+                    shipping = shippingValues.toCheckoutSessionShipping(),
                 )
                 confirmCheckoutSession(params)
             },
@@ -107,7 +107,8 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             intent = intent,
             paymentMethod = confirmationOption.paymentMethod,
             savePaymentMethod = null,
-            shippingInformation = confirmationOption.shippingInformation,
+            shipping = confirmationOption.shippingInformation.toCheckoutSessionShipping()
+                ?: shippingValues.toCheckoutSessionShipping(),
         )
         return confirmCheckoutSession(params)
     }
@@ -144,7 +145,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
         intent: StripeIntent,
         paymentMethod: PaymentMethod,
         savePaymentMethod: Boolean?,
-        shippingInformation: ShippingInformation?,
+        shipping: ConfirmCheckoutSessionParams.Shipping?,
     ): ConfirmCheckoutSessionParams = when (intent) {
         is PaymentIntent -> ConfirmCheckoutSessionParams(
             paymentMethodId = paymentMethod.id,
@@ -152,13 +153,13 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             returnUrl = returnUrl,
             expectedAmount = intent.amount,
             savePaymentMethod = savePaymentMethod,
-            shipping = shippingInformation.toCheckoutSessionShipping(),
+            shipping = shipping,
         )
         else -> ConfirmCheckoutSessionParams(
             paymentMethodId = paymentMethod.id,
             clientAttributionMetadata = clientAttributionMetadata,
             returnUrl = returnUrl,
-            shipping = shippingInformation.toCheckoutSessionShipping(),
+            shipping = shipping,
         )
     }
 
@@ -241,6 +242,15 @@ private fun ShippingInformation?.toCheckoutSessionShipping(): ConfirmCheckoutSes
         ConfirmCheckoutSessionParams.Shipping(
             name = it.name,
             address = it.address,
+        )
+    }
+}
+
+private fun ConfirmPaymentIntentParams.Shipping?.toCheckoutSessionShipping(): ConfirmCheckoutSessionParams.Shipping? {
+    return this?.let {
+        ConfirmCheckoutSessionParams.Shipping(
+            name = it.getName(),
+            address = it.getAddress(),
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -107,6 +107,9 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
             intent = intent,
             paymentMethod = confirmationOption.paymentMethod,
             savePaymentMethod = null,
+            // ECE Google Pay returns the buyer's final shipping address after confirmation starts.
+            // It cannot be reconciled with the earlier shippingValues snapshot, so use it for this
+            // confirmation and otherwise retain the controller shipping.
             shipping = confirmationOption.shippingInformation.toCheckoutSessionShipping()
                 ?: shippingValues.toCheckoutSessionShipping(),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -3,6 +3,8 @@ package com.stripe.android.paymentelement.confirmation.intent
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.checkouttesting.checkoutUpdate
@@ -12,6 +14,7 @@ import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
@@ -36,8 +39,13 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationDefinition
+import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -53,6 +61,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 
 @OptIn(CheckoutSessionPreview::class)
@@ -473,26 +482,69 @@ class CheckoutSessionConfirmationInterceptorTest {
     }
 
     @Test
-    fun `intercept with saved payment method prefers Google Pay shipping over controller shipping`() =
+    fun `Google Pay result shipping takes precedence over controller shipping at Checkout confirmation`() =
         runScenario {
             networkRule.checkoutConfirm(
-                bodyPart("shipping[name]", "Jenny Rosen"),
+                bodyPart("shipping[name]", "Google Pay Shipping"),
                 bodyPart("shipping[address][line1]", "510 Townsend St"),
+                bodyPart("shipping[address][line2]", "Floor 3"),
                 bodyPart("shipping[address][city]", "San Francisco"),
                 bodyPart("shipping[address][state]", "CA"),
                 bodyPart("shipping[address][postal_code]", "94103"),
                 bodyPart("shipping[address][country]", "US"),
                 not(bodyPart("shipping[name]", "Controller Shipping")),
                 not(bodyPart("shipping[address][line1]", "123 Controller Street")),
+                not(bodyPart("shipping[address][line2]", "Unit 4")),
+                not(bodyPart("shipping[address][city]", "Controller City")),
+                not(bodyPart("shipping[address][state]", "NY")),
+                not(bodyPart("shipping[address][postal_code]", "10001")),
+                not(bodyPart("shipping[address][country]", "CA")),
                 not(hasBodyPart("shipping[phone]")),
             ) { response ->
                 response.testBodyFromFile("checkout-session-confirm.json")
             }
 
-            interceptSavedPm(
-                shippingInformation = SHIPPING_INFORMATION,
-                shippingValues = CONTROLLER_SHIPPING,
-                originatedFromWallet = true,
+            val confirmationArgs = ConfirmationHandler.Args(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    stripeIntent = PaymentIntentFactory.create(),
+                    integrationMetadata = integrationMetadata,
+                    shippingDetails = CONTROLLER_SHIPPING_DETAILS,
+                ),
+                statusBarColor = null,
+            )
+            val googlePayResult = GooglePayConfirmationDefinition(
+                instanceId = "test",
+                context = applicationContext,
+                googlePayPaymentMethodLauncherFactory = mock(),
+                userFacingLogger = null,
+            ).toResult(
+                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
+                confirmationArgs = confirmationArgs,
+                launcherArgs = EmptyConfirmationLauncherArgs,
+                result = com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.Result.Completed(
+                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
+                    shippingInformation = GOOGLE_PAY_SHIPPING_INFORMATION,
+                ),
+            )
+
+            assertThat(googlePayResult).isInstanceOf<ConfirmationDefinition.Result.NextStep>()
+            val nextStep = googlePayResult as ConfirmationDefinition.Result.NextStep
+            assertThat(nextStep.arguments.paymentMethodMetadata.shippingDetails)
+                .isEqualTo(CONTROLLER_SHIPPING_DETAILS)
+
+            IntentConfirmationDefinition(
+                intentConfirmationInterceptorFactory = object : IntentConfirmationInterceptor.Factory {
+                    override suspend fun create(
+                        integrationMetadata: IntegrationMetadata,
+                        customerMetadata: CustomerMetadata?,
+                        clientAttributionMetadata: ClientAttributionMetadata,
+                    ): IntentConfirmationInterceptor = interceptor
+                },
+                paymentLauncherFactory = { _, _ -> error("No payment launcher is needed") },
+            ).action(
+                confirmationOption = nextStep.confirmationOption as PaymentMethodConfirmationOption.Saved,
+                confirmationArgs = nextStep.arguments,
             )
         }
 
@@ -545,12 +597,13 @@ class CheckoutSessionConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
+        val integrationMetadata = IntegrationMetadata.CheckoutSession(
+            id = checkoutSessionResponse.id,
+            instancesKey = "test_key",
+            checkoutSessionResponse = checkoutSessionResponse,
+        )
         val interceptor = CheckoutSessionConfirmationInterceptor(
-            integrationMetadata = IntegrationMetadata.CheckoutSession(
-                id = checkoutSessionResponse.id,
-                instancesKey = "test_key",
-                checkoutSessionResponse = checkoutSessionResponse,
-            ),
+            integrationMetadata = integrationMetadata,
             customerMetadata = customerMetadata,
             clientAttributionMetadata = ClientAttributionMetadata(
                 elementsSessionConfigId = "test_session_id",
@@ -568,6 +621,7 @@ class CheckoutSessionConfirmationInterceptorTest {
         runTest {
             val scenario = Scenario(
                 interceptor = interceptor,
+                integrationMetadata = integrationMetadata,
             )
 
             scenario.block()
@@ -576,6 +630,7 @@ class CheckoutSessionConfirmationInterceptorTest {
 
     private data class Scenario(
         val interceptor: CheckoutSessionConfirmationInterceptor,
+        val integrationMetadata: IntegrationMetadata.CheckoutSession,
     ) {
         suspend fun interceptNewPm(
             shouldSave: Boolean = false,
@@ -659,6 +714,46 @@ class CheckoutSessionConfirmationInterceptorTest {
             ),
             name = "Controller Shipping",
             phone = "1-800-555-0000",
+        )
+
+        val CONTROLLER_SHIPPING_DETAILS = AddressDetails(
+            name = "Controller Shipping",
+            address = PaymentSheet.Address(
+                line1 = "123 Controller Street",
+                line2 = "Unit 4",
+                city = "Controller City",
+                state = "NY",
+                postalCode = "10001",
+                country = "CA",
+            ),
+            phoneNumber = "1-800-555-0000",
+        )
+
+        val GOOGLE_PAY_CONFIRMATION_OPTION = GooglePayConfirmationOption(
+            config = GooglePayConfirmationOption.Config(
+                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
+                merchantName = "Test merchant",
+                merchantCountryCode = "US",
+                merchantCurrencyCode = "USD",
+                customAmount = null,
+                customLabel = null,
+                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
+                cardBrandFilter = DefaultCardBrandFilter,
+                cardFundingFilter = DefaultCardFundingFilter,
+            ),
+        )
+
+        val GOOGLE_PAY_SHIPPING_INFORMATION = ShippingInformation(
+            name = "Google Pay Shipping",
+            phone = "1-800-555-1234",
+            address = Address(
+                line1 = "510 Townsend St",
+                line2 = "Floor 3",
+                city = "San Francisco",
+                state = "CA",
+                postalCode = "94103",
+                country = "US",
+            ),
         )
 
         val SAVE_ENABLED_CUSTOMER_METADATA = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -3,8 +3,6 @@ package com.stripe.android.paymentelement.confirmation.intent
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.DefaultCardBrandFilter
-import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.checkout.CheckoutSessionTaxRegionUpdater
 import com.stripe.android.checkouttesting.checkoutConfirm
 import com.stripe.android.checkouttesting.checkoutUpdate
@@ -14,7 +12,6 @@ import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
@@ -39,13 +36,8 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
-import com.stripe.android.paymentelement.confirmation.EmptyConfirmationLauncherArgs
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationDefinition
-import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.R
-import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -61,7 +53,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 
 @OptIn(CheckoutSessionPreview::class)
@@ -451,10 +442,10 @@ class CheckoutSessionConfirmationInterceptorTest {
             bodyPart("shipping[name]", "Controller Shipping"),
             bodyPart("shipping[address][line1]", "123 Controller Street"),
             bodyPart("shipping[address][line2]", "Unit 4"),
-            bodyPart("shipping[address][city]", "San Francisco"),
-            bodyPart("shipping[address][state]", "CA"),
-            bodyPart("shipping[address][postal_code]", "94111"),
-            bodyPart("shipping[address][country]", "US"),
+            bodyPart("shipping[address][city]", "Controller City"),
+            bodyPart("shipping[address][state]", "NY"),
+            bodyPart("shipping[address][postal_code]", "10001"),
+            bodyPart("shipping[address][country]", "CA"),
             not(hasBodyPart("shipping[phone]")),
         ) { response ->
             response.testBodyFromFile("checkout-session-confirm.json")
@@ -469,10 +460,10 @@ class CheckoutSessionConfirmationInterceptorTest {
             bodyPart("shipping[name]", "Controller Shipping"),
             bodyPart("shipping[address][line1]", "123 Controller Street"),
             bodyPart("shipping[address][line2]", "Unit 4"),
-            bodyPart("shipping[address][city]", "San Francisco"),
-            bodyPart("shipping[address][state]", "CA"),
-            bodyPart("shipping[address][postal_code]", "94111"),
-            bodyPart("shipping[address][country]", "US"),
+            bodyPart("shipping[address][city]", "Controller City"),
+            bodyPart("shipping[address][state]", "NY"),
+            bodyPart("shipping[address][postal_code]", "10001"),
+            bodyPart("shipping[address][country]", "CA"),
             not(hasBodyPart("shipping[phone]")),
         ) { response ->
             response.testBodyFromFile("checkout-session-confirm.json")
@@ -482,69 +473,23 @@ class CheckoutSessionConfirmationInterceptorTest {
     }
 
     @Test
-    fun `Google Pay result shipping takes precedence over controller shipping at Checkout confirmation`() =
+    fun `intercept with saved payment method prefers option shipping over controller shipping`() =
         runScenario {
             networkRule.checkoutConfirm(
-                bodyPart("shipping[name]", "Google Pay Shipping"),
+                bodyPart("shipping[name]", "Jenny Rosen"),
                 bodyPart("shipping[address][line1]", "510 Townsend St"),
                 bodyPart("shipping[address][line2]", "Floor 3"),
                 bodyPart("shipping[address][city]", "San Francisco"),
                 bodyPart("shipping[address][state]", "CA"),
                 bodyPart("shipping[address][postal_code]", "94103"),
                 bodyPart("shipping[address][country]", "US"),
-                not(bodyPart("shipping[name]", "Controller Shipping")),
-                not(bodyPart("shipping[address][line1]", "123 Controller Street")),
-                not(bodyPart("shipping[address][line2]", "Unit 4")),
-                not(bodyPart("shipping[address][city]", "Controller City")),
-                not(bodyPart("shipping[address][state]", "NY")),
-                not(bodyPart("shipping[address][postal_code]", "10001")),
-                not(bodyPart("shipping[address][country]", "CA")),
-                not(hasBodyPart("shipping[phone]")),
             ) { response ->
                 response.testBodyFromFile("checkout-session-confirm.json")
             }
 
-            val confirmationArgs = ConfirmationHandler.Args(
-                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-                    stripeIntent = PaymentIntentFactory.create(),
-                    integrationMetadata = integrationMetadata,
-                    shippingDetails = CONTROLLER_SHIPPING_DETAILS,
-                ),
-                statusBarColor = null,
-            )
-            val googlePayResult = GooglePayConfirmationDefinition(
-                instanceId = "test",
-                context = applicationContext,
-                googlePayPaymentMethodLauncherFactory = mock(),
-                userFacingLogger = null,
-            ).toResult(
-                confirmationOption = GOOGLE_PAY_CONFIRMATION_OPTION,
-                confirmationArgs = confirmationArgs,
-                launcherArgs = EmptyConfirmationLauncherArgs,
-                result = com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncher.Result.Completed(
-                    paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD,
-                    shippingInformation = GOOGLE_PAY_SHIPPING_INFORMATION,
-                ),
-            )
-
-            assertThat(googlePayResult).isInstanceOf<ConfirmationDefinition.Result.NextStep>()
-            val nextStep = googlePayResult as ConfirmationDefinition.Result.NextStep
-            assertThat(nextStep.arguments.paymentMethodMetadata.shippingDetails)
-                .isEqualTo(CONTROLLER_SHIPPING_DETAILS)
-
-            IntentConfirmationDefinition(
-                intentConfirmationInterceptorFactory = object : IntentConfirmationInterceptor.Factory {
-                    override suspend fun create(
-                        integrationMetadata: IntegrationMetadata,
-                        customerMetadata: CustomerMetadata?,
-                        clientAttributionMetadata: ClientAttributionMetadata,
-                    ): IntentConfirmationInterceptor = interceptor
-                },
-                paymentLauncherFactory = { _, _ -> error("No payment launcher is needed") },
-            ).action(
-                confirmationOption = nextStep.confirmationOption as PaymentMethodConfirmationOption.Saved,
-                confirmationArgs = nextStep.arguments,
+            interceptSavedPm(
+                shippingInformation = SHIPPING_INFORMATION,
+                shippingValues = CONTROLLER_SHIPPING,
             )
         }
 
@@ -597,13 +542,12 @@ class CheckoutSessionConfirmationInterceptorTest {
             stripeAccountIdProvider = { null },
         )
 
-        val integrationMetadata = IntegrationMetadata.CheckoutSession(
-            id = checkoutSessionResponse.id,
-            instancesKey = "test_key",
-            checkoutSessionResponse = checkoutSessionResponse,
-        )
         val interceptor = CheckoutSessionConfirmationInterceptor(
-            integrationMetadata = integrationMetadata,
+            integrationMetadata = IntegrationMetadata.CheckoutSession(
+                id = checkoutSessionResponse.id,
+                instancesKey = "test_key",
+                checkoutSessionResponse = checkoutSessionResponse,
+            ),
             customerMetadata = customerMetadata,
             clientAttributionMetadata = ClientAttributionMetadata(
                 elementsSessionConfigId = "test_session_id",
@@ -621,7 +565,6 @@ class CheckoutSessionConfirmationInterceptorTest {
         runTest {
             val scenario = Scenario(
                 interceptor = interceptor,
-                integrationMetadata = integrationMetadata,
             )
 
             scenario.block()
@@ -630,7 +573,6 @@ class CheckoutSessionConfirmationInterceptorTest {
 
     private data class Scenario(
         val interceptor: CheckoutSessionConfirmationInterceptor,
-        val integrationMetadata: IntegrationMetadata.CheckoutSession,
     ) {
         suspend fun interceptNewPm(
             shouldSave: Boolean = false,
@@ -646,13 +588,11 @@ class CheckoutSessionConfirmationInterceptorTest {
             intent: StripeIntent = PaymentIntentFactory.create(),
             shippingInformation: ShippingInformation? = null,
             shippingValues: ConfirmPaymentIntentParams.Shipping? = null,
-            originatedFromWallet: Boolean = false,
         ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> =
             interceptor.intercept(
                 intent = intent,
                 confirmationOption = SAVED_PM_OPTION.copy(
                     shippingInformation = shippingInformation,
-                    originatedFromWallet = originatedFromWallet,
                 ),
                 shippingValues = shippingValues,
             )
@@ -696,6 +636,7 @@ class CheckoutSessionConfirmationInterceptorTest {
             phone = "1-800-555-1234",
             address = Address(
                 line1 = "510 Townsend St",
+                line2 = "Floor 3",
                 city = "San Francisco",
                 state = "CA",
                 postalCode = "94103",
@@ -707,53 +648,13 @@ class CheckoutSessionConfirmationInterceptorTest {
             address = Address(
                 line1 = "123 Controller Street",
                 line2 = "Unit 4",
-                city = "San Francisco",
-                state = "CA",
-                postalCode = "94111",
-                country = "US",
-            ),
-            name = "Controller Shipping",
-            phone = "1-800-555-0000",
-        )
-
-        val CONTROLLER_SHIPPING_DETAILS = AddressDetails(
-            name = "Controller Shipping",
-            address = PaymentSheet.Address(
-                line1 = "123 Controller Street",
-                line2 = "Unit 4",
                 city = "Controller City",
                 state = "NY",
                 postalCode = "10001",
                 country = "CA",
             ),
-            phoneNumber = "1-800-555-0000",
-        )
-
-        val GOOGLE_PAY_CONFIRMATION_OPTION = GooglePayConfirmationOption(
-            config = GooglePayConfirmationOption.Config(
-                environment = PaymentSheet.GooglePayConfiguration.Environment.Test,
-                merchantName = "Test merchant",
-                merchantCountryCode = "US",
-                merchantCurrencyCode = "USD",
-                customAmount = null,
-                customLabel = null,
-                billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(),
-                cardBrandFilter = DefaultCardBrandFilter,
-                cardFundingFilter = DefaultCardFundingFilter,
-            ),
-        )
-
-        val GOOGLE_PAY_SHIPPING_INFORMATION = ShippingInformation(
-            name = "Google Pay Shipping",
-            phone = "1-800-555-1234",
-            address = Address(
-                line1 = "510 Townsend St",
-                line2 = "Floor 3",
-                city = "San Francisco",
-                state = "CA",
-                postalCode = "94103",
-                country = "US",
-            ),
+            name = "Controller Shipping",
+            phone = "1-800-555-0000",
         )
 
         val SAVE_ENABLED_CUSTOMER_METADATA = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -16,6 +16,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixt
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
 import com.stripe.android.model.ClientAttributionMetadata
+import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentIntentCreationFlow
 import com.stripe.android.model.PaymentMethod
@@ -435,6 +436,90 @@ class CheckoutSessionConfirmationInterceptorTest {
         interceptSavedPm(shippingInformation = SHIPPING_INFORMATION)
     }
 
+    @Test
+    fun `intercept with new payment method passes controller shipping`() = runScenario {
+        networkRule.checkoutConfirm(
+            bodyPart("shipping[name]", "Controller Shipping"),
+            bodyPart("shipping[address][line1]", "123 Controller Street"),
+            bodyPart("shipping[address][line2]", "Unit 4"),
+            bodyPart("shipping[address][city]", "San Francisco"),
+            bodyPart("shipping[address][state]", "CA"),
+            bodyPart("shipping[address][postal_code]", "94111"),
+            bodyPart("shipping[address][country]", "US"),
+            not(hasBodyPart("shipping[phone]")),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        interceptNewPm(shippingValues = CONTROLLER_SHIPPING)
+    }
+
+    @Test
+    fun `intercept with saved payment method falls back to controller shipping`() = runScenario {
+        networkRule.checkoutConfirm(
+            bodyPart("shipping[name]", "Controller Shipping"),
+            bodyPart("shipping[address][line1]", "123 Controller Street"),
+            bodyPart("shipping[address][line2]", "Unit 4"),
+            bodyPart("shipping[address][city]", "San Francisco"),
+            bodyPart("shipping[address][state]", "CA"),
+            bodyPart("shipping[address][postal_code]", "94111"),
+            bodyPart("shipping[address][country]", "US"),
+            not(hasBodyPart("shipping[phone]")),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        interceptSavedPm(shippingValues = CONTROLLER_SHIPPING)
+    }
+
+    @Test
+    fun `intercept with saved payment method prefers Google Pay shipping over controller shipping`() =
+        runScenario {
+            networkRule.checkoutConfirm(
+                bodyPart("shipping[name]", "Jenny Rosen"),
+                bodyPart("shipping[address][line1]", "510 Townsend St"),
+                bodyPart("shipping[address][city]", "San Francisco"),
+                bodyPart("shipping[address][state]", "CA"),
+                bodyPart("shipping[address][postal_code]", "94103"),
+                bodyPart("shipping[address][country]", "US"),
+                not(bodyPart("shipping[name]", "Controller Shipping")),
+                not(bodyPart("shipping[address][line1]", "123 Controller Street")),
+                not(hasBodyPart("shipping[phone]")),
+            ) { response ->
+                response.testBodyFromFile("checkout-session-confirm.json")
+            }
+
+            interceptSavedPm(
+                shippingInformation = SHIPPING_INFORMATION,
+                shippingValues = CONTROLLER_SHIPPING,
+                originatedFromWallet = true,
+            )
+        }
+
+    @Test
+    fun `intercept with new payment method omits shipping when none is provided`() = runScenario {
+        networkRule.checkoutConfirm(
+            not(hasBodyPart("shipping[name]")),
+            not(hasBodyPart("shipping[address][line1]")),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        interceptNewPm()
+    }
+
+    @Test
+    fun `intercept with saved payment method omits shipping when none is provided`() = runScenario {
+        networkRule.checkoutConfirm(
+            not(hasBodyPart("shipping[name]")),
+            not(hasBodyPart("shipping[address][line1]")),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        interceptSavedPm()
+    }
+
     private fun runScenario(
         createPaymentMethodResult: Result<PaymentMethod> = Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
         customerMetadata: CustomerMetadata? = null,
@@ -495,20 +580,26 @@ class CheckoutSessionConfirmationInterceptorTest {
         suspend fun interceptNewPm(
             shouldSave: Boolean = false,
             intent: StripeIntent = PaymentIntentFactory.create(),
+            shippingValues: ConfirmPaymentIntentParams.Shipping? = null,
         ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> = interceptor.intercept(
             intent = intent,
             confirmationOption = NEW_PM_OPTION.copy(shouldSave = shouldSave),
-            shippingValues = null,
+            shippingValues = shippingValues,
         )
 
         suspend fun interceptSavedPm(
             intent: StripeIntent = PaymentIntentFactory.create(),
             shippingInformation: ShippingInformation? = null,
+            shippingValues: ConfirmPaymentIntentParams.Shipping? = null,
+            originatedFromWallet: Boolean = false,
         ): ConfirmationDefinition.Action<IntentConfirmationDefinition.Args> =
             interceptor.intercept(
                 intent = intent,
-                confirmationOption = SAVED_PM_OPTION.copy(shippingInformation = shippingInformation),
-                shippingValues = null,
+                confirmationOption = SAVED_PM_OPTION.copy(
+                    shippingInformation = shippingInformation,
+                    originatedFromWallet = originatedFromWallet,
+                ),
+                shippingValues = shippingValues,
             )
     }
 
@@ -555,6 +646,19 @@ class CheckoutSessionConfirmationInterceptorTest {
                 postalCode = "94103",
                 country = "US",
             ),
+        )
+
+        val CONTROLLER_SHIPPING = ConfirmPaymentIntentParams.Shipping(
+            address = Address(
+                line1 = "123 Controller Street",
+                line2 = "Unit 4",
+                city = "San Francisco",
+                state = "CA",
+                postalCode = "94111",
+                country = "US",
+            ),
+            name = "Controller Shipping",
+            phone = "1-800-555-0000",
         )
 
         val SAVE_ENABLED_CUSTOMER_METADATA = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.copy(


### PR DESCRIPTION
# Summary
Propagate CheckoutController-collected shipping to Checkout Session confirmation.

New PaymentMethods use controller shipping. Saved PaymentMethods use option-provided shipping when present, then fall back to controller shipping.

For ECE Google Pay, option-provided shipping is the final shipping returned after confirmation starts, so it supersedes the earlier controller snapshot for that confirmation.

# Motivation
`IntentConfirmationDefinition` already passes controller shipping to the Checkout Session interceptor. The interceptor previously discarded it for new PaymentMethods, while saved PaymentMethods omitted it whenever option-provided shipping was absent.

The confirmation source selection is now:

```text
New PaymentMethod:   controller shipping
Saved PaymentMethod: option shipping, or controller shipping when absent
```

The interceptor selects one source for the confirmation request. It does not merge address fields or mutate CheckoutController state.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Request-body coverage verifies:

- New PaymentMethods serialize controller shipping.
- Saved PaymentMethods fall back to controller shipping.
- Saved-option shipping takes precedence when both sources contain distinct values for every serialized field.
- Shipping phone is omitted.
- Shipping is omitted when neither source is present.

Existing focused coverage separately verifies that a completed Google Pay result carries shipping into the saved confirmation option and that ECE requests Google Pay shipping when configured.

The focused interceptor, Google Pay definition, and ECE performer test classes passed locally, along with PaymentSheet API and detekt checks, `git diff --check`, and path-aware pre-push checks. CI is pending.

# Screenshots
Not applicable. This changes the Checkout Session confirmation request payload and has no UI changes.

# Changelog
No changelog entry. This change does not modify public API.

Committed and created by Codex.
