### PR TITLE
Add PrefsTestStore test rule

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -15,7 +15,7 @@ import com.stripe.android.paymentsheet.utils.CustomerSheetTestTypeProvider
 import com.stripe.android.paymentsheet.utils.CustomerSheetUtils
 import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
-import com.stripe.android.paymentsheet.utils.PrefsTestStore
+import com.stripe.android.paymentsheet.utils.PrefsTestStoreRule
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.runCustomerSheetTest
 import org.junit.Rule
@@ -25,7 +25,9 @@ import org.junit.runner.RunWith
 @RunWith(TestParameterInjector::class)
 internal class CustomerSheetTest {
     @get:Rule
-    val testRules: TestRules = TestRules.create()
+    val testRules: TestRules = TestRules.create {
+        around(PrefsTestStoreRule())
+    }
 
     private val composeTestRule = testRules.compose
     private val networkRule = testRules.networkRule
@@ -96,10 +98,6 @@ internal class CustomerSheetTest {
             assertThat(card?.brand).isEqualTo(CardBrand.Visa)
         }
     ) { context ->
-        context.scenario.onActivity {
-            PrefsTestStore(it).clear()
-        }
-
         networkRule.elementsSession { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }
@@ -132,10 +130,6 @@ internal class CustomerSheetTest {
             assertThat(card?.brand).isEqualTo(CardBrand.Visa)
         }
     ) { context ->
-        context.scenario.onActivity {
-            PrefsTestStore(it).clear()
-        }
-
         networkRule.elementsSession { response ->
             response.testBodyFromFile("elements-sessions-requires_payment_method.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CustomerSheetTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.paymentsheet
 import com.google.common.truth.Truth.assertThat
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
-import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetResult
 import com.stripe.android.customersheet.PaymentOptionSelection
@@ -15,7 +14,6 @@ import com.stripe.android.paymentsheet.utils.CustomerSheetTestTypeProvider
 import com.stripe.android.paymentsheet.utils.CustomerSheetUtils
 import com.stripe.android.paymentsheet.utils.IntegrationType
 import com.stripe.android.paymentsheet.utils.IntegrationTypeProvider
-import com.stripe.android.paymentsheet.utils.PrefsTestStoreRule
 import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.utils.runCustomerSheetTest
 import org.junit.Rule
@@ -25,9 +23,7 @@ import org.junit.runner.RunWith
 @RunWith(TestParameterInjector::class)
 internal class CustomerSheetTest {
     @get:Rule
-    val testRules: TestRules = TestRules.create {
-        around(PrefsTestStoreRule())
-    }
+    val testRules: TestRules = TestRules.create()
 
     private val composeTestRule = testRules.compose
     private val networkRule = testRules.networkRule

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PrefsTestStoreRule.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/PrefsTestStoreRule.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.paymentsheet.utils
+
+import androidx.test.core.app.ApplicationProvider
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+internal class PrefsTestStoreRule : TestRule {
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                val prefsTestStore = PrefsTestStore(ApplicationProvider.getApplicationContext())
+                prefsTestStore.clear()
+
+                try {
+                    base.evaluate()
+                } finally {
+                    prefsTestStore.clear()
+                }
+            }
+        }
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/TestRules.kt
@@ -35,6 +35,7 @@ class TestRules private constructor(
                 .around(DetectLeaksAfterTestSuccess())
                 .around(FakeGooglePayRepositoryRule())
                 .around(composeTestRule)
+                .around(PrefsTestStoreRule())
                 .let { chain ->
                     retryRule?.let(chain::around) ?: chain
                 }


### PR DESCRIPTION
# Summary
Add a reusable `PrefsTestStoreRule` that clears PaymentSheet test preferences before and after each test, and migrate existing `PrefsTestStore` users to the rule.

# Motivation
Tests that write through `PrefsTestStore` can leak saved preference state into later tests. The rule provides consistent isolation, including cleanup when a test fails.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :paymentsheet:compileDebugAndroidTestKotlin :paymentsheet:detekt`

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| N/A | N/A |

# Changelog
No user-facing change.

Committed and created by Codex.
