### PR TITLE
Save Checkout playground customer payment methods

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
@@ -26,17 +26,23 @@ internal object CheckoutControllerExampleRequestFactory {
                     "customer",
                     if (customer == RETURNING_CUSTOMER) returningCustomerId ?: customer else customer,
                 )
+                if (session.paymentMethodSave.isApplicable(settings)) {
+                    put(
+                        "checkout_session_payment_method_save",
+                        if (settings[session.paymentMethodSave]) "enabled" else "disabled",
+                    )
+                }
                 put("customer_email", settings[session.customerEmail])
                 put("currency", settings[session.currency].value)
-                if (settings[session.automaticPaymentMethods]) {
-                    put("automatic_payment_methods", true)
-                } else {
+                if (session.paymentMethodTypes.isApplicable(settings)) {
                     put(
                         "payment_method_types",
                         JsonArray(
                             settings[session.paymentMethodTypes].map(::JsonPrimitive)
                         )
                     )
+                } else {
+                    put("automatic_payment_methods", true)
                 }
                 put("automatic_tax", settings[session.automaticTax])
                 put("shipping_address_collection", settings[session.shippingAddressCollection])

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingDefinition.kt
@@ -16,7 +16,7 @@ internal sealed interface CheckoutPlaygroundSettingDefinition {
         val defaultValue: T,
         val options: List<Option<T>>,
         val input: Input,
-        val isVisible: (CheckoutPlaygroundSettings) -> Boolean,
+        val isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean,
         private val encode: (T) -> String,
         private val decode: (String) -> Result<T>,
     ) : CheckoutPlaygroundSettingDefinition {
@@ -43,6 +43,10 @@ internal sealed interface CheckoutPlaygroundSettingDefinition {
             Color,
         }
     }
+}
+
+internal interface CheckoutPlaygroundSettingValues {
+    operator fun <T> get(definition: CheckoutPlaygroundSettingDefinition.Value<T>): T
 }
 
 internal fun CheckoutPlaygroundSettingDefinition.Configuration.values():

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingFactories.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingFactories.kt
@@ -14,12 +14,14 @@ internal fun boolean(
     key: String,
     displayName: String,
     defaultValue: Boolean,
+    isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean = { true },
 ) = choice(
     key = key,
     displayName = displayName,
     defaultValue = defaultValue,
     options = listOf("On" to true, "Off" to false),
     serialize = Boolean::toString,
+    isApplicable = isApplicable,
 )
 
 internal inline fun <reified T : Enum<T>> enumChoice(
@@ -40,12 +42,14 @@ internal fun <T> choice(
     defaultValue: T,
     options: List<Pair<String, T>>,
     serialize: (T) -> String,
+    isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean = { true },
 ): CheckoutPlaygroundSettingDefinition.Value<T> {
     return value(
         key = key,
         displayName = displayName,
         defaultValue = defaultValue,
         options = options,
+        isApplicable = isApplicable,
         encode = serialize,
         decode = { serialized ->
             options.firstOrNull { (_, option) -> serialize(option) == serialized }
@@ -60,7 +64,7 @@ internal fun <T> value(
     key: String,
     displayName: String,
     defaultValue: T,
-    isVisible: (CheckoutPlaygroundSettings) -> Boolean = { true },
+    isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean = { true },
     options: List<Pair<String, T>> = emptyList(),
     input: CheckoutPlaygroundSettingDefinition.Value.Input = CheckoutPlaygroundSettingDefinition.Value.Input.Text,
     encode: (T) -> String,
@@ -76,7 +80,7 @@ internal fun <T> value(
         )
     },
     input = input,
-    isVisible = isVisible,
+    isApplicable = isApplicable,
     encode = encode,
     decode = decode,
 )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
@@ -18,7 +18,7 @@ internal class CheckoutPlaygroundSettings private constructor(
     initialReturningCustomerId: String?,
     private val persist: (Map<String, String>) -> Unit,
     private val persistReturningCustomerId: (String?) -> Unit,
-) {
+) : CheckoutPlaygroundSettingValues {
     private val definitionsByKey = root.values().associateBy { it.key }
     private val defaults = definitionsByKey.values.associateWith { it.defaultSerializedValue } +
         defaultValues.sanitized()
@@ -28,7 +28,7 @@ internal class CheckoutPlaygroundSettings private constructor(
     var returningCustomerId: String? = initialReturningCustomerId
         private set
 
-    fun <T> value(definition: CheckoutPlaygroundSettingDefinition.Value<T>): T {
+    override operator fun <T> get(definition: CheckoutPlaygroundSettingDefinition.Value<T>): T {
         return definition.deserialize(serializedValue(definition)).getOrThrow()
     }
 
@@ -93,8 +93,8 @@ internal class CheckoutPlaygroundSettings private constructor(
     @JvmInline
     value class Snapshot internal constructor(
         private val values: Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>,
-    ) {
-        operator fun <T> get(definition: CheckoutPlaygroundSettingDefinition.Value<T>): T {
+    ) : CheckoutPlaygroundSettingValues {
+        override operator fun <T> get(definition: CheckoutPlaygroundSettingDefinition.Value<T>): T {
             return definition.deserialize(requireNotNull(values[definition])).getOrThrow()
         }
     }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
@@ -45,6 +45,7 @@ import com.godaddy.android.colorpicker.ClassicColorPicker
 import com.godaddy.android.colorpicker.HsvColor
 
 internal const val CheckoutSettingsScreenTestTag = "checkout_settings_screen"
+internal const val CheckoutCustomerIdTestTag = "checkout_customer_id"
 private const val CheckoutSettingGroupTestTagPrefix = "checkout_setting_group:"
 private const val CheckoutSettingValueTestTagPrefix = "checkout_setting_value:"
 
@@ -60,7 +61,7 @@ internal fun CheckoutPlaygroundSettingsUi(
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         configuration.children.filter { definition ->
-            definition !is CheckoutPlaygroundSettingDefinition.Value<*> || definition.isVisible(settings)
+            definition !is CheckoutPlaygroundSettingDefinition.Value<*> || definition.isApplicable(settings)
         }.forEach { definition ->
             when (definition) {
                 is CheckoutPlaygroundSettingDefinition.Configuration -> ConfigurationRow(
@@ -71,6 +72,20 @@ internal fun CheckoutPlaygroundSettingsUi(
                     definition = definition,
                     value = requireNotNull(values[definition]),
                     onValueChanged = { settings.updateSerialized(definition, it) },
+                )
+            }
+            if (
+                definition == CheckoutPlaygroundDefinitions.session.customer &&
+                values[definition] == "returning"
+            ) {
+                OutlinedTextField(
+                    value = settings.returningCustomerId ?: "Backend fixture",
+                    onValueChange = {},
+                    readOnly = true,
+                    label = { Text("Customer ID") },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag(CheckoutCustomerIdTestTag),
                 )
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
@@ -26,6 +26,12 @@ internal object CheckoutSessionDefinitions {
         ),
         serialize = { it },
     )
+    val paymentMethodSave = boolean(
+        key = "session.payment_method_save",
+        displayName = "Save payment methods",
+        defaultValue = true,
+        isApplicable = { settings -> settings[customer] != GUEST_CUSTOMER },
+    )
     val customerEmail = text(
         key = "session.customer_email",
         displayName = "Customer email",
@@ -59,7 +65,7 @@ internal object CheckoutSessionDefinitions {
                     .distinct()
             )
         },
-        isVisible = { settings -> !settings.value(automaticPaymentMethods) },
+        isApplicable = { settings -> !settings[automaticPaymentMethods] },
     )
     val automaticTax = boolean(
         key = "session.automatic_tax",
@@ -82,6 +88,7 @@ internal object CheckoutSessionDefinitions {
         children = arrayOf(
             backendUrl,
             customer,
+            paymentMethodSave,
             customerEmail,
             currency,
             automaticPaymentMethods,
@@ -91,4 +98,6 @@ internal object CheckoutSessionDefinitions {
             billingAddressCollection,
         ),
     )
+
+    private const val GUEST_CUSTOMER = "guest"
 }

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -12,7 +12,7 @@ import org.junit.Test
 
 class CheckoutControllerExampleRequestFactoryTest {
     @Test
-    fun `defaults create a Checkout Session request`() = runScenario {
+    fun `guest creates a Checkout Session request without payment method saving`() = runScenario {
         val request = CheckoutControllerExampleRequestFactory.create(
             settings = settings.snapshot(),
             returningCustomerId = null,
@@ -33,7 +33,7 @@ class CheckoutControllerExampleRequestFactoryTest {
     }
 
     @Test
-    fun `session settings are included in request`() = runScenario {
+    fun `new customer enables payment method saving`() = runScenario {
         settings.update(session.customer, "new")
         settings.update(session.customerEmail, "another@example.com")
         settings.update(session.currency, Currency.EUR)
@@ -49,6 +49,7 @@ class CheckoutControllerExampleRequestFactoryTest {
         assertThat(request.body).isEqualTo(
             buildJsonObject {
                 put("customer", "new")
+                put("checkout_session_payment_method_save", "enabled")
                 put("customer_email", "another@example.com")
                 put("currency", "eur")
                 put("automatic_payment_methods", true)
@@ -60,7 +61,31 @@ class CheckoutControllerExampleRequestFactoryTest {
     }
 
     @Test
-    fun `returning customer uses saved customer ID`() = runScenario {
+    fun `new customer can disable payment method saving`() = runScenario {
+        settings.update(session.customer, "new")
+        settings.update(session.paymentMethodSave, false)
+
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings = settings.snapshot(),
+            returningCustomerId = null,
+        )
+
+        assertThat(request.body).isEqualTo(
+            buildJsonObject {
+                put("customer", "new")
+                put("checkout_session_payment_method_save", "disabled")
+                put("customer_email", "email@example.com")
+                put("currency", "usd")
+                put("automatic_payment_methods", true)
+                put("automatic_tax", false)
+                put("shipping_address_collection", false)
+                put("billing_address_collection", false)
+            }
+        )
+    }
+
+    @Test
+    fun `returning customer with saved ID enables payment method saving`() = runScenario {
         settings.update(session.customer, "returning")
 
         val request = CheckoutControllerExampleRequestFactory.create(
@@ -68,7 +93,41 @@ class CheckoutControllerExampleRequestFactoryTest {
             returningCustomerId = "cus_123",
         )
 
-        assertThat(request.body["customer"]).isEqualTo(JsonPrimitive("cus_123"))
+        assertThat(request.body).isEqualTo(
+            buildJsonObject {
+                put("customer", "cus_123")
+                put("checkout_session_payment_method_save", "enabled")
+                put("customer_email", "email@example.com")
+                put("currency", "usd")
+                put("automatic_payment_methods", true)
+                put("automatic_tax", false)
+                put("shipping_address_collection", false)
+                put("billing_address_collection", false)
+            }
+        )
+    }
+
+    @Test
+    fun `returning customer without saved ID uses fixture and enables payment method saving`() = runScenario {
+        settings.update(session.customer, "returning")
+
+        val request = CheckoutControllerExampleRequestFactory.create(
+            settings = settings.snapshot(),
+            returningCustomerId = null,
+        )
+
+        assertThat(request.body).isEqualTo(
+            buildJsonObject {
+                put("customer", "returning")
+                put("checkout_session_payment_method_save", "enabled")
+                put("customer_email", "email@example.com")
+                put("currency", "usd")
+                put("automatic_payment_methods", true)
+                put("automatic_tax", false)
+                put("shipping_address_collection", false)
+                put("billing_address_collection", false)
+            }
+        )
     }
 
     @Test

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
@@ -12,7 +12,7 @@ class CheckoutPlaygroundSettingsTest {
             defaultBackendUrl = "https://default.example/",
         )
 
-        assertThat(settings.value(CheckoutPlaygroundDefinitions.session.backendUrl))
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.backendUrl])
             .isEqualTo("https://default.example/")
     }
 
@@ -27,7 +27,7 @@ class CheckoutPlaygroundSettingsTest {
 
         settings.reset()
 
-        assertThat(settings.value(definition)).isEqualTo("https://default.example/")
+        assertThat(settings[definition]).isEqualTo("https://default.example/")
     }
 
     @Test
@@ -36,15 +36,25 @@ class CheckoutPlaygroundSettingsTest {
 
         val restored = CheckoutPlaygroundSettings.createInMemory(settings.asJsonString())
 
-        assertThat(restored.value(CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.scale))
+        assertThat(restored[CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.scale])
             .isEqualTo(1.25f)
+    }
+
+    @Test
+    fun `payment method saving survives JSON round trip`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.session.paymentMethodSave
+        settings.update(definition, false)
+
+        val restored = CheckoutPlaygroundSettings.createInMemory(settings.asJsonString())
+
+        assertThat(restored[definition]).isFalse()
     }
 
     @Test
     fun `unknown and invalid persisted values fall back to defaults`() = runScenario(
         json = """{"unknown":"value","currency.appearance.scale":"not-a-number"}"""
     ) {
-        assertThat(settings.value(CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.scale))
+        assertThat(settings[CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.scale])
             .isEqualTo(1f)
     }
 
@@ -55,14 +65,14 @@ class CheckoutPlaygroundSettingsTest {
 
         settings.reset()
 
-        assertThat(settings.value(definition)).isTrue()
+        assertThat(settings[definition]).isTrue()
     }
 
     @Test
     fun `terms display defaults to automatic`() = runScenario {
         val definitions = CheckoutPlaygroundDefinitions.Controller.payment.terms.values.values
 
-        assertThat(definitions.map(settings::value).distinct())
+        assertThat(definitions.map { settings[it] }.distinct())
             .containsExactly(CheckoutTermsDisplay.Automatic)
     }
 
@@ -93,7 +103,7 @@ class CheckoutPlaygroundSettingsTest {
 
         val restored = CheckoutPlaygroundSettings.createInMemory(settings.asJsonString())
 
-        assertThat(restored.value(definition)).isEqualTo(Color(0xFF112233))
+        assertThat(restored[definition]).isEqualTo(Color(0xFF112233))
     }
 
     @Test
@@ -103,7 +113,7 @@ class CheckoutPlaygroundSettingsTest {
         settings.saveReturningCustomer("cus_123")
 
         assertThat(settings.returningCustomerId).isEqualTo("cus_123")
-        assertThat(settings.value(CheckoutPlaygroundDefinitions.session.customer)).isEqualTo("returning")
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo("returning")
     }
 
     @Test
@@ -114,7 +124,7 @@ class CheckoutPlaygroundSettingsTest {
         settings.reset()
 
         assertThat(settings.returningCustomerId).isNull()
-        assertThat(settings.value(CheckoutPlaygroundDefinitions.session.customer)).isEqualTo("guest")
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo("guest")
     }
 
     private fun runScenario(

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -92,7 +93,59 @@ class CheckoutPlaygroundSettingsUiTest {
         composeRule.onNodeWithText("Guest").assertIsDisplayed()
         composeRule.onNodeWithText("New").assertIsDisplayed().performClick()
 
-        assertThat(settings.value(definition)).isEqualTo("new")
+        assertThat(settings[definition]).isEqualTo("new")
+    }
+
+    @Test
+    fun `returning customer displays stored customer ID`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
+        configureSettings = { saveReturningCustomer("cus_123") },
+    ) {
+        composeRule.onNodeWithTag(CheckoutCustomerIdTestTag)
+            .assertIsDisplayed()
+            .assertTextContains("Customer ID")
+            .assertTextContains("cus_123")
+    }
+
+    @Test
+    fun `returning customer without stored ID displays backend fixture`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
+        configureSettings = {
+            update(CheckoutPlaygroundDefinitions.session.customer, "returning")
+        },
+    ) {
+        composeRule.onNodeWithTag(CheckoutCustomerIdTestTag)
+            .assertIsDisplayed()
+            .assertTextContains("Customer ID")
+            .assertTextContains("Backend fixture")
+    }
+
+    @Test
+    fun `customer ID is hidden for guest and new customers`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
+    ) {
+        composeRule.onNodeWithTag(CheckoutCustomerIdTestTag).assertDoesNotExist()
+
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithTag(CheckoutCustomerIdTestTag).assertDoesNotExist()
+    }
+
+    @Test
+    fun `payment method saving is displayed only for customers`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
+    ) {
+        val definition = CheckoutPlaygroundDefinitions.session.paymentMethodSave
+        page.value(definition).assertDoesNotExist()
+
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
+        composeRule.waitForIdle()
+        page.value(definition).assertIsDisplayed()
+
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, "returning")
+        composeRule.waitForIdle()
+        page.value(definition).assertIsDisplayed()
     }
 
     @Test
@@ -109,9 +162,10 @@ class CheckoutPlaygroundSettingsUiTest {
 
     private fun runScenario(
         initialConfiguration: CheckoutPlaygroundSettingDefinition.Configuration = CheckoutPlaygroundDefinitions.root,
+        configureSettings: CheckoutPlaygroundSettings.() -> Unit = {},
         block: Scenario.() -> Unit,
     ) {
-        val settings = CheckoutPlaygroundSettings.createInMemory()
+        val settings = CheckoutPlaygroundSettings.createInMemory().apply(configureSettings)
         var current by mutableStateOf(initialConfiguration)
         composeRule.setContent {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {


### PR DESCRIPTION
# Summary

Enable configurable Checkout Session payment-method saving for New and Returning customers in the CheckoutController playground, and show the stored Returning Customer ID, or `Backend fixture`, in a read-only field.

# What changed

- New and Returning customers expose a persisted `Save payment methods` setting. It defaults to On and sends `checkout_session_payment_method_save` as `enabled` or `disabled`.
- Guest hides the setting and continues to omit the request parameter.
- Setting definitions own applicability rules shared by the settings UI and request serialization. The existing manual `payment_method_types` setting uses the same shared rule.
- Returning settings show the stored Customer ID when available and `Backend fixture` otherwise. Guest and New hide the field.

# What stays the same

- When a New response includes a Customer ID, it is persisted only after `CheckoutController.configure` succeeds.
- Returning requests substitute the persisted Customer ID when non-null and otherwise send the backend fixture value `returning`.
- Guest behavior, backend implementation, public APIs, and changelog remain unchanged.

# Testing

- [x] Added tests
- [x] Modified tests
- [x] Manually verified

Focused coverage passed for exact Guest, enabled New, disabled New, stored Returning, and fixture Returning request payloads; manual `payment_method_types` serialization; save-setting persistence; Guest, New, and Returning save-setting visibility; and manual `payment_method_types` visibility.

Local assembly, Detekt, API, and path-aware pre-push checks passed. CI is pending for the amended commit.

On Base Debug / emulator-5554 (API 36), New and Returning showed the default-On `Save payment methods` setting, while Guest hid it. Returning also showed the stored Customer ID in a read-only field. No Checkout Session or payment was created during this follow-up verification. The applicability refactor does not change this UI, so the existing fresh local screenshots were reused without creating another payment.

The existing isolated color-picker test remains red locally: it expects `#FF000000` but observes `#FF007AFF`; it is unrelated to this change.

# Screenshots

Fresh New and Returning settings screenshots are ready locally and will replace the first two images after upload. The images below are earlier end-to-end evidence and do not show the new setting; the saved-method image was not recaptured from the amended commit.

| New customer | Returning customer | Saved method after reopen |
| --- | --- | --- |
| <img width="216" height="484" alt="checkout-new-settings" src="https://github.com/user-attachments/assets/088e997f-2a53-4f46-a84a-11885cc2f867" /> | <img width="216" height="484" alt="checkout-returning-settings-redacted" src="https://github.com/user-attachments/assets/56466927-8129-465c-8841-7c0494e1fc72" /> | <img width="216" height="484" alt="checkout-returning-saved-method" src="https://github.com/user-attachments/assets/bdb59f81-6e35-47d8-8372-b51b03ae90ca" /> |

# Changelog

None. This is an internal example-app change.

Committed and created by Codex.
