### PR TITLE
[Identity] Hide Branding Header Icons

### DIFF
--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheet.kt
@@ -31,7 +31,28 @@ interface IdentityVerificationSheet {
          * Optional color to use for the native flow's primary action buttons.
          */
         @get:ColorInt val brandColor: Int? = null
-    )
+    ) {
+        /**
+         * Configuration for the biometric consent screen's header.
+         *
+         * When `null`, the biometric consent screen uses the default header.
+         */
+        @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @set:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        var biometricConsent: BiometricConsentConfiguration? = null
+
+        /**
+         * Configuration for the biometric consent screen's header.
+         */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+        @Parcelize
+        data class BiometricConsentConfiguration(
+            /**
+             * Whether to hide the branding header above the consent title.
+             */
+            val hideBrandingHeader: Boolean
+        ) : Parcelable
+    }
 
     /**
      * Result of verification.

--- a/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheetContract.kt
+++ b/identity/src/main/java/com/stripe/android/identity/IdentityVerificationSheetContract.kt
@@ -18,6 +18,7 @@ internal class IdentityVerificationSheetContract :
         val ephemeralKeySecret: String,
         val brandLogo: Uri,
         val brandColor: Int?,
+        val biometricConsent: IdentityVerificationSheet.Configuration.BiometricConsentConfiguration?,
         @InjectorKey val injectorKey: String,
         val presentTime: Long
     ) : Parcelable {

--- a/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
+++ b/identity/src/main/java/com/stripe/android/identity/StripeIdentityVerificationSheet.kt
@@ -97,6 +97,7 @@ internal class StripeIdentityVerificationSheet internal constructor(
                 ephemeralKeySecret,
                 configuration.brandLogo,
                 configuration.brandColor,
+                configuration.biometricConsent,
                 injectorKey,
                 System.currentTimeMillis()
             )

--- a/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/ConsentScreen.kt
@@ -89,6 +89,7 @@ internal fun ConsentScreen(
             verificationPage.biometricConsent,
             verificationPage.bottomSheet,
             visitedIndividualWelcomePage,
+            hideBrandingHeader = identityViewModel.verificationArgs.biometricConsent?.hideBrandingHeader == true,
             showStripeLogo = !verificationPage.isStripe,
             onConsentAgreed = {
                 coroutineScope.launch {
@@ -124,6 +125,7 @@ private fun SuccessUI(
     consentPage: VerificationPageStaticContentConsentPage,
     bottomSheets: Map<String, VerificationPageStaticContentBottomSheetContent>?,
     visitedIndividualWelcomePage: Boolean,
+    hideBrandingHeader: Boolean,
     showStripeLogo: Boolean = true,
     onConsentAgreed: () -> Unit,
     onConsentDeclined: () -> Unit
@@ -152,7 +154,7 @@ private fun SuccessUI(
                 modifier = Modifier.testTag(CONSENT_HEADER_TAG),
                 merchantLogoUri = merchantLogoUri,
                 title = consentPage.title,
-                showLogos = visitedIndividualWelcomePage.not(),
+                showLogos = !hideBrandingHeader && !visitedIndividualWelcomePage,
                 showStripeLogo = showStripeLogo
             )
             ConsentLines(
@@ -263,6 +265,7 @@ internal fun ConsentPreview() {
                 )
             ),
             visitedIndividualWelcomePage = false,
+            hideBrandingHeader = false,
             bottomSheets = mapOf(),
             onConsentAgreed = {},
             onConsentDeclined = {}

--- a/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.identity.ui
 
 import android.os.Build
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -140,6 +141,28 @@ class ConsentScreenTest {
 
         setComposeTestRuleWith(Resource.success(verificationPage)) {
             onNodeWithTag(CONSENT_HEADER_TAG).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun `when hideBrandingHeader is false consent header is shown`() {
+        whenever(mockVerificationArgs.biometricConsent).thenReturn(
+            IdentityVerificationSheet.Configuration.BiometricConsentConfiguration(
+                hideBrandingHeader = false
+            )
+        )
+
+        setComposeTestRuleWith(Resource.success(verificationPage)) {
+            onNodeWithTag(CONSENT_HEADER_TAG).assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `when biometric consent configuration is null consent header is shown`() {
+        whenever(mockVerificationArgs.biometricConsent).thenReturn(null)
+
+        setComposeTestRuleWith(Resource.success(verificationPage)) {
+            onNodeWithTag(CONSENT_HEADER_TAG).assertIsDisplayed()
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/ConsentScreenTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.lifecycle.MutableLiveData
 import androidx.navigation.NavController
+import com.stripe.android.identity.IdentityVerificationSheet
 import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.TestApplication
 import com.stripe.android.identity.navigation.ConsentDestination
@@ -126,6 +127,19 @@ class ConsentScreenTest {
             onNodeWithTag(DECLINE_BUTTON_TAG).onChildAt(0)
                 .assertTextEquals(CONSENT_DECLINE_TEXT.uppercase())
             onNodeWithTag(DECLINE_BUTTON_TAG).onChildAt(1).assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun `when hideBrandingHeader is true consent header is hidden`() {
+        whenever(mockVerificationArgs.biometricConsent).thenReturn(
+            IdentityVerificationSheet.Configuration.BiometricConsentConfiguration(
+                hideBrandingHeader = true
+            )
+        )
+
+        setComposeTestRuleWith(Resource.success(verificationPage)) {
+            onNodeWithTag(CONSENT_HEADER_TAG).assertDoesNotExist()
         }
     }
 

--- a/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/viewmodel/IdentityViewModelTest.kt
@@ -155,6 +155,7 @@ internal class IdentityViewModelTest {
             ephemeralKeySecret = EPHEMERAL_KEY,
             brandLogo = BRAND_LOGO,
             brandColor = null,
+            biometricConsent = null,
             injectorKey = DUMMY_INJECTOR_KEY,
             presentTime = 0
         ),


### PR DESCRIPTION
# Summary
Matching https://github.com/stripe/stripe-ios/pull/6913, hides the biometric consent page's branding icons conditionally based on an internal configuration param.

# Motivation
Allow client apps to remove the icon header shown on the biometric screen based on design preference.

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Demo

Note this demo is recorded with a toggle added to the playground for easy demoing. This code wasn't added to this branch, as we don't need to expose this users.

https://github.com/user-attachments/assets/bceab66a-f874-415c-ae30-9a4a9504c26c