### PR TITLE
Add Checkout shipping address WIP button

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -35,6 +35,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         val presenter = viewModel.controller.createPresenter(this)
         val paymentElement = presenter.paymentElement()
+        val shippingAddressElement = presenter.shippingAddressElement()
         val currencySelectorElement = presenter.currencySelectorElement()
         val expressCheckoutElement = presenter.expressCheckoutElement()
 
@@ -148,6 +149,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                                 displayMandate = viewModel.displayMandate,
                                 onClearPaymentMethod = viewModel::clearPaymentOption,
                                 onSelectPaymentMethod = paymentElement::present,
+                                onSetShippingAddress = shippingAddressElement::present,
                                 onConfirm = {
                                     viewModel.clearConfirmationMessage()
                                     presenter.confirm()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/ConfirmationControls.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/ConfirmationControls.kt
@@ -26,6 +26,7 @@ internal fun ConfirmationControls(
     displayMandate: Boolean,
     onClearPaymentMethod: () -> Unit,
     onSelectPaymentMethod: () -> Unit,
+    onSetShippingAddress: () -> Unit,
     onConfirm: () -> Unit,
 ) {
     PaymentOptionRow(paymentOption)
@@ -47,6 +48,10 @@ internal fun ConfirmationControls(
             modifier = Modifier.weight(1f),
         ) { Text("Select") }
     }
+    Button(
+        onClick = onSetShippingAddress,
+        modifier = Modifier.fillMaxWidth(),
+    ) { Text("Set shipping address (WIP)") }
     Button(
         onClick = onConfirm,
         enabled = !isUpdating,


### PR DESCRIPTION
# Summary

Adds an enabled `Set shipping address (WIP)` button to the CheckoutController example. The button calls the existing `ShippingAddressElement.present()` preview entrypoint and appears between payment method selection and confirmation for every configured scenario.

This is an example-only integration. Tapping the button currently terminates the example with `NotImplementedError: An operation is not implemented: Not yet implemented` because Shipping Address Element presentation is not implemented yet. A follow-up will implement `present()` without changing this example integration.

# Motivation

This gives the existing Shipping Address Element preview entrypoint its first Checkout example caller and makes the intended integration point visible while the presentation implementation is still in progress.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Verified the configured No Tax scenario on emulator-5554 (API 36):

- `Select Payment Method`, `Set shipping address (WIP)`, and `Confirm` appear in that order.
- The WIP button is enabled.
- Tapping it reaches `ShippingAddressElement.present()` and produces the expected `NotImplementedError: An operation is not implemented: Not yet implemented`.
- `:paymentsheet-example:assembleBaseDebug` passed.
- `:paymentsheet-example:detekt` passed.
- The path-aware pre-push check passed.

No automated UI test was added for this temporary failure behavior.

# Changelog

Not applicable. This is an example-only private-preview integration.

Committed and created by Codex.
