### PR TITLE
Deduplicate US bank account form arguments

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -1,12 +1,9 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
-import com.stripe.android.lpmfoundations.paymentmethod.IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.LinkMode
-import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.financialconnections.FinancialConnectionsAvailability
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -78,48 +75,28 @@ internal class USBankAccountFormArguments(
             selectedPaymentMethodCode: String,
             bankFormInteractor: BankFormInteractor,
         ): USBankAccountFormArguments {
-            val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
-                code = selectedPaymentMethodCode,
-                intent = paymentMethodMetadata.stripeIntent,
-                paymentMethodSaveConsentBehavior = paymentMethodMetadata.customerMetadata?.saveConsent,
-                hasCustomerConfiguration = paymentMethodMetadata.customerMetadata != null,
-            )
-            val instantDebits = selectedPaymentMethodCode == PaymentMethod.Type.Link.code
-            val stripeIntent = paymentMethodMetadata.stripeIntent
-            return USBankAccountFormArguments(
-                showCheckbox = isSaveForFutureUseValueChangeable &&
-                    // Instant Debits does not support saving for future use
-                    instantDebits.not(),
+            return USBankAccountFormArgumentsFactory.create(
+                paymentMethodMetadata = paymentMethodMetadata,
+                selectedPaymentMethodCode = selectedPaymentMethodCode,
                 hostedSurface = hostedSurface,
-                instantDebits = instantDebits,
-                linkMode = paymentMethodMetadata.linkMode,
-                onBehalfOf = paymentMethodMetadata.onBehalfOf,
-                isCompleteFlow = viewModel.isCompleteFlow,
-                isPaymentFlow = stripeIntent is PaymentIntent,
-                stripeIntentId = stripeIntent.id,
-                clientSecret = stripeIntent.clientSecret,
-                shippingDetails = viewModel.config.shippingDetails,
-                autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
-                onAnalyticsEvent = { viewModel.eventReporter.onUsBankAccountFormEvent(it) },
-                draftPaymentSelection = viewModel.newPaymentSelection?.paymentSelection,
-                onMandateTextChanged = viewModel.mandateHandler::updateMandateText,
-                onLinkedBankAccountChanged = bankFormInteractor::handleLinkedBankAccountChanged,
-                onUpdatePrimaryButtonUIState = { viewModel.customPrimaryButtonUiState.update(it) },
-                onUpdatePrimaryButtonState = viewModel::updatePrimaryButtonState,
-                onError = viewModel::onError,
-                onFormCompleted = {
-                    viewModel.eventReporter.onPaymentMethodFormCompleted(PaymentMethod.Type.USBankAccount.code)
-                },
-                incentive = paymentMethodMetadata.paymentMethodIncentive,
-                setAsDefaultPaymentMethodEnabled =
-                paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
-                    ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
-                financialConnectionsAvailability = paymentMethodMetadata.financialConnectionsAvailability,
-                setAsDefaultMatchesSaveForFutureUse = viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
-                termsDisplay = paymentMethodMetadata.termsDisplayForCode(selectedPaymentMethodCode),
-                sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
-                forceSetupFutureUseBehavior = paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate,
-                clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+                host = USBankAccountFormArgumentsFactory.Host(
+                    isCompleteFlow = viewModel.isCompleteFlow,
+                    shippingDetails = viewModel.config.shippingDetails,
+                    draftPaymentSelection = viewModel.newPaymentSelection?.paymentSelection,
+                    autocompleteAddressInteractorFactory = viewModel.autocompleteAddressInteractorFactory,
+                    setAsDefaultMatchesSaveForFutureUse =
+                        viewModel.customerStateHolder.paymentMethods.value.isEmpty(),
+                    termsDisplay = paymentMethodMetadata.termsDisplayForCode(selectedPaymentMethodCode),
+                    onAnalyticsEvent = viewModel.eventReporter::onUsBankAccountFormEvent,
+                    onMandateTextChanged = viewModel.mandateHandler::updateMandateText,
+                    onLinkedBankAccountChanged = bankFormInteractor::handleLinkedBankAccountChanged,
+                    onUpdatePrimaryButtonUIState = { viewModel.customPrimaryButtonUiState.update(it) },
+                    onUpdatePrimaryButtonState = viewModel::updatePrimaryButtonState,
+                    onError = viewModel::onError,
+                    onFormCompleted = {
+                        viewModel.eventReporter.onPaymentMethodFormCompleted(PaymentMethod.Type.USBankAccount.code)
+                    },
+                )
             )
         }
 
@@ -138,45 +115,26 @@ internal class USBankAccountFormArguments(
             onError: (ResolvableString?) -> Unit,
             onFormCompleted: () -> Unit,
         ): USBankAccountFormArguments {
-            val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
-                code = selectedPaymentMethodCode,
-                intent = paymentMethodMetadata.stripeIntent,
-                paymentMethodSaveConsentBehavior = paymentMethodMetadata.customerMetadata?.saveConsent,
-                hasCustomerConfiguration = paymentMethodMetadata.customerMetadata != null,
-            )
-            val instantDebits = selectedPaymentMethodCode == PaymentMethod.Type.Link.code
-            return USBankAccountFormArguments(
-                showCheckbox = isSaveForFutureUseValueChangeable && instantDebits.not(),
+            return USBankAccountFormArgumentsFactory.create(
+                paymentMethodMetadata = paymentMethodMetadata,
+                selectedPaymentMethodCode = selectedPaymentMethodCode,
                 hostedSurface = hostedSurface,
-                instantDebits = instantDebits,
-                linkMode = paymentMethodMetadata.linkMode,
-                onBehalfOf = paymentMethodMetadata.onBehalfOf,
-                isCompleteFlow = isCompleteFlow,
-                isPaymentFlow = paymentMethodMetadata.stripeIntent is PaymentIntent,
-                stripeIntentId = paymentMethodMetadata.stripeIntent.id,
-                clientSecret = paymentMethodMetadata.stripeIntent.clientSecret,
-                shippingDetails = paymentMethodMetadata.shippingDetails,
-                draftPaymentSelection = draftPaymentSelection,
-                onMandateTextChanged = onMandateTextChanged,
-                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
-                onAnalyticsEvent = onAnalyticsEvent,
-                onLinkedBankAccountChanged = bankFormInteractor::handleLinkedBankAccountChanged,
-                onUpdatePrimaryButtonUIState = onUpdatePrimaryButtonUIState,
-                onUpdatePrimaryButtonState = {
-                },
-                onError = onError,
-                onFormCompleted = onFormCompleted,
-                incentive = paymentMethodMetadata.paymentMethodIncentive,
-                setAsDefaultPaymentMethodEnabled =
-                paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
-                    ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
-                financialConnectionsAvailability = paymentMethodMetadata.financialConnectionsAvailability,
-                // If no saved payment methods, then first saved payment method is automatically set as default
-                setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods,
-                termsDisplay = paymentMethodMetadata.termsDisplayForType(PaymentMethod.Type.USBankAccount),
-                sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
-                forceSetupFutureUseBehavior = paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate,
-                clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+                host = USBankAccountFormArgumentsFactory.Host(
+                    isCompleteFlow = isCompleteFlow,
+                    shippingDetails = paymentMethodMetadata.shippingDetails,
+                    draftPaymentSelection = draftPaymentSelection,
+                    autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+                    // If no saved payment methods, then first saved payment method is automatically set as default.
+                    setAsDefaultMatchesSaveForFutureUse = !hasSavedPaymentMethods,
+                    termsDisplay = paymentMethodMetadata.termsDisplayForType(PaymentMethod.Type.USBankAccount),
+                    onAnalyticsEvent = onAnalyticsEvent,
+                    onMandateTextChanged = onMandateTextChanged,
+                    onLinkedBankAccountChanged = bankFormInteractor::handleLinkedBankAccountChanged,
+                    onUpdatePrimaryButtonUIState = onUpdatePrimaryButtonUIState,
+                    onUpdatePrimaryButtonState = {},
+                    onError = onError,
+                    onFormCompleted = onFormCompleted,
+                )
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactory.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.paymentsheet.paymentdatacollection.ach
+
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.lpmfoundations.luxe.isSaveForFutureUseValueChangeable
+import com.stripe.android.lpmfoundations.paymentmethod.IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodCode
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.ui.PrimaryButton
+import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
+
+internal object USBankAccountFormArgumentsFactory {
+    data class Host(
+        val isCompleteFlow: Boolean,
+        val shippingDetails: AddressDetails?,
+        val draftPaymentSelection: PaymentSelection?,
+        val autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
+        val setAsDefaultMatchesSaveForFutureUse: Boolean,
+        val termsDisplay: PaymentSheet.TermsDisplay,
+        val onAnalyticsEvent: (USBankAccountFormViewModel.AnalyticsEvent) -> Unit,
+        val onMandateTextChanged: (mandate: ResolvableString?, showAbove: Boolean) -> Unit,
+        val onLinkedBankAccountChanged: (PaymentSelection.New.USBankAccount?) -> Unit,
+        val onUpdatePrimaryButtonUIState: ((PrimaryButton.UIState?) -> PrimaryButton.UIState?) -> Unit,
+        val onUpdatePrimaryButtonState: (PrimaryButton.State) -> Unit,
+        val onError: (ResolvableString?) -> Unit,
+        val onFormCompleted: () -> Unit,
+    )
+
+    fun create(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        selectedPaymentMethodCode: PaymentMethodCode,
+        hostedSurface: String,
+        host: Host,
+    ): USBankAccountFormArguments {
+        val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
+            code = selectedPaymentMethodCode,
+            intent = paymentMethodMetadata.stripeIntent,
+            paymentMethodSaveConsentBehavior = paymentMethodMetadata.customerMetadata?.saveConsent,
+            hasCustomerConfiguration = paymentMethodMetadata.customerMetadata != null,
+        )
+        val instantDebits = selectedPaymentMethodCode == PaymentMethod.Type.Link.code
+        val stripeIntent = paymentMethodMetadata.stripeIntent
+
+        return USBankAccountFormArguments(
+            showCheckbox = isSaveForFutureUseValueChangeable && instantDebits.not(),
+            hostedSurface = hostedSurface,
+            instantDebits = instantDebits,
+            linkMode = paymentMethodMetadata.linkMode,
+            onBehalfOf = paymentMethodMetadata.onBehalfOf,
+            isCompleteFlow = host.isCompleteFlow,
+            isPaymentFlow = stripeIntent is PaymentIntent,
+            stripeIntentId = stripeIntent.id,
+            clientSecret = stripeIntent.clientSecret,
+            shippingDetails = host.shippingDetails,
+            draftPaymentSelection = host.draftPaymentSelection,
+            autocompleteAddressInteractorFactory = host.autocompleteAddressInteractorFactory,
+            onAnalyticsEvent = host.onAnalyticsEvent,
+            onMandateTextChanged = host.onMandateTextChanged,
+            onLinkedBankAccountChanged = host.onLinkedBankAccountChanged,
+            onUpdatePrimaryButtonUIState = host.onUpdatePrimaryButtonUIState,
+            onUpdatePrimaryButtonState = host.onUpdatePrimaryButtonState,
+            onError = host.onError,
+            onFormCompleted = host.onFormCompleted,
+            incentive = paymentMethodMetadata.paymentMethodIncentive,
+            setAsDefaultPaymentMethodEnabled =
+                paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
+                    ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
+            financialConnectionsAvailability = paymentMethodMetadata.financialConnectionsAvailability,
+            setAsDefaultMatchesSaveForFutureUse = host.setAsDefaultMatchesSaveForFutureUse,
+            termsDisplay = host.termsDisplay,
+            sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
+            forceSetupFutureUseBehavior = paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate,
+            clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactoryTest.kt
@@ -1,0 +1,67 @@
+package com.stripe.android.paymentsheet.paymentdatacollection.ach
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.TestAutocompleteAddressInteractor
+import com.stripe.android.paymentsheet.model.PaymentMethodIncentive
+import org.junit.Test
+
+internal class USBankAccountFormArgumentsFactoryTest {
+
+    @Test
+    fun `create combines metadata and host arguments`() {
+        val incentive = PaymentMethodIncentive(
+            identifier = "link_instant_debits",
+            displayText = "$5",
+        )
+        val metadata = PaymentMethodMetadataFactory.create(
+            paymentMethodIncentive = incentive,
+            onBehalfOf = "acct_123",
+            sellerBusinessName = "Rocket Rides",
+            forceSetupFutureUseBehaviorAndNewMandate = true,
+        )
+        val draftPaymentSelection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+        val autocompleteAddressInteractorFactory = TestAutocompleteAddressInteractor.noOpFactory()
+
+        val arguments = USBankAccountFormArgumentsFactory.create(
+            paymentMethodMetadata = metadata,
+            selectedPaymentMethodCode = PaymentMethod.Type.Link.code,
+            hostedSurface = "test_surface",
+            host = USBankAccountFormArgumentsFactory.Host(
+                isCompleteFlow = true,
+                shippingDetails = null,
+                draftPaymentSelection = draftPaymentSelection,
+                autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
+                setAsDefaultMatchesSaveForFutureUse = true,
+                termsDisplay = PaymentSheet.TermsDisplay.NEVER,
+                onAnalyticsEvent = {},
+                onMandateTextChanged = { _, _ -> },
+                onLinkedBankAccountChanged = {},
+                onUpdatePrimaryButtonUIState = { it },
+                onUpdatePrimaryButtonState = {},
+                onError = {},
+                onFormCompleted = {},
+            ),
+        )
+
+        assertThat(arguments.hostedSurface).isEqualTo("test_surface")
+        assertThat(arguments.instantDebits).isTrue()
+        assertThat(arguments.showCheckbox).isFalse()
+        assertThat(arguments.isCompleteFlow).isTrue()
+        assertThat(arguments.isPaymentFlow).isTrue()
+        assertThat(arguments.stripeIntentId).isEqualTo(metadata.stripeIntent.id)
+        assertThat(arguments.clientSecret).isEqualTo(metadata.stripeIntent.clientSecret)
+        assertThat(arguments.draftPaymentSelection).isSameInstanceAs(draftPaymentSelection)
+        assertThat(arguments.autocompleteAddressInteractorFactory)
+            .isSameInstanceAs(autocompleteAddressInteractorFactory)
+        assertThat(arguments.incentive).isSameInstanceAs(incentive)
+        assertThat(arguments.setAsDefaultMatchesSaveForFutureUse).isTrue()
+        assertThat(arguments.termsDisplay).isEqualTo(PaymentSheet.TermsDisplay.NEVER)
+        assertThat(arguments.onBehalfOf).isEqualTo("acct_123")
+        assertThat(arguments.sellerBusinessName).isEqualTo("Rocket Rides")
+        assertThat(arguments.forceSetupFutureUseBehavior).isTrue()
+    }
+}


### PR DESCRIPTION
# Summary

Deduplicate PaymentSheet and embedded US bank account argument mapping behind `USBankAccountFormArgumentsFactory` while retaining flow-specific adapters for state and callbacks.

This is PR 3 of 3 in the replacement stack for #14236 and depends on the shared form-construction layer below it.

# Motivation

The two existing creation paths independently mapped the same payment-method metadata into `USBankAccountFormArguments`. Keeping the common mapping in one factory prevents field additions from being applied to only one flow without introducing a broad cross-flow dependency object.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Automated validation:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArgumentsFactoryTest' --tests 'com.stripe.android.paymentelement.embedded.sheet.EmbeddedAddPaymentMethodInteractorFactoryTest' --tests 'com.stripe.android.paymentsheet.verticalmode.DefaultVerticalModeFormInteractorTest'`
- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew detekt`
- `git diff --check`

No tests were ignored.

# Screenshots

Not applicable — this is an internal argument-construction refactor with no UI changes.

# Changelog

Not applicable — this changes internal implementation only and does not alter the public API.

Committed and created by Codex.
