### PR TITLE
Run PaymentSheet example unit tests in CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -78,7 +78,7 @@ workflows:
           title: Run static analysis, unit, and screenshot tests
           timeout: 1200
           inputs:
-            - content: ./gradlew detekt lintRelease apiCheck verifyReleaseResources runUnitAndScreenshotTests --init-script build-configuration/unit-test-init.gradle --continue
+            - content: ./gradlew detekt lintRelease apiCheck verifyReleaseResources runUnitAndScreenshotTests :paymentsheet-example:testBaseDebugUnitTest --init-script build-configuration/unit-test-init.gradle --continue
       - bundle::export_unit_test_results:
           title: Export unit & screenshot test results
           inputs:

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
@@ -77,6 +77,8 @@ class CheckoutPlaygroundSettingsUiTest {
         initialConfiguration = CheckoutPlaygroundDefinitions.Controller.payment.appearance.lightColors.configuration,
     ) {
         val definition = CheckoutPlaygroundDefinitions.Controller.payment.appearance.lightColors.primary
+        settings.updateSerialized(definition, "")
+        composeRule.waitForIdle()
         page.value(definition).performClick()
 
         composeRule.onNodeWithText("Pick color").assertIsDisplayed().performClick()


### PR DESCRIPTION
# Summary

Run the `paymentsheet-example` base debug unit tests in the main Bitrise check-and-test workflow. Update the color-picker UI test to explicitly exercise its empty-value behavior.

# Motivation

The shared `runUnitAndScreenshotTests` task looks for `testDebugUnitTest`, but `paymentsheet-example` exposes the flavored `testBaseDebugUnitTest` task. As a result, its Robolectric tests were not running in CI.

# Testing

- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

Ran:

- `./gradlew :paymentsheet-example:testBaseDebugUnitTest --init-script build-configuration/unit-test-init.gradle`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable; this only changes CI test coverage and test setup.

# Changelog

Not applicable; this does not change SDK behavior.

Committed and created by Codex.
