### PR TITLE
CryptoOnramp SDK: Exposes Link Session Key Via LinkController

### DIFF
--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -1913,14 +1913,16 @@ class OnrampInteractorTest {
         email = "test@email.com",
         redactedPhoneNumber = "***-***-1234",
         sessionState = LinkController.SessionState.LoggedIn,
-        consumerSessionClientSecret = "secret_123"
+        consumerSessionClientSecret = "secret_123",
+        linkSessionKey = "lsk_123",
     )
 
     private fun mockLinkAccountWithoutSecret(): LinkController.LinkAccount = LinkController.LinkAccount(
         email = "test@email.com",
         redactedPhoneNumber = "***-***-1234",
         sessionState = LinkController.SessionState.LoggedIn,
-        consumerSessionClientSecret = null
+        consumerSessionClientSecret = null,
+        linkSessionKey = null,
     )
 
     private fun createConfigurationState(

--- a/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/ConsumerSession.kt
@@ -35,6 +35,8 @@ data class ConsumerSession(
     val linkBrand: LinkBrand? = null,
     @SerialName("support_payment_details_types")
     val supportedPaymentDetailsTypes: List<String> = emptyList(),
+    @SerialName("link_session_key")
+    val linkSessionKey: String? = null,
 ) : StripeModel {
 
     val meetsMinimumAuthenticationLevel: Boolean

--- a/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
+++ b/payments-model/src/main/java/com/stripe/android/model/parsers/ConsumerSessionJsonParser.kt
@@ -44,6 +44,7 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
 
         return ConsumerSession(
             clientSecret = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_SECRET),
+            linkSessionKey = optString(consumerSessionJson, FIELD_LINK_SESSION_KEY),
             emailAddress = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_EMAIL),
             redactedFormattedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_FORMATTED_PHONE),
             redactedPhoneNumber = consumerSessionJson.getString(FIELD_CONSUMER_SESSION_PHONE),
@@ -80,6 +81,7 @@ class ConsumerSessionJsonParser : ModelJsonParser<ConsumerSession> {
         private const val FIELD_CONSUMER_SESSION = "consumer_session"
 
         private const val FIELD_CONSUMER_SESSION_SECRET = "client_secret"
+        private const val FIELD_LINK_SESSION_KEY = "link_session_key"
         private const val FIELD_CONSUMER_SESSION_EMAIL = "email_address"
         private const val FIELD_CONSUMER_SESSION_PHONE = "redacted_phone_number"
         private const val FIELD_CONSUMER_SESSION_FORMATTED_PHONE = "redacted_formatted_phone_number"

--- a/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/model/parsers/ConsumerSessionJsonParserTest.kt
@@ -204,4 +204,33 @@ class ConsumerSessionJsonParserTest {
         val result = ConsumerSessionJsonParser().parse(json)
         assertThat(result?.supportedPaymentDetailsTypes).isEmpty()
     }
+
+    @Test
+    fun `Parse consumer with link_session_key`() {
+        val json = JSONObject(
+            """
+                {
+                  "consumer_session": {
+                    "client_secret": "secret_123",
+                    "link_session_key": "lsk_123",
+                    "email_address": "test@stripe.com",
+                    "redacted_phone_number": "+1********56",
+                    "redacted_formatted_phone_number": "(***) *** **56",
+                    "verification_sessions": []
+                  }
+                }
+            """.trimIndent()
+        )
+
+        val result = ConsumerSessionJsonParser().parse(json)
+
+        assertThat(result?.linkSessionKey).isEqualTo("lsk_123")
+    }
+
+    @Test
+    fun `Parse consumer without link_session_key returns null`() {
+        val result = ConsumerSessionJsonParser().parse(ConsumerFixtures.CONSUMER_VERIFIED_JSON)
+
+        assertThat(result?.linkSessionKey).isNull()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkController.kt
@@ -841,6 +841,7 @@ class LinkController @Inject internal constructor(
      * @param redactedPhoneNumber The phone number associated with the account, with sensitive digits redacted.
      * @param sessionState The current session state of the Link account.
      * @param consumerSessionClientSecret The client secret for the consumer session, if available.
+     * @param linkSessionKey The key for authenticating Link-scoped API requests, if available.
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     @Parcelize
@@ -850,6 +851,7 @@ class LinkController @Inject internal constructor(
         val redactedPhoneNumber: String,
         val sessionState: SessionState,
         val consumerSessionClientSecret: String?,
+        val linkSessionKey: String?,
     ) : Parcelable
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -93,7 +93,8 @@ internal class LinkControllerInteractor @Inject constructor(
                     LinkState.LoginState.LoggedIn ->
                         LinkController.SessionState.LoggedIn
                 },
-                consumerSessionClientSecret = account.clientSecret
+                consumerSessionClientSecret = account.clientSecret,
+                linkSessionKey = account.linkSessionKey,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -53,6 +53,9 @@ internal data class LinkAccount(
     val clientSecret = consumerSession.clientSecret
 
     @IgnoredOnParcel
+    val linkSessionKey = consumerSession.linkSessionKey
+
+    @IgnoredOnParcel
     val email = consumerSession.emailAddress
 
     @IgnoredOnParcel

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -101,6 +101,10 @@ class LinkControllerInteractorTest {
     @Test
     fun `state is updated when account changes`() = runTest {
         val interactor = createInteractor()
+        val linkSessionKey = "lsk_123"
+        val linkAccount = LinkAccount(
+            TestFactory.CONSUMER_SESSION.copy(linkSessionKey = linkSessionKey)
+        )
 
         interactor.state(application).test {
             awaitItem().run {
@@ -108,16 +112,17 @@ class LinkControllerInteractorTest {
                 assertThat(internalLinkAccount).isNull()
             }
 
-            linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+            linkAccountHolder.set(LinkAccountUpdate.Value(linkAccount))
 
             awaitItem().run {
                 assertThat(isConsumerVerified).isTrue()
                 assertThat(internalLinkAccount).isEqualTo(
                     LinkController.LinkAccount(
-                        email = TestFactory.LINK_ACCOUNT.email,
-                        redactedPhoneNumber = TestFactory.LINK_ACCOUNT.redactedPhoneNumber,
+                        email = linkAccount.email,
+                        redactedPhoneNumber = linkAccount.redactedPhoneNumber,
                         sessionState = LinkController.SessionState.LoggedIn,
-                        consumerSessionClientSecret = TestFactory.LINK_ACCOUNT.clientSecret,
+                        consumerSessionClientSecret = linkAccount.clientSecret,
+                        linkSessionKey = linkSessionKey,
                     )
                 )
             }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Parses and exposes the Link Session Key (LSK) for upcoming Swapped document collection work to be used with the `/v1/files` API.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

- [API Review](https://docs.google.com/document/d/1hUXmwrrHf3eHteW1aVb2kwFqNcEaaQLjxyGtu656Hpo/edit?tab=t.0#bookmark=id.wi6sj72qh5hz)
- Link to discussion in Slack: [Stripe](https://stripe.slack.com/archives/C094P3BRBL1/p1788287341498429) | [Lickability](https://lickability.slack.com/archives/C094P3BRBL1/p1788287341498429)

## Testing
1. Made sure existing tests passed.
2. Added additional tests to payments-model and paymentsheet to verify behavior.
3. Added a print statement temporarily from `CryptoOnrampCoordinator` to trigger access to this value after a login.