### PR TITLE
Load ECE-specific payment method metadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -10,6 +10,8 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -50,6 +52,7 @@ internal class CheckoutStateLoader @Inject constructor(
         customerStateHolder.setCustomerState(null)
     }
 
+    @Suppress("LongMethod")
     private suspend fun commit(
         configuration: CheckoutController.Configuration.State,
         response: CheckoutSessionResponse,
@@ -73,21 +76,46 @@ internal class CheckoutStateLoader @Inject constructor(
             collectedDetails = collectedDetails,
         )
 
-        val loaderState = paymentElementLoader.load(
-            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
-                instancesKey = response.id,
-                checkoutSessionResponse = response,
-            ),
-            integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
-                isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
-                configuration = embeddedConfig,
-                paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout.asPaymentSheet(),
-            ),
-            metadata = PaymentElementLoader.Metadata(
-                isReloadingAfterProcessDeath = false,
-                initializedViaCompose = false,
-            ),
-        ).getOrThrow()
+        val expressCheckoutElementConfiguration = commonConfigurationFactory.createForExpressCheckoutElement(
+            configuration = configuration,
+            checkoutSessionResponse = response,
+            collectedDetails = collectedDetails,
+        )
+
+        val initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(response.id, response)
+
+        val paymentElementLoaderMetadata = PaymentElementLoader.Metadata(
+            isReloadingAfterProcessDeath = false,
+            initializedViaCompose = false,
+        )
+
+        val (loaderState, expressCheckoutElementPaymentMethodMetadata) = coroutineScope {
+            val loaderState = async {
+                paymentElementLoader.load(
+                    initializationMode = initializationMode,
+                    integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
+                        isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
+                        configuration = embeddedConfig,
+                        paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout
+                            .asPaymentSheet(),
+                    ),
+                    metadata = paymentElementLoaderMetadata,
+                ).getOrThrow()
+            }
+            val expressCheckoutElementMetadata = expressCheckoutElementConfiguration?.let { eceConfiguration ->
+                async {
+                    paymentElementLoader.load(
+                        initializationMode = initializationMode,
+                        integrationConfiguration = PaymentElementLoader.Configuration.ExpressCheckoutElement(
+                            commonConfiguration = eceConfiguration,
+                        ),
+                        metadata = paymentElementLoaderMetadata,
+                    ).getOrThrow().paymentMethodMetadata
+                }
+            }
+
+            loaderState.await() to expressCheckoutElementMetadata?.await()
+        }
 
         // Preserve the customer's existing selection across reloads when it's still valid, rather
         // than blindly adopting the loader's recomputed selection (reuses the embedded logic). The
@@ -107,7 +135,7 @@ internal class CheckoutStateLoader @Inject constructor(
             flagImages = flagImages,
             collectedDetails = collectedDetails,
             paymentMethodMetadata = loaderState.paymentMethodMetadata,
-            expressCheckoutElementPaymentMethodMetadata = loaderState.paymentMethodMetadata,
+            expressCheckoutElementPaymentMethodMetadata = expressCheckoutElementPaymentMethodMetadata,
             embeddedConfiguration = embeddedConfig,
             paymentSelection = selection,
             temporarySelection = carryForward.temporarySelection,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -10,8 +10,6 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -89,33 +87,25 @@ internal class CheckoutStateLoader @Inject constructor(
             initializedViaCompose = false,
         )
 
-        val (loaderState, expressCheckoutElementPaymentMethodMetadata) = coroutineScope {
-            val loaderState = async {
-                paymentElementLoader.load(
-                    initializationMode = initializationMode,
-                    integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
-                        isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
-                        configuration = embeddedConfig,
-                        paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout
-                            .asPaymentSheet(),
-                    ),
-                    metadata = paymentElementLoaderMetadata,
-                ).getOrThrow()
-            }
-            val expressCheckoutElementMetadata = expressCheckoutElementConfiguration?.let { eceConfiguration ->
-                async {
-                    paymentElementLoader.load(
-                        initializationMode = initializationMode,
-                        integrationConfiguration = PaymentElementLoader.Configuration.ExpressCheckoutElement(
-                            commonConfiguration = eceConfiguration,
-                        ),
-                        metadata = paymentElementLoaderMetadata,
-                    ).getOrThrow().paymentMethodMetadata
-                }
-            }
-
-            loaderState.await() to expressCheckoutElementMetadata?.await()
-        }
+        val loaderState = paymentElementLoader.load(
+            initializationMode = initializationMode,
+            integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
+                isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
+                configuration = embeddedConfig,
+                paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout
+                    .asPaymentSheet(),
+            ),
+            metadata = paymentElementLoaderMetadata,
+        ).getOrThrow()
+        val expressCheckoutElementLoaderState = expressCheckoutElementConfiguration?.let { eceConfiguration ->
+            paymentElementLoader.load(
+                initializationMode = initializationMode,
+                integrationConfiguration = PaymentElementLoader.Configuration.ExpressCheckoutElement(
+                    commonConfiguration = eceConfiguration,
+                ),
+                metadata = paymentElementLoaderMetadata,
+            )
+        }?.getOrThrow()
 
         // Preserve the customer's existing selection across reloads when it's still valid, rather
         // than blindly adopting the loader's recomputed selection (reuses the embedded logic). The
@@ -135,7 +125,7 @@ internal class CheckoutStateLoader @Inject constructor(
             flagImages = flagImages,
             collectedDetails = collectedDetails,
             paymentMethodMetadata = loaderState.paymentMethodMetadata,
-            expressCheckoutElementPaymentMethodMetadata = expressCheckoutElementPaymentMethodMetadata,
+            expressCheckoutElementPaymentMethodMetadata = expressCheckoutElementLoaderState?.paymentMethodMetadata,
             embeddedConfiguration = embeddedConfig,
             paymentSelection = selection,
             temporarySelection = carryForward.temporarySelection,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
@@ -125,13 +125,19 @@ internal class DefaultAnalyticsMetadataFactory @Inject constructor(
     }
 
     private fun PaymentElementLoader.Configuration.analyticsMap() = buildMap<String, AnalyticsMetadata.Value> {
-        putAll(commonConfiguration.analyticsMap())
-
         when (this@analyticsMap) {
-            is PaymentElementLoader.Configuration.PaymentSheet -> putAll(analyticsMap())
-            is PaymentElementLoader.Configuration.Embedded -> putAll(analyticsMap())
+            is PaymentElementLoader.Configuration.PaymentSheet -> {
+                putAll(commonConfiguration.analyticsMap())
+                putAll(analyticsMap())
+            }
+            is PaymentElementLoader.Configuration.Embedded -> {
+                putAll(commonConfiguration.analyticsMap())
+                putAll(analyticsMap())
+            }
+            is PaymentElementLoader.Configuration.ExpressCheckoutElement ->
+                putAll(commonConfiguration.analyticsMap())
             is PaymentElementLoader.Configuration.CryptoOnramp,
-            is PaymentElementLoader.Configuration.StandaloneLink -> Unit
+            is PaymentElementLoader.Configuration.StandaloneLink -> putAll(commonConfiguration.analyticsMap())
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactory.kt
@@ -125,19 +125,14 @@ internal class DefaultAnalyticsMetadataFactory @Inject constructor(
     }
 
     private fun PaymentElementLoader.Configuration.analyticsMap() = buildMap<String, AnalyticsMetadata.Value> {
+        putAll(commonConfiguration.analyticsMap())
+
         when (this@analyticsMap) {
-            is PaymentElementLoader.Configuration.PaymentSheet -> {
-                putAll(commonConfiguration.analyticsMap())
-                putAll(analyticsMap())
-            }
-            is PaymentElementLoader.Configuration.Embedded -> {
-                putAll(commonConfiguration.analyticsMap())
-                putAll(analyticsMap())
-            }
-            is PaymentElementLoader.Configuration.ExpressCheckoutElement ->
-                putAll(commonConfiguration.analyticsMap())
+            is PaymentElementLoader.Configuration.PaymentSheet -> putAll(analyticsMap())
+            is PaymentElementLoader.Configuration.Embedded -> putAll(analyticsMap())
             is PaymentElementLoader.Configuration.CryptoOnramp,
-            is PaymentElementLoader.Configuration.StandaloneLink -> putAll(commonConfiguration.analyticsMap())
+            is PaymentElementLoader.Configuration.ExpressCheckoutElement,
+            is PaymentElementLoader.Configuration.StandaloneLink -> Unit
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -110,6 +110,10 @@ internal interface PaymentElementLoader {
         ) : Configuration {
             override val commonConfiguration: CommonConfiguration = configuration.asCommonConfiguration()
         }
+
+        data class ExpressCheckoutElement(
+            override val commonConfiguration: CommonConfiguration
+        ) : Configuration
     }
 
     sealed class InitializationMode : Parcelable {
@@ -625,6 +629,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     ): PaymentMethodLayout {
         return when (integrationConfiguration) {
             is PaymentElementLoader.Configuration.CryptoOnramp,
+            is PaymentElementLoader.Configuration.ExpressCheckoutElement,
             is PaymentElementLoader.Configuration.StandaloneLink -> PaymentMethodLayout.Vertical
             is PaymentElementLoader.Configuration.Embedded ->
                 if (

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -9,6 +9,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.elements.ExpressCheckoutElement
 import com.stripe.android.elements.PaymentElement
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -47,6 +48,8 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(
     CheckoutSessionPreview::class,
@@ -57,11 +60,38 @@ import kotlin.test.assertFailsWith
 internal class CheckoutStateLoaderTest {
 
     @Test
-    fun `loadInitial commits state with payment method metadata`() = runScenario {
+    fun `loadInitial commits only payment element metadata when ECE is not configured`() = runScenario {
         loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
 
         assertThat(stateHolder.state?.paymentMethodMetadata).isNotNull()
+        assertThat(stateHolder.state?.expressCheckoutElementPaymentMethodMetadata).isNull()
+    }
+
+    @Test
+    fun `loadInitial commits ECE payment method metadata when ECE is configured`() = runScenario {
+        val configuration = CheckoutController.Configuration()
+            .expressCheckoutElement(ExpressCheckoutElement.Configuration())
+            .build()
+
+        loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
+
         assertThat(stateHolder.state?.expressCheckoutElementPaymentMethodMetadata).isNotNull()
+    }
+
+    @Test
+    fun `loadInitial loads payment element and ECE metadata in parallel`() = runScenario(
+        loaderDelay = 1.seconds,
+    ) {
+        val startTime = currentTime()
+
+        loader.loadInitial(
+            configuration = CheckoutController.Configuration()
+                .expressCheckoutElement(ExpressCheckoutElement.Configuration())
+                .build(),
+            checkoutSessionResponse = response(),
+        )
+
+        assertThat(currentTime() - startTime).isEqualTo(1.seconds.inWholeMilliseconds)
     }
 
     @Test
@@ -393,6 +423,7 @@ internal class CheckoutStateLoaderTest {
         isGooglePayAvailable: Boolean = false,
         customer: CustomerState? = null,
         internalRowSelectionCallback: (() -> Unit)? = null,
+        loaderDelay: Duration = Duration.ZERO,
         // When null, a RecordingSelectionChooser is used. Pass a factory to exercise the real
         // DefaultEmbeddedSelectionChooser (it needs the shared SavedStateHandle to track state).
         selectionChooser: ((SavedStateHandle) -> EmbeddedSelectionChooser)? = null,
@@ -429,6 +460,7 @@ internal class CheckoutStateLoaderTest {
             shouldFail = shouldFail,
             isGooglePayAvailable = isGooglePayAvailable,
             customer = customer,
+            delay = loaderDelay,
         )
         val loader = CheckoutStateLoader(
             embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
@@ -448,6 +480,7 @@ internal class CheckoutStateLoaderTest {
             paymentElementLoader = paymentElementLoader,
             chooser = recordingChooser,
             imageLoader = imageLoader,
+            currentTime = { testScheduler.currentTime },
         ).block()
 
         imageLoader.ensureAllEventsConsumed()
@@ -460,6 +493,7 @@ internal class CheckoutStateLoaderTest {
         val paymentElementLoader: FakePaymentElementLoader,
         val chooser: RecordingSelectionChooser,
         val imageLoader: FakeStripeImageLoader,
+        val currentTime: () -> Long,
     )
 
     // Records the arguments of the most recent choose() call and returns a preconfigured selection,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -48,8 +48,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 
 @OptIn(
     CheckoutSessionPreview::class,
@@ -76,22 +74,6 @@ internal class CheckoutStateLoaderTest {
         loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
 
         assertThat(stateHolder.state?.expressCheckoutElementPaymentMethodMetadata).isNotNull()
-    }
-
-    @Test
-    fun `loadInitial loads payment element and ECE metadata in parallel`() = runScenario(
-        loaderDelay = 1.seconds,
-    ) {
-        val startTime = currentTime()
-
-        loader.loadInitial(
-            configuration = CheckoutController.Configuration()
-                .expressCheckoutElement(ExpressCheckoutElement.Configuration())
-                .build(),
-            checkoutSessionResponse = response(),
-        )
-
-        assertThat(currentTime() - startTime).isEqualTo(1.seconds.inWholeMilliseconds)
     }
 
     @Test
@@ -423,7 +405,6 @@ internal class CheckoutStateLoaderTest {
         isGooglePayAvailable: Boolean = false,
         customer: CustomerState? = null,
         internalRowSelectionCallback: (() -> Unit)? = null,
-        loaderDelay: Duration = Duration.ZERO,
         // When null, a RecordingSelectionChooser is used. Pass a factory to exercise the real
         // DefaultEmbeddedSelectionChooser (it needs the shared SavedStateHandle to track state).
         selectionChooser: ((SavedStateHandle) -> EmbeddedSelectionChooser)? = null,
@@ -460,7 +441,6 @@ internal class CheckoutStateLoaderTest {
             shouldFail = shouldFail,
             isGooglePayAvailable = isGooglePayAvailable,
             customer = customer,
-            delay = loaderDelay,
         )
         val loader = CheckoutStateLoader(
             embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
@@ -480,7 +460,6 @@ internal class CheckoutStateLoaderTest {
             paymentElementLoader = paymentElementLoader,
             chooser = recordingChooser,
             imageLoader = imageLoader,
-            currentTime = { testScheduler.currentTime },
         ).block()
 
         imageLoader.ensureAllEventsConsumed()
@@ -493,7 +472,6 @@ internal class CheckoutStateLoaderTest {
         val paymentElementLoader: FakePaymentElementLoader,
         val chooser: RecordingSelectionChooser,
         val imageLoader: FakeStripeImageLoader,
-        val currentTime: () -> Long,
     )
 
     // Records the arguments of the most recent choose() call and returns a preconfigured selection,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultAnalyticsMetadataFactoryTest.kt
@@ -77,6 +77,23 @@ class DefaultAnalyticsMetadataFactoryTest {
     }
 
     @Test
+    fun `create returns ECE configuration analytics metadata`() = runScenario {
+        val commonConfiguration = PaymentElementLoader.Configuration.PaymentSheet(
+            configuration = PaymentSheet.Configuration(
+                merchantDisplayName = "Test Merchant",
+                paymentMethodOrder = listOf("link", "card"),
+            )
+        ).commonConfiguration
+
+        val resultMap = createAnalyticsMetadata(
+            configuration = PaymentElementLoader.Configuration.ExpressCheckoutElement(commonConfiguration)
+        )
+
+        val mpeConfig = resultMap["mpe_config"] as? Map<*, *>
+        assertThat(mpeConfig?.get("payment_method_order")).isEqualTo("link,card")
+    }
+
+    @Test
     fun `create returns expected values for payment intent`() = runScenario {
         val clientSecret = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD.clientSecret!!
         val resultMap = createAnalyticsMetadata(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -80,6 +80,7 @@ internal class FakePaymentElementLoader(
                 ?: PaymentMethodMetadataFactory.defaultIntegrationMetadata(stripeIntent),
             paymentMethodLayout = when (integrationConfiguration) {
                 is PaymentElementLoader.Configuration.CryptoOnramp,
+                is PaymentElementLoader.Configuration.ExpressCheckoutElement,
                 is PaymentElementLoader.Configuration.StandaloneLink,
                 is PaymentElementLoader.Configuration.Embedded -> PaymentSheet.PaymentMethodLayout.Vertical
                 is PaymentElementLoader.Configuration.PaymentSheet ->


### PR DESCRIPTION
# Summary
Load dedicated payment method metadata for Express Checkout Element using its own configuration.

# Motivation
ECE and the embedded Payment Element can use different billing and Link configurations, so they must not share payment method metadata.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Committed and created by Codex.
