### PR TITLE
Share payment method form construction

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedFormHelperFactory.kt
@@ -8,12 +8,11 @@ import com.stripe.android.link.LinkConfigurationCoordinator
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCode
-import com.stripe.android.paymentsheet.DefaultFormDefinitionFactory
-import com.stripe.android.paymentsheet.DefaultFormHelper
 import com.stripe.android.paymentsheet.FormDefinitionFactory
 import com.stripe.android.paymentsheet.FormHelper
 import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.NewPaymentOptionSelection
+import com.stripe.android.paymentsheet.PaymentMethodFormFactory
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
@@ -31,6 +30,13 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val isNfcScanningAvailable: IsNfcScanningAvailable,
 ) {
+    private val formFactory = PaymentMethodFormFactory(
+        linkConfigurationCoordinator = linkConfigurationCoordinator,
+        cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+        savedStateHandle = savedStateHandle,
+        isNfcScanningAvailable = isNfcScanningAvailable,
+    )
+
     fun create(
         coroutineScope: CoroutineScope,
         setAsDefaultMatchesSaveForFutureUse: Boolean,
@@ -43,23 +49,20 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
         selectionUpdater: (PaymentSelection?) -> Unit,
     ): FormHelper {
         val linkInlineHandler = LinkInlineHandler.create()
-        return DefaultFormHelper(
-            coroutineScope = coroutineScope,
-            linkInlineHandler = linkInlineHandler,
-            paymentMethodMetadata = paymentMethodMetadata,
-            selectionUpdater = selectionUpdater,
-            eventReporter = eventReporter,
-            savedStateHandle = savedStateHandle,
-            formDefinitionFactory = createFormDefinitionFactory(
+        return formFactory.createFormHelper(
+            PaymentMethodFormFactory.FormHelperArguments(
                 coroutineScope = coroutineScope,
-                setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+                linkInlineHandler = linkInlineHandler,
                 paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = ::newPaymentSelection,
+                selectionUpdater = selectionUpdater,
+                eventReporter = eventReporter,
+                setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
                 automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
                 tapToAddHelper = tapToAddHelper,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
                 autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-                linkInlineHandler = linkInlineHandler,
-            ),
+            )
         )
     }
 
@@ -73,20 +76,18 @@ internal class EmbeddedFormHelperFactory @Inject constructor(
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
         linkInlineHandler: LinkInlineHandler,
     ): FormDefinitionFactory {
-        return DefaultFormDefinitionFactory(
-            coroutineScope = coroutineScope,
-            linkInlineHandler = linkInlineHandler,
-            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
-            paymentMethodMetadata = paymentMethodMetadata,
-            newPaymentSelectionProvider = ::newPaymentSelection,
-            linkConfigurationCoordinator = linkConfigurationCoordinator,
-            setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
-            autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-            isLinkUI = false,
-            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
-            tapToAddHelper = tapToAddHelper,
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
-            isNfcScanningAvailable = isNfcScanningAvailable,
+        return formFactory.createFormDefinitionFactory(
+            PaymentMethodFormFactory.FormDefinitionArguments(
+                coroutineScope = coroutineScope,
+                linkInlineHandler = linkInlineHandler,
+                paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = ::newPaymentSelection,
+                setAsDefaultMatchesSaveForFutureUse = setAsDefaultMatchesSaveForFutureUse,
+                automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
+                tapToAddHelper = tapToAddHelper,
+                paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+            )
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/BaseSheetFormHelperFactory.kt
@@ -10,6 +10,13 @@ import kotlinx.coroutines.CoroutineScope
 internal class BaseSheetFormHelperFactory(
     private val viewModel: BaseSheetViewModel,
 ) {
+    private val formFactory = PaymentMethodFormFactory(
+        linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
+        cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
+        savedStateHandle = viewModel.savedStateHandle,
+        isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
+    )
+
     fun create(
         coroutineScope: CoroutineScope,
         paymentMethodMetadata: PaymentMethodMetadata,
@@ -17,47 +24,23 @@ internal class BaseSheetFormHelperFactory(
         shouldCreateAutomaticallyLaunchedCardScanFormDataHelper: Boolean,
         paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
     ): FormHelper {
-        return DefaultFormHelper(
-            coroutineScope = coroutineScope,
-            linkInlineHandler = linkInlineHandler,
-            paymentMethodMetadata = paymentMethodMetadata,
-            selectionUpdater = viewModel::updateSelection,
-            eventReporter = viewModel.eventReporter,
-            savedStateHandle = viewModel.savedStateHandle,
-            formDefinitionFactory = createFormDefinitionFactory(
+        return formFactory.createFormHelper(
+            PaymentMethodFormFactory.FormHelperArguments(
                 coroutineScope = coroutineScope,
-                paymentMethodMetadata = paymentMethodMetadata,
                 linkInlineHandler = linkInlineHandler,
+                paymentMethodMetadata = paymentMethodMetadata,
+                newPaymentSelectionProvider = { viewModel.newPaymentSelection },
+                selectionUpdater = viewModel::updateSelection,
+                eventReporter = viewModel.eventReporter,
+                setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
                 automaticallyLaunchedCardScanFormDataHelper = createAutomaticallyLaunchedCardScanFormDataHelper(
                     shouldCreate = shouldCreateAutomaticallyLaunchedCardScanFormDataHelper,
                     paymentMethodMetadata = paymentMethodMetadata,
                 ),
+                tapToAddHelper = viewModel.tapToAddHelper,
                 paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
-            ),
-        )
-    }
-
-    private fun createFormDefinitionFactory(
-        coroutineScope: CoroutineScope,
-        paymentMethodMetadata: PaymentMethodMetadata,
-        linkInlineHandler: LinkInlineHandler,
-        automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
-        paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
-    ): FormDefinitionFactory {
-        return DefaultFormDefinitionFactory(
-            coroutineScope = coroutineScope,
-            linkInlineHandler = linkInlineHandler,
-            cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
-            paymentMethodMetadata = paymentMethodMetadata,
-            newPaymentSelectionProvider = { viewModel.newPaymentSelection },
-            linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
-            setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
-            autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
-            isLinkUI = false,
-            automaticallyLaunchedCardScanFormDataHelper = automaticallyLaunchedCardScanFormDataHelper,
-            tapToAddHelper = viewModel.tapToAddHelper,
-            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
-            isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
+                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+            )
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/FormDefinitionFactory.kt
@@ -135,20 +135,24 @@ internal class DefaultFormDefinitionFactory(
             viewModel: BaseSheetViewModel,
             paymentMethodMetadata: PaymentMethodMetadata,
         ): FormDefinitionFactory {
-            return DefaultFormDefinitionFactory(
-                coroutineScope = viewModel.viewModelScope,
-                linkInlineHandler = LinkInlineHandler.create(),
-                cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
-                paymentMethodMetadata = paymentMethodMetadata,
-                newPaymentSelectionProvider = { viewModel.newPaymentSelection },
+            val formFactory = PaymentMethodFormFactory(
                 linkConfigurationCoordinator = viewModel.linkHandler.linkConfigurationCoordinator,
-                setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
-                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
-                isLinkUI = false,
-                automaticallyLaunchedCardScanFormDataHelper = null,
-                tapToAddHelper = viewModel.tapToAddHelper,
-                paymentMethodMessagePromotionsHelper = null,
+                cardAccountRangeRepositoryFactory = viewModel.cardAccountRangeRepositoryFactory,
+                savedStateHandle = viewModel.savedStateHandle,
                 isNfcScanningAvailable = viewModel.isNfcScanningAvailable,
+            )
+            return formFactory.createFormDefinitionFactory(
+                PaymentMethodFormFactory.FormDefinitionArguments(
+                    coroutineScope = viewModel.viewModelScope,
+                    linkInlineHandler = LinkInlineHandler.create(),
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    newPaymentSelectionProvider = { viewModel.newPaymentSelection },
+                    setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
+                    automaticallyLaunchedCardScanFormDataHelper = null,
+                    tapToAddHelper = viewModel.tapToAddHelper,
+                    paymentMethodMessagePromotionsHelper = null,
+                    autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+                )
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodFormFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentMethodFormFactory.kt
@@ -1,0 +1,92 @@
+package com.stripe.android.paymentsheet
+
+import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.cards.CardAccountRangeRepository
+import com.stripe.android.common.nfcscan.IsNfcScanningAvailable
+import com.stripe.android.common.taptoadd.TapToAddHelper
+import com.stripe.android.link.LinkConfigurationCoordinator
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+import kotlinx.coroutines.CoroutineScope
+
+internal class PaymentMethodFormFactory(
+    private val linkConfigurationCoordinator: LinkConfigurationCoordinator,
+    private val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
+    private val savedStateHandle: SavedStateHandle,
+    private val isNfcScanningAvailable: IsNfcScanningAvailable,
+) {
+    data class FormHelperArguments(
+        val coroutineScope: CoroutineScope,
+        val linkInlineHandler: LinkInlineHandler,
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val newPaymentSelectionProvider: (PaymentMethodCode) -> NewPaymentOptionSelection?,
+        val selectionUpdater: (PaymentSelection?) -> Unit,
+        val eventReporter: EventReporter,
+        val setAsDefaultMatchesSaveForFutureUse: Boolean,
+        val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+        val tapToAddHelper: TapToAddHelper?,
+        val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+        val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    )
+
+    data class FormDefinitionArguments(
+        val coroutineScope: CoroutineScope,
+        val linkInlineHandler: LinkInlineHandler,
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val newPaymentSelectionProvider: (PaymentMethodCode) -> NewPaymentOptionSelection?,
+        val setAsDefaultMatchesSaveForFutureUse: Boolean,
+        val automaticallyLaunchedCardScanFormDataHelper: AutomaticallyLaunchedCardScanFormDataHelper?,
+        val tapToAddHelper: TapToAddHelper?,
+        val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper?,
+        val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+    )
+
+    fun createFormHelper(arguments: FormHelperArguments): FormHelper {
+        return DefaultFormHelper(
+            coroutineScope = arguments.coroutineScope,
+            linkInlineHandler = arguments.linkInlineHandler,
+            paymentMethodMetadata = arguments.paymentMethodMetadata,
+            selectionUpdater = arguments.selectionUpdater,
+            eventReporter = arguments.eventReporter,
+            savedStateHandle = savedStateHandle,
+            formDefinitionFactory = createFormDefinitionFactory(
+                FormDefinitionArguments(
+                    coroutineScope = arguments.coroutineScope,
+                    linkInlineHandler = arguments.linkInlineHandler,
+                    paymentMethodMetadata = arguments.paymentMethodMetadata,
+                    newPaymentSelectionProvider = arguments.newPaymentSelectionProvider,
+                    setAsDefaultMatchesSaveForFutureUse = arguments.setAsDefaultMatchesSaveForFutureUse,
+                    automaticallyLaunchedCardScanFormDataHelper =
+                        arguments.automaticallyLaunchedCardScanFormDataHelper,
+                    tapToAddHelper = arguments.tapToAddHelper,
+                    paymentMethodMessagePromotionsHelper = arguments.paymentMethodMessagePromotionsHelper,
+                    autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
+                )
+            ),
+        )
+    }
+
+    fun createFormDefinitionFactory(arguments: FormDefinitionArguments): FormDefinitionFactory {
+        return DefaultFormDefinitionFactory(
+            coroutineScope = arguments.coroutineScope,
+            linkInlineHandler = arguments.linkInlineHandler,
+            cardAccountRangeRepositoryFactory = cardAccountRangeRepositoryFactory,
+            paymentMethodMetadata = arguments.paymentMethodMetadata,
+            newPaymentSelectionProvider = arguments.newPaymentSelectionProvider,
+            linkConfigurationCoordinator = linkConfigurationCoordinator,
+            setAsDefaultMatchesSaveForFutureUse = arguments.setAsDefaultMatchesSaveForFutureUse,
+            autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
+            isLinkUI = false,
+            automaticallyLaunchedCardScanFormDataHelper =
+                arguments.automaticallyLaunchedCardScanFormDataHelper,
+            tapToAddHelper = arguments.tapToAddHelper,
+            paymentMethodMessagePromotionsHelper = arguments.paymentMethodMessagePromotionsHelper,
+            isNfcScanningAvailable = isNfcScanningAvailable,
+        )
+    }
+}


### PR DESCRIPTION
# Summary

Centralize `FormHelper` and `FormDefinitionFactory` assembly in a small shared `PaymentMethodFormFactory`.

The existing BaseSheet and embedded factories remain as thin policy adapters for selection restoration, automatic card scan behavior, and flow-specific dependencies. This is PR 2 of 3 in the replacement stack for #14236 and depends on the embedded incentive fix below it.

# Motivation

PaymentSheet and embedded flows duplicated the low-level form construction, but replacing their adapters with one broad dependency object increased coupling and caller churn. Sharing only the common construction keeps flow policy localized while preventing the implementations from drifting.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactoryTest' --tests 'com.stripe.android.paymentsheet.FormHelperOpenCardScanAutomaticallyTest' --tests 'com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooserTest'`
- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew detekt`
- `git diff --check`

No tests were ignored.

# Screenshots

Not applicable — this is an internal construction refactor with no UI changes.

# Changelog

Not applicable — this changes internal implementation only and does not alter the public API.

Committed and created by Codex.
