### PR TITLE
Fix `createAlipay` using default hardcoded URL in web-view path.

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -192,7 +192,14 @@ constructor(
         authenticator: AlipayAuthenticator,
         requestOptions: ApiRequest.Options
     ): Result<PaymentIntentResult> {
-        val paymentIntentResult = confirmPaymentIntent(confirmPaymentIntentParams, requestOptions)
+        val params = if (confirmPaymentIntentParams.returnUrl == null) {
+            // return_url is no longer used by is still required by the backend
+            confirmPaymentIntentParams.copy(returnUrl = "stripe://return_url")
+        } else {
+            confirmPaymentIntentParams
+        }
+
+        val paymentIntentResult = confirmPaymentIntent(params, requestOptions)
 
         return paymentIntentResult.mapResult { paymentIntent ->
             authenticateAlipay(

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -611,9 +611,6 @@ constructor(
             return ConfirmPaymentIntentParams(
                 clientSecret = clientSecret,
                 paymentMethodCreateParams = PaymentMethodCreateParams.createAlipay(),
-                // return_url is no longer used by is still required by the backend
-                // TODO(smaskell): remove this when no longer required
-                returnUrl = "stripe://return_url",
                 paymentMethodCode = PaymentMethod.Type.Alipay.code,
             )
         }

--- a/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/StripePaymentControllerTest.kt
@@ -183,7 +183,7 @@ internal class StripePaymentControllerTest {
     }
 
     @Test
-    fun `confirmAndAuthenticateAlipay() should return expected outcome`() =
+    fun `confirmAndAuthenticateAlipay() adds a return URL when one is not provided`() =
         runTest {
             whenever(alipayRepository.authenticate(any(), any(), any())).thenReturn(
                 AlipayAuthResult(
@@ -203,6 +203,8 @@ internal class StripePaymentControllerTest {
             ).getOrThrow()
 
             assertThat(stripeRepository.confirmPaymentIntentArgs).hasSize(1)
+            assertThat(stripeRepository.confirmPaymentIntentArgs[0].first.returnUrl)
+                .isEqualTo("stripe://return_url")
             assertThat(stripeRepository.confirmPaymentIntentArgs[0].first.shouldUseStripeSdk()).isTrue()
             assertThat(stripeRepository.confirmPaymentIntentArgs[0].second).isSameInstanceAs(
                 REQUEST_OPTIONS
@@ -212,6 +214,31 @@ internal class StripePaymentControllerTest {
             )
             assertThat(actualResponse.intent).isEqualTo(PaymentIntentFixtures.ALIPAY_REQUIRES_ACTION)
             assertThat(actualResponse.outcome).isEqualTo(StripeIntentResult.Outcome.SUCCEEDED)
+        }
+
+    @Test
+    fun `confirmAndAuthenticateAlipay() preserves a provided return URL`() =
+        runTest {
+            whenever(alipayRepository.authenticate(any(), any(), any())).thenReturn(
+                AlipayAuthResult(
+                    StripeIntentResult.Outcome.SUCCEEDED
+                )
+            )
+            stripeRepository.retrievePaymentIntentResponse =
+                PaymentIntentFixtures.ALIPAY_REQUIRES_ACTION
+
+            controller.confirmAndAuthenticateAlipay(
+                ConfirmPaymentIntentParams.createWithPaymentMethodId(
+                    "pm_123",
+                    "client_secret"
+                ).copy(returnUrl = "example://return_url"),
+                mock(),
+                REQUEST_OPTIONS
+            ).getOrThrow()
+
+            assertThat(stripeRepository.confirmPaymentIntentArgs).hasSize(1)
+            assertThat(stripeRepository.confirmPaymentIntentArgs[0].first.returnUrl)
+                .isEqualTo("example://return_url")
         }
 
     private fun createController(): StripePaymentController {

--- a/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/ConfirmPaymentIntentParamsTest.kt
@@ -508,7 +508,6 @@ class ConfirmPaymentIntentParamsTest {
                 mapOf(
                     "client_secret" to CLIENT_SECRET,
                     "use_stripe_sdk" to false,
-                    "return_url" to "stripe://return_url",
                     "payment_method_data" to mapOf(
                         "type" to "alipay"
                     ),


### PR DESCRIPTION
# Summary
Fix `createAlipay` using default hardcoded URL in web-view path.

# Motivation
ir-nickel-fresh

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified