### PR TITLE
Defer embedded sheet initialization until Checkout is ready

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/ConfirmationControls.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/ConfirmationControls.kt
@@ -44,7 +44,6 @@ internal fun ConfirmationControls(
         ) { Text("Clear") }
         Button(
             onClick = onSelectPaymentMethod,
-            enabled = !isUpdating,
             modifier = Modifier.weight(1f),
         ) { Text("Select") }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -4,6 +4,8 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -16,6 +18,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
@@ -28,20 +31,41 @@ import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+internal class CheckoutSheetLauncherState @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) {
+    var isAwaitingPaymentOptionsReady: Boolean
+        get() = savedStateHandle.get<Boolean>(AWAITING_PAYMENT_OPTIONS_READY_KEY) == true
+        set(value) {
+            savedStateHandle[AWAITING_PAYMENT_OPTIONS_READY_KEY] = value
+        }
+
+    private companion object {
+        const val AWAITING_PAYMENT_OPTIONS_READY_KEY =
+            "CheckoutSheetLauncherState_AWAITING_PAYMENT_OPTIONS_READY"
+    }
+}
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutSheetLauncher @Inject constructor(
     activityResultCaller: ActivityResultCaller,
-    lifecycleOwner: LifecycleOwner,
+    private val lifecycleOwner: LifecycleOwner,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
     private val errorReporter: ErrorReporter,
     private val sessionRefresher: CheckoutSessionRefresher,
     private val operationCoordinator: CheckoutOperationCoordinator,
+    private val launcherState: CheckoutSheetLauncherState,
+    private val embeddedContentState: StateFlow<EmbeddedContentHelperStateHolder.State?>,
     private val logger: Logger,
     @ViewModelScope private val coroutineScope: CoroutineScope,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
@@ -63,6 +87,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private val activityLauncher: ActivityResultLauncher<EmbeddedActivityArgs> =
         activityResultCaller.registerForActivityResult(EmbeddedSheetContract) { result ->
+            launcherState.isAwaitingPaymentOptionsReady = false
             sheetStateHolder.sheetIsOpen = false
             when (result.launchMode) {
                 is EmbeddedLaunchMode.Form -> {
@@ -73,6 +98,10 @@ internal class CheckoutSheetLauncher @Inject constructor(
                 is EmbeddedLaunchMode.PaymentOptions -> handlePaymentOptionsResult(result)
             }
         }
+
+    init {
+        resumePendingReadyLaunch()
+    }
 
     private fun handleFormResult(result: EmbeddedActivityResult) {
         when (result) {
@@ -179,6 +208,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
             ),
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -208,6 +238,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.Manage,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -226,7 +257,62 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
-        val args = EmbeddedActivityArgs(
+        val initialArgs = createPaymentOptionsArgs(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = configuration,
+            selection = selection,
+            customerState = customerState,
+            presentationState = if (operationCoordinator.isUpdating.value) {
+                EmbeddedActivityArgs.PresentationState.Loading
+            } else {
+                EmbeddedActivityArgs.PresentationState.Ready
+            },
+        )
+        launcherState.isAwaitingPaymentOptionsReady =
+            initialArgs.presentationState == EmbeddedActivityArgs.PresentationState.Loading
+        activityLauncher.launch(initialArgs)
+
+        resumePendingReadyLaunch()
+    }
+
+    private fun resumePendingReadyLaunch() {
+        if (!launcherState.isAwaitingPaymentOptionsReady) return
+
+        lifecycleOwner.lifecycleScope.launch {
+            operationCoordinator.isUpdating.first { isUpdating -> !isUpdating }
+            if (!sheetStateHolder.sheetIsOpen) {
+                launcherState.isAwaitingPaymentOptionsReady = false
+                return@launch
+            }
+
+            val refreshedState = embeddedContentState.value
+            if (refreshedState == null) {
+                errorReporter.report(
+                    ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                )
+                return@launch
+            }
+            activityLauncher.launch(
+                createPaymentOptionsArgs(
+                    paymentMethodMetadata = refreshedState.paymentMethodMetadata,
+                    configuration = refreshedState.configuration,
+                    selection = selectionHolder.selection.value,
+                    customerState = customerStateHolder.customer.value,
+                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+                )
+            )
+            launcherState.isAwaitingPaymentOptionsReady = false
+        }
+    }
+
+    private fun createPaymentOptionsArgs(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customerState: CustomerState?,
+        selection: PaymentSelection?,
+        configuration: EmbeddedPaymentElement.Configuration,
+        presentationState: EmbeddedActivityArgs.PresentationState,
+    ): EmbeddedActivityArgs {
+        return EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
             productUsage = productUsage,
@@ -237,7 +323,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = presentationState,
         )
-        activityLauncher.launch(args)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
@@ -23,7 +23,13 @@ internal data class EmbeddedActivityArgs(
     val customerState: CustomerState?,
     val promotions: List<PaymentMethodMessagePromotion>,
     val launchMode: EmbeddedLaunchMode,
+    val presentationState: PresentationState,
 ) : Parcelable {
+    internal enum class PresentationState {
+        Loading,
+        Ready,
+    }
+
     companion object {
         internal const val EXTRA_ARGS: String = "extra_activity_args"
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -194,6 +194,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
             ),
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -223,6 +224,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.Manage,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -252,6 +254,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -1,152 +1,61 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
-import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
-import androidx.activity.addCallback
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.dp
-import androidx.lifecycle.lifecycleScope
-import com.stripe.android.common.ui.BottomSheetScaffold
+import androidx.core.os.BundleCompat
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
-import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.ui.PaymentElementTheme
-import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
-import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
-import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
-import com.stripe.android.uicore.getOuterFormInsets
-import com.stripe.android.uicore.strings.resolve
-import com.stripe.android.uicore.stripeFormInsets
-import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.fadeOut
-import kotlinx.coroutines.launch
-import javax.inject.Inject
 
+@OptIn(ExperimentalMaterialApi::class)
 internal class EmbeddedSheetActivity : AppCompatActivity() {
-    private val args: EmbeddedActivityArgs? by lazy {
-        EmbeddedActivityArgs.fromIntent(intent)
-    }
-
-    private val viewModel: EmbeddedSheetViewModel by viewModels {
-        EmbeddedSheetViewModel.Factory {
-            requireNotNull(args)
-        }
-    }
-
-    @Inject
-    lateinit var eventReporter: EventReporter
-
-    @Inject
-    lateinit var customerStateHolder: CustomerStateHolder
-
-    @Inject
-    lateinit var embeddedNavigator: EmbeddedNavigator
-
-    @Inject
-    lateinit var selectionHolder: EmbeddedSelectionHolder
-
-    @Inject
-    lateinit var sheetActivityRegistrar: SheetActivityRegistrar
-
-    @Inject
-    lateinit var sheetActivityStateHolder: SheetActivityStateHolder
+    private var coordinator: EmbeddedSheetActivityCoordinator? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val activityArgs = args ?: run {
+        val activityArgs = savedInstanceState?.let {
+            BundleCompat.getParcelable(it, STATE_ACTIVITY_ARGS, EmbeddedActivityArgs::class.java)
+        } ?: EmbeddedActivityArgs.fromIntent(intent) ?: run {
             finish()
             return
         }
-
         renderEdgeToEdge()
-        viewModel.component.inject(this)
-
-        sheetActivityRegistrar.registerAndBootstrap(
-            activityResultCaller = this,
-            lifecycleOwner = this,
+        val coordinator = EmbeddedSheetActivityCoordinator(
+            activity = this,
+            initialArgs = activityArgs,
+            presentationFactory = EmbeddedSheetPresentation,
         )
-
-        lifecycleScope.launch {
-            sheetActivityStateHolder.result.collect {
-                setActivityResult(it)
-                finish()
-            }
-        }
-
-        onBackPressedDispatcher.addCallback {
-            if (!embeddedNavigator.screen.value.isPerformingNetworkOperation().value) {
-                embeddedNavigator.performAction(EmbeddedNavigator.Action.Back)
-            }
-        }
-
+        this.coordinator = coordinator
+        coordinator.register()
         setContent {
             PaymentElementTheme(appearance = activityArgs.configuration.appearance) {
-                EventReporterProvider(eventReporter) {
-                    SheetContent()
+                val bottomSheetState = rememberStripeBottomSheetState(
+                    confirmValueChange = { coordinator.canDismiss() },
+                )
+                ElementsBottomSheetLayout(
+                    state = bottomSheetState,
+                    onDismissed = coordinator::onDismissed,
+                ) {
+                    coordinator.Content()
                 }
             }
         }
     }
 
-    @OptIn(ExperimentalMaterialApi::class)
-    @Composable
-    private fun SheetContent() {
-        val screen by embeddedNavigator.screen.collectAsState()
-        val bottomSheetState = rememberStripeBottomSheetState(
-            confirmValueChange = { !screen.isPerformingNetworkOperation().value }
-        )
-        ElementsBottomSheetLayout(
-            state = bottomSheetState,
-            onDismissed = ::dismissAndFinish,
-        ) {
-            var hasResult by remember { mutableStateOf(false) }
-            if (!hasResult) {
-                Box(modifier = Modifier.padding(bottom = 20.dp)) {
-                    EmbeddedSheetScreenContent(embeddedNavigator, screen)
-                }
-                LaunchedEffect(Unit) {
-                    embeddedNavigator.result.collect { result ->
-                        hasResult = true
-                        when (args?.launchMode) {
-                            is EmbeddedLaunchMode.Form -> dismissAndFinish()
-                            is EmbeddedLaunchMode.PaymentOptions -> {
-                                setCancelledPaymentOptionsResult()
-                                finish()
-                            }
-                            is EmbeddedLaunchMode.Manage, null -> {
-                                setManageResult(shouldInvokeSelectionCallback = result == true)
-                                finish()
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    public override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleNewIntent(intent)
+    }
+
+    internal fun handleNewIntent(intent: Intent) {
+        coordinator?.handleNewIntent(intent)
     }
 
     override fun finish() {
@@ -154,113 +63,19 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         fadeOut()
     }
 
+    override fun onSaveInstanceState(outState: Bundle) {
+        EmbeddedActivityArgs.fromIntent(intent)?.let {
+            outState.putParcelable(STATE_ACTIVITY_ARGS, it)
+        }
+        super.onSaveInstanceState(outState)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
-
-        if (isFinishing) {
-            if (::eventReporter.isInitialized) {
-                eventReporter.onDismiss()
-            }
-        }
+        coordinator?.onDestroy()
     }
 
-    private fun dismissAndFinish() {
-        when (val launchMode = args?.launchMode) {
-            is EmbeddedLaunchMode.Form -> {
-                setActivityResult(
-                    EmbeddedActivityResult.Cancelled(
-                        customerState = customerStateHolder.customer.value,
-                        launchMode = launchMode,
-                    )
-                )
-            }
-            is EmbeddedLaunchMode.Manage, null -> {
-                setManageResult(shouldInvokeSelectionCallback = false)
-            }
-            is EmbeddedLaunchMode.PaymentOptions -> {
-                setCancelledPaymentOptionsResult()
-            }
-        }
-        finish()
+    private companion object {
+        const val STATE_ACTIVITY_ARGS = "embedded_sheet_activity_args"
     }
-
-    private fun setManageResult(
-        shouldInvokeSelectionCallback: Boolean,
-    ) {
-        setActivityResult(
-            EmbeddedActivityResult.Complete(
-                selection = selectionHolder.selection.value,
-                previousNewSelections = selectionHolder.previousNewSelections,
-                hasBeenConfirmed = false,
-                customerState = customerStateHolder.customer.value,
-                checkoutSessionResponse = null,
-                shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
-                launchMode = args?.launchMode ?: EmbeddedLaunchMode.Manage,
-            )
-        )
-    }
-
-    private fun setCancelledPaymentOptionsResult() {
-        setActivityResult(
-            EmbeddedActivityResult.Cancelled(
-                customerState = customerStateHolder.customer.value,
-                launchMode = EmbeddedLaunchMode.PaymentOptions,
-            )
-        )
-    }
-
-    private fun setActivityResult(result: EmbeddedActivityResult) {
-        setResult(
-            Activity.RESULT_OK,
-            EmbeddedActivityResult.toIntent(intent, result)
-        )
-    }
-}
-
-@Composable
-internal fun EmbeddedSheetScreenContent(
-    navigator: EmbeddedNavigator,
-    screen: EmbeddedNavigator.Screen,
-) {
-    val density = LocalDensity.current
-    var contentHeight by remember { mutableStateOf(0.dp) }
-    val scrollState = rememberScrollState()
-    BottomSheetScaffold(
-        topBar = {
-            val topBarState by remember(screen) {
-                screen.topBarState()
-            }.collectAsState()
-            val isPerformingNetworkOperation by remember(screen) {
-                screen.isPerformingNetworkOperation()
-            }.collectAsState()
-            PaymentSheetTopBar(
-                state = topBarState,
-                canNavigateBack = navigator.canGoBack,
-                isEnabled = !isPerformingNetworkOperation,
-                handleBackPressed = { navigator.performAction(EmbeddedNavigator.Action.Back) },
-            )
-        },
-        content = {
-            val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
-            val headerText by remember(screen) {
-                screen.title()
-            }.collectAsState()
-            headerText?.let { text ->
-                H4Text(
-                    text = text.resolve(),
-                    modifier = Modifier
-                        .padding(bottom = 16.dp)
-                        .padding(horizontalPadding),
-                )
-            }
-
-            Column(modifier = Modifier.animateContentSize()) {
-                screen.Content()
-            }
-        },
-        modifier = Modifier.onGloballyPositioned {
-            contentHeight = with(density) { it.size.height.toDp() }
-        },
-        scrollState = scrollState,
-    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinator.kt
@@ -1,0 +1,79 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import android.content.Intent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.stripe.android.common.ui.PaymentElementActivityResultCaller
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+
+internal class EmbeddedSheetActivityCoordinator(
+    private val activity: EmbeddedSheetActivity,
+    initialArgs: EmbeddedActivityArgs,
+    private val presentationFactory: EmbeddedSheetPresentationFactory,
+) {
+    private var state by mutableStateOf(
+        State(
+            args = initialArgs,
+            presentation = presentationFactory.create(
+                activity = activity,
+                args = initialArgs,
+                activityResultCaller = activity,
+            ),
+        ),
+    )
+
+    fun register() {
+        state.presentation.register()
+    }
+
+    fun canDismiss(): Boolean {
+        return state.presentation.canDismiss()
+    }
+
+    fun onDismissed() {
+        state.presentation.onDismissed()
+    }
+
+    @Composable
+    fun Content() {
+        state.presentation.Content()
+    }
+
+    fun handleNewIntent(intent: Intent) {
+        val updatedArgs = EmbeddedActivityArgs.fromIntent(intent) ?: return
+        val isValidTransition =
+            !activity.isFinishing &&
+                state.args.presentationState == EmbeddedActivityArgs.PresentationState.Loading &&
+                state.args.launchMode is EmbeddedLaunchMode.PaymentOptions &&
+                updatedArgs.presentationState == EmbeddedActivityArgs.PresentationState.Ready &&
+                updatedArgs.launchMode is EmbeddedLaunchMode.PaymentOptions
+        if (!isValidTransition) return
+
+        activity.intent = intent
+        state.presentation.onDestroy()
+        state = State(
+            args = updatedArgs,
+            presentation = presentationFactory.create(
+                activity = activity,
+                args = updatedArgs,
+                activityResultCaller = PaymentElementActivityResultCaller(
+                    key = "EmbeddedSheetActivity_${updatedArgs.paymentElementCallbackIdentifier}",
+                    registryOwner = activity,
+                ),
+            ),
+        )
+        state.presentation.register()
+    }
+
+    fun onDestroy() {
+        state.presentation.onDestroy()
+    }
+
+    private data class State(
+        val args: EmbeddedActivityArgs,
+        val presentation: EmbeddedSheetPresentation,
+    )
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
@@ -42,10 +42,9 @@ import javax.inject.Singleton
 )
 @Singleton
 internal interface EmbeddedSheetComponent {
+    val viewModel: EmbeddedSheetViewModel
     val selectionHolder: EmbeddedSelectionHolder
     val customerStateHolder: CustomerStateHolder
-
-    fun inject(activity: EmbeddedSheetActivity)
 
     @Component.Factory
     interface Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetContract.kt
@@ -9,6 +9,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 internal object EmbeddedSheetContract : ActivityResultContract<EmbeddedActivityArgs, EmbeddedActivityResult>() {
     override fun createIntent(context: Context, input: EmbeddedActivityArgs): Intent {
         return Intent(context, EmbeddedSheetActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             .putExtra(EmbeddedActivityArgs.EXTRA_ARGS, input)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
@@ -1,0 +1,66 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import android.app.Activity
+import androidx.activity.result.ActivityResultCaller
+import androidx.compose.runtime.Composable
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+
+internal interface EmbeddedSheetPresentation {
+    fun register()
+
+    fun canDismiss(): Boolean
+
+    fun onDismissed()
+
+    @Composable
+    fun Content()
+
+    fun onDestroy()
+
+    interface Factory {
+        fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): EmbeddedSheetPresentation
+    }
+
+    companion object : EmbeddedSheetPresentationFactory {
+        override fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): EmbeddedSheetPresentation {
+            return when (args.presentationState) {
+                EmbeddedActivityArgs.PresentationState.Loading -> LoadingEmbeddedSheetPresentation.Factory.create(
+                    activity = activity,
+                    args = args,
+                    activityResultCaller = activityResultCaller,
+                )
+                EmbeddedActivityArgs.PresentationState.Ready ->
+                    EmbeddedSheetViewModel.Factory { args }.createReadyPresentation(
+                        activity = activity,
+                        args = args,
+                        activityResultCaller = activityResultCaller,
+                    )
+            }
+        }
+    }
+}
+
+internal interface EmbeddedSheetPresentationFactory {
+    fun create(
+        activity: EmbeddedSheetActivity,
+        args: EmbeddedActivityArgs,
+        activityResultCaller: ActivityResultCaller,
+    ): EmbeddedSheetPresentation
+}
+
+internal fun EmbeddedSheetActivity.finishWithResult(result: EmbeddedActivityResult) {
+    setResult(
+        Activity.RESULT_OK,
+        EmbeddedActivityResult.toIntent(intent, result),
+    )
+    finish()
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
@@ -11,9 +12,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import javax.inject.Inject
 
-internal class EmbeddedSheetViewModel(
-    val component: EmbeddedSheetComponent,
+internal class EmbeddedSheetViewModel @Inject constructor(
+    private val embeddedSheetPresentationFactory: ReadyEmbeddedSheetPresentation.Factory,
     @ViewModelScope private val customViewModelScope: CoroutineScope,
 ) : ViewModel() {
     override fun onCleared() {
@@ -23,6 +25,19 @@ internal class EmbeddedSheetViewModel(
     class Factory(
         private val argsSupplier: () -> EmbeddedActivityArgs,
     ) : ViewModelProvider.Factory {
+        fun createReadyPresentation(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): EmbeddedSheetPresentation {
+            val viewModel = ViewModelProvider(activity, this)[EmbeddedSheetViewModel::class.java]
+            return viewModel.embeddedSheetPresentationFactory.create(
+                activity = activity,
+                args = args,
+                activityResultCaller = activityResultCaller,
+            )
+        }
+
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val args = argsSupplier()
@@ -39,15 +54,11 @@ internal class EmbeddedSheetViewModel(
                 launchMode = args.launchMode,
                 viewModelScope = customViewModelScope,
             )
-
             component.customerStateHolder.setCustomerState(args.customerState)
             component.selectionHolder.setPreviousNewSelections(args.previousNewSelections)
             component.selectionHolder.setSelection(args.selection)
 
-            return EmbeddedSheetViewModel(
-                component = component,
-                customViewModelScope = customViewModelScope,
-            ) as T
+            return component.viewModel as T
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/LoadingEmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/LoadingEmbeddedSheetPresentation.kt
@@ -1,0 +1,66 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
+import androidx.activity.result.ActivityResultCaller
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.stripe.android.common.ui.BottomSheetLoadingIndicator
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+
+internal class LoadingEmbeddedSheetPresentation(
+    private val activity: EmbeddedSheetActivity,
+    private val args: EmbeddedActivityArgs,
+) : EmbeddedSheetPresentation {
+    private var backCallback: OnBackPressedCallback? = null
+
+    override fun register() {
+        backCallback = activity.onBackPressedDispatcher.addCallback {
+            activity.finishWithResult(createCancellationResult())
+        }
+    }
+
+    override fun canDismiss(): Boolean {
+        return true
+    }
+
+    override fun onDismissed() {
+        activity.finishWithResult(createCancellationResult())
+    }
+
+    @Composable
+    override fun Content() {
+        BottomSheetLoadingIndicator(
+            modifier = Modifier.testTag(EMBEDDED_SHEET_LOADING_TEST_TAG),
+        )
+    }
+
+    override fun onDestroy() {
+        backCallback?.remove()
+    }
+
+    private fun createCancellationResult(): EmbeddedActivityResult {
+        return EmbeddedActivityResult.Cancelled(
+            customerState = args.customerState,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+    }
+
+    object Factory : EmbeddedSheetPresentation.Factory {
+        override fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): LoadingEmbeddedSheetPresentation {
+            return LoadingEmbeddedSheetPresentation(
+                activity = activity,
+                args = args,
+            )
+        }
+    }
+}
+
+internal const val EMBEDDED_SHEET_LOADING_TEST_TAG = "embedded_sheet_loading"

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/ReadyEmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/ReadyEmbeddedSheetPresentation.kt
@@ -1,0 +1,218 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.activity.addCallback
+import androidx.activity.result.ActivityResultCaller
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import com.stripe.android.common.ui.BottomSheetScaffold
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
+import com.stripe.android.ui.core.elements.H4Text
+import com.stripe.android.uicore.getOuterFormInsets
+import com.stripe.android.uicore.strings.resolve
+import com.stripe.android.uicore.stripeFormInsets
+import com.stripe.android.uicore.utils.collectAsState
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.launch
+
+internal class ReadyEmbeddedSheetPresentation @AssistedInject constructor(
+    @Assisted private val activity: EmbeddedSheetActivity,
+    @Assisted private val args: EmbeddedActivityArgs,
+    @Assisted private val activityResultCaller: ActivityResultCaller,
+    private val eventReporter: EventReporter,
+    private val customerStateHolder: CustomerStateHolder,
+    private val embeddedNavigator: EmbeddedNavigator,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val sheetActivityRegistrar: SheetActivityRegistrar,
+    private val sheetActivityStateHolder: SheetActivityStateHolder,
+) : EmbeddedSheetPresentation {
+    override fun register() {
+        sheetActivityRegistrar.registerAndBootstrap(
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = activity,
+        )
+
+        activity.lifecycleScope.launch {
+            sheetActivityStateHolder.result.collect(activity::finishWithResult)
+        }
+
+        activity.onBackPressedDispatcher.addCallback {
+            if (!embeddedNavigator.screen.value.isPerformingNetworkOperation().value) {
+                embeddedNavigator.performAction(EmbeddedNavigator.Action.Back)
+            }
+        }
+    }
+
+    override fun canDismiss(): Boolean {
+        return !embeddedNavigator.screen.value.isPerformingNetworkOperation().value
+    }
+
+    override fun onDismissed() {
+        activity.finishWithResult(createDismissalResult())
+    }
+
+    @Composable
+    override fun Content() {
+        EventReporterProvider(eventReporter) {
+            EmbeddedSheetReadyContent(
+                navigator = embeddedNavigator,
+                onResult = { result ->
+                    activity.finishWithResult(createNavigatorResult(result))
+                },
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        if (activity.isFinishing) {
+            eventReporter.onDismiss()
+        }
+    }
+
+    private fun createDismissalResult(): EmbeddedActivityResult {
+        return when (val launchMode = args.launchMode) {
+            is EmbeddedLaunchMode.Form -> EmbeddedActivityResult.Cancelled(
+                customerState = customerStateHolder.customer.value,
+                launchMode = launchMode,
+            )
+            is EmbeddedLaunchMode.Manage -> createManageResult(
+                shouldInvokeSelectionCallback = false,
+                launchMode = launchMode,
+            )
+            is EmbeddedLaunchMode.PaymentOptions -> createPaymentOptionsCancellationResult()
+        }
+    }
+
+    private fun createNavigatorResult(result: Boolean?): EmbeddedActivityResult {
+        return when (val launchMode = args.launchMode) {
+            is EmbeddedLaunchMode.Form -> createDismissalResult()
+            is EmbeddedLaunchMode.Manage -> createManageResult(
+                shouldInvokeSelectionCallback = result == true,
+                launchMode = launchMode,
+            )
+            is EmbeddedLaunchMode.PaymentOptions -> createPaymentOptionsCancellationResult()
+        }
+    }
+
+    private fun createManageResult(
+        shouldInvokeSelectionCallback: Boolean,
+        launchMode: EmbeddedLaunchMode.Manage,
+    ): EmbeddedActivityResult {
+        return EmbeddedActivityResult.Complete(
+            selection = selectionHolder.selection.value,
+            previousNewSelections = selectionHolder.previousNewSelections,
+            hasBeenConfirmed = false,
+            customerState = customerStateHolder.customer.value,
+            checkoutSessionResponse = null,
+            shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
+            launchMode = launchMode,
+        )
+    }
+
+    private fun createPaymentOptionsCancellationResult(): EmbeddedActivityResult {
+        return EmbeddedActivityResult.Cancelled(
+            customerState = customerStateHolder.customer.value,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+    }
+
+    @Composable
+    private fun EmbeddedSheetReadyContent(
+        navigator: EmbeddedNavigator,
+        onResult: (Boolean?) -> Unit,
+    ) {
+        val screen by navigator.screen.collectAsState()
+        var hasResult by remember { mutableStateOf(false) }
+        if (!hasResult) {
+            Box(modifier = Modifier.padding(bottom = 20.dp)) {
+                EmbeddedSheetScreenContent(navigator, screen)
+            }
+            LaunchedEffect(navigator) {
+                navigator.result.collect { result ->
+                    hasResult = true
+                    onResult(result)
+                }
+            }
+        }
+    }
+
+    @AssistedFactory
+    interface Factory : EmbeddedSheetPresentation.Factory {
+        override fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): ReadyEmbeddedSheetPresentation
+    }
+}
+
+@Composable
+internal fun EmbeddedSheetScreenContent(
+    navigator: EmbeddedNavigator,
+    screen: EmbeddedNavigator.Screen,
+) {
+    val density = LocalDensity.current
+    var contentHeight by remember { mutableStateOf(0.dp) }
+    val scrollState = rememberScrollState()
+    BottomSheetScaffold(
+        topBar = {
+            val topBarState by remember(screen) {
+                screen.topBarState()
+            }.collectAsState()
+            val isPerformingNetworkOperation by remember(screen) {
+                screen.isPerformingNetworkOperation()
+            }.collectAsState()
+            PaymentSheetTopBar(
+                state = topBarState,
+                canNavigateBack = navigator.canGoBack,
+                isEnabled = !isPerformingNetworkOperation,
+                handleBackPressed = { navigator.performAction(EmbeddedNavigator.Action.Back) },
+            )
+        },
+        content = {
+            val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
+            val headerText by remember(screen) {
+                screen.title()
+            }.collectAsState()
+            headerText?.let { text ->
+                H4Text(
+                    text = text.resolve(),
+                    modifier = Modifier
+                        .padding(bottom = 16.dp)
+                        .padding(horizontalPadding),
+                )
+            }
+
+            Column(modifier = Modifier.animateContentSize()) {
+                screen.Content()
+            }
+        },
+        modifier = Modifier.onGloballyPositioned {
+            contentHeight = with(density) { it.size.height.toDp() }
+        },
+        scrollState = scrollState,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationFactory
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentelement.embedded.previousNewSelection
@@ -39,6 +40,10 @@ import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.asCallbackFor
 import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -81,6 +86,7 @@ internal class CheckoutSheetLauncherTest {
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
             ),
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
@@ -372,6 +378,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.Manage,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchManage(
@@ -500,6 +507,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchPaymentOptions(
@@ -512,6 +520,180 @@ internal class CheckoutSheetLauncherTest {
 
         assertThat(launchCall).isEqualTo(expectedArgs)
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `updating launch sends loading then refreshed ready arguments`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                mutationGate.await()
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+
+        val initialState = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = initialState.paymentMethodMetadata,
+            customerState = null,
+            selection = null,
+            configuration = initialState.configuration,
+        )
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(loadingArgs.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
+        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+
+        val refreshedMetadata = PaymentMethodMetadataFactory.create()
+        val refreshedConfiguration = EmbeddedConfigurationFactory.create(merchantDisplayName = "Refreshed merchant")
+        val refreshedCustomer = createCustomerState()
+        embeddedContentState.value = EmbeddedContentHelperStateHolder.State(
+            paymentMethodMetadata = refreshedMetadata,
+            embeddedViewDisplaysMandateText = true,
+            configuration = refreshedConfiguration,
+        )
+        customerStateHolder.setCustomerState(refreshedCustomer)
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(readyArgs.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
+        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
+        assertThat(readyArgs.paymentMethodMetadata).isEqualTo(refreshedMetadata)
+        assertThat(readyArgs.configuration).isEqualTo(refreshedConfiguration)
+        assertThat(readyArgs.customerState).isEqualTo(refreshedCustomer)
+        assertThat(readyArgs.selection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `recreated launcher sends ready arguments when mutation finishes`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                mutationGate.await()
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+
+        val initialState = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = initialState.paymentMethodMetadata,
+            customerState = null,
+            selection = null,
+            configuration = initialState.configuration,
+        )
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+        assertThat(launcherState.isAwaitingPaymentOptionsReady).isTrue()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        dummyActivityResultCallerScenario.awaitNextUnregisteredLauncher()
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        val recreatedLauncherState = CheckoutSheetLauncherState(savedStateHandle)
+        recreateSheetLauncher(TestLifecycleOwner(), recreatedLauncherState)
+        runCurrent()
+
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
+        assertThat(recreatedLauncherState.isAwaitingPaymentOptionsReady).isFalse()
+    }
+
+    @Test
+    fun `failed mutation sends retained state as ready arguments`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation<Unit> {
+                mutationGate.await()
+                Result.failure(IllegalStateException("Failed mutation"))
+            }
+        }
+        runCurrent()
+
+        val retainedState = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = retainedState.paymentMethodMetadata,
+            customerState = customerStateHolder.customer.value,
+            selection = selectionHolder.selection.value,
+            configuration = retainedState.configuration,
+        )
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
+        assertThat(readyArgs.paymentMethodMetadata).isEqualTo(retainedState.paymentMethodMetadata)
+        assertThat(readyArgs.configuration).isEqualTo(retainedState.configuration)
+    }
+
+    @Test
+    fun `missing refreshed state does not crash when mutation finishes`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                mutationGate.await()
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+
+        val initialState = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = initialState.paymentMethodMetadata,
+            customerState = null,
+            selection = null,
+            configuration = initialState.configuration,
+        )
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+
+        embeddedContentState.value = null
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            "unexpected_error.embedded.embedded_sheet_launcher.embedded_state_is_null"
+        )
+        assertThat(launcherState.isAwaitingPaymentOptionsReady).isTrue()
+    }
+
+    @Test
+    fun `cancelling loading suppresses ready launch`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                mutationGate.await()
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+
+        val state = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            customerState = null,
+            selection = null,
+            configuration = state.configuration,
+        )
+        dummyActivityResultCallerScenario.awaitLaunchCall()
+
+        registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(
+            EmbeddedActivityResult.Cancelled(
+                customerState = null,
+                launchMode = EmbeddedLaunchMode.PaymentOptions,
+            )
+        )
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(launcherState.isAwaitingPaymentOptionsReady).isFalse()
     }
 
     @Test
@@ -739,24 +921,41 @@ internal class CheckoutSheetLauncherTest {
             logger = logger,
             resultCallback = CheckoutController.ResultCallback {},
         )
+        val launcherState = CheckoutSheetLauncherState(savedStateHandle)
+        val embeddedContentState = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(
+            EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata = paymentMethodMetadata,
+                embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedConfigurationFactory.create(),
+            )
+        )
 
         DummyActivityResultCaller.test {
-            val sheetLauncher = CheckoutSheetLauncher(
-                activityResultCaller = activityResultCaller,
-                lifecycleOwner = lifecycleOwner,
-                selectionHolder = selectionHolder,
-                customerStateHolder = customerStateHolder,
-                sheetStateHolder = sheetStateHolder,
-                errorReporter = errorReporter,
-                sessionRefresher = sessionRefresher,
-                operationCoordinator = operationCoordinator,
-                logger = logger,
-                coroutineScope = testScope,
-                productUsage = setOf("Checkout"),
-                statusBarColor = null,
-                paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
-                rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
-            )
+            fun createSheetLauncher(
+                owner: TestLifecycleOwner,
+                state: CheckoutSheetLauncherState,
+            ): CheckoutSheetLauncher {
+                return CheckoutSheetLauncher(
+                    activityResultCaller = activityResultCaller,
+                    lifecycleOwner = owner,
+                    selectionHolder = selectionHolder,
+                    customerStateHolder = customerStateHolder,
+                    sheetStateHolder = sheetStateHolder,
+                    errorReporter = errorReporter,
+                    sessionRefresher = sessionRefresher,
+                    operationCoordinator = operationCoordinator,
+                    launcherState = state,
+                    embeddedContentState = embeddedContentState,
+                    logger = logger,
+                    coroutineScope = testScope,
+                    productUsage = setOf("Checkout"),
+                    statusBarColor = null,
+                    paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+                    rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
+                )
+            }
+
+            val sheetLauncher = createSheetLauncher(lifecycleOwner, launcherState)
             val registerCall = awaitRegisterCall()
             val launcher = awaitNextRegisteredLauncher()
 
@@ -777,6 +976,11 @@ internal class CheckoutSheetLauncherTest {
                 sessionRefresher = sessionRefresher,
                 logger = logger,
                 operationCoordinator = operationCoordinator,
+                launcherState = launcherState,
+                savedStateHandle = savedStateHandle,
+                embeddedContentState = embeddedContentState,
+                coroutineScope = testScope,
+                createSheetLauncher = ::createSheetLauncher,
                 runCurrent = testScheduler::runCurrent,
             ).block()
         }
@@ -799,10 +1003,27 @@ internal class CheckoutSheetLauncherTest {
         val sessionRefresher: FakeCheckoutSessionRefresher,
         val logger: FakeLogger,
         val operationCoordinator: CheckoutOperationCoordinator,
+        val launcherState: CheckoutSheetLauncherState,
+        val savedStateHandle: SavedStateHandle,
+        val embeddedContentState: MutableStateFlow<EmbeddedContentHelperStateHolder.State?>,
+        val coroutineScope: CoroutineScope,
+        private val createSheetLauncher: (
+            TestLifecycleOwner,
+            CheckoutSheetLauncherState,
+        ) -> CheckoutSheetLauncher,
         private val runCurrent: () -> Unit,
     ) {
         fun runCurrent() {
             runCurrent.invoke()
+        }
+
+        suspend fun recreateSheetLauncher(
+            lifecycleOwner: TestLifecycleOwner,
+            launcherState: CheckoutSheetLauncherState,
+        ) {
+            createSheetLauncher(lifecycleOwner, launcherState)
+            dummyActivityResultCallerScenario.awaitRegisterCall()
+            dummyActivityResultCallerScenario.awaitNextRegisteredLauncher()
         }
 
         suspend fun awaitRefreshCall(): FakeCheckoutSessionRefresher.Call {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -84,6 +84,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
             ),
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
@@ -408,6 +409,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.Manage,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchManage(
@@ -588,6 +590,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchPaymentOptions(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -33,7 +33,6 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetActivity
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.paymentsheet.createCustomerState
@@ -49,6 +48,8 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import com.stripe.android.paymentsheet.R as PaymentSheetR
 
 @RunWith(RobolectricTestRunner::class)
@@ -90,32 +91,13 @@ internal class EmbeddedSheetActivityTest {
     }
 
     @Test
-    fun `processing shows spinner and blocks back on form`() = launch { scenario ->
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.updateProcessing(true)
-        }
-        composeTestRule.waitForIdle()
-        primaryButton.performScrollTo()
-
-        composeTestRule.onNodeWithText(
-            applicationContext.getString(PaymentSheetR.string.stripe_paymentsheet_primary_button_processing)
-        ).assertIsDisplayed()
-        pressBack()
-        onIdle()
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.Form>()
-        }
-    }
-
-    @Test
     fun `checkout Continue displays error and keeps form open`() {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error":{"message":"Invalid tax region"}}""")
         }
 
-        launch(paymentMethodMetadata = checkoutPaymentMethodMetadata()) { scenario ->
+        launch(paymentMethodMetadata = checkoutPaymentMethodMetadata()) {
             val expectedError = applicationContext.getString(PaymentSheetR.string.stripe_something_went_wrong)
             fillOutCheckoutCard()
             primaryButton.performScrollTo().assertIsEnabled().performClick()
@@ -127,9 +109,45 @@ internal class EmbeddedSheetActivityTest {
             }
             composeTestRule.onNodeWithText(expectedError).performScrollTo().assertIsDisplayed()
             primaryButton.assertIsEnabled()
-            scenario.onActivity { activity ->
-                assertThat(activity.embeddedNavigator.screen.value)
-                    .isInstanceOf<EmbeddedNavigator.Screen.Form>()
+            formPage.waitUntilVisible()
+        }
+    }
+
+    @Test
+    fun `processing shows progress and blocks back on form`() {
+        val requestReceived = CountDownLatch(1)
+        val releaseResponse = CountDownLatch(1)
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"Invalid tax region"}}""")
+            requestReceived.countDown()
+            check(releaseResponse.await(10, TimeUnit.SECONDS))
+        }
+
+        launch(paymentMethodMetadata = checkoutPaymentMethodMetadata()) { scenario ->
+            try {
+                fillOutCheckoutCard()
+                primaryButton.performScrollTo().assertIsEnabled().performClick()
+                val processingLabel = applicationContext.getString(
+                    PaymentSheetR.string.stripe_paymentsheet_primary_button_processing
+                )
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    composeTestRule.onAllNodes(hasText(processingLabel))
+                        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                        .isNotEmpty()
+                }
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    requestReceived.count == 0L
+                }
+                composeTestRule.onNodeWithText(processingLabel).assertIsDisplayed()
+
+                scenario.onActivity { activity ->
+                    activity.onBackPressedDispatcher.onBackPressed()
+                }
+
+                formPage.waitUntilVisible()
+            } finally {
+                releaseResponse.countDown()
             }
         }
     }
@@ -183,31 +201,6 @@ internal class EmbeddedSheetActivityTest {
                 checkoutSessionResponse = response,
             ),
         )
-    }
-
-    @Test
-    fun `When SheetActivityStateHolder has result, activity finishes with that result`() = launch { scenario ->
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.setResult(
-                EmbeddedActivityResult.Complete(
-                    previousNewSelections = Bundle(),
-                    selection = null,
-                    hasBeenConfirmed = true,
-                    customerState = null,
-                    checkoutSessionResponse = null,
-                    shouldInvokeSelectionCallback = false,
-                    launchMode = EmbeddedLaunchMode.Form(
-                        selectedPaymentMethodCode = "card",
-                    ),
-                )
-            )
-        }
-
-        onIdle()
-
-        assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_OK)
-        val result = EmbeddedSheetContract.parseResult(scenario.result.resultCode, scenario.result.resultData)
-        assertThat(result).isInstanceOf<EmbeddedActivityResult.Complete>()
     }
 
     @Test
@@ -272,6 +265,7 @@ internal class EmbeddedSheetActivityTest {
                     launchMode = EmbeddedLaunchMode.Form(
                         selectedPaymentMethodCode = selectedPaymentMethodCode,
                     ),
+                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinatorTest.kt
@@ -1,0 +1,290 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.result.ActivityResultCaller
+import androidx.compose.runtime.Composable
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class EmbeddedSheetActivityCoordinatorTest {
+
+    @Test
+    fun `register delegates to initial presentation`() = runScenario {
+        coordinator.register()
+
+        assertThat(initialPresentation.registerCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `canDismiss delegates to current presentation`() = runScenario {
+        initialPresentation.canDismissResult = false
+
+        assertThat(coordinator.canDismiss()).isFalse()
+        assertThat(initialPresentation.canDismissCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `onDismissed delegates to current presentation`() = runScenario {
+        coordinator.onDismissed()
+
+        assertThat(initialPresentation.onDismissedCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `onDestroy delegates to initial presentation`() = runScenario {
+        coordinator.onDestroy()
+
+        assertThat(initialPresentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `valid loading to ready transition replaces presentation`() = runScenario {
+        val readyArgs = createArgs(
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            callbackIdentifier = "updated_callback_identifier",
+        )
+        val readyIntent = createIntent(readyArgs)
+
+        coordinator.handleNewIntent(readyIntent)
+
+        assertThat(initialPresentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
+        val createCall = presentationFactory.createCalls.awaitItem()
+        assertThat(createCall.activity).isSameInstanceAs(activity)
+        assertThat(createCall.args).isEqualTo(readyArgs)
+        assertThat(createCall.activityResultCaller).isNotSameInstanceAs(activity)
+        assertThat(readyPresentation.registerCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(activity.intent).isSameInstanceAs(readyIntent)
+
+        assertTransitionIgnored(
+            createIntent(
+                createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready),
+            )
+        )
+
+        coordinator.onDestroy()
+        assertThat(readyPresentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `intent without args is ignored`() = runScenario {
+        assertTransitionIgnored(Intent())
+    }
+
+    @Test
+    fun `loading intent is ignored`() = runScenario {
+        assertTransitionIgnored(
+            createIntent(
+                createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Loading),
+            )
+        )
+    }
+
+    @Test
+    fun `ready manage intent is ignored`() = runScenario {
+        assertTransitionIgnored(
+            createIntent(
+                createArgs(
+                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+                    launchMode = EmbeddedLaunchMode.Manage,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `ready coordinator ignores later ready intent`() = runScenario(
+        initialArgs = createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready),
+    ) {
+        assertTransitionIgnored(
+            createIntent(
+                createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready),
+            )
+        )
+    }
+
+    @Test
+    fun `non-payment-options coordinator ignores ready intent`() = runScenario(
+        initialArgs = createArgs(
+            presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+            launchMode = EmbeddedLaunchMode.Manage,
+        ),
+    ) {
+        assertTransitionIgnored(
+            createIntent(
+                createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready),
+            )
+        )
+    }
+
+    @Test
+    fun `finishing activity ignores ready intent`() = runScenario {
+        activity.finish()
+        assertThat(activity.isFinishing).isTrue()
+
+        assertTransitionIgnored(
+            createIntent(
+                createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready),
+            )
+        )
+    }
+
+    private fun runScenario(
+        initialArgs: EmbeddedActivityArgs = createArgs(
+            presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+        ),
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val activity = Robolectric.buildActivity(EmbeddedSheetActivity::class.java).get()
+        val initialPresentation = FakeEmbeddedSheetPresentation()
+        val readyPresentation = FakeEmbeddedSheetPresentation()
+        val presentationFactory = FakeEmbeddedSheetPresentationFactory(
+            initialPresentation = initialPresentation,
+            readyPresentation = readyPresentation,
+        )
+        val coordinator = EmbeddedSheetActivityCoordinator(
+            activity = activity,
+            initialArgs = initialArgs,
+            presentationFactory = presentationFactory,
+        )
+        val createCall = presentationFactory.createCalls.awaitItem()
+        assertThat(createCall.activity).isSameInstanceAs(activity)
+        assertThat(createCall.args).isEqualTo(initialArgs)
+        assertThat(createCall.activityResultCaller).isSameInstanceAs(activity)
+
+        Scenario(
+            activity = activity,
+            coordinator = coordinator,
+            initialPresentation = initialPresentation,
+            readyPresentation = readyPresentation,
+            presentationFactory = presentationFactory,
+        ).block()
+
+        presentationFactory.ensureAllEventsConsumed()
+        initialPresentation.ensureAllEventsConsumed()
+        readyPresentation.ensureAllEventsConsumed()
+    }
+
+    private data class Scenario(
+        val activity: EmbeddedSheetActivity,
+        val coordinator: EmbeddedSheetActivityCoordinator,
+        val initialPresentation: FakeEmbeddedSheetPresentation,
+        val readyPresentation: FakeEmbeddedSheetPresentation,
+        val presentationFactory: FakeEmbeddedSheetPresentationFactory,
+    ) {
+        suspend fun assertTransitionIgnored(intent: Intent) {
+            val originalIntent = activity.intent
+
+            coordinator.handleNewIntent(intent)
+
+            assertThat(activity.intent).isSameInstanceAs(originalIntent)
+            presentationFactory.createCalls.expectNoEvents()
+            initialPresentation.registerCalls.expectNoEvents()
+            initialPresentation.onDestroyCalls.expectNoEvents()
+            readyPresentation.registerCalls.expectNoEvents()
+            readyPresentation.onDestroyCalls.expectNoEvents()
+        }
+    }
+
+    private class FakeEmbeddedSheetPresentationFactory(
+        private val initialPresentation: EmbeddedSheetPresentation,
+        private val readyPresentation: EmbeddedSheetPresentation,
+    ) : EmbeddedSheetPresentationFactory {
+        val createCalls = Turbine<CreateCall>()
+
+        override fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): EmbeddedSheetPresentation {
+            createCalls.add(CreateCall(activity, args, activityResultCaller))
+            return when (args.presentationState) {
+                EmbeddedActivityArgs.PresentationState.Loading -> initialPresentation
+                EmbeddedActivityArgs.PresentationState.Ready -> readyPresentation
+            }
+        }
+
+        fun ensureAllEventsConsumed() {
+            createCalls.ensureAllEventsConsumed()
+        }
+
+        data class CreateCall(
+            val activity: EmbeddedSheetActivity,
+            val args: EmbeddedActivityArgs,
+            val activityResultCaller: ActivityResultCaller,
+        )
+    }
+
+    private class FakeEmbeddedSheetPresentation : EmbeddedSheetPresentation {
+        var canDismissResult = true
+
+        val registerCalls = Turbine<Unit>()
+        val canDismissCalls = Turbine<Unit>()
+        val onDismissedCalls = Turbine<Unit>()
+        val onDestroyCalls = Turbine<Unit>()
+
+        override fun register() {
+            registerCalls.add(Unit)
+        }
+
+        override fun canDismiss(): Boolean {
+            canDismissCalls.add(Unit)
+            return canDismissResult
+        }
+
+        override fun onDismissed() {
+            onDismissedCalls.add(Unit)
+        }
+
+        @Composable
+        override fun Content() = Unit
+
+        override fun onDestroy() {
+            onDestroyCalls.add(Unit)
+        }
+
+        fun ensureAllEventsConsumed() {
+            registerCalls.ensureAllEventsConsumed()
+            canDismissCalls.ensureAllEventsConsumed()
+            onDismissedCalls.ensureAllEventsConsumed()
+            onDestroyCalls.ensureAllEventsConsumed()
+        }
+    }
+
+    private companion object {
+        fun createArgs(
+            presentationState: EmbeddedActivityArgs.PresentationState,
+            launchMode: EmbeddedLaunchMode = EmbeddedLaunchMode.PaymentOptions,
+            callbackIdentifier: String = "callback_identifier",
+        ): EmbeddedActivityArgs {
+            return EmbeddedActivityArgs(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+                productUsage = setOf("EmbeddedPaymentElement"),
+                paymentElementCallbackIdentifier = callbackIdentifier,
+                statusBarColor = null,
+                selection = null,
+                previousNewSelections = Bundle(),
+                customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+                promotions = emptyList(),
+                launchMode = launchMode,
+                presentationState = presentationState,
+            )
+        }
+
+        fun createIntent(args: EmbeddedActivityArgs): Intent {
+            return Intent().putExtra(EmbeddedActivityArgs.EXTRA_ARGS, args)
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -276,6 +276,7 @@ internal class EmbeddedSheetActivityTest {
                     ),
                     promotions = emptyList(),
                     launchMode = EmbeddedLaunchMode.Manage,
+                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -18,7 +18,6 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onIdle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.checkoutUpdate
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -31,6 +30,7 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -40,9 +40,10 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
-import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
+import com.stripe.paymentelementtestpages.FormPage
 import com.stripe.paymentelementtestpages.ManagePage
 import com.stripe.paymentelementtestpages.VerticalModePage
 import org.junit.Rule
@@ -50,11 +51,14 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentOptionsEmbeddedSheetActivityTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
-    private val composeTestRule = createAndroidComposeRule<EmbeddedSheetActivity>()
+    private val composeTestRule = createEmptyComposeRule()
+    private val formPage = FormPage(composeTestRule)
     private val managePage = ManagePage(composeTestRule)
     private val verticalModePage = VerticalModePage(composeTestRule)
     private val networkRule = NetworkRule()
@@ -66,7 +70,83 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         .around(PaymentConfigurationTestRule(applicationContext))
 
     @Test
+    fun `loading renders and cancellation returns PaymentOptions`() = launch(
+        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+    ) { scenario ->
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
+
+        Espresso.pressBack()
+        onIdle()
+
+        val result = EmbeddedSheetContract.parseResult(
+            scenario.result.resultCode,
+            scenario.result.resultData,
+        ) as EmbeddedActivityResult.Cancelled
+        assertThat(result.customerState).isEqualTo(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
+        assertThat(result.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
+    }
+
+    @Test
+    fun `recreated loading activity remains loading`() = launch(
+        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+    ) { scenario ->
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
+
+        scenario.recreate()
+        onIdle()
+
+        scenario.onActivity { activity ->
+            assertThat(activity.isFinishing).isFalse()
+        }
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun `ready intent updates loading content without replacing composition and survives recreation`() = launch(
+        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+    ) { scenario ->
+        val readyIntent = EmbeddedSheetContract.createIntent(
+            applicationContext,
+            createArgs(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+                ),
+                presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            ),
+        )
+
+        scenario.recreate()
+        onIdle()
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
+
+        val initialBottomSheetNodeId = composeTestRule
+            .onNodeWithTag(BottomSheetContentTestTag)
+            .fetchSemanticsNode()
+            .id
+        scenario.onActivity { activity ->
+            activity.onNewIntent(readyIntent)
+        }
+        composeTestRule.waitForIdle()
+
+        formPage.waitUntilVisible()
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertDoesNotExist()
+        val currentBottomSheetNodeId = composeTestRule
+            .onNodeWithTag(BottomSheetContentTestTag)
+            .fetchSemanticsNode()
+            .id
+        assertThat(currentBottomSheetNodeId).isEqualTo(initialBottomSheetNodeId)
+
+        scenario.recreate()
+        onIdle()
+
+        formPage.waitUntilVisible()
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
     fun `pressing back returns cancelled result with PaymentOptions launch mode`() = launch { scenario ->
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertDoesNotExist()
+
         Espresso.pressBack()
 
         onIdle()
@@ -81,80 +161,48 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     }
 
     @Test
-    fun `when SheetActivityStateHolder has result, activity finishes with that result`() = launch { scenario ->
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.setResult(
-                EmbeddedActivityResult.Complete(
-                    previousNewSelections = Bundle(),
-                    selection = null,
-                    hasBeenConfirmed = false,
-                    customerState = null,
-                    checkoutSessionResponse = null,
-                    shouldInvokeSelectionCallback = false,
-                    launchMode = EmbeddedLaunchMode.PaymentOptions,
-                )
-            )
-        }
+    fun `continue returns the selection and previous new selections`() {
+        val previousNewSelection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION
+        val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
-        onIdle()
+        launch(
+            selection = selection,
+            previousNewSelections = Bundle().apply {
+                stashNewSelection(previousNewSelection)
+            },
+        ) { scenario ->
+            composeTestRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG)
+                .performScrollTo()
+                .assertIsEnabled()
+                .performClick()
+            onIdle()
 
-        assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_OK)
-        val result = EmbeddedSheetContract.parseResult(scenario.result.resultCode, scenario.result.resultData)
-        assertThat(result).isInstanceOf<EmbeddedActivityResult.Complete>()
-        val complete = result as EmbeddedActivityResult.Complete
-        assertThat(complete.launchMode).isEqualTo(
-            EmbeddedLaunchMode.PaymentOptions
-        )
-    }
-
-    @Test
-    fun `navigator back emits cancelled result`() = launch { scenario ->
-        scenario.onActivity { activity ->
-            activity.embeddedNavigator.performAction(EmbeddedNavigator.Action.Back)
-        }
-
-        onIdle()
-
-        assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_OK)
-        val result = EmbeddedSheetContract.parseResult(scenario.result.resultCode, scenario.result.resultData)
-        assertThat(result).isInstanceOf<EmbeddedActivityResult.Cancelled>()
-        val cancelled = result as EmbeddedActivityResult.Cancelled
-        assertThat(cancelled.launchMode).isEqualTo(
-            EmbeddedLaunchMode.PaymentOptions
-        )
-    }
-
-    @Test
-    fun `restores previously entered new selections into the selection holder`() = launch(
-        previousNewSelections = Bundle().apply {
-            stashNewSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-        },
-    ) { scenario ->
-        scenario.onActivity { activity ->
-            assertThat(activity.selectionHolder.getPreviousNewSelection("cashapp"))
-                .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            val result = EmbeddedSheetContract.parseResult(
+                scenario.result.resultCode,
+                scenario.result.resultData,
+            ) as EmbeddedActivityResult.Complete
+            assertThat(result.selection).isEqualTo(selection)
+            assertThat(result.previousNewSelections.previousNewSelection("cashapp"))
+                .isEqualTo(previousNewSelection)
+            assertThat(result.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
         }
     }
 
     @Test
-    fun `new selection requiring a form opens on the form and back returns to the list`() = launch(
+    fun `new selection requiring a form survives recreation and back returns to the list`() = launch(
         selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
     ) { scenario ->
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.canGoBack).isTrue()
-            assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.Form>()
-        }
+        formPage.waitUntilVisible()
+
+        scenario.recreate()
+        onIdle()
+        formPage.waitUntilVisible()
 
         Espresso.pressBack()
         onIdle()
 
-        // Back returns to the payment options list rather than cancelling the sheet.
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.canGoBack).isFalse()
-            assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
-        }
+        formPage.assertIsNotDisplayed()
+        verticalModePage.waitUntilVisible()
     }
 
     @Test
@@ -165,7 +213,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                 paymentMethods = paymentMethods,
             ),
-        ) { scenario ->
+        ) {
             verticalModePage.clickViewMore()
             managePage.waitUntilVisible()
 
@@ -174,41 +222,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
             managePage.assertNotVisible()
             verticalModePage.waitUntilVisible()
-            scenario.onActivity { activity ->
-                assertThat(activity.embeddedNavigator.canGoBack).isFalse()
-                assertThat(activity.embeddedNavigator.screen.value)
-                    .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
-            }
         }
-    }
-
-    @Test
-    fun `configuration change keeps saved payment method confirmation screen`() = launch { scenario ->
-        val interactor = FakeSavedPaymentMethodConfirmInteractor()
-        lateinit var originalScreen: EmbeddedNavigator.Screen.SavedPaymentMethodConfirm
-        scenario.onActivity { activity ->
-            originalScreen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
-                interactor = interactor,
-                isLiveMode = true,
-                sheetActivityStateHolder = activity.sheetActivityStateHolder,
-                confirmationHelper = FakeSheetActivityConfirmationHelper(),
-                embeddedSelectionHolder = activity.selectionHolder,
-                customerStateHolder = activity.customerStateHolder,
-                launchMode = EmbeddedLaunchMode.PaymentOptions,
-            )
-            activity.embeddedNavigator.performAction(
-                EmbeddedNavigator.Action.ReplaceCurrentScreen(originalScreen)
-            )
-        }
-        onIdle()
-
-        scenario.recreate()
-        onIdle()
-
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.screen.value).isSameInstanceAs(originalScreen)
-        }
-        interactor.validate()
     }
 
     @Test
@@ -223,40 +237,6 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     }
 
     @Test
-    fun `processing blocks back and disables vertical payment method rows`() = launch { scenario ->
-        val cardRow = composeTestRule.onNodeWithTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_card")
-        cardRow.assertIsEnabled()
-
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.updateProcessing(true)
-        }
-        composeTestRule.waitForIdle()
-
-        cardRow.assertIsNotEnabled()
-        composeTestRule.onNodeWithText(
-            applicationContext.getString(R.string.stripe_paymentsheet_primary_button_processing)
-        ).assertIsDisplayed()
-        Espresso.pressBack()
-        onIdle()
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
-        }
-    }
-
-    @Test
-    fun `vertical payment options displays activity error`() = launch { scenario ->
-        val errorMessage = "Unable to update the tax region."
-
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.updateError(errorMessage.resolvableString)
-        }
-        composeTestRule.waitForIdle()
-
-        composeTestRule.onNodeWithText(errorMessage).assertIsDisplayed()
-    }
-
-    @Test
     fun `saved checkout selection displays update error and re-enables payment options`() {
         val selection = savedSelectionWithBillingAddress()
         networkRule.checkoutUpdate { response ->
@@ -267,7 +247,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         launch(
             selection = selection,
             paymentMethodMetadata = checkoutPaymentMethodMetadata(),
-        ) { scenario ->
+        ) {
             val primaryButton = composeTestRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG)
             val expectedError = applicationContext.getString(R.string.stripe_something_went_wrong)
             primaryButton.performScrollTo().assertIsDisplayed().assertIsEnabled().performClick()
@@ -280,10 +260,54 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             composeTestRule.onNodeWithText(expectedError).performScrollTo().assertIsDisplayed()
             primaryButton.assertIsEnabled()
             composeTestRule.onNodeWithTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_card").assertIsEnabled()
-            scenario.onActivity { activity ->
-                assertThat(activity.embeddedNavigator.screen.value)
-                    .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
-                assertThat(activity.sheetActivityStateHolder.state.value.isProcessing).isFalse()
+            verticalModePage.waitUntilVisible()
+        }
+    }
+
+    @Test
+    fun `processing disables payment options and blocks back`() {
+        val requestReceived = CountDownLatch(1)
+        val releaseResponse = CountDownLatch(1)
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"Invalid tax region"}}""")
+            requestReceived.countDown()
+            check(releaseResponse.await(10, TimeUnit.SECONDS))
+        }
+
+        launch(
+            selection = savedSelectionWithBillingAddress(),
+            paymentMethodMetadata = checkoutPaymentMethodMetadata(),
+        ) { scenario ->
+            try {
+                val cardRow = composeTestRule.onNodeWithTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_card")
+                cardRow.assertIsEnabled()
+                composeTestRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG)
+                    .performScrollTo()
+                    .assertIsEnabled()
+                    .performClick()
+                val processingLabel = applicationContext.getString(
+                    R.string.stripe_paymentsheet_primary_button_processing
+                )
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    composeTestRule.onAllNodesWithText(processingLabel)
+                        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                        .isNotEmpty()
+                }
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    requestReceived.count == 0L
+                }
+                cardRow.assertIsNotEnabled()
+                composeTestRule.onNodeWithText(processingLabel).assertIsDisplayed()
+
+                scenario.onActivity { activity ->
+                    activity.onBackPressedDispatcher.onBackPressed()
+                }
+
+                verticalModePage.waitUntilVisible()
+                cardRow.assertIsNotEnabled()
+            } finally {
+                releaseResponse.countDown()
             }
         }
     }
@@ -294,6 +318,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         ),
+        presentationState: EmbeddedActivityArgs.PresentationState = EmbeddedActivityArgs.PresentationState.Ready,
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) = launch(
         selection = selection,
@@ -304,6 +329,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                 listOf(it.paymentMethod)
             }.orEmpty(),
         ),
+        presentationState = presentationState,
         block = block,
     )
 
@@ -325,27 +351,47 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         previousNewSelections: Bundle,
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
+        presentationState: EmbeddedActivityArgs.PresentationState = EmbeddedActivityArgs.PresentationState.Ready,
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) {
         ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
             EmbeddedSheetContract.createIntent(
                 context = applicationContext,
-                input = EmbeddedActivityArgs(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-                    productUsage = setOf("EmbeddedPaymentElement"),
-                    statusBarColor = null,
-                    paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
+                input = createArgs(
                     selection = selection,
                     previousNewSelections = previousNewSelections,
+                    paymentMethodMetadata = paymentMethodMetadata,
                     customerState = customerState,
-                    promotions = emptyList(),
-                    launchMode = EmbeddedLaunchMode.PaymentOptions,
+                    presentationState = presentationState,
                 ),
             )
         ).use { scenario ->
             block(scenario)
         }
+    }
+
+    private fun createArgs(
+        selection: PaymentSelection? = null,
+        previousNewSelections: Bundle = Bundle(),
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        ),
+        customerState: CustomerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+        presentationState: EmbeddedActivityArgs.PresentationState,
+    ): EmbeddedActivityArgs {
+        return EmbeddedActivityArgs(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+            productUsage = setOf("EmbeddedPaymentElement"),
+            statusBarColor = null,
+            paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
+            selection = selection,
+            previousNewSelections = previousNewSelections,
+            customerState = customerState,
+            promotions = emptyList(),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = presentationState,
+        )
     }
 
     private fun checkoutPaymentMethodMetadata(): PaymentMethodMetadata {


### PR DESCRIPTION
# Summary

- Present the embedded payment-options loading sheet immediately while Checkout mutations finish.
- Transition the existing activity to refreshed ready arguments with `singleTop`, then create one immutable `EmbeddedSheetComponent`.
- Keep loading out of `EmbeddedLaunchMode`, dependency injection, navigation, and activity results.

# Motivation

Checkout can open embedded payment options while a session mutation is still refreshing its arguments. Building the sheet component from the pre-refresh arguments leaves long-lived dependencies with stale state. This keeps the immediate loading presentation while deferring component construction until refreshed arguments are available.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Validated with focused `:paymentsheet:testDebugUnitTest` launcher and Robolectric activity tests, `./gradlew :paymentsheet:compileDebugAndroidTestKotlin :paymentsheet:apiCheck`, and repository-wide `./gradlew detekt`.

No tests were newly ignored.

# Screenshots

Not applicable: the existing loading indicator is preserved without visual changes.

# Changelog

Not applicable: this is an internal Checkout/embedded-sheet initialization fix with no public API change.

Committed and created by Codex.
