### PR TITLE
Rename US bank account factory integration inputs

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -79,7 +79,7 @@ internal class USBankAccountFormArguments(
                 paymentMethodMetadata = paymentMethodMetadata,
                 selectedPaymentMethodCode = selectedPaymentMethodCode,
                 hostedSurface = hostedSurface,
-                host = USBankAccountFormArgumentsFactory.Host(
+                integrationInputs = USBankAccountFormArgumentsFactory.IntegrationInputs(
                     isCompleteFlow = viewModel.isCompleteFlow,
                     shippingDetails = viewModel.config.shippingDetails,
                     draftPaymentSelection = viewModel.newPaymentSelection?.paymentSelection,
@@ -119,7 +119,7 @@ internal class USBankAccountFormArguments(
                 paymentMethodMetadata = paymentMethodMetadata,
                 selectedPaymentMethodCode = selectedPaymentMethodCode,
                 hostedSurface = hostedSurface,
-                host = USBankAccountFormArgumentsFactory.Host(
+                integrationInputs = USBankAccountFormArgumentsFactory.IntegrationInputs(
                     isCompleteFlow = isCompleteFlow,
                     shippingDetails = paymentMethodMetadata.shippingDetails,
                     draftPaymentSelection = draftPaymentSelection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactory.kt
@@ -14,7 +14,7 @@ import com.stripe.android.paymentsheet.ui.PrimaryButton
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 
 internal object USBankAccountFormArgumentsFactory {
-    data class Host(
+    data class IntegrationInputs(
         val isCompleteFlow: Boolean,
         val shippingDetails: AddressDetails?,
         val draftPaymentSelection: PaymentSelection?,
@@ -34,7 +34,7 @@ internal object USBankAccountFormArgumentsFactory {
         paymentMethodMetadata: PaymentMethodMetadata,
         selectedPaymentMethodCode: PaymentMethodCode,
         hostedSurface: String,
-        host: Host,
+        integrationInputs: IntegrationInputs,
     ): USBankAccountFormArguments {
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = selectedPaymentMethodCode,
@@ -51,27 +51,27 @@ internal object USBankAccountFormArgumentsFactory {
             instantDebits = instantDebits,
             linkMode = paymentMethodMetadata.linkMode,
             onBehalfOf = paymentMethodMetadata.onBehalfOf,
-            isCompleteFlow = host.isCompleteFlow,
+            isCompleteFlow = integrationInputs.isCompleteFlow,
             isPaymentFlow = stripeIntent is PaymentIntent,
             stripeIntentId = stripeIntent.id,
             clientSecret = stripeIntent.clientSecret,
-            shippingDetails = host.shippingDetails,
-            draftPaymentSelection = host.draftPaymentSelection,
-            autocompleteAddressInteractorFactory = host.autocompleteAddressInteractorFactory,
-            onAnalyticsEvent = host.onAnalyticsEvent,
-            onMandateTextChanged = host.onMandateTextChanged,
-            onLinkedBankAccountChanged = host.onLinkedBankAccountChanged,
-            onUpdatePrimaryButtonUIState = host.onUpdatePrimaryButtonUIState,
-            onUpdatePrimaryButtonState = host.onUpdatePrimaryButtonState,
-            onError = host.onError,
-            onFormCompleted = host.onFormCompleted,
+            shippingDetails = integrationInputs.shippingDetails,
+            draftPaymentSelection = integrationInputs.draftPaymentSelection,
+            autocompleteAddressInteractorFactory = integrationInputs.autocompleteAddressInteractorFactory,
+            onAnalyticsEvent = integrationInputs.onAnalyticsEvent,
+            onMandateTextChanged = integrationInputs.onMandateTextChanged,
+            onLinkedBankAccountChanged = integrationInputs.onLinkedBankAccountChanged,
+            onUpdatePrimaryButtonUIState = integrationInputs.onUpdatePrimaryButtonUIState,
+            onUpdatePrimaryButtonState = integrationInputs.onUpdatePrimaryButtonState,
+            onError = integrationInputs.onError,
+            onFormCompleted = integrationInputs.onFormCompleted,
             incentive = paymentMethodMetadata.paymentMethodIncentive,
             setAsDefaultPaymentMethodEnabled =
                 paymentMethodMetadata.customerMetadata?.isPaymentMethodSetAsDefaultEnabled
                     ?: IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE,
             financialConnectionsAvailability = paymentMethodMetadata.financialConnectionsAvailability,
-            setAsDefaultMatchesSaveForFutureUse = host.setAsDefaultMatchesSaveForFutureUse,
-            termsDisplay = host.termsDisplay,
+            setAsDefaultMatchesSaveForFutureUse = integrationInputs.setAsDefaultMatchesSaveForFutureUse,
+            termsDisplay = integrationInputs.termsDisplay,
             sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
             forceSetupFutureUseBehavior = paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate,
             clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactoryTest.kt
@@ -30,7 +30,7 @@ internal class USBankAccountFormArgumentsFactoryTest {
             paymentMethodMetadata = metadata,
             selectedPaymentMethodCode = PaymentMethod.Type.Link.code,
             hostedSurface = "test_surface",
-            host = USBankAccountFormArgumentsFactory.Host(
+            integrationInputs = USBankAccountFormArgumentsFactory.IntegrationInputs(
                 isCompleteFlow = true,
                 shippingDetails = null,
                 draftPaymentSelection = draftPaymentSelection,


### PR DESCRIPTION
# Summary

Rename `USBankAccountFormArgumentsFactory.Host` to `IntegrationInputs` and update its parameter and call sites.

# Motivation

`Host` was ambiguous because the type does not host an Android component or manage a lifecycle. `IntegrationInputs` more clearly describes the state, dependencies, and callbacks supplied by each PaymentSheet integration to the shared arguments factory.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:
- `./gradlew detekt`
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArgumentsFactoryTest'`

No tests were newly ignored.

# Screenshots

Not applicable; this is an internal naming-only refactor with no UI changes.

# Changelog

Not applicable; this internal rename does not affect SDK users or behavior.

Committed and created by Codex.
