### PR TITLE
Add additonal EmbeddedPaymentElementTests

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -1,9 +1,14 @@
 package com.stripe.android.paymentelement
 
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextReplacement
+import androidx.test.espresso.intent.rule.IntentsRule
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -14,6 +19,7 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.utils.TestRules
+import com.stripe.android.paymentsheet.utils.UsBankAccountFormTestUtils
 import com.stripe.paymentelementnetwork.CardPaymentMethodDetails
 import com.stripe.paymentelementnetwork.setupPaymentMethodDetachResponse
 import com.stripe.paymentelementnetwork.setupV1PaymentMethodsResponse
@@ -29,7 +35,9 @@ internal class EmbeddedPaymentElementTest {
     private val networkRule = NetworkRule()
 
     @get:Rule
-    val testRules: TestRules = TestRules.create(networkRule = networkRule)
+    val testRules: TestRules = TestRules.create(networkRule = networkRule) {
+        around(IntentsRule())
+    }
 
     private val embeddedContentPage = EmbeddedContentPage(testRules.compose)
     private val managePage = ManagePage(testRules.compose)
@@ -339,6 +347,222 @@ internal class EmbeddedPaymentElementTest {
         )
 
         testContext.markTestSucceeded()
+    }
+
+    @Test
+    fun testSuccessfulCashAppPayment() = runEmbeddedPaymentElementTest(
+        networkRule = networkRule,
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success("pi_example_secret_12345")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        testContext.configure {
+            formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+        }
+
+        embeddedContentPage.clickOnLpm("cashapp")
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_methods"),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/payment_intents/pi_example"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-get-requires_payment_method.json")
+        }
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm.json")
+        }
+
+        testContext.consumePaymentOptionEvent("cashapp", "Cash App Pay")
+        testContext.confirm()
+        assertThat(testContext.paymentOptionTurbine.awaitItem()).isNull()
+    }
+
+    @Test
+    fun testSuccessfulUsBankAccountPayment() = runEmbeddedPaymentElementTest(
+        networkRule = networkRule,
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success("pi_example_secret_example")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        UsBankAccountFormTestUtils.setupSuccessfulCompletionOfUsBankAccountForm()
+
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        testContext.configure {
+            allowsDelayedPaymentMethods(true)
+            formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+        }
+
+        embeddedContentPage.clickOnLpm("us_bank_account")
+
+        formPage.waitUntilVisible()
+        testRules.compose.onNode(hasText("Full name"))
+            .performTextReplacement("Jane Doe")
+        testRules.compose.onNode(hasText("Email"))
+            .performTextReplacement("janedoe@example.com")
+
+        formPage.clickPrimaryButtonWithoutWaitingForDismissal()
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_methods"),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create-us_bank_account.json")
+        }
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/payment_intents/pi_example"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-get-requires_payment_method-us_bank_account.json")
+        }
+        networkRule.enqueue(
+            host("api.stripe.com"),
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm-us_bank_account.json")
+        }
+
+        formPage.clickPrimaryButton()
+        formPage.waitUntilMissing()
+    }
+
+    @Test
+    fun testSuccessfulCardPaymentWithLinkSignUp() = runEmbeddedPaymentElementTest(
+        networkRule = networkRule,
+        createIntentCallback = { _, _ ->
+            CreateIntentResult.Success("pi_example_secret_12345")
+        },
+        resultCallback = ::assertCompleted,
+    ) { testContext ->
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-requires_payment_method.json")
+        }
+
+        testContext.configure {
+            formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+        }
+
+        embeddedContentPage.clickOnLpm("card")
+        formPage.fillOutCardDetails()
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/sessions/lookup"),
+        ) { response ->
+            response.testBodyFromFile("consumer-session-lookup-success.json")
+        }
+
+        // Click the "Save my info" checkbox and fill out Link signup fields
+        testRules.compose.onNode(hasText("Save my info for faster checkout with Link"))
+            .performClick()
+
+        testRules.compose.onNode(hasText("Email"))
+            .performTextReplacement("email@email.com")
+
+        testRules.compose.waitUntil(timeoutMillis = 15_000) {
+            testRules.compose
+                .onAllNodes(hasText("Phone number"))
+                .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                .isNotEmpty()
+        }
+
+        testRules.compose.onNode(hasText("Phone number"))
+            .performTextReplacement("+12113526421")
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/accounts/sign_up"),
+        ) { response ->
+            response.testBodyFromFile("consumer-accounts-signup-success.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/consumers/payment_details"),
+            bodyPart("card[number]", "4242424242424242"),
+        ) { response ->
+            response.testBodyFromFile("consumer-payment-details-success.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_methods"),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        networkRule.enqueue(
+            method("GET"),
+            path("/v1/payment_intents/pi_example"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-get-requires_payment_method.json")
+        }
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_intents/pi_example/confirm"),
+        ) { response ->
+            response.testBodyFromFile("payment-intent-confirm.json")
+        }
+
+        formPage.clickPrimaryButton()
+        formPage.waitUntilMissing()
+    }
+
+    @Test
+    fun testCardMetadataQueryExecutedOncePerCardSessionForBin() {
+        repeat(2) {
+            runEmbeddedPaymentElementTest(
+                networkRule = networkRule,
+                createIntentCallback = { _, shouldSavePaymentMethod ->
+                    assertThat(shouldSavePaymentMethod).isFalse()
+                    CreateIntentResult.Success("pi_example_secret_12345")
+                },
+                resultCallback = ::assertCompleted
+            ) { testContext ->
+                networkRule.elementsSession { response ->
+                    response.testBodyFromFile("elements-sessions-requires_payment_method_with_cbc.json")
+                }
+
+                testContext.configure{
+                    formSheetAction(EmbeddedPaymentElement.FormSheetAction.Confirm)
+                }
+
+                networkRule.enqueue(
+                    method("GET"),
+                    path("edge-internal/card-metadata")
+                ) { response ->
+                    response.testBodyFromFile("card-metadata-get.json")
+                }
+
+                embeddedContentPage.clickOnLpm("card")
+                formPage.fillOutCardDetails()
+
+                enqueueDeferredIntentConfirmationRequests()
+
+                formPage.clickPrimaryButton()
+                formPage.waitUntilMissing()
+            }
+        }
     }
 
     private fun enqueueDeferredIntentConfirmationRequests() {


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
- Add network tests for Link signup, US Bank account, cashapp, and card metadata to EmbeddedPaymentElementTest

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Pre-work for ApiConfiguration

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [ ] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
