### PR TITLE
Make checkout settings search breadcrumbs clickable

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -127,6 +127,10 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                                 searchQuery = settingsSearchQuery,
                                 settings = viewModel.settings,
                                 onOpenConfiguration = { navigationPath += it.key },
+                                onOpenConfigurationPath = { configurationPath ->
+                                    navigationPath = configurationPath.map { it.key }
+                                    settingsSearchQuery = ""
+                                },
                             )
                         }
                         CheckoutControllerExampleViewModel.Status.Loading -> LoadingContent()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUi.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
 import com.godaddy.android.colorpicker.ClassicColorPicker
@@ -61,6 +62,7 @@ internal fun CheckoutPlaygroundSettingsUi(
     searchQuery: String,
     settings: CheckoutPlaygroundSettings,
     onOpenConfiguration: (CheckoutPlaygroundSettingDefinition.Configuration) -> Unit,
+    onOpenConfigurationPath: (List<CheckoutPlaygroundSettingDefinition.Configuration>) -> Unit,
 ) {
     val values by settings.values.collectAsState()
     val searchResults = remember(searchQuery) {
@@ -87,6 +89,7 @@ internal fun CheckoutPlaygroundSettingsUi(
                 results = searchResults,
                 values = values,
                 settings = settings,
+                onOpenConfigurationPath = onOpenConfigurationPath,
             )
         }
     }
@@ -122,15 +125,19 @@ private fun SearchResultsContent(
     results: List<SearchResult>,
     values: Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>,
     settings: CheckoutPlaygroundSettings,
+    onOpenConfigurationPath: (List<CheckoutPlaygroundSettingDefinition.Configuration>) -> Unit,
 ) {
     results.forEach { result ->
         val enabled = result.definition.isApplicable(settings)
         Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
             Text(
                 text = result.breadcrumb,
-                modifier = Modifier.testTag(checkoutSettingBreadcrumbTestTag(result.definition)),
+                modifier = Modifier
+                    .testTag(checkoutSettingBreadcrumbTestTag(result.definition))
+                    .clickable { onOpenConfigurationPath(result.configurationPath) },
                 style = MaterialTheme.typography.caption,
-                color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium),
+                color = MaterialTheme.colors.primary.copy(alpha = ContentAlpha.medium),
+                textDecoration = TextDecoration.Underline,
             )
             ValueRow(
                 definition = result.definition,
@@ -148,19 +155,21 @@ private fun SearchResultsContent(
 
 private data class SearchResult(
     val definition: CheckoutPlaygroundSettingDefinition.Value<*>,
-    val breadcrumb: String,
-)
+    val configurationPath: List<CheckoutPlaygroundSettingDefinition.Configuration>,
+) {
+    val breadcrumb: String = configurationPath.joinToString(" › ") { it.displayName }
+}
 
 private fun CheckoutPlaygroundSettingDefinition.Configuration.searchResults(
     query: String,
-    parents: List<String>,
+    parents: List<CheckoutPlaygroundSettingDefinition.Configuration>,
 ): List<SearchResult> {
     return children.flatMap { definition ->
         when (definition) {
             is CheckoutPlaygroundSettingDefinition.Configuration -> {
                 definition.searchResults(
                     query = query,
-                    parents = parents + definition.displayName,
+                    parents = parents + definition,
                 )
             }
             is CheckoutPlaygroundSettingDefinition.Value<*> -> {
@@ -168,7 +177,7 @@ private fun CheckoutPlaygroundSettingDefinition.Configuration.searchResults(
                     listOf(
                         SearchResult(
                             definition = definition,
-                            breadcrumb = parents.joinToString(" › "),
+                            configurationPath = parents,
                         )
                     )
                 } else {

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
@@ -105,6 +105,23 @@ class CheckoutPlaygroundSettingsUiTest {
     }
 
     @Test
+    fun `clicking a search result breadcrumb opens its nested configuration`() = runScenario {
+        val cornerRadius = CheckoutPlaygroundDefinitions.Controller.payment.appearance.primaryButton.shape
+            .cornerRadius
+
+        setSearchQuery("corner radius")
+        page.breadcrumb(cornerRadius).performScrollTo().performClick()
+
+        page.value(cornerRadius).assertIsDisplayed()
+        page.value(CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.cornerRadius)
+            .assertDoesNotExist()
+        assertThat(currentConfiguration()).isEqualTo(
+            CheckoutPlaygroundDefinitions.Controller.payment.appearance.primaryButton.shape.configuration
+        )
+        assertThat(searchQuery()).isEmpty()
+    }
+
+    @Test
     fun `search displays an empty state when there are no matches`() = runScenario {
         setSearchQuery("not a setting")
 
@@ -257,6 +274,10 @@ class CheckoutPlaygroundSettingsUiTest {
                     searchQuery = searchQuery,
                     settings = settings,
                     onOpenConfiguration = { current = it },
+                    onOpenConfigurationPath = { configurationPath ->
+                        current = configurationPath.lastOrNull() ?: CheckoutPlaygroundDefinitions.root
+                        searchQuery = ""
+                    },
                 )
             }
         }
@@ -264,7 +285,9 @@ class CheckoutPlaygroundSettingsUiTest {
             Scenario(
                 page = Page(composeRule),
                 settings = settings,
+                currentConfiguration = { current },
                 openConfiguration = { current = it },
+                searchQuery = { searchQuery },
                 setSearchQuery = { query ->
                     composeRule.runOnIdle {
                         searchQuery = query
@@ -277,7 +300,9 @@ class CheckoutPlaygroundSettingsUiTest {
     private data class Scenario(
         val page: Page,
         val settings: CheckoutPlaygroundSettings,
+        val currentConfiguration: () -> CheckoutPlaygroundSettingDefinition.Configuration,
         val openConfiguration: (CheckoutPlaygroundSettingDefinition.Configuration) -> Unit,
+        val searchQuery: () -> String,
         val setSearchQuery: (String) -> Unit,
     )
 


### PR DESCRIPTION
# Summary
Make search-result breadcrumbs in the Checkout playground settings clickable so they navigate directly to the result's nested configuration and clear the active search.

Committed and created by Codex.

# Motivation
Search results identify where a setting lives, but users previously had to reconstruct and navigate that hierarchy manually. Linking the breadcrumb makes it easy to open the surrounding configuration and inspect related settings.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Ran `./gradlew detekt` and the focused `CheckoutPlaygroundSettingsUiTest` on the `BaseDebug` variant.

# Screenshots
Not applicable: this adds breadcrumb navigation behavior without changing the screen layout.

# Changelog
Not applicable: this only affects the internal Checkout playground example.
