### PR TITLE
Add Link and confirmation saved-state primitives

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/LinkAccountHolder.kt
@@ -7,11 +7,20 @@ import kotlinx.coroutines.flow.StateFlow
 internal class LinkAccountHolder(
     private val savedStateHandle: SavedStateHandle
 ) {
+    private var hasStoredState = savedStateHandle.contains(LINK_ACCOUNT_HOLDER_STATE)
+
     val linkAccountInfo: StateFlow<LinkAccountUpdate.Value> = savedStateHandle
         .getStateFlow(LINK_ACCOUNT_HOLDER_STATE, LinkAccountUpdate.Value(null, null))
 
     fun set(info: LinkAccountUpdate.Value) {
+        hasStoredState = true
         savedStateHandle[LINK_ACCOUNT_HOLDER_STATE] = info
+    }
+
+    fun setIfAbsent(info: LinkAccountUpdate.Value) {
+        if (!hasStoredState) {
+            set(info)
+        }
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandler.kt
@@ -326,5 +326,9 @@ internal class DefaultConfirmationHandler(
     internal companion object {
         private const val AWAITING_CONFIRMATION_RESULT_KEY = "AwaitingConfirmationResult"
         private const val INITIAL_CONFIRMATION_ARGUMENTS_KEY = "INITIAL_CONFIRMATION_ARGUMENTS_KEY"
+
+        fun wasAwaitingResult(savedStateHandle: SavedStateHandle): Boolean {
+            return savedStateHandle.contains(AWAITING_CONFIRMATION_RESULT_KEY)
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/link/account/LinkAccountHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/account/LinkAccountHolderTest.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.link.account
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkAccountUpdate.Value.UpdateReason.LoggedOut
+import com.stripe.android.link.TestFactory
+import kotlin.test.Test
+
+internal class LinkAccountHolderTest {
+    @Test
+    fun `setIfAbsent stores state when none was previously stored`() {
+        val holder = LinkAccountHolder(SavedStateHandle())
+        val accountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+
+        holder.setIfAbsent(accountInfo)
+
+        assertThat(holder.linkAccountInfo.value).isEqualTo(accountInfo)
+    }
+
+    @Test
+    fun `setIfAbsent does not overwrite restored state`() {
+        val savedStateHandle = SavedStateHandle()
+        val restoredInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+        LinkAccountHolder(savedStateHandle).set(restoredInfo)
+        val restoredHolder = LinkAccountHolder(savedStateHandle)
+
+        restoredHolder.setIfAbsent(LinkAccountUpdate.Value(null, LoggedOut))
+
+        assertThat(restoredHolder.linkAccountInfo.value).isEqualTo(restoredInfo)
+    }
+
+    @Test
+    fun `setIfAbsent does not overwrite explicitly empty state`() {
+        val holder = LinkAccountHolder(SavedStateHandle())
+        val emptyInfo = LinkAccountUpdate.Value(account = null)
+        holder.set(emptyInfo)
+
+        holder.setIfAbsent(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
+        assertThat(holder.linkAccountInfo.value).isEqualTo(emptyInfo)
+    }
+
+    @Test
+    fun `set overwrites state and prevents a later setIfAbsent`() {
+        val holder = LinkAccountHolder(SavedStateHandle())
+        holder.setIfAbsent(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+        val overwrittenInfo = LinkAccountUpdate.Value(null, LoggedOut)
+
+        holder.set(overwrittenInfo)
+        holder.setIfAbsent(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+
+        assertThat(holder.linkAccountInfo.value).isEqualTo(overwrittenInfo)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/DefaultConfirmationHandlerTest.kt
@@ -39,6 +39,16 @@ class DefaultConfirmationHandlerTest {
     val coroutineScopeCleanupRule = CleanupTestRule<CoroutineScope> { cancel() }
 
     @Test
+    fun `wasAwaitingResult returns false when awaiting result state is absent`() {
+        assertThat(DefaultConfirmationHandler.wasAwaitingResult(SavedStateHandle())).isFalse()
+    }
+
+    @Test
+    fun `wasAwaitingResult returns true when awaiting result state is present`() {
+        assertThat(DefaultConfirmationHandler.wasAwaitingResult(createPrepopulatedSavedStateHandle(false))).isTrue()
+    }
+
+    @Test
     fun `On initial register, should create launchers for each definition`() = test(shouldRegister = false) {
         assertThat(confirmationHandler.hasReloadedFromProcessDeath).isFalse()
 


### PR DESCRIPTION
# Summary

Adds saved-state primitives for Link account initialization and confirmation restoration.

This is layer 1 of 2 in the stack. It adds `LinkAccountHolder.setIfAbsent` so restored or explicitly empty account state is preserved, and exposes whether confirmation-awaiting state was previously stored.

# Motivation

Shared sheet initialization needs to distinguish absent saved state from state that was deliberately stored. These helpers make that distinction without overwriting restored Link state or conflating a stored `false` confirmation value with a missing value.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew detekt`

No tests were newly ignored.

# Screenshots

Not applicable; this PR changes non-visual saved-state primitives.

# Changelog

Not applicable; this is an internal implementation change with no public API impact.

Committed and created by Codex.
