### PR TITLE
Re-enable Financial Connections tests

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,7 +19,7 @@ pipelines:
       check-and-test: { }
       run-instrumentation-and-ime-tests: { }
       run-paymentsheet-instrumentation-tests: { }
-#      run-financial-connections-and-crypto-instrumentation-tests: { }
+      run-financial-connections-and-crypto-instrumentation-tests: { }
       run-connections-e2e-tests-on-push: { }
       run-cardscan-and-google-pay-tests: { }
       run-paymentsheet-e2e: { }


### PR DESCRIPTION
# Summary
Re-enables the Financial Connections and crypto instrumentation test pipeline by reverting #14325.

# Motivation
The incident that required temporarily disabling these tests is now fully mitigated, so restore the CI coverage.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified the revert and ran git diff --check

# Screenshots
Not applicable.

# Changelog
No user-facing changes.

Committed and created by Codex.