### PR TITLE
Enable Stripe-hosted address autocomplete by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ NEXT_VERSION_BUMP: PATCH
 * [ADDED] Added support for SeQura.
 * [ADDED] Added support for PAYCO.
 
+### AddressElement
+* [CHANGED] Use Stripe-hosted address autocomplete by default.
+
 ## 23.17.1 - 2026-08-31
 
 ### PaymentSheet

--- a/paymentsheet-example/src/androidTest/java/com/stripe/android/addresselement/AddressElementTest.kt
+++ b/paymentsheet-example/src/androidTest/java/com/stripe/android/addresselement/AddressElementTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.addresselement
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithText
@@ -27,7 +28,10 @@ internal class AddressElementTest {
         selectAddressButton.waitForEnabled()
         selectAddressButton.click()
         replaceText("Full name", "Real Name")
-        replaceText("Address line 1", "1234 Main St")
+        replaceText("Address", "1234 Main St")
+        waitUntilDisplayed("Enter address manually")
+        rules.compose.onNodeWithText("Enter address manually").performScrollTo().performClick()
+        waitUntilDisplayed("City", editable = true)
         replaceText("City", "Boston")
         replaceText("ZIP Code", "12345")
         rules.compose.onNodeWithText("State").performScrollTo().performClick()
@@ -41,6 +45,15 @@ internal class AddressElementTest {
     }
 
     private fun replaceText(label: String, text: String) {
-        rules.compose.onNodeWithText(label).performScrollTo().performTextReplacement(text)
+        rules.compose.onNode(hasText(label).and(hasSetTextAction())).performScrollTo().performTextReplacement(text)
+    }
+
+    private fun waitUntilDisplayed(label: String, editable: Boolean = false) {
+        val matcher = hasText(label).let { matcher ->
+            if (editable) matcher.and(hasSetTextAction()) else matcher
+        }
+        rules.compose.waitUntil {
+            rules.compose.onAllNodes(matcher).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -112,7 +112,7 @@ class AddressLauncher internal constructor(
         internal val googlePlacesApiKey: String? = null,
         internal val autocompleteCountries: Set<String> = AUTOCOMPLETE_DEFAULT_COUNTRIES,
         internal val billingAddress: PaymentSheet.BillingDetails?,
-        internal val useStripeHostedAutocomplete: Boolean = false,
+        internal val useStripeHostedAutocomplete: Boolean = true,
     ) : Parcelable {
         @JvmOverloads
         constructor(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -140,16 +140,28 @@ class InputAddressViewModelTest {
     }
 
     @Test
-    fun `internal config can enable stripe-hosted autocomplete`() = runTest(UnconfinedTestDispatcher()) {
-        val viewModel = createViewModel(
-            config = AddressLauncher.Configuration(
-                billingAddress = null,
-                useStripeHostedAutocomplete = true,
-            )
-        )
+    fun `default configuration enables stripe-hosted autocomplete with hosted countries`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val viewModel = createViewModel(config = AddressLauncher.Configuration())
 
-        assertThat(viewModel.autocompleteConfig.shouldUseStripeHostedAutocomplete).isTrue()
-    }
+            assertThat(viewModel.autocompleteConfig.shouldUseStripeHostedAutocomplete).isTrue()
+            assertThat(viewModel.autocompleteConfig.autocompleteCountries)
+                .isEqualTo(AUTOCOMPLETE_STRIPE_HOSTED_DEFAULT_COUNTRIES)
+        }
+
+    @Test
+    fun `builder preserves custom autocomplete countries with stripe-hosted autocomplete`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val customCountries = setOf("US", "GB")
+            val viewModel = createViewModel(
+                config = AddressLauncher.Configuration.Builder()
+                    .autocompleteCountries(customCountries)
+                    .build()
+            )
+
+            assertThat(viewModel.autocompleteConfig.shouldUseStripeHostedAutocomplete).isTrue()
+            assertThat(viewModel.autocompleteConfig.autocompleteCountries).isEqualTo(customCountries)
+        }
 
     @Test
     fun `viewModel emits onComplete event`() = runTest(UnconfinedTestDispatcher()) {
@@ -383,13 +395,12 @@ class InputAddressViewModelTest {
                 mapOf(
                     IdentifierSpec.Name to FormFieldEntry(value = "", isComplete = false),
                     IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false)
+                    IdentifierSpec.Generic("address") to FormFieldEntry(value = "", isComplete = false),
                 )
             )
+
+            viewModel.onEnterManuallyFromInline()
+            assertThat(formValuesTurbine.awaitItem().keys).contains(IdentifierSpec.Line1)
 
             viewModel.setRawValues(
                 mapOf(
@@ -645,11 +656,7 @@ class InputAddressViewModelTest {
                 mapOf(
                     IdentifierSpec.Name to FormFieldEntry(value = "", isComplete = false),
                     IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false)
+                    IdentifierSpec.Generic("address") to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
@@ -724,11 +731,7 @@ class InputAddressViewModelTest {
                 mapOf(
                     IdentifierSpec.Name to FormFieldEntry(value = "", isComplete = false),
                     IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false)
+                    IdentifierSpec.Generic("address") to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
@@ -892,11 +895,7 @@ class InputAddressViewModelTest {
                 mapOf(
                     IdentifierSpec.Name to FormFieldEntry(value = "", isComplete = false),
                     IdentifierSpec.Country to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false)
+                    IdentifierSpec.Generic("address") to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
@@ -1007,7 +1006,7 @@ class InputAddressViewModelTest {
     }
 
     @Test
-    fun `onEnterManuallyFromInline emits OnExpandForm with null values when query is empty`() = runTest {
+    fun `onEnterManuallyFromInline emits OnExpandForm with current country when query is empty`() = runTest {
         val viewModel = createInlineViewModel()
         var emittedEvent: AutocompleteAddressInteractor.Event? = null
         viewModel.register { emittedEvent = it }
@@ -1015,7 +1014,11 @@ class InputAddressViewModelTest {
         viewModel.onEnterManuallyFromInline()
 
         assertThat(emittedEvent)
-            .isEqualTo(AutocompleteAddressInteractor.Event.OnExpandForm(values = null))
+            .isEqualTo(
+                AutocompleteAddressInteractor.Event.OnExpandForm(
+                    values = mapOf(IdentifierSpec.Country to "US")
+                )
+            )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
@@ -5,7 +5,9 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.FakeStripeAutocompleteRepository
+import com.stripe.android.paymentsheet.addresselement.StripeHostedPlacesClientProxy
 import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
+import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import org.junit.Test
 import org.mockito.kotlin.mock
 
@@ -13,21 +15,20 @@ class AddressElementViewModelModuleTest {
     private val module = AddressElementViewModelModule()
 
     @Test
-    fun `provideInlinePlacesClient returns hosted client without google api key when hosted autocomplete is enabled`() {
+    fun `provideInlinePlacesClient returns hosted client by default when google client is available`() {
+        val googlePlacesClient = mock<PlacesClientProxy>()
         val placesClient = module.provideInlinePlacesClient(
             args = AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
-                config = AddressLauncher.Configuration(
-                    billingAddress = null,
-                    useStripeHostedAutocomplete = true,
-                ),
+                config = AddressLauncher.Configuration(),
             ),
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
-            googlePlacesClient = null,
+            googlePlacesClient = googlePlacesClient,
             addressLauncherEventReporter = FakeAddressLauncherEventReporter(),
         )
 
-        assertThat(placesClient).isNotNull()
+        assertThat(placesClient).isInstanceOf(StripeHostedPlacesClientProxy::class.java)
+        assertThat(placesClient).isNotSameInstanceAs(googlePlacesClient)
     }
 
     @Test


### PR DESCRIPTION
# Summary

Use the Stripe-hosted autocomplete endpoint by default for Address Element and direct consumers such as Link app.

This changes the internal default for `AddressLauncher.Configuration` without changing public APIs or the existing routing implementation. The standard country configuration expands to the existing Stripe-hosted country set, while custom country sets remain unchanged.

# Motivation

[Slack thread](https://stripe.slack.com/archives/C0B0NKX2H6E/p1788290746204229)

Link directly uses Address Element, but could not enable hosted autocomplete because the controlling flag was internal and defaulted to `false`. Defaulting the flag to `true` makes Stripe-hosted autocomplete the standard Address Element behavior.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused PaymentSheet tests verify the hosted default countries, preservation of custom countries, and Stripe-hosted client selection when a Google client is available. `apiCheck`, `detekt`, and the path-aware pre-push hook passed locally.

# Screenshots

N/A. This is a configuration-only change.

# Notes

The in-repo Native Link factory constructs its own autocomplete configuration and remains outside this diff.

# Changelog

* [CHANGED] Use Stripe-hosted address autocomplete by default.

Committed and created by Codex.