### PR TITLE
Make ECE payment method metadata nullable

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -20,7 +20,7 @@ internal data class CheckoutControllerState(
     val flagImages: Map<String, Bitmap>?,
     val collectedDetails: CheckoutCollectedDetails,
     val paymentMethodMetadata: PaymentMethodMetadata,
-    val expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata,
+    val expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata?,
     val embeddedConfiguration: EmbeddedPaymentElement.Configuration,
     val paymentSelection: PaymentSelection?,
     val temporarySelection: String?,

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/AvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/AvailableExpressButtonTypesFactory.kt
@@ -10,7 +10,7 @@ import javax.inject.Inject
 
 internal fun interface AvailableExpressButtonTypesFactory {
     fun create(
-        paymentMethodMetadata: PaymentMethodMetadata,
+        paymentMethodMetadata: PaymentMethodMetadata?,
         expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State?,
     ): List<ExpressButtonType>
 }
@@ -18,10 +18,11 @@ internal fun interface AvailableExpressButtonTypesFactory {
 internal class DefaultAvailableExpressButtonTypesFactory @Inject internal constructor() :
     AvailableExpressButtonTypesFactory {
     override fun create(
-        paymentMethodMetadata: PaymentMethodMetadata,
+        paymentMethodMetadata: PaymentMethodMetadata?,
         expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State?,
     ): List<ExpressButtonType> {
         expressCheckoutElementConfiguration ?: return emptyList()
+        paymentMethodMetadata ?: return emptyList()
 
         val availableExpressButtonTypes = paymentMethodMetadata.availableWallets.mapNotNull { walletType ->
             when (walletType) {

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -75,6 +75,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
             checkoutSessionResponse = state.checkoutSessionResponse,
             collectedDetails = state.collectedDetails,
         ) ?: return null
+        val paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata ?: return null
         val shippingAddressRequired = (expressButton as? ExpressButton.GooglePay)?.shippingAddressRequired == true
         val shippingAddressParameters = if (shippingAddressRequired) {
             GooglePayJsonFactory.ShippingAddressParameters(
@@ -86,18 +87,18 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
         }
         val confirmationOption = expressButton.toSelection().toConfirmationOption(
             configuration = configuration,
-            linkConfiguration = state.expressCheckoutElementPaymentMethodMetadata.linkState?.configuration,
-            cardFundingFilter = state.expressCheckoutElementPaymentMethodMetadata.cardFundingFilter,
+            linkConfiguration = paymentMethodMetadata.linkState?.configuration,
+            cardFundingFilter = paymentMethodMetadata.cardFundingFilter,
             googlePayBillingEmailOverride = GooglePayBillingEmailOverrideProvider.get(
                 configuration = configuration,
-                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+                paymentMethodMetadata = paymentMethodMetadata,
             ),
             googlePayShippingAddressParameters = shippingAddressParameters,
         ) ?: return null
 
         return ConfirmationHandler.Args(
             confirmationOption = confirmationOption,
-            paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+            paymentMethodMetadata = paymentMethodMetadata,
             statusBarColor = statusBarColor,
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementEventReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementEventReporter.kt
@@ -59,13 +59,14 @@ internal class DefaultExpressCheckoutElementEventReporter @Inject constructor(
         val state = stateHolder.state ?: return emptyMap()
         val expressCheckoutElementConfiguration = state.configuration.expressCheckoutElementConfiguration
             ?: return emptyMap()
+        val paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata ?: return emptyMap()
         val orderedLpms = stateHolder.session.value?.availableExpressButtonTypes.orEmpty().map {
             when (it) {
                 is ExpressButtonType.GooglePay -> "google_pay"
                 ExpressButtonType.Link -> "link"
             }
         }
-        return state.expressCheckoutElementPaymentMethodMetadata.analyticsMetadata.paramsMap + mapOf(
+        return paymentMethodMetadata.analyticsMetadata.paramsMap + mapOf(
             FIELD_ORDERED_LPMS to orderedLpms.joinToString(","),
             FIELD_ECE_CONFIG to mapOf(
                 FIELD_LINK_VISIBILITY to expressCheckoutElementConfiguration.linkConfiguration.display

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementInteractor.kt
@@ -51,7 +51,8 @@ internal class DefaultExpressCheckoutElementInteractor @Inject constructor(
         stateHolder.session,
     ) { linkAccountInfo, state, session, ->
         val configuration = state?.configuration?.expressCheckoutElementConfiguration
-        if (configuration == null || session == null) {
+        val paymentMethodMetadata = state?.expressCheckoutElementPaymentMethodMetadata
+        if (configuration == null || paymentMethodMetadata == null || session == null) {
             return@combineAsStateFlow ExpressCheckoutElementInteractor.State(
                 expressButtons = emptyList(),
                 buttonLayout = ExpressCheckoutElement.Configuration.Appearance.ButtonLayout().build(),
@@ -62,12 +63,12 @@ internal class DefaultExpressCheckoutElementInteractor @Inject constructor(
             expressButtons = session.availableExpressButtonTypes.map { expressButtonType ->
                 when (expressButtonType) {
                     ExpressButtonType.Link -> ExpressButton.Link.create(
-                        paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+                        paymentMethodMetadata = paymentMethodMetadata,
                         linkAccountInfo = linkAccountInfo,
                         buttonTheme = configuration.appearance.buttonTheme,
                     )
                     is ExpressButtonType.GooglePay -> ExpressButton.GooglePay.create(
-                        paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+                        paymentMethodMetadata = paymentMethodMetadata,
                         googlePayConfiguration = expressButtonType.googlePayConfiguration,
                         shippingAddressRequired = configuration.shippingAddressRequired,
                         buttonTheme = configuration.appearance.buttonTheme,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -26,7 +26,7 @@ internal object CheckoutControllerStateFactory {
         flagImages: Map<String, Bitmap>? = null,
         collectedDetails: CheckoutCollectedDetails = CheckoutCollectedDetails(email = null),
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-        expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata? = PaymentMethodMetadataFactory.create(),
         embeddedConfiguration: EmbeddedPaymentElement.Configuration =
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection: PaymentSelection? = null,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -198,7 +198,7 @@ internal class CheckoutControllerStateHolderTest {
         temporarySelection: String? = null,
         previousNewSelections: Bundle = Bundle(),
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
-        expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata? = PaymentMethodMetadataFactory.create(),
     ) = CheckoutControllerState(
         configuration = CheckoutController.Configuration().build(),
         checkoutSessionResponse = CheckoutSessionResponseFactory.create(),

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
@@ -21,6 +21,16 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
     }
 
     @Test
+    fun `create returns no express button types when ECE metadata is absent`() {
+        val availableExpressButtonTypes = DefaultAvailableExpressButtonTypesFactory().create(
+            paymentMethodMetadata = null,
+            expressCheckoutElementConfiguration = ExpressCheckoutElement.Configuration().build(),
+        )
+
+        assertThat(availableExpressButtonTypes).isEmpty()
+    }
+
+    @Test
     fun `create keeps only express button types returned by metadata`() {
         val availableExpressButtonTypes = create(
             availableWallets = listOf(WalletType.GooglePay),

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -81,7 +81,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = createGooglePayExpressButton(
-                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+                paymentMethodMetadata = requireNotNull(state.expressCheckoutElementPaymentMethodMetadata),
             ),
         ) {
             performer.confirm(expressButton)
@@ -104,7 +104,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = createGooglePayExpressButton(
-                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+                paymentMethodMetadata = requireNotNull(state.expressCheckoutElementPaymentMethodMetadata),
                 shippingAddressRequired = true,
             ),
         ) {
@@ -141,7 +141,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = createGooglePayExpressButton(
-                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+                paymentMethodMetadata = requireNotNull(state.expressCheckoutElementPaymentMethodMetadata),
             ),
         ) {
             performer.confirm(expressButton)
@@ -172,7 +172,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = createGooglePayExpressButton(
-                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+                paymentMethodMetadata = requireNotNull(state.expressCheckoutElementPaymentMethodMetadata),
             ),
         ) {
             performer.confirm(expressButton)
@@ -200,7 +200,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         runScenario(
             state = state,
             expressButton = ExpressButton.Link.create(
-                paymentMethodMetadata = state.expressCheckoutElementPaymentMethodMetadata,
+                paymentMethodMetadata = requireNotNull(state.expressCheckoutElementPaymentMethodMetadata),
                 linkAccountInfo = LinkAccountUpdate.Value(null),
                 buttonTheme = ButtonTheme.Automatic,
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/FakeAvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/FakeAvailableExpressButtonTypesFactory.kt
@@ -15,7 +15,7 @@ internal class FakeAvailableExpressButtonTypesFactory(
 ) : AvailableExpressButtonTypesFactory {
 
     override fun create(
-        paymentMethodMetadata: PaymentMethodMetadata,
+        paymentMethodMetadata: PaymentMethodMetadata?,
         expressCheckoutElementConfiguration: ExpressCheckoutElement.Configuration.State?,
     ): List<ExpressButtonType> {
         return availableExpressButtonTypes


### PR DESCRIPTION
# Summary
Make `expressCheckoutElementPaymentMethodMetadata` nullable and safely handle sessions where ECE metadata is absent.

# Motivation
ECE metadata only exists when Express Checkout Element is configured. Modeling it as nullable prevents callers from treating absent metadata as valid ECE state.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:testDebugUnitTest`

# Screenshots
| Before  | After |
| ------------- | ------------- |
| Not applicable | Not applicable |

# Changelog
No user-facing changelog entry required.

Committed and created by Codex.
