### PR TITLE
Fix duplicate Link save checkbox in Checkout Sessions

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -107,8 +107,8 @@ internal class DefaultCreateLinkState @Inject constructor(
             signupModeResult = getLinkSignupMode(
                 accountStatus = accountStatus,
                 elementsSession = elementsSession,
-                configuration = configuration,
                 linkConfiguration = linkConfiguration,
+                customerMetadata = customerMetadata,
             )
         )
     }
@@ -176,8 +176,8 @@ internal class DefaultCreateLinkState @Inject constructor(
     private fun getLinkSignupMode(
         accountStatus: AccountStatus,
         elementsSession: ElementsSession,
-        configuration: CommonConfiguration,
         linkConfiguration: LinkConfiguration,
+        customerMetadata: CustomerMetadata?,
     ): LinkSignupModeResult {
         if (accountStatus != AccountStatus.SignedOut) {
             return LinkSignupModeResult.AlreadyRegistered
@@ -195,8 +195,8 @@ internal class DefaultCreateLinkState @Inject constructor(
         val isSaveForFutureUseValueChangeable = isSaveForFutureUseValueChangeable(
             code = PaymentMethod.Type.Card.code,
             intent = elementsSession.stripeIntent,
-            paymentMethodSaveConsentBehavior = elementsSession.toPaymentSheetSaveConsentBehavior(),
-            hasCustomerConfiguration = configuration.customer != null,
+            paymentMethodSaveConsentBehavior = customerMetadata?.saveConsent,
+            hasCustomerConfiguration = customerMetadata != null,
         )
         val signupMode = when {
             // If signup toggle enabled, we show a future usage + link combined toggle

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -3,11 +3,14 @@ package com.stripe.android.paymentsheet.state
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilterFactory
 import com.stripe.android.model.ClientAttributionMetadata
@@ -108,6 +111,33 @@ internal class DefaultCreateLinkStateTest {
         val disabledState = result as LinkDisabledState
         assertThat(disabledState.linkDisabledReasons)
             .contains(LinkDisabledReason.AutomaticTaxBillingAddress)
+    }
+
+    @Test
+    fun `uses checkout session save consent to determine Link signup mode`() = runTest {
+        val createLinkState = createLinkStateFactory()
+        val elementsSession = createElementsSession()
+        val customerMetadata = CustomerMetadata.CheckoutSession(
+            sessionId = "cs_test_123",
+            customerId = "cus_123",
+            removePaymentMethod = PaymentMethodRemovePermission.None,
+            saveConsent = PaymentMethodSaveConsentBehavior.Enabled,
+        )
+        val initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+            instancesKey = "DefaultCreateLinkStateTest",
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(elementsSession = elementsSession),
+        )
+
+        val result = createLinkState(
+            elementsSession = elementsSession,
+            configuration = PaymentSheetFixtures.CONFIG_MINIMUM.asCommonConfiguration(),
+            initializationMode = initializationMode,
+            customerMetadata = customerMetadata,
+            clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+        )
+
+        assertThat(result).isInstanceOf<LinkState>()
+        assertThat((result as LinkState).signupMode).isEqualTo(LinkSignupMode.AlongsideSaveForFutureUse)
     }
 
     private fun testLinkInlineSignupWithSavedPaymentMethodsEnabledFlag(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -2344,7 +2344,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         val result = loader.load(
             initializationMode = DEFAULT_INITIALIZATION_MODE,
-            paymentSheetConfiguration = DEFAULT_PAYMENT_SHEET_CONFIG,
+            paymentSheetConfiguration = CUSTOMER_SESSION_PAYMENT_SHEET_CONFIG,
             metadata = PaymentElementLoader.Metadata(
                 initializedViaCompose = false,
             ),
@@ -2369,7 +2369,7 @@ internal class DefaultPaymentElementLoaderTest {
 
         val result = loader.load(
             initializationMode = DEFAULT_INITIALIZATION_MODE,
-            paymentSheetConfiguration = DEFAULT_PAYMENT_SHEET_CONFIG,
+            paymentSheetConfiguration = CUSTOMER_SESSION_PAYMENT_SHEET_CONFIG,
             metadata = PaymentElementLoader.Metadata(
                 initializedViaCompose = false,
             ),
@@ -5093,6 +5093,13 @@ internal class DefaultPaymentElementLoaderTest {
             customer = PaymentSheet.CustomerConfiguration(
                 id = "cus_123",
                 ephemeralKeySecret = "ek_123",
+            ),
+        )
+        private val CUSTOMER_SESSION_PAYMENT_SHEET_CONFIG = PaymentSheet.Configuration(
+            merchantDisplayName = "Some Name",
+            customer = PaymentSheet.CustomerConfiguration.createWithCustomerSession(
+                id = "cus_1",
+                clientSecret = "cuss_1",
             ),
         )
         private val DEFAULT_INITIALIZATION_MODE = PaymentElementLoader.InitializationMode.PaymentIntent(


### PR DESCRIPTION
# Summary

- Use `CustomerMetadata.saveConsent` when choosing the Link inline signup mode.
- Add regression coverage for Checkout Sessions that allow customers to save payment methods.

# Motivation

Checkout Sessions model the customer and save consent differently from ordinary PaymentSheet integrations. The customer comes from the Checkout Session response, and `saved_payment_methods_offer_save` is converted into `CustomerMetadata.saveConsent`; consequently, `CommonConfiguration.customer` remains null.

The card form already used `CustomerMetadata` to decide whether to show its "Save for future use" checkbox. Link independently reconstructed that decision from `ElementsSession.toPaymentSheetSaveConsentBehavior()` and `CommonConfiguration.customer`. For a Checkout Session that offered saving, these calculations disagreed:

- The card form saw an eligible Checkout Session customer and displayed "Save for future use."
- Link saw a null configuration customer, assumed no save checkbox was available, selected `InsteadOfSaveForFutureUse`, and displayed its own checkbox.

That produced two checkboxes in the same card form. `DefaultCreateLinkState` already receives the resolved `CustomerMetadata`, so this change uses its save consent and presence for Link's calculation as well. Both the card form and Link now share the same source of truth, causing Link to select `AlongsideSaveForFutureUse` when the Checkout Session save checkbox is present.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.paymentsheet.state.DefaultCreateLinkStateTest'`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable. This is a state-selection fix covered by a focused regression test; no visual assets changed.

# Changelog

Not applicable. Checkout Session support is a preview API, and this corrects its internal Link form state selection.

Committed and created by Codex.
