### PR TITLE
Make checkout customer ID configurable

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactory.kt
@@ -14,18 +14,17 @@ internal data class CheckoutControllerExampleRequest(
 )
 
 internal object CheckoutControllerExampleRequestFactory {
-    fun create(
-        settings: CheckoutPlaygroundSettings.Snapshot,
-        returningCustomerId: String?,
-    ): CheckoutControllerExampleRequest {
+    fun create(settings: CheckoutPlaygroundSettings.Snapshot): CheckoutControllerExampleRequest {
         return CheckoutControllerExampleRequest(
             endpoint = "checkout_session",
             body = buildJsonObject {
                 val customer = settings[session.customer]
-                put(
-                    "customer",
-                    if (customer == RETURNING_CUSTOMER) returningCustomerId ?: customer else customer,
-                )
+                val customerId = if (session.customerId.isApplicable(settings)) {
+                    settings[session.customerId]
+                } else {
+                    null
+                }
+                put("customer", customerId ?: customer)
                 if (session.paymentMethodSave.isApplicable(settings)) {
                     put(
                         "checkout_session_payment_method_save",
@@ -50,6 +49,4 @@ internal object CheckoutControllerExampleRequestFactory {
             },
         )
     }
-
-    private const val RETURNING_CUSTOMER = "returning"
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -115,10 +115,7 @@ internal class CheckoutControllerExampleViewModel(
         configurationJob?.cancel()
         val generation = ++configurationGeneration
         configurationJob = viewModelScope.launch {
-            val request = CheckoutControllerExampleRequestFactory.create(
-                settings = snapshot,
-                returningCustomerId = settings.returningCustomerId,
-            )
+            val request = CheckoutControllerExampleRequestFactory.create(settings = snapshot)
             val fetchResult = repository.fetchCheckoutSession(
                 request = request,
                 backendUrl = snapshot[CheckoutPlaygroundDefinitions.session.backendUrl],

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
@@ -20,13 +20,12 @@ internal class CheckoutPlaygroundSettings private constructor(
     private val persistReturningCustomerId: (String?) -> Unit,
 ) : CheckoutPlaygroundSettingValues {
     private val definitionsByKey = root.values().associateBy { it.key }
-    private val defaults = definitionsByKey.values.associateWith { it.defaultSerializedValue } +
+    private val definitionDefaults = definitionsByKey.values.associateWith { it.defaultSerializedValue } +
         defaultValues.sanitized()
-    private val _values = MutableStateFlow(defaults + initialValues.sanitized())
-    val values: StateFlow<Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>> = _values.asStateFlow()
-
     var returningCustomerId: String? = initialReturningCustomerId
         private set
+    private val _values = MutableStateFlow(currentDefaults() + initialValues.sanitized())
+    val values: StateFlow<Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>> = _values.asStateFlow()
 
     override operator fun <T> get(definition: CheckoutPlaygroundSettingDefinition.Value<T>): T {
         return definition.deserialize(serializedValue(definition)).getOrThrow()
@@ -52,16 +51,18 @@ internal class CheckoutPlaygroundSettings private constructor(
     }
 
     fun reset() {
-        _values.value = defaults
-        returningCustomerId = null
+        _values.value = currentDefaults()
         persist(_values.value.serialized())
-        persistReturningCustomerId(null)
     }
 
     fun saveReturningCustomer(customerId: String) {
         returningCustomerId = customerId
         persistReturningCustomerId(customerId)
-        update(CheckoutPlaygroundDefinitions.session.customer, RETURNING_CUSTOMER)
+        _values.value += mapOf(
+            CheckoutPlaygroundDefinitions.session.customerId to customerId,
+            CheckoutPlaygroundDefinitions.session.customer to RETURNING_CUSTOMER,
+        )
+        persist(_values.value.serialized())
     }
 
     fun validationErrors(): Map<CheckoutPlaygroundSettingDefinition.Value<*>, String> {
@@ -88,6 +89,11 @@ internal class CheckoutPlaygroundSettings private constructor(
                 ?.takeIf { it.validationError(value) == null }
                 ?.let { it to value }
         }.toMap()
+    }
+
+    private fun currentDefaults(): Map<CheckoutPlaygroundSettingDefinition.Value<*>, String> {
+        val customerId = CheckoutPlaygroundDefinitions.session.customerId
+        return definitionDefaults + (customerId to customerId.serialize(returningCustomerId))
     }
 
     @JvmInline

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
@@ -45,7 +45,6 @@ import com.godaddy.android.colorpicker.ClassicColorPicker
 import com.godaddy.android.colorpicker.HsvColor
 
 internal const val CheckoutSettingsScreenTestTag = "checkout_settings_screen"
-internal const val CheckoutCustomerIdTestTag = "checkout_customer_id"
 private const val CheckoutSettingGroupTestTagPrefix = "checkout_setting_group:"
 private const val CheckoutSettingValueTestTagPrefix = "checkout_setting_value:"
 
@@ -72,20 +71,6 @@ internal fun CheckoutPlaygroundSettingsUi(
                     definition = definition,
                     value = requireNotNull(values[definition]),
                     onValueChanged = { settings.updateSerialized(definition, it) },
-                )
-            }
-            if (
-                definition == CheckoutPlaygroundDefinitions.session.customer &&
-                values[definition] == "returning"
-            ) {
-                OutlinedTextField(
-                    value = settings.returningCustomerId ?: "Backend fixture",
-                    onValueChange = {},
-                    readOnly = true,
-                    label = { Text("Customer ID") },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .testTag(CheckoutCustomerIdTestTag),
                 )
             }
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundValueFactories.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundValueFactories.kt
@@ -29,10 +29,25 @@ internal fun optionalText(
     displayName: String,
     validate: (String) -> String? = { null },
 ): CheckoutPlaygroundSettingDefinition.Value<String?> {
+    return optionalText(
+        key = key,
+        displayName = displayName,
+        validate = validate,
+        isApplicable = { true },
+    )
+}
+
+internal fun optionalText(
+    key: String,
+    displayName: String,
+    validate: (String) -> String?,
+    isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean,
+): CheckoutPlaygroundSettingDefinition.Value<String?> {
     return value(
         key = key,
         displayName = displayName,
         defaultValue = null,
+        isApplicable = isApplicable,
         encode = { it.orEmpty() },
         decode = { serialized ->
             validate(serialized)?.let { invalid(message = it) } ?: Result.success(serialized.trim().ifEmpty { null })

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
@@ -26,6 +26,12 @@ internal object CheckoutSessionDefinitions {
         ),
         serialize = { it },
     )
+    val customerId = optionalText(
+        key = "session.customer_id",
+        displayName = "Customer ID",
+        validate = { null },
+        isApplicable = { settings -> settings[customer] == RETURNING_CUSTOMER },
+    )
     val paymentMethodSave = boolean(
         key = "session.payment_method_save",
         displayName = "Save payment methods",
@@ -88,6 +94,7 @@ internal object CheckoutSessionDefinitions {
         children = arrayOf(
             backendUrl,
             customer,
+            customerId,
             paymentMethodSave,
             customerEmail,
             currency,
@@ -100,4 +107,5 @@ internal object CheckoutSessionDefinitions {
     )
 
     private const val GUEST_CUSTOMER = "guest"
+    private const val RETURNING_CUSTOMER = "returning"
 }

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -13,10 +13,7 @@ import org.junit.Test
 class CheckoutControllerExampleRequestFactoryTest {
     @Test
     fun `guest creates a Checkout Session request without payment method saving`() = runScenario {
-        val request = CheckoutControllerExampleRequestFactory.create(
-            settings = settings.snapshot(),
-            returningCustomerId = null,
-        )
+        val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
 
         assertThat(request.endpoint).isEqualTo("checkout_session")
         assertThat(request.body).isEqualTo(
@@ -34,6 +31,7 @@ class CheckoutControllerExampleRequestFactoryTest {
 
     @Test
     fun `new customer enables payment method saving`() = runScenario {
+        settings.update(session.customerId, "cus_ignored")
         settings.update(session.customer, "new")
         settings.update(session.customerEmail, "another@example.com")
         settings.update(session.currency, Currency.EUR)
@@ -41,10 +39,7 @@ class CheckoutControllerExampleRequestFactoryTest {
         settings.update(session.shippingAddressCollection, true)
         settings.update(session.billingAddressCollection, true)
 
-        val request = CheckoutControllerExampleRequestFactory.create(
-            settings = settings.snapshot(),
-            returningCustomerId = null,
-        )
+        val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
 
         assertThat(request.body).isEqualTo(
             buildJsonObject {
@@ -65,10 +60,7 @@ class CheckoutControllerExampleRequestFactoryTest {
         settings.update(session.customer, "new")
         settings.update(session.paymentMethodSave, false)
 
-        val request = CheckoutControllerExampleRequestFactory.create(
-            settings = settings.snapshot(),
-            returningCustomerId = null,
-        )
+        val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
 
         assertThat(request.body).isEqualTo(
             buildJsonObject {
@@ -85,17 +77,15 @@ class CheckoutControllerExampleRequestFactoryTest {
     }
 
     @Test
-    fun `returning customer with saved ID enables payment method saving`() = runScenario {
+    fun `returning customer with arbitrary ID enables payment method saving`() = runScenario {
         settings.update(session.customer, "returning")
+        settings.update(session.customerId, "cus_custom")
 
-        val request = CheckoutControllerExampleRequestFactory.create(
-            settings = settings.snapshot(),
-            returningCustomerId = "cus_123",
-        )
+        val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
 
         assertThat(request.body).isEqualTo(
             buildJsonObject {
-                put("customer", "cus_123")
+                put("customer", "cus_custom")
                 put("checkout_session_payment_method_save", "enabled")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
@@ -111,10 +101,7 @@ class CheckoutControllerExampleRequestFactoryTest {
     fun `returning customer without saved ID uses fixture and enables payment method saving`() = runScenario {
         settings.update(session.customer, "returning")
 
-        val request = CheckoutControllerExampleRequestFactory.create(
-            settings = settings.snapshot(),
-            returningCustomerId = null,
-        )
+        val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
 
         assertThat(request.body).isEqualTo(
             buildJsonObject {
@@ -135,10 +122,7 @@ class CheckoutControllerExampleRequestFactoryTest {
         settings.update(session.automaticPaymentMethods, false)
         settings.update(session.paymentMethodTypes, listOf("card", "klarna"))
 
-        val request = CheckoutControllerExampleRequestFactory.create(
-            settings = settings.snapshot(),
-            returningCustomerId = null,
-        )
+        val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
 
         assertThat(request.body).containsEntry(
             "payment_method_types",

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
@@ -51,6 +51,16 @@ class CheckoutPlaygroundSettingsTest {
     }
 
     @Test
+    fun `customer ID survives JSON round trip`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.session.customerId
+        settings.update(definition, "cus_custom")
+
+        val restored = CheckoutPlaygroundSettings.createInMemory(settings.asJsonString())
+
+        assertThat(restored[definition]).isEqualTo("cus_custom")
+    }
+
+    @Test
     fun `unknown and invalid persisted values fall back to defaults`() = runScenario(
         json = """{"unknown":"value","currency.appearance.scale":"not-a-number"}"""
     ) {
@@ -114,16 +124,18 @@ class CheckoutPlaygroundSettingsTest {
 
         assertThat(settings.returningCustomerId).isEqualTo("cus_123")
         assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo("returning")
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customerId]).isEqualTo("cus_123")
     }
 
     @Test
-    fun `reset clears returning customer`() = runScenario {
+    fun `reset preserves returning customer ID as default`() = runScenario {
         settings.saveReturningCustomer("cus_123")
-        assertThat(settings.returningCustomerId).isEqualTo("cus_123")
+        settings.update(CheckoutPlaygroundDefinitions.session.customerId, "cus_custom")
 
         settings.reset()
 
-        assertThat(settings.returningCustomerId).isNull()
+        assertThat(settings.returningCustomerId).isEqualTo("cus_123")
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customerId]).isEqualTo("cus_123")
         assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo("guest")
     }
 

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextReplacement
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
@@ -103,35 +104,47 @@ class CheckoutPlaygroundSettingsUiTest {
         initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
         configureSettings = { saveReturningCustomer("cus_123") },
     ) {
-        composeRule.onNodeWithTag(CheckoutCustomerIdTestTag)
+        page.value(CheckoutPlaygroundDefinitions.session.customerId)
             .assertIsDisplayed()
             .assertTextContains("Customer ID")
             .assertTextContains("cus_123")
     }
 
     @Test
-    fun `returning customer without stored ID displays backend fixture`() = runScenario(
+    fun `returning customer without stored ID displays empty customer ID setting`() = runScenario(
         initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
         configureSettings = {
             update(CheckoutPlaygroundDefinitions.session.customer, "returning")
         },
     ) {
-        composeRule.onNodeWithTag(CheckoutCustomerIdTestTag)
+        page.value(CheckoutPlaygroundDefinitions.session.customerId)
             .assertIsDisplayed()
             .assertTextContains("Customer ID")
-            .assertTextContains("Backend fixture")
+    }
+
+    @Test
+    fun `returning customer can enter arbitrary customer ID`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
+        configureSettings = {
+            update(CheckoutPlaygroundDefinitions.session.customer, "returning")
+        },
+    ) {
+        page.value(CheckoutPlaygroundDefinitions.session.customerId)
+            .performTextReplacement("cus_custom")
+
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customerId]).isEqualTo("cus_custom")
     }
 
     @Test
     fun `customer ID is hidden for guest and new customers`() = runScenario(
         initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
     ) {
-        composeRule.onNodeWithTag(CheckoutCustomerIdTestTag).assertDoesNotExist()
+        page.value(CheckoutPlaygroundDefinitions.session.customerId).assertDoesNotExist()
 
         settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
         composeRule.waitForIdle()
 
-        composeRule.onNodeWithTag(CheckoutCustomerIdTestTag).assertDoesNotExist()
+        page.value(CheckoutPlaygroundDefinitions.session.customerId).assertDoesNotExist()
     }
 
     @Test


### PR DESCRIPTION
# Summary

Replace the Checkout playground's bespoke read-only customer ID field with a regular editable playground setting. The setting is shown only for Returning customers, defaults to the last automatically saved customer ID, and is captured in the settings snapshot used to create the Checkout Session request.

# Motivation

The previous UI special-cased the Customer selection row and read `settings.returningCustomerId` directly. That duplicated conditional rendering outside the setting definition and passed mutable state separately from the request snapshot. Modeling Customer ID as a normal setting makes applicability, persistence, editing, reset behavior, and request serialization consistent with the rest of the playground.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Passed:

- `./gradlew :paymentsheet-example:testBaseDebugUnitTest --tests 'com.stripe.android.paymentsheet.example.playground.checkout.CheckoutControllerExampleRequestFactoryTest' --tests 'com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettingsTest' --tests 'com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettingsUiTest'`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable. This is an internal playground settings refactor whose visibility and editing behavior are covered by Compose tests; the field retains the standard outlined text-field presentation.

# Changelog

Not applicable. This changes only the internal example application and does not affect the SDK's public API.

Committed and created by Codex.
