### PR TITLE
Remove unreachable shipping launcher recovery

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -56,23 +56,18 @@ class ShippingAddressElement @Inject internal constructor(
         }
 
         shippingAddressElementStateHolder.isPresenting = true
-        try {
-            activityLauncher.launch(
-                AddressElementActivityContract.Args(
-                    publishableKey = paymentConfiguration.get().publishableKey,
-                    config = AddressLauncher.Configuration(
-                        additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
-                            phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,
-                        ),
-                        billingAddress = null,
-                        useStripeHostedAutocomplete = true,
+        activityLauncher.launch(
+            AddressElementActivityContract.Args(
+                publishableKey = paymentConfiguration.get().publishableKey,
+                config = AddressLauncher.Configuration(
+                    additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
+                        phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,
                     ),
-                )
+                    billingAddress = null,
+                    useStripeHostedAutocomplete = true,
+                ),
             )
-        } catch (exception: IllegalStateException) {
-            shippingAddressElementStateHolder.isPresenting = false
-            throw exception
-        }
+        )
     }
 
     @CheckoutSessionPreview

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -28,7 +28,6 @@ import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertThrows
 import org.junit.Rule
 import org.junit.Test
 import javax.inject.Provider
@@ -175,26 +174,6 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `synchronous launch failure clears presentation`() = runScenario {
-        val expectedException = IllegalStateException("Launch failed")
-        activityLauncher.launchException = expectedException
-
-        val exception = assertThrows(IllegalStateException::class.java) {
-            shippingAddressElement.present()
-        }
-
-        assertThat(exception).isSameInstanceAs(expectedException)
-        assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
-        activityLauncher.launchCalls.awaitItem()
-
-        activityLauncher.launchException = null
-        shippingAddressElement.present()
-        activityLauncher.launchCalls.awaitItem()
-        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
-        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
-    }
-
-    @Test
     fun `lifecycle destruction unregisters the launcher`() = runScenario {
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
@@ -289,10 +268,7 @@ internal class ShippingAddressElementTest {
             options: ActivityOptionsCompat?,
         ) {
             launchCalls.add(LaunchCall(input))
-            launchException?.let { throw it }
         }
-
-        var launchException: RuntimeException? = null
 
         override fun unregister() {
             unregisterCalls.add(Unit)


### PR DESCRIPTION
# Summary

Removes the synchronous `IllegalStateException` recovery from `ShippingAddressElement` presentation. The configured-state guard, duplicate-presentation guard, and result callback remain unchanged.

# Motivation

The launcher is valid during the supported Activity-bound presentation lifecycle. The removed catch only handled stale or destroyed-presenter misuse, and its test modeled that path with a fake synchronous launcher exception.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
- Focused `ShippingAddressElementTest` passed locally.

# Screenshots

Not applicable. No user-visible behavior changes.

# Changelog

Not applicable. No public API or user-visible behavior changes.

Committed and created by Codex.