### PR TITLE
Add emailRequired to Express Checkout Element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ NEXT_VERSION_BUMP: MINOR
 * [ADDED] Added support for SeQura.
 * [ADDED] Added support for PAYCO.
 * [ADDED] Added support for Korean cards.
-* [ADDED] Added `ExpressCheckoutElement.Configuration.emailRequired` to require email collection.
 
 ### AddressElement
 * [CHANGED] Use Stripe-hosted address autocomplete by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ NEXT_VERSION_BUMP: MINOR
 * [ADDED] Added support for SeQura.
 * [ADDED] Added support for PAYCO.
 * [ADDED] Added support for Korean cards.
+* [ADDED] Added `ExpressCheckoutElement.Configuration.emailRequired` to require email collection.
 
 ### AddressElement
 * [CHANGED] Use Stripe-hosted address autocomplete by default.

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -43,6 +43,11 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
                 configuration.toExpressCheckoutElementGooglePayConfiguration(checkoutSessionResponse),
             linkConfiguration = expressCheckoutElementConfiguration.linkConfiguration.asPaymentSheet(),
             billingDetailsCollectionConfiguration = PaymentSheetBillingDetails(
+                email = if (expressCheckoutElementConfiguration.emailRequired) {
+                    PaymentSheetBillingDetails.CollectionMode.Always
+                } else {
+                    PaymentSheetBillingDetails.CollectionMode.Automatic
+                },
                 address = if (checkoutSessionResponse.requiresBillingAddress) {
                     PaymentSheetBillingDetails.AddressCollectionMode.Full
                 } else {

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
@@ -334,6 +334,7 @@ class ExpressCheckoutElement @Inject internal constructor(
         private var googlePayConfiguration: GooglePayConfiguration = GooglePayConfiguration()
 
         private var shippingAddressRequired: Boolean = false
+        private var emailRequired: Boolean = false
         private var paymentMethodOrder: List<PaymentMethod> = emptyList()
         private var appearance: Appearance = Appearance()
 
@@ -354,6 +355,17 @@ class ExpressCheckoutElement @Inject internal constructor(
             shippingAddressRequired: Boolean,
         ): Configuration = apply {
             this.shippingAddressRequired = shippingAddressRequired
+        }
+
+        /**
+         * Sets whether an email address is required.
+         *
+         * @param emailRequired If true, the customer's email will be collected.
+         */
+        fun emailRequired(
+            emailRequired: Boolean,
+        ): Configuration = apply {
+            this.emailRequired = emailRequired
         }
 
         /**
@@ -379,6 +391,7 @@ class ExpressCheckoutElement @Inject internal constructor(
             val linkConfiguration: LinkConfiguration.State,
             val googlePayConfiguration: CheckoutGooglePayConfiguration,
             val shippingAddressRequired: Boolean,
+            val emailRequired: Boolean,
             val paymentMethodOrder: List<PaymentMethodType>,
             val appearance: Appearance.State,
         ) : Parcelable
@@ -392,6 +405,7 @@ class ExpressCheckoutElement @Inject internal constructor(
             linkConfiguration = linkConfiguration.build(),
             googlePayConfiguration = googlePayConfiguration.build(),
             shippingAddressRequired = shippingAddressRequired,
+            emailRequired = emailRequired,
             paymentMethodOrder = paymentMethodOrder.map { paymentMethod ->
                 when (paymentMethod) {
                     is PaymentMethod.GooglePay -> PaymentMethodType.GooglePay

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -235,6 +235,24 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
+    fun `createForExpressCheckoutElement always collects email when required`() {
+        val configuration = CheckoutController.Configuration()
+            .expressCheckoutElement(
+                ExpressCheckoutElement.Configuration().emailRequired(true)
+            )
+            .build()
+
+        val result = factory().createForExpressCheckoutElement(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result?.billingDetailsCollectionConfiguration?.email)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
+    }
+
+    @Test
     fun `createForPaymentElement uses payment element configuration`() {
         val configuration = CheckoutController.Configuration()
             .paymentElement(


### PR DESCRIPTION
# Summary
Add `ExpressCheckoutElement.Configuration.emailRequired(Boolean)` and map it to always collect email in the PaymentSheet billing details configuration.

Committed and created by Codex.

# Motivation
Recent change to the ECE API review: https://docs.google.com/document/d/18Mn6y4NG7V-pkiJLRW7wi1w_a0GGAnJWnBkTGYK9Ato/edit?tab=t.0

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified