### PR TITLE
Present Checkout shipping address form

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -358,6 +358,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         CHECKOUT_SELECTION_SET_BEFORE_LOAD(
             partialEventName = "checkout.selection_set_before_load"
         ),
+        CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED(
+            partialEventName = "checkout.shipping_address_element.present.not_configured"
+        ),
         CHECKOUT_SESSION_GOOGLE_PAY_UNEXPECTED_CALLBACK_TRIGGER(
             partialEventName = "checkout.google_pay.unexpected_callback_trigger"
         );

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -200,6 +200,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         PAYMENT_OPTION_CARD_ART_LOAD_FAILURE(
             eventName = "elements.payment_option.card_art.load_failure"
+        ),
+        CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED(
+            eventName = "checkout.shipping_address_element.present.not_configured"
         )
     }
 
@@ -357,9 +360,6 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         CHECKOUT_SELECTION_SET_BEFORE_LOAD(
             partialEventName = "checkout.selection_set_before_load"
-        ),
-        CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED(
-            partialEventName = "checkout.shipping_address_element.present.not_configured"
         ),
         CHECKOUT_SESSION_GOOGLE_PAY_UNEXPECTED_CALLBACK_TRIGGER(
             partialEventName = "checkout.google_pay.unexpected_callback_trigger"

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ShippingAddressElementStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ShippingAddressElementStateHolder.kt
@@ -1,0 +1,20 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class ShippingAddressElementStateHolder @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) {
+    var isPresenting: Boolean
+        get() = savedStateHandle.get<Boolean>(IS_PRESENTING_KEY) == true
+        set(value) {
+            savedStateHandle[IS_PRESENTING_KEY] = value
+        }
+
+    private companion object {
+        const val IS_PRESENTING_KEY = "ShippingAddressElementStateHolder_IS_PRESENTING_KEY"
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/ShippingAddressElementStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/ShippingAddressElementStateHolder.kt
@@ -10,9 +10,7 @@ internal class ShippingAddressElementStateHolder @Inject constructor(
 ) {
     var isPresenting: Boolean
         get() = savedStateHandle.get<Boolean>(IS_PRESENTING_KEY) == true
-        set(value) {
-            savedStateHandle[IS_PRESENTING_KEY] = value
-        }
+        set(value) = savedStateHandle.set(IS_PRESENTING_KEY, value)
 
     private companion object {
         const val IS_PRESENTING_KEY = "ShippingAddressElementStateHolder_IS_PRESENTING_KEY"

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -1,17 +1,64 @@
 package com.stripe.android.elements
 
 import android.os.Parcelable
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.RestrictTo
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
+import com.stripe.android.paymentsheet.addresselement.AddressLauncher
+import dagger.Lazy
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class ShippingAddressElement @Inject internal constructor() {
+class ShippingAddressElement @Inject internal constructor(
+    activityResultCaller: ActivityResultCaller,
+    lifecycleOwner: LifecycleOwner,
+    private val paymentConfiguration: Lazy<PaymentConfiguration>,
+    private val stateHolder: CheckoutControllerStateHolder,
+) {
+    private var isPresenting = false
+
+    private val activityLauncher: ActivityResultLauncher<AddressElementActivityContract.Args> =
+        activityResultCaller.registerForActivityResult(AddressElementActivityContract) {
+            isPresenting = false
+        }
+
+    init {
+        lifecycleOwner.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    activityLauncher.unregister()
+                    super.onDestroy(owner)
+                }
+            }
+        )
+    }
 
     fun present() {
-        TODO("Not yet implemented")
+        if (stateHolder.state == null || isPresenting) {
+            return
+        }
+
+        isPresenting = true
+        activityLauncher.launch(
+            AddressElementActivityContract.Args(
+                publishableKey = paymentConfiguration.get().publishableKey,
+                config = AddressLauncher.Configuration(
+                    additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
+                        phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,
+                    ),
+                    billingAddress = null,
+                    useStripeHostedAutocomplete = true,
+                ),
+            )
+        )
     }
 
     @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -46,7 +46,7 @@ class ShippingAddressElement @Inject internal constructor(
     fun present() {
         if (stateHolder.state == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED
+                ErrorReporter.ExpectedErrorEvent.CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED
             )
             return
         }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.checkout.ShippingAddressElementStateHolder
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
@@ -23,13 +24,12 @@ class ShippingAddressElement @Inject internal constructor(
     lifecycleOwner: LifecycleOwner,
     private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val stateHolder: CheckoutControllerStateHolder,
+    private val shippingAddressElementStateHolder: ShippingAddressElementStateHolder,
     private val errorReporter: ErrorReporter,
 ) {
-    private var isPresenting = false
-
     private val activityLauncher: ActivityResultLauncher<AddressElementActivityContract.Args> =
         activityResultCaller.registerForActivityResult(AddressElementActivityContract) {
-            isPresenting = false
+            shippingAddressElementStateHolder.isPresenting = false
         }
 
     init {
@@ -51,23 +51,28 @@ class ShippingAddressElement @Inject internal constructor(
             return
         }
 
-        if (isPresenting) {
+        if (shippingAddressElementStateHolder.isPresenting) {
             return
         }
 
-        isPresenting = true
-        activityLauncher.launch(
-            AddressElementActivityContract.Args(
-                publishableKey = paymentConfiguration.get().publishableKey,
-                config = AddressLauncher.Configuration(
-                    additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
-                        phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,
+        shippingAddressElementStateHolder.isPresenting = true
+        try {
+            activityLauncher.launch(
+                AddressElementActivityContract.Args(
+                    publishableKey = paymentConfiguration.get().publishableKey,
+                    config = AddressLauncher.Configuration(
+                        additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
+                            phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,
+                        ),
+                        billingAddress = null,
+                        useStripeHostedAutocomplete = true,
                     ),
-                    billingAddress = null,
-                    useStripeHostedAutocomplete = true,
-                ),
+                )
             )
-        )
+        } catch (exception: IllegalStateException) {
+            shippingAddressElementStateHolder.isPresenting = false
+            throw exception
+        }
     }
 
     @CheckoutSessionPreview

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -9,19 +9,21 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
-import dagger.Lazy
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
+import javax.inject.Provider
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class ShippingAddressElement @Inject internal constructor(
     activityResultCaller: ActivityResultCaller,
     lifecycleOwner: LifecycleOwner,
-    private val paymentConfiguration: Lazy<PaymentConfiguration>,
+    private val paymentConfiguration: Provider<PaymentConfiguration>,
     private val stateHolder: CheckoutControllerStateHolder,
+    private val errorReporter: ErrorReporter,
 ) {
     private var isPresenting = false
 
@@ -42,7 +44,14 @@ class ShippingAddressElement @Inject internal constructor(
     }
 
     fun present() {
-        if (stateHolder.state == null || isPresenting) {
+        if (stateHolder.state == null) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED
+            )
+            return
+        }
+
+        if (isPresenting) {
             return
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -41,10 +41,10 @@ internal class ShippingAddressElementTest {
 
         val call = errorReporter.awaitCall()
         assertThat(call.errorEvent).isEqualTo(
-            ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED
+            ErrorReporter.ExpectedErrorEvent.CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED
         )
         assertThat(call.errorEvent.eventName).isEqualTo(
-            "unexpected_error.checkout.shipping_address_element.present.not_configured"
+            "checkout.shipping_address_element.present.not_configured"
         )
         assertThat(call.stripeException).isNull()
         assertThat(call.additionalNonPiiParams).isEmpty()

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -1,0 +1,216 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.elements
+
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.checkout.CheckoutControllerStateFactory
+import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
+import com.stripe.android.paymentsheet.addresselement.AddressDetails
+import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
+import com.stripe.android.paymentsheet.addresselement.AddressLauncher
+import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
+import com.stripe.android.testing.CoroutineTestRule
+import dagger.Lazy
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+internal class ShippingAddressElementTest {
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun `present before checkout configuration does not launch`() = runScenario(configured = false) {
+        shippingAddressElement.present()
+
+        activityLauncher.launchCalls.expectNoEvents()
+        paymentConfiguration.getCalls.expectNoEvents()
+    }
+
+    @Test
+    fun `present launches a blank address form with hosted autocomplete`() = runScenario {
+        shippingAddressElement.present()
+
+        val launch = activityLauncher.launchCalls.awaitItem()
+        assertThat(launch.input.publishableKey).isEqualTo(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+
+        val config = requireNotNull(launch.input.config)
+        assertThat(config.appearance).isEqualTo(PaymentSheet.Appearance())
+        assertThat(config.address).isNull()
+        assertThat(config.allowedCountries).isEmpty()
+        assertThat(config.buttonTitle).isNull()
+        assertThat(config.additionalFields?.phone)
+            .isEqualTo(AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN)
+        assertThat(config.additionalFields?.checkboxLabel).isNull()
+        assertThat(config.title).isNull()
+        assertThat(config.googlePlacesApiKey).isNull()
+        assertThat(config.autocompleteCountries).isEqualTo(AUTOCOMPLETE_DEFAULT_COUNTRIES)
+        assertThat(config.billingAddress).isNull()
+        assertThat(config.useStripeHostedAutocomplete).isTrue()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `present suppresses duplicate presentations`() = runScenario {
+        shippingAddressElement.present()
+        shippingAddressElement.present()
+
+        activityLauncher.launchCalls.awaitItem()
+        activityLauncher.launchCalls.expectNoEvents()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `result clears presentation and ignores saved address`() = runScenario {
+        val originalState = stateHolder.state
+        shippingAddressElement.present()
+        activityLauncher.launchCalls.awaitItem()
+
+        registration.dispatch(
+            AddressLauncherResult.Succeeded(
+                AddressDetails(name = "Ignored address"),
+            )
+        )
+
+        shippingAddressElement.present()
+        activityLauncher.launchCalls.awaitItem()
+        assertThat(stateHolder.state).isSameInstanceAs(originalState)
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `lifecycle destruction unregisters the launcher`() = runScenario {
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+        assertThat(activityLauncher.unregisterCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    private fun runScenario(
+        configured: Boolean = true,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val activityResultCaller = RecordingActivityResultCaller()
+        val activityLauncher = activityResultCaller.launcher
+        val lifecycleOwner = TestLifecycleOwner()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(
+            savedStateHandle = SavedStateHandle(),
+        )
+        if (configured) {
+            stateHolder.state = CheckoutControllerStateFactory.create()
+        }
+        val paymentConfiguration = RecordingLazy(
+            PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
+        )
+        val shippingAddressElement = ShippingAddressElement(
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = lifecycleOwner,
+            paymentConfiguration = paymentConfiguration,
+            stateHolder = stateHolder,
+        )
+        val registration = activityResultCaller.registerCalls.awaitItem()
+        assertThat(registration.contract).isSameInstanceAs(AddressElementActivityContract)
+
+        Scenario(
+            shippingAddressElement = shippingAddressElement,
+            activityLauncher = activityLauncher,
+            lifecycleOwner = lifecycleOwner,
+            stateHolder = stateHolder,
+            paymentConfiguration = paymentConfiguration,
+            registration = registration,
+        ).block()
+
+        activityResultCaller.registerCalls.ensureAllEventsConsumed()
+        activityLauncher.launchCalls.ensureAllEventsConsumed()
+        activityLauncher.unregisterCalls.ensureAllEventsConsumed()
+        paymentConfiguration.getCalls.ensureAllEventsConsumed()
+    }
+
+    private class RecordingActivityResultCaller : ActivityResultCaller {
+        val registerCalls = Turbine<Registration>()
+        val launcher = RecordingActivityResultLauncher()
+
+        override fun <I : Any?, O : Any?> registerForActivityResult(
+            contract: ActivityResultContract<I, O>,
+            callback: ActivityResultCallback<O>,
+        ): ActivityResultLauncher<I> {
+            registerCalls.add(Registration(contract, callback))
+            @Suppress("UNCHECKED_CAST")
+            return launcher as ActivityResultLauncher<I>
+        }
+
+        override fun <I : Any?, O : Any?> registerForActivityResult(
+            contract: ActivityResultContract<I, O>,
+            registry: ActivityResultRegistry,
+            callback: ActivityResultCallback<O>,
+        ): ActivityResultLauncher<I> = error("The registry overload is not used in this test")
+    }
+
+    private class RecordingActivityResultLauncher :
+        ActivityResultLauncher<AddressElementActivityContract.Args>() {
+        val launchCalls = Turbine<LaunchCall>()
+        val unregisterCalls = Turbine<Unit>()
+
+        override fun launch(
+            input: AddressElementActivityContract.Args,
+            options: ActivityOptionsCompat?,
+        ) {
+            launchCalls.add(LaunchCall(input))
+        }
+
+        override fun unregister() {
+            unregisterCalls.add(Unit)
+        }
+
+        override val contract: ActivityResultContract<AddressElementActivityContract.Args, *>
+            get() = AddressElementActivityContract
+    }
+
+    private class RecordingLazy<T>(
+        private val value: T,
+    ) : Lazy<T> {
+        val getCalls = Turbine<Unit>()
+
+        override fun get(): T {
+            getCalls.add(Unit)
+            return value
+        }
+    }
+
+    private data class Registration(
+        val contract: ActivityResultContract<*, *>,
+        val callback: ActivityResultCallback<*>,
+    ) {
+        @Suppress("UNCHECKED_CAST")
+        fun dispatch(result: AddressLauncherResult) {
+            (callback as ActivityResultCallback<AddressLauncherResult>).onActivityResult(result)
+        }
+    }
+
+    private data class LaunchCall(
+        val input: AddressElementActivityContract.Args,
+    )
+
+    private data class Scenario(
+        val shippingAddressElement: ShippingAddressElement,
+        val activityLauncher: RecordingActivityResultLauncher,
+        val lifecycleOwner: TestLifecycleOwner,
+        val stateHolder: CheckoutControllerStateHolder,
+        val paymentConfiguration: RecordingLazy<PaymentConfiguration>,
+        val registration: Registration,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
@@ -24,19 +25,29 @@ import com.stripe.android.paymentsheet.addresselement.AddressElementActivityCont
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import com.stripe.android.testing.CoroutineTestRule
-import dagger.Lazy
+import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import javax.inject.Provider
 
 internal class ShippingAddressElementTest {
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
 
     @Test
-    fun `present before checkout configuration does not launch`() = runScenario(configured = false) {
+    fun `present before checkout configuration reports and does not launch`() = runScenario(configured = false) {
         shippingAddressElement.present()
 
+        val call = errorReporter.awaitCall()
+        assertThat(call.errorEvent).isEqualTo(
+            ErrorReporter.UnexpectedErrorEvent.CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED
+        )
+        assertThat(call.errorEvent.eventName).isEqualTo(
+            "unexpected_error.checkout.shipping_address_element.present.not_configured"
+        )
+        assertThat(call.stripeException).isNull()
+        assertThat(call.additionalNonPiiParams).isEmpty()
         activityLauncher.launchCalls.expectNoEvents()
         paymentConfiguration.getCalls.expectNoEvents()
     }
@@ -71,6 +82,24 @@ internal class ShippingAddressElementTest {
 
         activityLauncher.launchCalls.awaitItem()
         activityLauncher.launchCalls.expectNoEvents()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `present resolves the latest payment configuration`() = runScenario {
+        shippingAddressElement.present()
+
+        val firstLaunch = activityLauncher.launchCalls.awaitItem()
+        assertThat(firstLaunch.input.publishableKey).isEqualTo(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+
+        registration.dispatch(AddressLauncherResult.Canceled())
+        paymentConfiguration.value = PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
+
+        shippingAddressElement.present()
+
+        val secondLaunch = activityLauncher.launchCalls.awaitItem()
+        assertThat(secondLaunch.input.publishableKey).isEqualTo(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
     }
 
@@ -113,14 +142,16 @@ internal class ShippingAddressElementTest {
         if (configured) {
             stateHolder.state = CheckoutControllerStateFactory.create()
         }
-        val paymentConfiguration = RecordingLazy(
+        val paymentConfiguration = RecordingProvider(
             PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
         )
+        val errorReporter = FakeErrorReporter()
         val shippingAddressElement = ShippingAddressElement(
             activityResultCaller = activityResultCaller,
             lifecycleOwner = lifecycleOwner,
             paymentConfiguration = paymentConfiguration,
             stateHolder = stateHolder,
+            errorReporter = errorReporter,
         )
         val registration = activityResultCaller.registerCalls.awaitItem()
         assertThat(registration.contract).isSameInstanceAs(AddressElementActivityContract)
@@ -131,6 +162,7 @@ internal class ShippingAddressElementTest {
             lifecycleOwner = lifecycleOwner,
             stateHolder = stateHolder,
             paymentConfiguration = paymentConfiguration,
+            errorReporter = errorReporter,
             registration = registration,
         ).block()
 
@@ -138,6 +170,7 @@ internal class ShippingAddressElementTest {
         activityLauncher.launchCalls.ensureAllEventsConsumed()
         activityLauncher.unregisterCalls.ensureAllEventsConsumed()
         paymentConfiguration.getCalls.ensureAllEventsConsumed()
+        errorReporter.ensureAllEventsConsumed()
     }
 
     private class RecordingActivityResultCaller : ActivityResultCaller {
@@ -180,9 +213,9 @@ internal class ShippingAddressElementTest {
             get() = AddressElementActivityContract
     }
 
-    private class RecordingLazy<T>(
-        private val value: T,
-    ) : Lazy<T> {
+    private class RecordingProvider<T>(
+        var value: T,
+    ) : Provider<T> {
         val getCalls = Turbine<Unit>()
 
         override fun get(): T {
@@ -210,7 +243,8 @@ internal class ShippingAddressElementTest {
         val activityLauncher: RecordingActivityResultLauncher,
         val lifecycleOwner: TestLifecycleOwner,
         val stateHolder: CheckoutControllerStateHolder,
-        val paymentConfiguration: RecordingLazy<PaymentConfiguration>,
+        val paymentConfiguration: RecordingProvider<PaymentConfiguration>,
+        val errorReporter: FakeErrorReporter,
         val registration: Registration,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -17,6 +17,7 @@ import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.checkout.ShippingAddressElementStateHolder
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNTRIES
@@ -27,6 +28,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Provider
@@ -86,6 +88,20 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
+    fun `recreated element suppresses presentation while original is active`() = runScenario {
+        shippingAddressElement.present()
+        activityLauncher.launchCalls.awaitItem()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+
+        val recreated = createElement()
+        recreated.shippingAddressElement.present()
+
+        recreated.activityLauncher.launchCalls.expectNoEvents()
+        assertThat(shippingAddressElementStateHolder.isPresenting).isTrue()
+        recreated.ensureAllEventsConsumed()
+    }
+
+    @Test
     fun `present resolves the latest payment configuration`() = runScenario {
         shippingAddressElement.present()
 
@@ -123,6 +139,62 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
+    fun `recreated element result clears presentation after host destruction`() = runScenario {
+        shippingAddressElement.present()
+        activityLauncher.launchCalls.awaitItem()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        activityLauncher.unregisterCalls.awaitItem()
+        assertThat(shippingAddressElementStateHolder.isPresenting).isTrue()
+
+        val recreated = createElement()
+        recreated.shippingAddressElement.present()
+        recreated.activityLauncher.launchCalls.expectNoEvents()
+
+        recreated.registration.dispatch(AddressLauncherResult.Canceled())
+        assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
+
+        recreated.shippingAddressElement.present()
+        recreated.activityLauncher.launchCalls.awaitItem()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+        recreated.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `presentation state survives process death`() {
+        val savedStateHandle = SavedStateHandle()
+        val stateHolder = ShippingAddressElementStateHolder(savedStateHandle)
+        stateHolder.isPresenting = true
+
+        val restoredStateHolder = ShippingAddressElementStateHolder(
+            savedStateHandle = savedStateHandle.simulateProcessDeath(),
+        )
+
+        assertThat(restoredStateHolder.isPresenting).isTrue()
+    }
+
+    @Test
+    fun `synchronous launch failure clears presentation`() = runScenario {
+        val expectedException = IllegalStateException("Launch failed")
+        activityLauncher.launchException = expectedException
+
+        val exception = assertThrows(IllegalStateException::class.java) {
+            shippingAddressElement.present()
+        }
+
+        assertThat(exception).isSameInstanceAs(expectedException)
+        assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
+        activityLauncher.launchCalls.awaitItem()
+
+        activityLauncher.launchException = null
+        shippingAddressElement.present()
+        activityLauncher.launchCalls.awaitItem()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
     fun `lifecycle destruction unregisters the launcher`() = runScenario {
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
@@ -133,42 +205,56 @@ internal class ShippingAddressElementTest {
         configured: Boolean = true,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val activityResultCaller = RecordingActivityResultCaller()
-        val activityLauncher = activityResultCaller.launcher
-        val lifecycleOwner = TestLifecycleOwner()
+        val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(
-            savedStateHandle = SavedStateHandle(),
+            savedStateHandle = savedStateHandle,
         )
         if (configured) {
             stateHolder.state = CheckoutControllerStateFactory.create()
         }
+        val shippingAddressElementStateHolder = ShippingAddressElementStateHolder(savedStateHandle)
         val paymentConfiguration = RecordingProvider(
             PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
         )
         val errorReporter = FakeErrorReporter()
-        val shippingAddressElement = ShippingAddressElement(
-            activityResultCaller = activityResultCaller,
-            lifecycleOwner = lifecycleOwner,
-            paymentConfiguration = paymentConfiguration,
-            stateHolder = stateHolder,
-            errorReporter = errorReporter,
-        )
-        val registration = activityResultCaller.registerCalls.awaitItem()
-        assertThat(registration.contract).isSameInstanceAs(AddressElementActivityContract)
+
+        suspend fun createElement(): ElementScenario {
+            val activityResultCaller = RecordingActivityResultCaller()
+            val lifecycleOwner = TestLifecycleOwner()
+            val shippingAddressElement = ShippingAddressElement(
+                activityResultCaller = activityResultCaller,
+                lifecycleOwner = lifecycleOwner,
+                paymentConfiguration = paymentConfiguration,
+                stateHolder = stateHolder,
+                shippingAddressElementStateHolder = shippingAddressElementStateHolder,
+                errorReporter = errorReporter,
+            )
+            val registration = activityResultCaller.registerCalls.awaitItem()
+            assertThat(registration.contract).isSameInstanceAs(AddressElementActivityContract)
+            return ElementScenario(
+                shippingAddressElement = shippingAddressElement,
+                activityResultCaller = activityResultCaller,
+                activityLauncher = activityResultCaller.launcher,
+                lifecycleOwner = lifecycleOwner,
+                registration = registration,
+            )
+        }
+
+        val element = createElement()
 
         Scenario(
-            shippingAddressElement = shippingAddressElement,
-            activityLauncher = activityLauncher,
-            lifecycleOwner = lifecycleOwner,
+            shippingAddressElement = element.shippingAddressElement,
+            activityLauncher = element.activityLauncher,
+            lifecycleOwner = element.lifecycleOwner,
             stateHolder = stateHolder,
+            shippingAddressElementStateHolder = shippingAddressElementStateHolder,
             paymentConfiguration = paymentConfiguration,
             errorReporter = errorReporter,
-            registration = registration,
+            registration = element.registration,
+            createElement = ::createElement,
         ).block()
 
-        activityResultCaller.registerCalls.ensureAllEventsConsumed()
-        activityLauncher.launchCalls.ensureAllEventsConsumed()
-        activityLauncher.unregisterCalls.ensureAllEventsConsumed()
+        element.ensureAllEventsConsumed()
         paymentConfiguration.getCalls.ensureAllEventsConsumed()
         errorReporter.ensureAllEventsConsumed()
     }
@@ -203,7 +289,10 @@ internal class ShippingAddressElementTest {
             options: ActivityOptionsCompat?,
         ) {
             launchCalls.add(LaunchCall(input))
+            launchException?.let { throw it }
         }
+
+        var launchException: RuntimeException? = null
 
         override fun unregister() {
             unregisterCalls.add(Unit)
@@ -238,13 +327,33 @@ internal class ShippingAddressElementTest {
         val input: AddressElementActivityContract.Args,
     )
 
+    private data class ElementScenario(
+        val shippingAddressElement: ShippingAddressElement,
+        val activityResultCaller: RecordingActivityResultCaller,
+        val activityLauncher: RecordingActivityResultLauncher,
+        val lifecycleOwner: TestLifecycleOwner,
+        val registration: Registration,
+    ) {
+        fun ensureAllEventsConsumed() {
+            activityResultCaller.registerCalls.ensureAllEventsConsumed()
+            activityLauncher.launchCalls.ensureAllEventsConsumed()
+            activityLauncher.unregisterCalls.ensureAllEventsConsumed()
+        }
+    }
+
     private data class Scenario(
         val shippingAddressElement: ShippingAddressElement,
         val activityLauncher: RecordingActivityResultLauncher,
         val lifecycleOwner: TestLifecycleOwner,
         val stateHolder: CheckoutControllerStateHolder,
+        val shippingAddressElementStateHolder: ShippingAddressElementStateHolder,
         val paymentConfiguration: RecordingProvider<PaymentConfiguration>,
         val errorReporter: FakeErrorReporter,
         val registration: Registration,
+        val createElement: suspend () -> ElementScenario,
     )
+
+    @Suppress("RestrictedApi")
+    private fun SavedStateHandle.simulateProcessDeath(): SavedStateHandle =
+        SavedStateHandle.createHandle(savedStateProvider().saveState(), null)
 }


### PR DESCRIPTION
# Summary

After Checkout is configured, `ShippingAddressElement.present()` launches the existing blank Address Element form. The form hides the phone field, enables Stripe-hosted autocomplete, and resolves the current `PaymentConfiguration` for each permitted launch.

Presentation is guarded by a controller-scoped `ShippingAddressElementStateHolder` backed by Checkout's `SavedStateHandle`. Elements created from the same controller share this state, suppressing duplicate launches across host recreation and saved-state restoration.

Host destruction unregisters the stale launcher without clearing the guard. Any Address Element result clears the guard. A synchronous launcher `IllegalStateException` clears the guard before propagating.

# Motivation

`ShippingAddressElement.present()` was previously unimplemented. This change adds presentation while preventing duplicate Address Element launches if the Activity-bound element is recreated during an active presentation.

Calling `present()` before Checkout configuration reports `checkout.shipping_address_element.present.not_configured` and returns without resolving `PaymentConfiguration` or launching.

Address Element results remain ignored. Success and cancellation do not update Checkout state, and `ShippingAddressElement.Configuration` remains unapplied. Result handling and configuration wiring are follow-up work.

# Testing

- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

Focused tests cover:

- Form configuration and fresh `PaymentConfiguration` resolution.
- Unconfigured presentation and its expected error event.
- Duplicate suppression within one element and across recreated elements.
- Launcher unregistration without clearing presentation state.
- Clearing the guard from a recreated element's result callback.
- Saved-state restoration.
- Synchronous launch failure.
- Ignored successful results and unchanged Checkout state.

Focused unit tests, whitespace validation, and path-aware static-analysis and API checks passed locally.

Manual verification on API 36 covered opening the blank no-phone Shipping Address form and dismissing it with Back. Save and process restoration were not manually verified.

# Screenshots

No visual styling changed. This PR presents the existing Address Element UI.

# Changelog

N/A. This is a non-public Checkout Session preview API.

Committed and created by Codex.
