### PR TITLE
Fix embedded bank incentive updates

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedFormPage.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasAnyDescendant
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
@@ -23,6 +24,7 @@ import com.stripe.android.paymentsheet.ui.SHEET_ERROR_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SHEET_MANDATE_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_DISABLED_OVERLAY_TEST_TAG
 import com.stripe.android.paymentsheet.ui.SHEET_PRIMARY_BUTTON_TEST_TAG
+import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_HEADER_PROMO_BADGE
 import kotlin.time.Duration.Companion.seconds
 
 internal class EmbeddedFormPage(
@@ -163,6 +165,34 @@ internal class EmbeddedFormPage(
         waitUntilVisible()
 
         composeTestRule.onNodeWithTag(SHEET_MANDATE_TEST_TAG)
+            .assertDoesNotExist()
+    }
+
+    fun assertHeaderPromoBadgeIsDisplayed(text: String) {
+        waitUntilVisible()
+
+        val matcher = hasTestTag(TEST_TAG_HEADER_PROMO_BADGE).and(
+            hasAnyDescendant(hasText(text, substring = true))
+        )
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(matcher, useUnmergedTree = true)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+
+        composeTestRule.onNode(matcher, useUnmergedTree = true)
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    fun waitUntilHeaderPromoBadgeIsMissing() {
+        composeTestRule.waitUntil {
+            composeTestRule.onAllNodesWithTag(TEST_TAG_HEADER_PROMO_BADGE)
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(TEST_TAG_HEADER_PROMO_BADGE)
             .assertDoesNotExist()
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementBankIncentiveTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementBankIncentiveTest.kt
@@ -1,0 +1,71 @@
+package com.stripe.android.paymentelement
+
+import androidx.test.espresso.intent.rule.IntentsRule
+import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.elementsSession
+import com.stripe.android.networktesting.testBodyFromFile
+import com.stripe.android.paymentsheet.CreateIntentResult
+import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.utils.UsBankAccountFormTestUtils
+import com.stripe.android.testing.FeatureFlagTestRule
+import com.stripe.paymentelementtestpages.FormPage
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Rule
+import org.junit.Test
+
+internal class EmbeddedPaymentElementBankIncentiveTest {
+    private val networkRule = NetworkRule()
+
+    @get:Rule
+    val testRules: TestRules = TestRules.create(networkRule = networkRule) {
+        around(FeatureFlagTestRule(FeatureFlags.instantDebitsIncentives, isEnabled = true))
+            .around(IntentsRule())
+    }
+
+    private val embeddedContentPage = EmbeddedContentPage(testRules.compose)
+    private val embeddedFormPage = EmbeddedFormPage(testRules.compose)
+    private val formPage = FormPage(testRules.compose)
+
+    @Test
+    fun testIneligibleLinkedBankAccountRemovesHeaderIncentive() = runEmbeddedPaymentElementTest(
+        networkRule = networkRule,
+        createIntentCallback = { _, _ -> CreateIntentResult.Success("pi_example_secret_12345") },
+        resultCallback = {},
+    ) { testContext ->
+        UsBankAccountFormTestUtils.setupSuccessfulCompletionOfInstantDebitsForm(
+            eligibleForIncentive = false,
+        )
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json") { json ->
+                json.getJSONObject("link_settings")
+                    .put("link_mode", "LINK_PAYMENT_METHOD")
+                    .put(
+                        "link_consumer_incentive",
+                        JSONObject()
+                            .put(
+                                "incentive_params",
+                                JSONObject().put("payment_method", "link_instant_debits")
+                            )
+                            .put("incentive_display_text", "$5")
+                    )
+                    .put(
+                        "link_supported_payment_methods_onboarding_enabled",
+                        JSONArray().put("INSTANT_DEBITS")
+                    )
+            }
+        }
+
+        testContext.configure()
+
+        embeddedContentPage.clickOnLpm("link_instant_debits")
+        embeddedFormPage.assertHeaderPromoBadgeIsDisplayed("$5")
+
+        formPage.fillOutEmail()
+        embeddedFormPage.clickPrimaryButtonWithoutWaitingForDismissal()
+
+        embeddedFormPage.waitUntilHeaderPromoBadgeIsMissing()
+        testContext.markTestSucceeded()
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/UsBankAccountFormTestUtils.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/UsBankAccountFormTestUtils.kt
@@ -7,6 +7,7 @@ import androidx.test.espresso.intent.Intents.intending
 import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
 import com.stripe.android.financialconnections.model.BankAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountContract
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResponseInternal
 import com.stripe.android.payments.bankaccount.navigation.CollectBankAccountResultInternal
@@ -37,6 +38,35 @@ object UsBankAccountFormTestUtils {
         }
 
     fun setupSuccessfulCompletionOfUsBankAccountForm() {
+        setupSuccessfulCompletion(bankAccountCompletedResult)
+    }
+
+    fun setupSuccessfulCompletionOfInstantDebitsForm(
+        eligibleForIncentive: Boolean,
+    ) {
+        setupSuccessfulCompletion(
+            CollectBankAccountResultInternal.Completed(
+                CollectBankAccountResponseInternal(
+                    intent = null,
+                    usBankAccountData = null,
+                    instantDebitsData = CollectBankAccountResponseInternal.InstantDebitsData(
+                        paymentMethod = PaymentMethod(
+                            id = "pm_123",
+                            created = null,
+                            liveMode = false,
+                            code = PaymentMethod.Type.Link.code,
+                            type = PaymentMethod.Type.Link,
+                        ),
+                        last4 = "6789",
+                        bankName = "Test Bank",
+                        eligibleForIncentive = eligibleForIncentive,
+                    ),
+                )
+            )
+        )
+    }
+
+    private fun setupSuccessfulCompletion(result: CollectBankAccountResultInternal.Completed) {
         intending(
             hasComponent(
                 CollectBankAccountActivity::class.java.name
@@ -46,7 +76,7 @@ object UsBankAccountFormTestUtils {
                 Activity.RESULT_OK,
                 Intent().putExtras(
                     CollectBankAccountContract.Result(
-                        bankAccountCompletedResult
+                        result
                     ).toBundle()
                 )
             )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/form/EmbeddedFormInteractorFactory.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFo
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.utils.childScope
+import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
@@ -56,10 +57,17 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
+        val bankFormInteractor = BankFormInteractor(
+            updateSelection = embeddedSelectionHolder::setSelection,
+            paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
+                paymentMethodMetadata.paymentMethodIncentive
+            ),
+        )
 
         val usBankAccountFormArguments = createUsBankAccountFormArguments(
             paymentMethodCode = paymentMethodCode,
             hasSavedPaymentMethods = hasSavedPaymentMethods,
+            bankFormInteractor = bankFormInteractor,
         )
 
         val formType = formHelper.formTypeForCode(paymentMethodCode)
@@ -87,9 +95,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             ),
             isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
             processing = sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing },
-            paymentMethodIncentive = PaymentMethodIncentiveInteractor(
-                paymentMethodMetadata.paymentMethodIncentive
-            ).displayedIncentive,
+            paymentMethodIncentive = bankFormInteractor.paymentMethodIncentiveInteractor.displayedIncentive,
             validationRequested = sheetActivityStateHolder.validationRequested,
             coroutineScope = coroutineScope,
             uiContext = Dispatchers.Main,
@@ -99,6 +105,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
     private fun createUsBankAccountFormArguments(
         paymentMethodCode: PaymentMethodCode,
         hasSavedPaymentMethods: Boolean,
+        bankFormInteractor: BankFormInteractor,
     ): USBankAccountFormArguments {
         return USBankAccountFormArguments.createForEmbedded(
             paymentMethodMetadata = paymentMethodMetadata,
@@ -106,7 +113,7 @@ internal class EmbeddedFormInteractorFactory @Inject constructor(
             hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
             isCompleteFlow = false,
             draftPaymentSelection = null,
-            setSelection = embeddedSelectionHolder::setSelection,
+            bankFormInteractor = bankFormInteractor,
             hasSavedPaymentMethods = hasSavedPaymentMethods,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
             onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactory.kt
@@ -17,6 +17,7 @@ import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotio
 import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
 import com.stripe.android.paymentsheet.utils.childScope
+import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
 import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -59,15 +60,19 @@ internal class EmbeddedAddPaymentMethodInteractorFactory @Inject constructor(
             paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         )
+        val bankFormInteractor = BankFormInteractor(
+            updateSelection = embeddedSelectionHolder::setSelection,
+            paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
+                paymentMethodMetadata.paymentMethodIncentive
+            ),
+        )
 
         return DefaultAddPaymentMethodInteractor(
             initiallySelectedPaymentMethodType = initialCode,
             selection = embeddedSelectionHolder.selection,
             processing = sheetActivityStateHolder.state.mapAsStateFlow { it.isProcessing },
             validationRequested = sheetActivityStateHolder.validationRequested,
-            incentive = PaymentMethodIncentiveInteractor(
-                paymentMethodMetadata.paymentMethodIncentive
-            ).displayedIncentive,
+            incentive = bankFormInteractor.paymentMethodIncentiveInteractor.displayedIncentive,
             supportedPaymentMethods = paymentMethodMetadata.sortedSupportedPaymentMethods(),
             createFormArguments = formHelper::createFormArguments,
             formElementsForCode = formHelper::formElementsForCode,
@@ -79,7 +84,7 @@ internal class EmbeddedAddPaymentMethodInteractorFactory @Inject constructor(
                 paymentMethodMessagePromotionsHelper.reportPromotionDisplayed(code, paymentMethodMetadata)
             },
             createUSBankAccountFormArguments = { code ->
-                createUsBankAccountFormArguments(code, hasSavedPaymentMethods)
+                createUsBankAccountFormArguments(code, hasSavedPaymentMethods, bankFormInteractor)
             },
             coroutineScope = coroutineScope,
             uiContext = Dispatchers.Main,
@@ -98,6 +103,7 @@ internal class EmbeddedAddPaymentMethodInteractorFactory @Inject constructor(
     private fun createUsBankAccountFormArguments(
         paymentMethodCode: PaymentMethodCode,
         hasSavedPaymentMethods: Boolean,
+        bankFormInteractor: BankFormInteractor,
     ): USBankAccountFormArguments {
         return USBankAccountFormArguments.createForEmbedded(
             paymentMethodMetadata = paymentMethodMetadata,
@@ -105,7 +111,7 @@ internal class EmbeddedAddPaymentMethodInteractorFactory @Inject constructor(
             hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
             isCompleteFlow = false,
             draftPaymentSelection = null,
-            setSelection = embeddedSelectionHolder::setSelection,
+            bankFormInteractor = bankFormInteractor,
             hasSavedPaymentMethods = hasSavedPaymentMethods,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
             onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -15,7 +15,6 @@ import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
-import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import kotlinx.coroutines.flow.update
@@ -130,7 +129,7 @@ internal class USBankAccountFormArguments(
             hostedSurface: String,
             isCompleteFlow: Boolean,
             draftPaymentSelection: PaymentSelection?,
-            setSelection: (PaymentSelection?) -> Unit,
+            bankFormInteractor: BankFormInteractor,
             hasSavedPaymentMethods: Boolean,
             autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
             onMandateTextChanged: (mandate: ResolvableString?, showAbove: Boolean) -> Unit,
@@ -146,13 +145,6 @@ internal class USBankAccountFormArguments(
                 hasCustomerConfiguration = paymentMethodMetadata.customerMetadata != null,
             )
             val instantDebits = selectedPaymentMethodCode == PaymentMethod.Type.Link.code
-            val bankFormInteractor = BankFormInteractor(
-                updateSelection = setSelection,
-                paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
-                    paymentMethodMetadata.paymentMethodIncentive
-                )
-            )
-
             return USBankAccountFormArguments(
                 showCheckbox = isSaveForFutureUseValueChangeable && instantDebits.not(),
                 hostedSurface = hostedSurface,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodInteractor.kt
@@ -210,6 +210,14 @@ internal class DefaultAddPaymentMethodInteractor(
         }
 
         coroutineScope.launch {
+            incentive.collect {
+                _state.value = _state.value.copy(
+                    incentive = it
+                )
+            }
+        }
+
+        coroutineScope.launch {
             validationRequested.collect {
                 withContext(uiContext) {
                     _state.value = _state.value.copy(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodRowButton.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/NewPaymentMethodRowButton.kt
@@ -41,7 +41,9 @@ internal fun NewPaymentMethodRowButton(
         onClick = {
             displayablePaymentMethod.onClick()
         },
-        modifier = modifier.testTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_${displayablePaymentMethod.code}"),
+        modifier = modifier.testTag(
+            "${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_${displayablePaymentMethod.syntheticCode}"
+        ),
         appearance = appearance,
         trailingContent = trailingContent,
         promotionProvider = displayablePaymentMethod.promotionProvider,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/VerticalModeFormUI.kt
@@ -32,6 +32,9 @@ import com.stripe.android.uicore.utils.collectAsState
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 const val TEST_TAG_HEADER_TITLE = "TEST_TAG_HEADER_TITLE"
 
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+const val TEST_TAG_HEADER_PROMO_BADGE = "TEST_TAG_HEADER_PROMO_BADGE"
+
 @Composable
 internal fun VerticalModeFormUI(
     interactor: VerticalModeFormInteractor,
@@ -118,7 +121,9 @@ internal fun VerticalModeFormHeaderUI(
         if (formHeaderInformation.promoBadge != null) {
             PromoBadge(
                 text = formHeaderInformation.promoBadge,
-                modifier = Modifier.padding(start = 12.dp),
+                modifier = Modifier
+                    .testTag(TEST_TAG_HEADER_PROMO_BADGE)
+                    .padding(start = 12.dp),
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedAddPaymentMethodInteractorFactoryTest.kt
@@ -1,19 +1,24 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.link.TestFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodCreateParams
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
@@ -79,6 +84,40 @@ internal class EmbeddedAddPaymentMethodInteractorFactoryTest {
     fun `US bank account arguments receive autocomplete factory`() = runScenario {
         assertThat(interactor.state.value.usBankAccountFormArguments.autocompleteAddressInteractorFactory)
             .isSameInstanceAs(autocompleteAddressInteractorFactory)
+    }
+
+    @Test
+    fun `linked bank account removes incentive`() {
+        val incentive = PaymentMethodIncentive(
+            identifier = "link_instant_debits",
+            displayText = "$5",
+        )
+
+        runScenario(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("link"),
+                ),
+                linkState = LinkState(
+                    configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                    loginState = LinkState.LoginState.LoggedOut,
+                    signupMode = null,
+                ),
+                paymentMethodIncentive = incentive,
+            ),
+        ) {
+            interactor.state.test {
+                val initialState = awaitItem()
+                assertThat(initialState.incentive).isEqualTo(incentive)
+
+                initialState.usBankAccountFormArguments.onLinkedBankAccountChanged(
+                    PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION
+                )
+
+                awaitItem()
+                assertThat(awaitItem().incentive).isNull()
+            }
+        }
     }
 
     private fun runScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -8,9 +8,12 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
+import com.stripe.android.link.TestFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
@@ -26,9 +29,11 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInteractor
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.forms.FormFieldValues
+import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.errorTest
 import com.stripe.android.paymentsheet.verticalmode.VerticalModeFormInteractor.ViewAction
 import com.stripe.android.testing.CleanupTestRule
@@ -257,6 +262,40 @@ internal class DefaultVerticalModeFormInteractorTest {
         interactor.close()
 
         assertThat(parentScope.isActive).isTrue()
+    }
+
+    @Test
+    fun `linked bank account removes embedded form incentive`() = runTest {
+        val incentive = PaymentMethodIncentive(
+            identifier = "link_instant_debits",
+            displayText = "$5",
+        )
+        val interactor = createEmbeddedFormInteractor(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf(PaymentMethod.Type.Link.code),
+                ),
+                linkState = LinkState(
+                    configuration = TestFactory.LINK_CONFIGURATION_WITH_INSTANT_DEBITS_ONBOARDING,
+                    loginState = LinkState.LoginState.LoggedOut,
+                    signupMode = null,
+                ),
+                paymentMethodIncentive = incentive,
+            ),
+            paymentMethodCode = PaymentMethod.Type.Link.code,
+        )
+        closeInteractorRule.track(interactor)
+
+        interactor.state.test {
+            val initialState = awaitItem()
+            assertThat(initialState.headerInformation?.promoBadge).isEqualTo("$5")
+
+            initialState.usBankAccountFormArguments.onLinkedBankAccountChanged(
+                PaymentMethodFixtures.US_BANK_PAYMENT_SELECTION
+            )
+
+            assertThat(awaitItem().headerInformation?.promoBadge).isNull()
+        }
     }
 
     private fun testSetAsDefaultElements(


### PR DESCRIPTION
# Summary

Fix embedded horizontal and vertical payment-method forms so bank incentives are removed after a bank account is linked.

This is PR 1 of 3 in the replacement stack for #14236.

# Motivation

Embedded forms created one `BankFormInteractor` for US bank account updates and a separate `PaymentMethodIncentiveInteractor` for the displayed incentive. Linking an account updated the unused incentive state, leaving the visible incentive stale. The horizontal add-payment interactor also did not observe later incentive emissions.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.paymentelement.EmbeddedPaymentElementBankIncentiveTest` (Pixel 9a API 36)
- `./gradlew :paymentsheet:testDebugUnitTest` (6,840 tests)
- `./gradlew detekt`
- `git diff --check`

The instrumentation test exercises the complete embedded Instant Debits behavior with a `NetworkRule` Elements Session response: it selects the payment method, verifies the server-provided $5 header incentive, completes the real form with an intercepted ineligible bank-link result, and verifies that the incentive disappears.

No tests were ignored.

# Screenshots

Not applicable — the behavior is covered by the instrumentation test.

# Changelog

Not applicable — this is an internal embedded payment-element correction with no public API change.

Committed and created by Codex.
