### PR TITLE
Add horizontal PaymentElement content

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -33,6 +33,7 @@ import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_VERT
 import com.stripe.paymentelementtestpages.BillingDetailsPage
 import com.stripe.paymentelementtestpages.VerticalModePage
 import okhttp3.mockwebserver.MockResponse
+import org.json.JSONArray
 import org.json.JSONObject
 import org.junit.After
 import org.junit.Rule
@@ -104,6 +105,47 @@ internal class CheckoutPaymentElementTest {
             contentPage.clickOnLpm("card")
             formPage.fillOutCardDetails()
             formPage.clickPrimaryButton()
+            context.confirm()
+        }
+
+        assertThat(checkoutResult).isInstanceOf(CheckoutController.Result.Completed::class.java)
+    }
+
+    @Test
+    fun testSingleLpmDisplaysAndConfirmsInlineForm() {
+        var checkoutResult: CheckoutController.Result? = null
+        lateinit var controller: CheckoutController
+        runCheckoutPaymentElementTest(
+            networkRule = networkRule,
+            resultCallback = { result -> checkoutResult = result },
+            checkoutInitResponse = { response ->
+                response.testBodyFromFile("checkout-session-init.json") { json ->
+                    json.put("customer_email", "checkout@example.com")
+                    json.getJSONObject("elements_session").apply {
+                        remove("link_settings")
+                        put("ordered_payment_method_types_and_wallets", JSONArray(listOf("card")))
+                        getJSONObject("payment_method_preference")
+                            .put("ordered_payment_method_types", JSONArray(listOf("card")))
+                    }
+                    json.getJSONObject("server_built_elements_session_params")
+                        .getJSONObject("deferred_intent")
+                        .put("payment_method_types", JSONArray(listOf("card")))
+                }
+            },
+            setup = {
+                controller = it
+                it.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+            },
+        ) { context ->
+            networkRule.createPaymentMethod()
+            networkRule.checkoutConfirm { response ->
+                response.testBodyFromFile("checkout-session-confirm.json")
+            }
+
+            formPage.fillOutCardDetails()
+            testRules.compose.waitUntil {
+                controller.session.value?.paymentOptionDisplayData != null
+            }
             context.confirm()
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -3,7 +3,11 @@ package com.stripe.android.checkout.injection
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.CheckoutLinkPaymentOptionsPresenter
 import com.stripe.android.checkout.CheckoutSheetLauncher
+import com.stripe.android.elements.DefaultPaymentElementHorizontalContentFactory
+import com.stripe.android.elements.DefaultPaymentElementHorizontalContentHelper
 import com.stripe.android.elements.PaymentElement
+import com.stripe.android.elements.PaymentElementHorizontalContentFactory
+import com.stripe.android.elements.PaymentElementHorizontalContentHelper
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentMethodSelectionLauncher
@@ -39,6 +43,16 @@ internal const val CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER =
 
 @Module
 internal interface PaymentElementModule {
+    @Binds
+    fun bindsPaymentElementHorizontalContentFactory(
+        factory: DefaultPaymentElementHorizontalContentFactory
+    ): PaymentElementHorizontalContentFactory
+
+    @Binds
+    fun bindsPaymentElementHorizontalContentHelper(
+        helper: DefaultPaymentElementHorizontalContentHelper
+    ): PaymentElementHorizontalContentHelper
+
     @Binds
     fun bindsEmbeddedContentHelper(helper: DefaultEmbeddedContentHelper): EmbeddedContentHelper
 

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -22,17 +22,20 @@ import javax.inject.Inject
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class PaymentElement @Inject internal constructor(
     private val contentHelper: EmbeddedContentHelper,
+    private val horizontalContentHelper: PaymentElementHorizontalContentHelper,
 ) {
 
     /**
      * A composable function that displays payment methods inline.
      *
-     * It can present a sheet to collect more details or display saved payment methods.
+     * It displays the full payment method form for horizontal layouts without saved payment methods.
+     * Otherwise, it can present a sheet to collect more details or display saved payment methods.
      */
     @Composable
     fun Content() {
+        val horizontalContent by horizontalContentHelper.content.collectAsState()
         val embeddedContent by contentHelper.embeddedContent.collectAsState()
-        embeddedContent?.Content()
+        horizontalContent?.Content() ?: embeddedContent?.Content()
     }
 
     /**
@@ -115,9 +118,7 @@ class PaymentElement @Inject internal constructor(
         }
 
         /**
-         * The layout of payment methods in the sheet. Defaults to [PaymentMethodLayout.Automatic].
-         *
-         * Note: Only used if you call [present].
+         * The layout of payment methods in [Content] and the sheet. Defaults to [PaymentMethodLayout.Automatic].
          *
          * @see [PaymentMethodLayout] for the list of available layouts.
          */

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElementHorizontalContent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElementHorizontalContent.kt
@@ -1,0 +1,211 @@
+package com.stripe.android.elements
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.stripe.android.core.injection.ViewModelScope
+import com.stripe.android.core.strings.ResolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
+import com.stripe.android.payments.bankaccount.CollectBankAccountLauncher.Companion.HOSTED_SURFACE_PAYMENT_ELEMENT
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.model.paymentMethodType
+import com.stripe.android.paymentsheet.paymentdatacollection.ach.USBankAccountFormArguments
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
+import com.stripe.android.paymentsheet.ui.AddPaymentMethod
+import com.stripe.android.paymentsheet.ui.AddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.ui.DefaultAddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.ui.PaymentElementTheme
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
+import com.stripe.android.paymentsheet.utils.childScope
+import com.stripe.android.paymentsheet.verticalmode.BankFormInteractor
+import com.stripe.android.paymentsheet.verticalmode.EmbeddedMandate
+import com.stripe.android.paymentsheet.verticalmode.PaymentMethodIncentiveInteractor
+import com.stripe.android.uicore.utils.collectAsState
+import com.stripe.android.uicore.utils.mapAsStateFlow
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import java.io.Closeable
+import javax.inject.Inject
+
+internal interface PaymentElementHorizontalContentHelper {
+    val content: StateFlow<PaymentElementHorizontalContent?>
+}
+
+internal class DefaultPaymentElementHorizontalContentHelper @Inject constructor(
+    @ViewModelScope coroutineScope: CoroutineScope,
+    state: StateFlow<EmbeddedContentHelperStateHolder.State?>,
+    customerStateHolder: CustomerStateHolder,
+    private val contentFactory: PaymentElementHorizontalContentFactory,
+) : PaymentElementHorizontalContentHelper {
+    private val _content = MutableStateFlow<PaymentElementHorizontalContent?>(null)
+    override val content: StateFlow<PaymentElementHorizontalContent?> = _content.asStateFlow()
+
+    init {
+        coroutineScope.launch {
+            combine(state, customerStateHolder.paymentMethods) { currentState, savedPaymentMethods ->
+                currentState?.takeIf {
+                    savedPaymentMethods.isEmpty() &&
+                        it.paymentMethodMetadata.paymentMethodOrientation() == PaymentMethodOrientation.Horizontal
+                }
+            }.distinctUntilChanged().collect { horizontalState ->
+                val replacement = horizontalState?.let(contentFactory::create)
+                _content.value?.close()
+                _content.value = replacement
+            }
+        }
+    }
+}
+
+internal fun interface PaymentElementHorizontalContentFactory {
+    fun create(state: EmbeddedContentHelperStateHolder.State): PaymentElementHorizontalContent
+}
+
+internal class DefaultPaymentElementHorizontalContentFactory @Inject constructor(
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val embeddedFormHelperFactory: EmbeddedFormHelperFactory,
+    private val confirmationHandler: ConfirmationHandler,
+    private val eventReporter: EventReporter,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
+) : PaymentElementHorizontalContentFactory {
+    @Suppress("LongMethod")
+    override fun create(state: EmbeddedContentHelperStateHolder.State): PaymentElementHorizontalContent {
+        val paymentMethodMetadata = state.paymentMethodMetadata
+        val interactorScope = coroutineScope.childScope(Dispatchers.Main)
+        val initialCode = selectionHolder.selection.value?.paymentMethodType
+            ?.takeIf { it in paymentMethodMetadata.supportedPaymentMethodTypes() }
+            ?: paymentMethodMetadata.supportedPaymentMethodTypes().first()
+        val mandate = MutableStateFlow<ResolvableString?>(null)
+        val formHelper = embeddedFormHelperFactory.create(
+            coroutineScope = interactorScope,
+            setAsDefaultMatchesSaveForFutureUse = true,
+            paymentMethodMetadata = paymentMethodMetadata,
+            eventReporter = eventReporter,
+            automaticallyLaunchedCardScanFormDataHelper =
+                embeddedFormHelperFactory.createAutomaticallyLaunchedCardScanFormDataHelper(
+                    selectedPaymentMethodCode = initialCode,
+                    paymentMethodMetadata = paymentMethodMetadata,
+                ),
+            tapToAddHelper = null,
+            paymentMethodMessagePromotionsHelper = paymentMethodMessagePromotionsHelper,
+            autocompleteAddressInteractorFactory = null,
+            selectionUpdater = selectionHolder::setSelection,
+        )
+        val bankFormInteractor = BankFormInteractor(
+            updateSelection = selectionHolder::setSelection,
+            paymentMethodIncentiveInteractor = PaymentMethodIncentiveInteractor(
+                paymentMethodMetadata.paymentMethodIncentive
+            ),
+        )
+        val validationRequested = MutableSharedFlow<Unit>()
+        val interactor = DefaultAddPaymentMethodInteractor(
+            initiallySelectedPaymentMethodType = initialCode,
+            selection = selectionHolder.selection,
+            processing = confirmationHandler.state.mapAsStateFlow {
+                it is ConfirmationHandler.State.Confirming
+            },
+            validationRequested = validationRequested,
+            incentive = bankFormInteractor.paymentMethodIncentiveInteractor.displayedIncentive,
+            supportedPaymentMethods = paymentMethodMetadata.sortedSupportedPaymentMethods(),
+            createFormArguments = formHelper::createFormArguments,
+            formElementsForCode = formHelper::formElementsForCode,
+            clearErrorMessages = {},
+            reportFieldInteraction = eventReporter::onPaymentMethodFormInteraction,
+            onFormFieldValuesChanged = formHelper::onFormFieldValuesChanged,
+            reportPaymentMethodTypeSelected = eventReporter::onSelectPaymentMethod,
+            reportPromotionDisplayed = { code ->
+                paymentMethodMessagePromotionsHelper.reportPromotionDisplayed(code, paymentMethodMetadata)
+            },
+            createUSBankAccountFormArguments = { code ->
+                USBankAccountFormArguments.createForEmbedded(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    selectedPaymentMethodCode = code,
+                    hostedSurface = HOSTED_SURFACE_PAYMENT_ELEMENT,
+                    isCompleteFlow = false,
+                    draftPaymentSelection = null,
+                    bankFormInteractor = bankFormInteractor,
+                    hasSavedPaymentMethods = customerStateHolder.paymentMethods.value.isNotEmpty(),
+                    autocompleteAddressInteractorFactory = null,
+                    onMandateTextChanged = { updatedMandate, _ -> mandate.value = updatedMandate },
+                    onAnalyticsEvent = eventReporter::onUsBankAccountFormEvent,
+                    onUpdatePrimaryButtonUIState = {},
+                    onError = {},
+                    onFormCompleted = {
+                        eventReporter.onPaymentMethodFormCompleted(PaymentMethod.Type.USBankAccount.code)
+                    },
+                )
+            },
+            coroutineScope = interactorScope,
+            uiContext = Dispatchers.Main,
+            onInitiallyDisplayedPaymentMethodVisibilitySnapshot = { visiblePaymentMethods, hiddenPaymentMethods ->
+                eventReporter.onInitiallyDisplayedPaymentMethodVisibilitySnapshot(
+                    visiblePaymentMethods = visiblePaymentMethods,
+                    hiddenPaymentMethods = hiddenPaymentMethods,
+                    walletsState = null,
+                    isVerticalLayout = false,
+                )
+            },
+            isLiveMode = paymentMethodMetadata.stripeIntent.isLiveMode,
+        )
+
+        return DefaultPaymentElementHorizontalContent(
+            interactor = interactor,
+            mandate = mandate,
+            embeddedViewDisplaysMandateText = state.embeddedViewDisplaysMandateText,
+            appearance = state.configuration.appearance,
+            eventReporter = eventReporter,
+            elementsSessionId = paymentMethodMetadata.elementsSessionId,
+        )
+    }
+}
+
+internal interface PaymentElementHorizontalContent : Closeable {
+    @Composable
+    fun Content()
+}
+
+internal class DefaultPaymentElementHorizontalContent(
+    private val interactor: AddPaymentMethodInteractor,
+    private val mandate: StateFlow<ResolvableString?>,
+    private val embeddedViewDisplaysMandateText: Boolean,
+    private val appearance: PaymentSheet.Appearance,
+    private val eventReporter: EventReporter,
+    private val elementsSessionId: String?,
+) : PaymentElementHorizontalContent {
+    @Composable
+    override fun Content() {
+        val currentMandate by mandate.collectAsState()
+        EventReporterProvider(eventReporter, elementsSessionId) {
+            PaymentElementTheme(appearance = appearance) {
+                Column(Modifier.animateContentSize()) {
+                    AddPaymentMethod(interactor = interactor)
+                    EmbeddedMandate(
+                        embeddedViewDisplaysMandateText = embeddedViewDisplaysMandateText,
+                        mandate = currentMandate,
+                    )
+                }
+            }
+        }
+    }
+
+    override fun close() {
+        interactor.close()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/verticalmode/PaymentMethodEmbeddedLayoutUI.kt
@@ -189,7 +189,7 @@ private fun OptionalEmbeddedDivider(rowStyle: Embedded.RowStyle) {
 }
 
 @Composable
-private fun EmbeddedMandate(
+internal fun EmbeddedMandate(
     embeddedViewDisplaysMandateText: Boolean,
     mandate: ResolvableString?,
 ) {

--- a/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementHorizontalContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementHorizontalContentHelperTest.kt
@@ -1,0 +1,164 @@
+package com.stripe.android.elements
+
+import app.cash.turbine.Turbine
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateFactory
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
+import com.stripe.android.paymentsheet.FakeCustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class PaymentElementHorizontalContentHelperTest {
+    @Test
+    fun `creates horizontal content when resolved layout is horizontal and no saved methods exist`() = runTest {
+        val state = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(null)
+        val content = FakeHorizontalContent()
+        val factory = FakeHorizontalContentFactory(content)
+        val customerStateHolder = FakeCustomerStateHolder()
+        val helper = DefaultPaymentElementHorizontalContentHelper(
+            coroutineScope = backgroundScope,
+            state = state,
+            customerStateHolder = customerStateHolder,
+            contentFactory = factory,
+        )
+        val horizontalState = createState(PaymentSheet.PaymentMethodLayout.Horizontal)
+
+        helper.content.test {
+            assertThat(awaitItem()).isNull()
+
+            state.value = horizontalState
+            runCurrent()
+
+            assertThat(awaitItem()).isSameInstanceAs(content)
+        }
+        assertThat(factory.createCalls.awaitItem()).isEqualTo(horizontalState)
+        factory.ensureAllEventsConsumed()
+        content.ensureAllEventsConsumed()
+        customerStateHolder.validate()
+    }
+
+    @Test
+    fun `does not create horizontal content when saved methods exist`() = runTest {
+        val state = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(null)
+        val content = FakeHorizontalContent()
+        val factory = FakeHorizontalContentFactory(content)
+        val customerStateHolder = FakeCustomerStateHolder(
+            paymentMethods = listOf(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
+        )
+        val helper = DefaultPaymentElementHorizontalContentHelper(
+            coroutineScope = backgroundScope,
+            state = state,
+            customerStateHolder = customerStateHolder,
+            contentFactory = factory,
+        )
+
+        state.value = createState(PaymentSheet.PaymentMethodLayout.Horizontal)
+        runCurrent()
+
+        assertThat(helper.content.value).isNull()
+        factory.createCalls.expectNoEvents()
+        factory.ensureAllEventsConsumed()
+        content.ensureAllEventsConsumed()
+        customerStateHolder.validate()
+    }
+
+    @Test
+    fun `does not create horizontal content when resolved layout is vertical`() = runTest {
+        val state = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(null)
+        val content = FakeHorizontalContent()
+        val factory = FakeHorizontalContentFactory(content)
+        val customerStateHolder = FakeCustomerStateHolder()
+        val helper = DefaultPaymentElementHorizontalContentHelper(
+            coroutineScope = backgroundScope,
+            state = state,
+            customerStateHolder = customerStateHolder,
+            contentFactory = factory,
+        )
+
+        state.value = createState(PaymentSheet.PaymentMethodLayout.Vertical)
+        runCurrent()
+
+        assertThat(helper.content.value).isNull()
+        factory.createCalls.expectNoEvents()
+        factory.ensureAllEventsConsumed()
+        content.ensureAllEventsConsumed()
+        customerStateHolder.validate()
+    }
+
+    @Test
+    fun `closes horizontal content when state is cleared`() = runTest {
+        val state = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(
+            createState(PaymentSheet.PaymentMethodLayout.Horizontal)
+        )
+        val content = FakeHorizontalContent()
+        val factory = FakeHorizontalContentFactory(content)
+        val customerStateHolder = FakeCustomerStateHolder()
+        val helper = DefaultPaymentElementHorizontalContentHelper(
+            coroutineScope = backgroundScope,
+            state = state,
+            customerStateHolder = customerStateHolder,
+            contentFactory = factory,
+        )
+        runCurrent()
+
+        assertThat(helper.content.value).isSameInstanceAs(content)
+        assertThat(factory.createCalls.awaitItem()).isEqualTo(state.value)
+
+        state.value = null
+        runCurrent()
+
+        assertThat(helper.content.value).isNull()
+        content.closeCalls.awaitItem()
+        factory.ensureAllEventsConsumed()
+        content.ensureAllEventsConsumed()
+        customerStateHolder.validate()
+    }
+
+    private fun createState(layout: PaymentSheet.PaymentMethodLayout): EmbeddedContentHelperStateHolder.State {
+        return EmbeddedContentHelperStateFactory.create(
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                    paymentMethodTypes = listOf("card"),
+                ),
+                paymentMethodLayout = layout,
+            )
+        )
+    }
+
+    private class FakeHorizontalContentFactory(
+        private val content: PaymentElementHorizontalContent,
+    ) : PaymentElementHorizontalContentFactory {
+        val createCalls = Turbine<EmbeddedContentHelperStateHolder.State>()
+
+        override fun create(state: EmbeddedContentHelperStateHolder.State): PaymentElementHorizontalContent {
+            createCalls.add(state)
+            return content
+        }
+
+        fun ensureAllEventsConsumed() {
+            createCalls.ensureAllEventsConsumed()
+        }
+    }
+
+    private class FakeHorizontalContent : PaymentElementHorizontalContent {
+        val closeCalls = Turbine<Unit>()
+
+        @androidx.compose.runtime.Composable
+        override fun Content() = Unit
+
+        override fun close() {
+            closeCalls.add(Unit)
+        }
+
+        fun ensureAllEventsConsumed() {
+            closeCalls.ensureAllEventsConsumed()
+        }
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/PaymentElementTest.kt
@@ -1,28 +1,37 @@
 package com.stripe.android.elements
 
+import android.os.Build
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.elements.PaymentElement.Configuration.GooglePayConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContent
 import com.stripe.android.paymentelement.embedded.content.FakeEmbeddedContentHelper
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
+import com.stripe.android.paymentsheet.analytics.FakeEventReporter
+import com.stripe.android.paymentsheet.ui.FORM_ELEMENT_TEST_TAG
+import com.stripe.android.paymentsheet.ui.FakeAddPaymentMethodInteractor
+import com.stripe.android.paymentsheet.ui.TEST_TAG_LIST
 import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT
 import com.stripe.android.testing.createComposeCleanupRule
+import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.Test
 
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
 internal class PaymentElementTest {
 
     @get:Rule
@@ -64,7 +73,7 @@ internal class PaymentElementTest {
     @Test
     fun `present delegates to the content helper`() = runTest {
         val contentHelper = FakeEmbeddedContentHelper()
-        val paymentElement = PaymentElement(contentHelper)
+        val paymentElement = PaymentElement(contentHelper, FakeHorizontalContentHelper())
 
         paymentElement.present()
 
@@ -75,7 +84,7 @@ internal class PaymentElementTest {
     @Test
     fun `Content renders nothing when there is no embedded content`() {
         val contentHelper = FakeEmbeddedContentHelper(embeddedContent = MutableStateFlow(null))
-        val paymentElement = PaymentElement(contentHelper)
+        val paymentElement = PaymentElement(contentHelper, FakeHorizontalContentHelper())
 
         composeRule.setContent {
             paymentElement.Content()
@@ -97,13 +106,84 @@ internal class PaymentElementTest {
             isImmediateAction = false,
         )
         val contentHelper = FakeEmbeddedContentHelper(embeddedContent = MutableStateFlow(content))
-        val paymentElement = PaymentElement(contentHelper)
+        val paymentElement = PaymentElement(contentHelper, FakeHorizontalContentHelper())
 
         composeRule.setContent {
             paymentElement.Content()
         }
 
         composeRule.onNodeWithTag(TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT).assertIsDisplayed()
+    }
+
+    @Test
+    fun `Content renders the entire horizontal form when one LPM is available`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card"),
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        )
+        val horizontalContent = DefaultPaymentElementHorizontalContent(
+            interactor = FakeAddPaymentMethodInteractor(
+                initialState = FakeAddPaymentMethodInteractor.createState(metadata = metadata),
+            ),
+            mandate = stateFlowOf(null),
+            embeddedViewDisplaysMandateText = true,
+            appearance = PaymentSheet.Appearance(),
+            eventReporter = FakeEventReporter(),
+            elementsSessionId = null,
+        )
+        val embeddedContent = EmbeddedContent(
+            interactor = FakePaymentMethodVerticalLayoutInteractor.create(metadata),
+            embeddedViewDisplaysMandateText = true,
+            appearance = PaymentSheet.Appearance(
+                embeddedAppearance = Embedded(Embedded.RowStyle.FloatingButton.default),
+            ),
+            isImmediateAction = false,
+        )
+        val paymentElement = PaymentElement(
+            contentHelper = FakeEmbeddedContentHelper(MutableStateFlow(embeddedContent)),
+            horizontalContentHelper = FakeHorizontalContentHelper(MutableStateFlow(horizontalContent)),
+        )
+
+        composeRule.setContent {
+            paymentElement.Content()
+        }
+
+        composeRule.onNodeWithTag(FORM_ELEMENT_TEST_TAG).assertIsDisplayed()
+        composeRule.onNodeWithTag(TEST_TAG_LIST).assertDoesNotExist()
+        composeRule.onNodeWithTag(TEST_TAG_PAYMENT_METHOD_EMBEDDED_LAYOUT).assertDoesNotExist()
+    }
+
+    @Test
+    fun `Content renders horizontal tabs and form when multiple LPMs are available`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.copy(
+                paymentMethodTypes = listOf("card", "cashapp"),
+            ),
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        )
+        val horizontalContent = DefaultPaymentElementHorizontalContent(
+            interactor = FakeAddPaymentMethodInteractor(
+                initialState = FakeAddPaymentMethodInteractor.createState(metadata = metadata),
+            ),
+            mandate = stateFlowOf(null),
+            embeddedViewDisplaysMandateText = true,
+            appearance = PaymentSheet.Appearance(),
+            eventReporter = FakeEventReporter(),
+            elementsSessionId = null,
+        )
+        val paymentElement = PaymentElement(
+            contentHelper = FakeEmbeddedContentHelper(),
+            horizontalContentHelper = FakeHorizontalContentHelper(MutableStateFlow(horizontalContent)),
+        )
+
+        composeRule.setContent {
+            paymentElement.Content()
+        }
+
+        composeRule.onNodeWithTag(TEST_TAG_LIST).assertIsDisplayed()
+        composeRule.onNodeWithTag(FORM_ELEMENT_TEST_TAG).assertIsDisplayed()
     }
 
     @Test
@@ -128,4 +208,8 @@ internal class PaymentElementTest {
 
         assertThat(callbackInvoked).isTrue()
     }
+
+    private class FakeHorizontalContentHelper(
+        override val content: MutableStateFlow<PaymentElementHorizontalContent?> = MutableStateFlow(null),
+    ) : PaymentElementHorizontalContentHelper
 }


### PR DESCRIPTION
# Summary

- Add horizontal layout support to Checkout `PaymentElement.Content()`.
- Render the full form inline when horizontal mode has no saved payment methods, omitting the selector when only one LPM is available.
- Preserve the existing embedded row layout for vertical mode and customers with saved payment methods.

# Motivation

`PaymentElement.Content()` previously always rendered the embedded vertical rows, even when its configuration resolved to horizontal mode. This prevented single-LPM Checkout integrations from displaying and collecting the complete payment form inline.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew :paymentsheet:compileDebugAndroidTestKotlin`
- `./gradlew :paymentsheet:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class='com.stripe.android.checkout.CheckoutPaymentElementTest#testSingleLpmDisplaysAndConfirmsInlineForm'`
- `./gradlew detekt`

No tests were newly ignored.

# Screenshots

Not applicable — this reuses the existing horizontal payment form UI, with rendering covered by Compose and on-device integration tests.

# Changelog

Not applicable — `PaymentElement` remains a Checkout Session preview API and this does not change a stable public API.

Committed and created by Codex.
