### PR TITLE
Add search to CheckoutController playground settings

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundActivity.kt
@@ -21,13 +21,8 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
 import androidx.compose.material.Text
-import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -36,17 +31,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.CustomerSheet
@@ -64,7 +51,6 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.rememberAddressLauncher
-import com.stripe.android.paymentsheet.example.R
 import com.stripe.android.paymentsheet.example.Settings
 import com.stripe.android.paymentsheet.example.playground.activity.AppearanceBottomSheetDialogFragment
 import com.stripe.android.paymentsheet.example.playground.activity.AppearanceStore
@@ -91,7 +77,6 @@ import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withContext
-import com.stripe.android.uicore.R as StripeUiCoreR
 
 @OptIn(
     WalletButtonsPreview::class,
@@ -797,74 +782,6 @@ internal class PaymentSheetPlaygroundActivity :
                 .putExtra(CustomPaymentMethodActivity.EXTRA_BILLING_DETAILS, billingDetails)
         )
     }
-}
-
-@Composable
-private fun SearchSettingsField(
-    query: String,
-    onQueryChanged: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var hasFocus by remember { mutableStateOf(false) }
-    val keyboardController = LocalSoftwareKeyboardController.current
-    TextField(
-        modifier = modifier
-            .onFocusChanged { hasFocus = it.isFocused }
-            .onKeyEvent {
-                if (it.key == Key.Enter) {
-                    keyboardController?.hide()
-                    true
-                } else {
-                    false
-                }
-            }
-            .fillMaxWidth(),
-        value = query,
-        placeholder = if (hasFocus) {
-            null
-        } else {
-            @Composable {
-                Text(text = "Search settings")
-            }
-        },
-        singleLine = true,
-        keyboardOptions = KeyboardOptions(
-            keyboardType = KeyboardType.Text,
-            imeAction = ImeAction.Done
-        ),
-        keyboardActions = KeyboardActions(
-            onDone = { keyboardController?.show() }
-        ),
-        leadingIcon = {
-            Icon(
-                painter = painterResource(R.drawable.ic_search),
-                contentDescription = null,
-            )
-        },
-        trailingIcon = if (query.isEmpty()) {
-            null
-        } else {
-            @Composable {
-                IconButton(onClick = { onQueryChanged("") }) {
-                    Icon(
-                        painter = painterResource(StripeUiCoreR.drawable.stripe_ic_material_close),
-                        contentDescription = null,
-                    )
-                }
-            }
-        },
-        onValueChange = onQueryChanged,
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun SearchSettingsFieldPreview() {
-    var query by remember { mutableStateOf("") }
-    SearchSettingsField(
-        query = query,
-        onQueryChanged = { query = it },
-    )
 }
 
 const val RELOAD_TEST_TAG = "RELOAD"

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/SearchSettingsField.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/SearchSettingsField.kt
@@ -1,0 +1,109 @@
+package com.stripe.android.paymentsheet.example.playground
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onKeyEvent
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import com.stripe.android.paymentsheet.example.R
+import com.stripe.android.uicore.R as StripeUiCoreR
+
+@Composable
+internal fun SearchSettingsField(
+    query: String,
+    onQueryChanged: (String) -> Unit,
+    modifier: Modifier,
+) {
+    var hasFocus by remember { mutableStateOf(false) }
+    val keyboardController = LocalSoftwareKeyboardController.current
+    TextField(
+        modifier = modifier
+            .onFocusChanged { hasFocus = it.isFocused }
+            .onKeyEvent {
+                if (it.key == Key.Enter) {
+                    keyboardController?.hide()
+                    true
+                } else {
+                    false
+                }
+            }
+            .fillMaxWidth(),
+        value = query,
+        placeholder = if (hasFocus) {
+            null
+        } else {
+            @Composable {
+                Text(text = "Search settings")
+            }
+        },
+        singleLine = true,
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Text,
+            imeAction = ImeAction.Done
+        ),
+        keyboardActions = KeyboardActions(
+            onDone = { keyboardController?.show() }
+        ),
+        leadingIcon = {
+            Icon(
+                painter = painterResource(R.drawable.ic_search),
+                contentDescription = null,
+            )
+        },
+        trailingIcon = if (query.isEmpty()) {
+            null
+        } else {
+            @Composable {
+                IconButton(onClick = { onQueryChanged("") }) {
+                    Icon(
+                        painter = painterResource(StripeUiCoreR.drawable.stripe_ic_material_close),
+                        contentDescription = null,
+                    )
+                }
+            }
+        },
+        onValueChange = onQueryChanged,
+    )
+}
+
+private val WordBoundaryRegex by lazy(LazyThreadSafetyMode.NONE) { "\\s+".toRegex() }
+
+internal fun String.matchesQuery(query: String): Boolean {
+    if (query.isBlank()) {
+        return true
+    }
+
+    val words = trim().split(WordBoundaryRegex)
+    val queryWords = query.trim().split(WordBoundaryRegex)
+    return queryWords.all { queryWord ->
+        words.any { word -> word.startsWith(queryWord, ignoreCase = true) }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SearchSettingsFieldPreview() {
+    var query by remember { mutableStateOf("") }
+    SearchSettingsField(
+        query = query,
+        onQueryChanged = { query = it },
+        modifier = Modifier,
+    )
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -8,6 +8,8 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.AppBarDefaults
 import androidx.compose.material.IconButton
 import androidx.compose.material.MaterialTheme
@@ -18,8 +20,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
+import com.stripe.android.paymentsheet.example.playground.SearchSettingsField
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettingsUi
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.configurations
@@ -56,52 +61,70 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
             var navigationPath by rememberSaveable {
                 mutableStateOf<List<String>>(emptyList())
             }
+            var settingsSearchQuery by rememberSaveable { mutableStateOf("") }
+            val isSearching = settingsSearchQuery.isNotBlank()
             val currentConfiguration = CheckoutPlaygroundDefinitions.root.configurations()
                 .firstOrNull { it.key == navigationPath.lastOrNull() }
                 ?: CheckoutPlaygroundDefinitions.root
             val navigateBack = {
                 if (status is CheckoutControllerExampleViewModel.Status.Settings) {
-                    navigationPath = navigationPath.dropLast(1)
+                    if (isSearching) {
+                        settingsSearchQuery = ""
+                    } else {
+                        navigationPath = navigationPath.dropLast(1)
+                    }
                 } else {
                     viewModel.returnToSettings()
                 }
             }
 
             BackHandler(
-                enabled = status !is CheckoutControllerExampleViewModel.Status.Settings || navigationPath.isNotEmpty()
+                enabled = status !is CheckoutControllerExampleViewModel.Status.Settings ||
+                    navigationPath.isNotEmpty() || isSearching
             ) { navigateBack() }
 
             PlaygroundTheme(
                 topBarContent = {
-                    TopAppBar(
-                        windowInsets = AppBarDefaults.topAppBarWindowInsets,
-                        title = {
-                            Text(
-                                if (status is CheckoutControllerExampleViewModel.Status.Settings) {
-                                    currentConfiguration.displayName
-                                } else {
-                                    "Checkout"
+                    Column {
+                        TopAppBar(
+                            windowInsets = AppBarDefaults.topAppBarWindowInsets,
+                            title = {
+                                Text(
+                                    when {
+                                        status !is CheckoutControllerExampleViewModel.Status.Settings -> "Checkout"
+                                        isSearching -> "Search settings"
+                                        else -> currentConfiguration.displayName
+                                    }
+                                )
+                            },
+                            navigationIcon = if (
+                                status !is CheckoutControllerExampleViewModel.Status.Settings ||
+                                navigationPath.isNotEmpty() || isSearching
+                            ) {
+                                {
+                                    IconButton(onClick = navigateBack) {
+                                        Text("‹", style = MaterialTheme.typography.h4)
+                                    }
                                 }
+                            } else {
+                                null
+                            },
+                        )
+                        if (status is CheckoutControllerExampleViewModel.Status.Settings) {
+                            SearchSettingsField(
+                                query = settingsSearchQuery,
+                                onQueryChanged = { settingsSearchQuery = it },
+                                modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                             )
-                        },
-                        navigationIcon = if (
-                            status !is CheckoutControllerExampleViewModel.Status.Settings || navigationPath.isNotEmpty()
-                        ) {
-                            {
-                                IconButton(onClick = navigateBack) {
-                                    Text("‹", style = MaterialTheme.typography.h4)
-                                }
-                            }
-                        } else {
-                            null
-                        },
-                    )
+                        }
+                    }
                 },
                 content = {
                     when (val currentStatus = status) {
                         CheckoutControllerExampleViewModel.Status.Settings -> {
                             CheckoutPlaygroundSettingsUi(
                                 configuration = currentConfiguration,
+                                searchQuery = settingsSearchQuery,
                                 settings = viewModel.settings,
                                 onOpenConfiguration = { navigationPath += it.key },
                             )

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ExposedDropdownMenuBox
@@ -26,6 +27,7 @@ import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.RadioButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -33,45 +35,145 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
 import com.godaddy.android.colorpicker.ClassicColorPicker
 import com.godaddy.android.colorpicker.HsvColor
+import com.stripe.android.paymentsheet.example.playground.matchesQuery
 
 internal const val CheckoutSettingsScreenTestTag = "checkout_settings_screen"
 private const val CheckoutSettingGroupTestTagPrefix = "checkout_setting_group:"
 private const val CheckoutSettingValueTestTagPrefix = "checkout_setting_value:"
+private const val CheckoutSettingBreadcrumbTestTagPrefix = "checkout_setting_breadcrumb:"
 
 @Composable
 internal fun CheckoutPlaygroundSettingsUi(
     configuration: CheckoutPlaygroundSettingDefinition.Configuration,
+    searchQuery: String,
     settings: CheckoutPlaygroundSettings,
     onOpenConfiguration: (CheckoutPlaygroundSettingDefinition.Configuration) -> Unit,
 ) {
     val values by settings.values.collectAsState()
+    val searchResults = remember(searchQuery) {
+        CheckoutPlaygroundDefinitions.root.searchResults(
+            query = searchQuery,
+            parents = emptyList(),
+        )
+    }
     Column(
         modifier = Modifier.testTag(CheckoutSettingsScreenTestTag),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        configuration.children.filter { definition ->
-            definition !is CheckoutPlaygroundSettingDefinition.Value<*> || definition.isApplicable(settings)
-        }.forEach { definition ->
-            when (definition) {
-                is CheckoutPlaygroundSettingDefinition.Configuration -> ConfigurationRow(
-                    configuration = definition,
-                    onClick = { onOpenConfiguration(definition) },
+        if (searchQuery.isBlank()) {
+            ConfigurationContent(
+                configuration = configuration,
+                values = values,
+                settings = settings,
+                onOpenConfiguration = onOpenConfiguration,
+            )
+        } else if (searchResults.isEmpty()) {
+            Text("No matching settings found")
+        } else {
+            SearchResultsContent(
+                results = searchResults,
+                values = values,
+                settings = settings,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConfigurationContent(
+    configuration: CheckoutPlaygroundSettingDefinition.Configuration,
+    values: Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>,
+    settings: CheckoutPlaygroundSettings,
+    onOpenConfiguration: (CheckoutPlaygroundSettingDefinition.Configuration) -> Unit,
+) {
+    configuration.children.filter { definition ->
+        definition !is CheckoutPlaygroundSettingDefinition.Value<*> || definition.isApplicable(settings)
+    }.forEach { definition ->
+        when (definition) {
+            is CheckoutPlaygroundSettingDefinition.Configuration -> ConfigurationRow(
+                configuration = definition,
+                onClick = { onOpenConfiguration(definition) },
+            )
+            is CheckoutPlaygroundSettingDefinition.Value<*> -> ValueRow(
+                definition = definition,
+                value = requireNotNull(values[definition]),
+                enabled = true,
+                onValueChanged = { settings.updateSerialized(definition, it) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchResultsContent(
+    results: List<SearchResult>,
+    values: Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>,
+    settings: CheckoutPlaygroundSettings,
+) {
+    results.forEach { result ->
+        val enabled = result.definition.isApplicable(settings)
+        Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+            Text(
+                text = result.breadcrumb,
+                modifier = Modifier.testTag(checkoutSettingBreadcrumbTestTag(result.definition)),
+                style = MaterialTheme.typography.caption,
+                color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+            )
+            ValueRow(
+                definition = result.definition,
+                value = requireNotNull(values[result.definition]),
+                enabled = enabled,
+                onValueChanged = { value ->
+                    if (enabled) {
+                        settings.updateSerialized(result.definition, value)
+                    }
+                },
+            )
+        }
+    }
+}
+
+private data class SearchResult(
+    val definition: CheckoutPlaygroundSettingDefinition.Value<*>,
+    val breadcrumb: String,
+)
+
+private fun CheckoutPlaygroundSettingDefinition.Configuration.searchResults(
+    query: String,
+    parents: List<String>,
+): List<SearchResult> {
+    return children.flatMap { definition ->
+        when (definition) {
+            is CheckoutPlaygroundSettingDefinition.Configuration -> {
+                definition.searchResults(
+                    query = query,
+                    parents = parents + definition.displayName,
                 )
-                is CheckoutPlaygroundSettingDefinition.Value<*> -> ValueRow(
-                    definition = definition,
-                    value = requireNotNull(values[definition]),
-                    onValueChanged = { settings.updateSerialized(definition, it) },
-                )
+            }
+            is CheckoutPlaygroundSettingDefinition.Value<*> -> {
+                if (definition.displayName.matchesQuery(query)) {
+                    listOf(
+                        SearchResult(
+                            definition = definition,
+                            breadcrumb = parents.joinToString(" › "),
+                        )
+                    )
+                } else {
+                    emptyList()
+                }
             }
         }
     }
@@ -104,16 +206,17 @@ private fun ConfigurationRow(
 private fun <T> ValueRow(
     definition: CheckoutPlaygroundSettingDefinition.Value<T>,
     value: String,
+    enabled: Boolean,
     onValueChanged: (String) -> Unit,
 ) {
     if (definition.input == CheckoutPlaygroundSettingDefinition.Value.Input.Color) {
-        ColorValue(definition, value, onValueChanged)
+        ColorValue(definition, value, enabled, onValueChanged)
     } else if (definition.options.isEmpty()) {
-        TextValue(definition, value, onValueChanged)
+        TextValue(definition, value, enabled, onValueChanged)
     } else if (definition.options.size <= MaxInlineOptions) {
-        RadioValue(definition, value, onValueChanged)
+        RadioValue(definition, value, enabled, onValueChanged)
     } else {
-        DropdownValue(definition, value, onValueChanged)
+        DropdownValue(definition, value, enabled, onValueChanged)
     }
 }
 
@@ -121,15 +224,22 @@ private fun <T> ValueRow(
 private fun <T> ColorValue(
     definition: CheckoutPlaygroundSettingDefinition.Value<T>,
     value: String,
+    enabled: Boolean,
     onValueChanged: (String) -> Unit,
 ) {
     var showPicker by remember { mutableStateOf(false) }
     val selectedColor = value.toComposeColorOrNull()
+    LaunchedEffect(enabled) {
+        if (!enabled) {
+            showPicker = false
+        }
+    }
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .testTag(checkoutSettingValueTestTag(definition))
-            .clickable { showPicker = true }
+            .alpha(if (enabled) 1f else ContentAlpha.disabled)
+            .clickable(enabled = enabled) { showPicker = true }
             .padding(vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
@@ -218,12 +328,14 @@ private fun Color.toSerializedColor(): String {
 private fun <T> TextValue(
     definition: CheckoutPlaygroundSettingDefinition.Value<T>,
     value: String,
+    enabled: Boolean,
     onValueChanged: (String) -> Unit,
 ) {
     val error = definition.validationError(value)
     OutlinedTextField(
         value = value,
         onValueChange = onValueChanged,
+        enabled = enabled,
         label = { Text(definition.displayName) },
         isError = error != null,
         keyboardOptions = KeyboardOptions(
@@ -247,9 +359,19 @@ private fun <T> TextValue(
 private fun <T> RadioValue(
     definition: CheckoutPlaygroundSettingDefinition.Value<T>,
     value: String,
+    enabled: Boolean,
     onValueChanged: (String) -> Unit,
 ) {
-    Column(modifier = Modifier.testTag(checkoutSettingValueTestTag(definition))) {
+    Column(
+        modifier = Modifier
+            .testTag(checkoutSettingValueTestTag(definition))
+            .semantics {
+                if (!enabled) {
+                    disabled()
+                }
+            }
+            .alpha(if (enabled) 1f else ContentAlpha.disabled)
+    ) {
         Text(text = definition.displayName, fontWeight = FontWeight.Bold)
         Row(modifier = Modifier.fillMaxWidth()) {
             definition.options.forEach { option ->
@@ -257,12 +379,17 @@ private fun <T> RadioValue(
                     modifier = Modifier
                         .selectable(
                             selected = value == definition.serialize(option.value),
+                            enabled = enabled,
                             onClick = { onValueChanged(definition.serialize(option.value)) },
                         )
                         .padding(end = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    RadioButton(selected = value == definition.serialize(option.value), onClick = null)
+                    RadioButton(
+                        selected = value == definition.serialize(option.value),
+                        onClick = null,
+                        enabled = enabled,
+                    )
                     Text(option.displayName)
                 }
             }
@@ -275,17 +402,30 @@ private fun <T> RadioValue(
 private fun <T> DropdownValue(
     definition: CheckoutPlaygroundSettingDefinition.Value<T>,
     value: String,
+    enabled: Boolean,
     onValueChanged: (String) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     val selected = definition.options.firstOrNull { definition.serialize(it.value) == value }
+    LaunchedEffect(enabled) {
+        if (!enabled) {
+            expanded = false
+        }
+    }
     ExposedDropdownMenuBox(
         expanded = expanded,
-        onExpandedChange = { expanded = it },
-        modifier = Modifier.testTag(checkoutSettingValueTestTag(definition)),
+        onExpandedChange = { expanded = enabled && it },
+        modifier = Modifier
+            .testTag(checkoutSettingValueTestTag(definition))
+            .semantics {
+                if (!enabled) {
+                    disabled()
+                }
+            },
     ) {
         OutlinedTextField(
             readOnly = true,
+            enabled = enabled,
             value = selected?.displayName.orEmpty(),
             onValueChange = {},
             label = { Text(definition.displayName) },
@@ -317,5 +457,9 @@ internal fun checkoutSettingGroupTestTag(
 internal fun checkoutSettingValueTestTag(
     definition: CheckoutPlaygroundSettingDefinition.Value<*>,
 ): String = CheckoutSettingValueTestTagPrefix + definition.key
+
+internal fun checkoutSettingBreadcrumbTestTag(
+    definition: CheckoutPlaygroundSettingDefinition.Value<*>,
+): String = CheckoutSettingBreadcrumbTestTagPrefix + definition.key
 
 private const val MaxInlineOptions = 4

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/SettingsUI.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
+import com.stripe.android.paymentsheet.example.playground.matchesQuery
 import kotlinx.coroutines.flow.StateFlow
 
 @Composable
@@ -58,23 +59,6 @@ internal fun SettingsUi(
                 Setting(settingDefinition, playgroundSettings)
             }
         }
-    }
-}
-
-private val WordBoundaryRegex by lazy(LazyThreadSafetyMode.NONE) { "\\s+".toRegex() }
-
-/**
- * Returns true if the string matches the query.
- */
-private fun String.matchesQuery(query: String): Boolean {
-    if (query.isBlank()) {
-        return true
-    }
-
-    val words = this.trim().split(WordBoundaryRegex)
-    val queryWords = query.trim().split(WordBoundaryRegex)
-    return queryWords.all { queryWord ->
-        words.any { word -> word.startsWith(queryWord, ignoreCase = true) }
     }
 }
 

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
@@ -10,6 +10,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -72,6 +74,71 @@ class CheckoutPlaygroundSettingsUiTest {
             .assertIsDisplayed()
         page.value(CheckoutPlaygroundDefinitions.Controller.payment.shouldSetConfiguration)
             .assertDoesNotExist()
+    }
+
+    @Test
+    fun `search finds settings globally and restores the current configuration when cleared`() = runScenario(
+        initialConfiguration = CheckoutPlaygroundDefinitions.Controller.express.configuration,
+    ) {
+        val paymentCornerRadius = CheckoutPlaygroundDefinitions.Controller.payment.appearance.primaryButton.shape
+            .cornerRadius
+        val currencyCornerRadius = CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.cornerRadius
+
+        page.value(CheckoutPlaygroundDefinitions.Controller.express.shouldSetConfiguration).assertIsDisplayed()
+
+        setSearchQuery("CoRn Ra")
+
+        page.value(paymentCornerRadius).performScrollTo().assertIsDisplayed()
+        page.breadcrumb(paymentCornerRadius).assertTextContains(
+            "CheckoutController.Configuration › Payment Element › Appearance › Primary button › Shape"
+        )
+        page.value(currencyCornerRadius).performScrollTo().assertIsDisplayed()
+        page.breadcrumb(currencyCornerRadius).assertTextContains(
+            "CheckoutController.Configuration › Currency Selector Element › Appearance"
+        )
+        page.value(CheckoutPlaygroundDefinitions.Controller.express.shouldSetConfiguration).assertDoesNotExist()
+
+        setSearchQuery("")
+
+        page.value(CheckoutPlaygroundDefinitions.Controller.express.shouldSetConfiguration).assertIsDisplayed()
+        page.value(paymentCornerRadius).assertDoesNotExist()
+    }
+
+    @Test
+    fun `search displays an empty state when there are no matches`() = runScenario {
+        setSearchQuery("not a setting")
+
+        composeRule.onNodeWithText("No matching settings found").assertIsDisplayed()
+    }
+
+    @Test
+    fun `search displays non-applicable choice settings as disabled`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.session.paymentMethodSave
+        setSearchQuery("save payment")
+
+        page.value(definition).performScrollTo().assertIsDisplayed().assertIsNotEnabled()
+        assertThat(settings[definition]).isTrue()
+
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
+        composeRule.waitForIdle()
+
+        page.value(definition).assertIsEnabled()
+        composeRule.onNodeWithText("Off").performClick()
+        assertThat(settings[definition]).isFalse()
+    }
+
+    @Test
+    fun `search displays non-applicable text settings as disabled`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.session.paymentMethodTypes
+        setSearchQuery("payment method types")
+
+        page.value(definition).performScrollTo().assertIsDisplayed().assertIsNotEnabled()
+
+        settings.update(CheckoutPlaygroundDefinitions.session.automaticPaymentMethods, false)
+        composeRule.waitForIdle()
+
+        page.value(definition).assertIsEnabled().performTextReplacement("card, cashapp")
+        assertThat(settings[definition]).containsExactly("card", "cashapp").inOrder()
     }
 
     @Test
@@ -182,22 +249,36 @@ class CheckoutPlaygroundSettingsUiTest {
     ) {
         val settings = CheckoutPlaygroundSettings.createInMemory().apply(configureSettings)
         var current by mutableStateOf(initialConfiguration)
+        var searchQuery by mutableStateOf("")
         composeRule.setContent {
             Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
                 CheckoutPlaygroundSettingsUi(
                     configuration = current,
+                    searchQuery = searchQuery,
                     settings = settings,
                     onOpenConfiguration = { current = it },
                 )
             }
         }
-        block(Scenario(Page(composeRule), settings, openConfiguration = { current = it }))
+        block(
+            Scenario(
+                page = Page(composeRule),
+                settings = settings,
+                openConfiguration = { current = it },
+                setSearchQuery = { query ->
+                    composeRule.runOnIdle {
+                        searchQuery = query
+                    }
+                },
+            )
+        )
     }
 
     private data class Scenario(
         val page: Page,
         val settings: CheckoutPlaygroundSettings,
         val openConfiguration: (CheckoutPlaygroundSettingDefinition.Configuration) -> Unit,
+        val setSearchQuery: (String) -> Unit,
     )
 
     private class Page(private val rule: ComposeContentTestRule) {
@@ -206,5 +287,8 @@ class CheckoutPlaygroundSettingsUiTest {
 
         fun value(definition: CheckoutPlaygroundSettingDefinition.Value<*>) =
             rule.onNodeWithTag(checkoutSettingValueTestTag(definition))
+
+        fun breadcrumb(definition: CheckoutPlaygroundSettingDefinition.Value<*>) =
+            rule.onNodeWithTag(checkoutSettingBreadcrumbTestTag(definition))
     }
 }


### PR DESCRIPTION
# Summary

Adds global search to the CheckoutController playground settings.

- Reuses a shared settings search field across the PaymentSheet and CheckoutController playgrounds.
- Displays matching checkout settings as a flat result list with configuration breadcrumbs.
- Includes non-applicable settings in search results as disabled, non-interactive controls while preserving their existing hidden behavior during normal navigation.
- Preserves the current nested settings location while search is active and restores it when search is cleared.

# Motivation

The CheckoutController playground now exposes a large, deeply nested configuration tree. Global search makes individual settings easier to find without manually navigating each configuration level, while disabled non-applicable results clarify that a setting exists and why it cannot currently be changed.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet-example:testBaseDebugUnitTest --no-daemon`
- `./gradlew :paymentsheet-example:assembleBaseDebug --no-daemon`
- `./gradlew :paymentsheet-example:detekt --no-daemon`
- `./gradlew detekt --no-daemon`

No tests were ignored.

# Screenshots

Not applicable. This internal playground UI change is covered by Robolectric Compose tests and was not manually verified on a device.

# Changelog

Not applicable. This changes only the internal `paymentsheet-example` application and does not affect the public SDK.

Committed and created by Codex.
