### PR TITLE
[PaymentSheet] Create ECE-specific payment method metadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -20,6 +20,7 @@ internal data class CheckoutControllerState(
     val flagImages: Map<String, Bitmap>?,
     val collectedDetails: CheckoutCollectedDetails,
     val paymentMethodMetadata: PaymentMethodMetadata,
+    val expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata,
     val embeddedConfiguration: EmbeddedPaymentElement.Configuration,
     val paymentSelection: PaymentSelection?,
     val temporarySelection: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -38,7 +38,7 @@ internal data class CheckoutControllerState(
                 paymentMethodMetadata = paymentMethodMetadata,
             ),
             availableExpressButtonTypes = availableExpressButtonTypesFactory.create(
-                paymentMethodMetadata = paymentMethodMetadata,
+                paymentMethodMetadata = expressCheckoutElementPaymentMethodMetadata,
                 expressCheckoutElementConfiguration = configuration.expressCheckoutElementConfiguration,
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -88,15 +88,16 @@ internal class CheckoutStateLoader @Inject constructor(
                 initializedViaCompose = false,
             ),
         ).getOrThrow()
+        val paymentElementState = loaderState.paymentElementState
 
         // Preserve the customer's existing selection across reloads when it's still valid, rather
         // than blindly adopting the loader's recomputed selection (reuses the embedded logic). The
         // previous selection comes from the incoming state, not a separate holder.
         val selection = selectionChooser.choose(
-            paymentMethodMetadata = loaderState.paymentMethodMetadata,
-            paymentMethods = loaderState.customer?.paymentMethods,
+            paymentMethodMetadata = paymentElementState.paymentMethodMetadata,
+            paymentMethods = paymentElementState.customer?.paymentMethods,
             previousSelection = carryForward.previousSelection,
-            newSelection = loaderState.paymentSelection,
+            newSelection = paymentElementState.paymentSelection,
             newConfiguration = commonConfiguration,
             formSheetAction = embeddedConfig.formSheetAction,
         )
@@ -106,14 +107,16 @@ internal class CheckoutStateLoader @Inject constructor(
             checkoutSessionResponse = response,
             flagImages = flagImages,
             collectedDetails = collectedDetails,
-            paymentMethodMetadata = loaderState.paymentMethodMetadata,
+            paymentMethodMetadata = paymentElementState.paymentMethodMetadata,
+            expressCheckoutElementPaymentMethodMetadata =
+                loaderState.expressCheckoutElementPaymentMethodMetadata,
             embeddedConfiguration = embeddedConfig,
             paymentSelection = selection,
             temporarySelection = carryForward.temporarySelection,
             previousNewSelections = carryForward.previousNewSelections,
         )
 
-        customerStateHolder.setCustomerState(loaderState.customer)
+        customerStateHolder.setCustomerState(paymentElementState.customer)
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -72,6 +72,11 @@ internal class CheckoutStateLoader @Inject constructor(
             checkoutSessionResponse = response,
             collectedDetails = collectedDetails,
         )
+        val expressCheckoutElementConfiguration = commonConfigurationFactory.createForExpressCheckoutElement(
+            configuration = configuration,
+            checkoutSessionResponse = response,
+            collectedDetails = collectedDetails,
+        )
 
         val loaderState = paymentElementLoader.loadForCheckoutSession(
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
@@ -83,6 +88,7 @@ internal class CheckoutStateLoader @Inject constructor(
                 configuration = embeddedConfig,
                 paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout.asPaymentSheet(),
             ),
+            expressCheckoutElementConfiguration = expressCheckoutElementConfiguration,
             metadata = PaymentElementLoader.Metadata(
                 isReloadingAfterProcessDeath = false,
                 initializedViaCompose = false,

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -86,18 +86,18 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
         }
         val confirmationOption = expressButton.toSelection().toConfirmationOption(
             configuration = configuration,
-            linkConfiguration = state.paymentMethodMetadata.linkState?.configuration,
-            cardFundingFilter = state.paymentMethodMetadata.cardFundingFilter,
+            linkConfiguration = state.expressCheckoutElementPaymentMethodMetadata.linkState?.configuration,
+            cardFundingFilter = state.expressCheckoutElementPaymentMethodMetadata.cardFundingFilter,
             googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                 configuration = configuration,
-                paymentMethodMetadata = state.paymentMethodMetadata,
+                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
             ),
             googlePayShippingAddressParameters = shippingAddressParameters,
         ) ?: return null
 
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
-            paymentMethodMetadata = state.paymentMethodMetadata,
+            paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
             statusBarColor = statusBarColor,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementEventReporter.kt
@@ -64,7 +64,7 @@ internal class DefaultExpressCheckoutElementEventReporter @Inject constructor(
                 ExpressButtonType.Link -> "link"
             }
         }
-        return state.paymentMethodMetadata.analyticsMetadata.paramsMap + mapOf(
+        return state.expressCheckoutElementPaymentMethodMetadata.analyticsMetadata.paramsMap + mapOf(
             FIELD_ORDERED_LPMS to orderedLpms.joinToString(","),
             FIELD_ECE_CONFIG to mapOf(
                 FIELD_LINK_VISIBILITY to expressCheckoutElementConfiguration.linkConfiguration.display

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementInteractor.kt
@@ -63,12 +63,12 @@ internal class DefaultExpressCheckoutElementInteractor @Inject constructor(
             expressButtons = session.availableExpressButtonTypes.map { expressButtonType ->
                 when (expressButtonType) {
                     ExpressButtonType.Link -> ExpressButton.Link.create(
-                        paymentMethodMetadata = state.paymentMethodMetadata,
+                        paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
                         linkAccountInfo = linkAccountInfo,
                         buttonTheme = configuration.appearance.buttonTheme,
                     )
                     is ExpressButtonType.GooglePay -> ExpressButton.GooglePay.create(
-                        paymentMethodMetadata = state.paymentMethodMetadata,
+                        paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
                         googlePayConfiguration = expressButtonType.googlePayConfiguration,
                         shippingAddressRequired = configuration.shippingAddressRequired,
                         buttonTheme = configuration.appearance.buttonTheme,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -80,6 +80,7 @@ internal interface PaymentElementLoader {
     suspend fun loadForCheckoutSession(
         initializationMode: InitializationMode.CheckoutSession,
         integrationConfiguration: Configuration,
+        expressCheckoutElementConfiguration: CommonConfiguration,
         metadata: Metadata,
     ): Result<CheckoutSessionState> = load(
         initializationMode = initializationMode,
@@ -324,29 +325,42 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     override suspend fun loadForCheckoutSession(
         initializationMode: PaymentElementLoader.InitializationMode.CheckoutSession,
         integrationConfiguration: PaymentElementLoader.Configuration,
+        expressCheckoutElementConfiguration: CommonConfiguration,
         metadata: PaymentElementLoader.Metadata,
     ): Result<PaymentElementLoader.CheckoutSessionState> = workContext.runCatching(::reportFailedLoad) {
         val validatedConfiguration = validateConfiguration(
             initializationMode = initializationMode,
             integrationConfiguration = integrationConfiguration,
         )
+        val expressCheckoutElementValidatedConfiguration = validateConfiguration(
+            initializationMode = initializationMode,
+            configuration = expressCheckoutElementConfiguration,
+        )
         val initialLoadResult = loadInitialData(
             initializationMode = initializationMode,
             validatedConfiguration = validatedConfiguration,
             metadata = metadata,
         )
-        val paymentMethodMetadataResult = createLinkStateAndPaymentMethodMetadata(
+        val paymentElementMetadataResult = createLinkStateAndPaymentMethodMetadata(
             initializationMode = initializationMode,
             integrationConfiguration = integrationConfiguration,
             validatedConfiguration = validatedConfiguration,
+            initialLoadResult = initialLoadResult,
+        )
+        val expressCheckoutElementMetadataResult = createLinkStateAndPaymentMethodMetadata(
+            initializationMode = initializationMode,
+            integrationConfiguration = integrationConfiguration,
+            validatedConfiguration = expressCheckoutElementValidatedConfiguration,
             initialLoadResult = initialLoadResult,
         )
         val loaderStateResult = createLoaderState(
             initializationMode = initializationMode,
             validatedConfiguration = validatedConfiguration,
             initialLoadResult = initialLoadResult,
-            paymentMethodMetadataResult = paymentMethodMetadataResult,
+            paymentMethodMetadataResult = paymentElementMetadataResult,
         )
+        val expressCheckoutElementPaymentMethodMetadata =
+            expressCheckoutElementMetadataResult.paymentMethodMetadata.await()
         val state = completeLoading(
             metadata = metadata,
             initialLoadResult = initialLoadResult,
@@ -355,7 +369,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
         PaymentElementLoader.CheckoutSessionState(
             paymentElementState = state,
-            expressCheckoutElementPaymentMethodMetadata = state.paymentMethodMetadata,
+            expressCheckoutElementPaymentMethodMetadata = expressCheckoutElementPaymentMethodMetadata,
         )
     }
 
@@ -405,8 +419,15 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private fun validateConfiguration(
         initializationMode: PaymentElementLoader.InitializationMode,
         integrationConfiguration: PaymentElementLoader.Configuration,
+    ): ValidatedConfigurationResult = validateConfiguration(
+        initializationMode = initializationMode,
+        configuration = integrationConfiguration.commonConfiguration,
+    )
+
+    private fun validateConfiguration(
+        initializationMode: PaymentElementLoader.InitializationMode,
+        configuration: CommonConfiguration,
     ): ValidatedConfigurationResult {
-        val configuration = integrationConfiguration.commonConfiguration
         initializationMode.validate()
         configuration.validate(
             initializationMode = initializationMode,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -81,11 +81,16 @@ internal interface PaymentElementLoader {
         initializationMode: InitializationMode.CheckoutSession,
         integrationConfiguration: Configuration,
         metadata: Metadata,
-    ): Result<State> = load(
+    ): Result<CheckoutSessionState> = load(
         initializationMode = initializationMode,
         integrationConfiguration = integrationConfiguration,
         metadata = metadata,
-    )
+    ).map { state ->
+        CheckoutSessionState(
+            paymentElementState = state,
+            expressCheckoutElementPaymentMethodMetadata = state.paymentMethodMetadata,
+        )
+    }
 
     data class Metadata(
         val isReloadingAfterProcessDeath: Boolean = false,
@@ -258,6 +263,11 @@ internal interface PaymentElementLoader {
         val stripeIntent: StripeIntent
             get() = paymentMethodMetadata.stripeIntent
     }
+
+    data class CheckoutSessionState(
+        val paymentElementState: State,
+        val expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata,
+    )
 }
 
 /**
@@ -315,11 +325,39 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode.CheckoutSession,
         integrationConfiguration: PaymentElementLoader.Configuration,
         metadata: PaymentElementLoader.Metadata,
-    ): Result<PaymentElementLoader.State> = loadInternal(
-        initializationMode = initializationMode,
-        integrationConfiguration = integrationConfiguration,
-        metadata = metadata,
-    )
+    ): Result<PaymentElementLoader.CheckoutSessionState> = workContext.runCatching(::reportFailedLoad) {
+        val validatedConfiguration = validateConfiguration(
+            initializationMode = initializationMode,
+            integrationConfiguration = integrationConfiguration,
+        )
+        val initialLoadResult = loadInitialData(
+            initializationMode = initializationMode,
+            validatedConfiguration = validatedConfiguration,
+            metadata = metadata,
+        )
+        val paymentMethodMetadataResult = createLinkStateAndPaymentMethodMetadata(
+            initializationMode = initializationMode,
+            integrationConfiguration = integrationConfiguration,
+            validatedConfiguration = validatedConfiguration,
+            initialLoadResult = initialLoadResult,
+        )
+        val loaderStateResult = createLoaderState(
+            initializationMode = initializationMode,
+            validatedConfiguration = validatedConfiguration,
+            initialLoadResult = initialLoadResult,
+            paymentMethodMetadataResult = paymentMethodMetadataResult,
+        )
+        val state = completeLoading(
+            metadata = metadata,
+            initialLoadResult = initialLoadResult,
+            loaderStateResult = loaderStateResult,
+        ).state
+
+        PaymentElementLoader.CheckoutSessionState(
+            paymentElementState = state,
+            expressCheckoutElementPaymentMethodMetadata = state.paymentMethodMetadata,
+        )
+    }
 
     override suspend fun load(
         initializationMode: PaymentElementLoader.InitializationMode,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -23,6 +23,7 @@ internal object CheckoutControllerStateFactory {
         flagImages: Map<String, Bitmap>? = null,
         collectedDetails: CheckoutCollectedDetails = CheckoutCollectedDetails(email = null),
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata = paymentMethodMetadata,
         embeddedConfiguration: EmbeddedPaymentElement.Configuration =
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection: PaymentSelection? = null,
@@ -35,6 +36,7 @@ internal object CheckoutControllerStateFactory {
             flagImages = flagImages,
             collectedDetails = collectedDetails,
             paymentMethodMetadata = paymentMethodMetadata,
+            expressCheckoutElementPaymentMethodMetadata = expressCheckoutElementPaymentMethodMetadata,
             embeddedConfiguration = embeddedConfiguration,
             paymentSelection = paymentSelection,
             temporarySelection = temporarySelection,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -173,6 +173,7 @@ internal class CheckoutControllerStateHolderTest {
         flagImages = null,
         collectedDetails = CheckoutCollectedDetails(email = null),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        expressCheckoutElementPaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -57,10 +57,18 @@ import kotlin.test.assertFailsWith
 internal class CheckoutStateLoaderTest {
 
     @Test
-    fun `loadInitial commits state with payment method metadata`() = runScenario {
+    fun `loadInitial commits state with payment element and express checkout element metadata`() = runScenario {
         loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
 
         assertThat(stateHolder.state?.paymentMethodMetadata).isNotNull()
+        assertThat(stateHolder.state?.expressCheckoutElementPaymentMethodMetadata).isNotNull()
+        assertThat(
+            stateHolder.state?.expressCheckoutElementPaymentMethodMetadata
+                ?.billingDetailsCollectionConfiguration
+        ).isEqualTo(
+            paymentElementLoader.lastExpressCheckoutElementConfiguration
+                ?.billingDetailsCollectionConfiguration
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -363,6 +363,7 @@ internal class CheckoutStateLoaderTest {
         flagImages = null,
         collectedDetails = CheckoutCollectedDetails(email = null),
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        expressCheckoutElementPaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -81,7 +81,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = createGooglePayExpressButton(
-                paymentMethodMetadata = state.paymentMethodMetadata,
+                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
             ),
         ) {
             performer.confirm(expressButton)
@@ -90,7 +90,8 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             assertThat(args.confirmationOption).isInstanceOf<GooglePayConfirmationOption>()
             val option = args.confirmationOption as GooglePayConfirmationOption
             assertThat(option.config.shippingAddressParameters).isNull()
-            assertThat(args.paymentMethodMetadata).isEqualTo(stateHolder.state?.paymentMethodMetadata)
+            assertThat(args.paymentMethodMetadata)
+                .isSameInstanceAs(stateHolder.state?.expressCheckoutElementPaymentMethodMetadata)
         }
     }
 
@@ -103,7 +104,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = createGooglePayExpressButton(
-                paymentMethodMetadata = state.paymentMethodMetadata,
+                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
                 shippingAddressRequired = true,
             ),
         ) {
@@ -140,7 +141,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = createGooglePayExpressButton(
-                paymentMethodMetadata = state.paymentMethodMetadata,
+                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
             ),
         ) {
             performer.confirm(expressButton)
@@ -171,7 +172,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = createGooglePayExpressButton(
-                paymentMethodMetadata = state.paymentMethodMetadata,
+                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
             ),
         ) {
             performer.confirm(expressButton)
@@ -187,7 +188,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
     @Test
     fun `confirm starts confirmation with a Link option`() {
         val state = CheckoutControllerStateFactory.create(
-            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            expressCheckoutElementPaymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 linkState = LinkState(
                     configuration = LinkTestUtils.createLinkConfiguration(),
                     loginState = LinkState.LoginState.NeedsVerification,
@@ -199,7 +200,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = ExpressButton.Link.create(
-                paymentMethodMetadata = state.paymentMethodMetadata,
+                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
                 linkAccountInfo = LinkAccountUpdate.Value(null),
                 buttonTheme = ButtonTheme.Automatic,
             ),
@@ -208,7 +209,8 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
 
             val args = confirmationHandler.startTurbine.awaitItem()
             assertThat(args.confirmationOption).isInstanceOf<LinkConfirmationOption>()
-            assertThat(args.paymentMethodMetadata).isEqualTo(stateHolder.state?.paymentMethodMetadata)
+            assertThat(args.paymentMethodMetadata)
+                .isSameInstanceAs(stateHolder.state?.expressCheckoutElementPaymentMethodMetadata)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementEventReporterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementEventReporterTest.kt
@@ -148,7 +148,8 @@ internal class DefaultExpressCheckoutElementEventReporterTest {
             configuration = CheckoutController.Configuration()
                 .expressCheckoutElement(expressCheckoutElementConfiguration)
                 .build(),
-            paymentMethodMetadata = paymentMethodMetadata,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            expressCheckoutElementPaymentMethodMetadata = paymentMethodMetadata,
         )
         val reporter = DefaultExpressCheckoutElementEventReporter(
             analyticsRequestExecutor = analyticsRequestExecutor,

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementInteractorTest.kt
@@ -299,7 +299,8 @@ internal class DefaultExpressCheckoutElementInteractorTest {
             ),
         )
         stateHolder.state = CheckoutControllerStateFactory.create(
-            paymentMethodMetadata = paymentMethodMetadata,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            expressCheckoutElementPaymentMethodMetadata = paymentMethodMetadata,
             configuration = CheckoutController.Configuration()
                 .expressCheckoutElement(configuration)
                 .build(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -3148,18 +3148,26 @@ internal class DefaultPaymentElementLoaderTest {
 
         runScenario {
             val loader = createPaymentElementLoader()
+            val integrationConfiguration = PaymentElementLoader.Configuration.PaymentSheet(
+                PaymentSheet.Configuration.Builder(
+                    merchantDisplayName = "Merchant, Inc.",
+                ).defaultBillingDetails(PaymentSheet.BillingDetails(email = "email@email.com"))
+                    .build(),
+            )
+            val expressCheckoutElementBillingDetailsCollectionConfiguration =
+                PaymentSheet.BillingDetailsCollectionConfiguration(allowedCountries = setOf("CA"))
+            val expressCheckoutElementConfiguration = integrationConfiguration.commonConfiguration.copy(
+                billingDetailsCollectionConfiguration =
+                    expressCheckoutElementBillingDetailsCollectionConfiguration,
+            )
 
             val checkoutSessionState = loader.loadForCheckoutSession(
                 initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                     instancesKey = "DefaultPaymentElementLoaderTest",
                     checkoutSessionResponse = checkoutSessionResponse,
                 ),
-                integrationConfiguration = PaymentElementLoader.Configuration.PaymentSheet(
-                    PaymentSheet.Configuration.Builder(
-                        merchantDisplayName = "Merchant, Inc.",
-                    ).defaultBillingDetails(PaymentSheet.BillingDetails(email = "email@email.com"))
-                        .build(),
-                ),
+                integrationConfiguration = integrationConfiguration,
+                expressCheckoutElementConfiguration = expressCheckoutElementConfiguration,
                 metadata = PaymentElementLoader.Metadata(
                     initializedViaCompose = false,
                 ),
@@ -3172,8 +3180,12 @@ internal class DefaultPaymentElementLoaderTest {
             // When removal is permitted, CheckoutSession doesn't restrict removing the last one.
             assertThat(paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
                 .isEqualTo(true)
-            assertThat(checkoutSessionState.expressCheckoutElementPaymentMethodMetadata)
-                .isEqualTo(paymentMethodMetadata)
+            assertThat(
+                checkoutSessionState.expressCheckoutElementPaymentMethodMetadata
+                    .billingDetailsCollectionConfiguration
+            ).isEqualTo(expressCheckoutElementBillingDetailsCollectionConfiguration)
+            assertThat(paymentMethodMetadata.billingDetailsCollectionConfiguration)
+                .isNotEqualTo(expressCheckoutElementBillingDetailsCollectionConfiguration)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -3149,7 +3149,7 @@ internal class DefaultPaymentElementLoaderTest {
         runScenario {
             val loader = createPaymentElementLoader()
 
-            val state = loader.loadForCheckoutSession(
+            val checkoutSessionState = loader.loadForCheckoutSession(
                 initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                     instancesKey = "DefaultPaymentElementLoaderTest",
                     checkoutSessionResponse = checkoutSessionResponse,
@@ -3164,13 +3164,16 @@ internal class DefaultPaymentElementLoaderTest {
                     initializedViaCompose = false,
                 ),
             ).getOrThrow()
+            val paymentMethodMetadata = checkoutSessionState.paymentElementState.paymentMethodMetadata
 
-            assertThat(state.paymentMethodMetadata.customerMetadata?.removePaymentMethod)
+            assertThat(paymentMethodMetadata.customerMetadata?.removePaymentMethod)
                 .isEqualTo(expectedPermission)
 
             // When removal is permitted, CheckoutSession doesn't restrict removing the last one.
-            assertThat(state.paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
+            assertThat(paymentMethodMetadata.customerMetadata?.canRemoveLastPaymentMethod)
                 .isEqualTo(true)
+            assertThat(checkoutSessionState.expressCheckoutElementPaymentMethodMetadata)
+                .isEqualTo(paymentMethodMetadata)
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -41,6 +41,8 @@ internal class FakePaymentElementLoader(
 
     var lastIntegrationConfiguration: PaymentElementLoader.Configuration? = null
         private set
+    var lastExpressCheckoutElementConfiguration: CommonConfiguration? = null
+        private set
 
     fun updateStripeIntent(intent: StripeIntent) {
         this.stripeIntent = intent
@@ -116,6 +118,28 @@ internal class FakePaymentElementLoader(
                         }
                     },
                 )
+            )
+        }
+    }
+
+    override suspend fun loadForCheckoutSession(
+        initializationMode: PaymentElementLoader.InitializationMode.CheckoutSession,
+        integrationConfiguration: PaymentElementLoader.Configuration,
+        expressCheckoutElementConfiguration: CommonConfiguration,
+        metadata: PaymentElementLoader.Metadata,
+    ): Result<PaymentElementLoader.CheckoutSessionState> {
+        lastExpressCheckoutElementConfiguration = expressCheckoutElementConfiguration
+        return load(
+            initializationMode = initializationMode,
+            integrationConfiguration = integrationConfiguration,
+            metadata = metadata,
+        ).map { paymentElementState ->
+            PaymentElementLoader.CheckoutSessionState(
+                paymentElementState = paymentElementState,
+                expressCheckoutElementPaymentMethodMetadata = createPaymentMethodMetadata(
+                    integrationConfiguration = integrationConfiguration,
+                    configuration = expressCheckoutElementConfiguration,
+                ),
             )
         }
     }


### PR DESCRIPTION
## Summary
- add a Checkout Session loader result that carries Payment Element and Express Checkout Element metadata
- accept the ECE common configuration and run Link/payment-method metadata creation separately for each element
- use ECE-specific metadata for express buttons, analytics, and confirmation

## Stack
- depends on #14299

## Testing
- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:compileDebugUnitTestKotlin`
- focused `:paymentsheet:testDebugUnitTest` coverage for the loader, checkout state, and ECE consumers
- `./gradlew :paymentsheet:detekt`
- `./gradlew :paymentsheet:apiCheck`
- `./gradlew :paymentsheet:lintDebug` *(blocked by pre-existing `ViewModelConstructorInComposable` in `AutocompleteScreenTest.kt`)*

Committed and created by Codex.