### PR TITLE
Fix Link display configuration in CheckoutController

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -32,6 +32,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .termsDisplay(configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet())
             .appearance(configuration.paymentElementConfiguration.appearance.asPaymentSheet())
             .googlePay(configuration.toExpressCheckoutElementGooglePayConfiguration(checkoutSessionResponse))
+            .link(configuration.paymentElementConfiguration.linkConfiguration.asPaymentSheet())
             .defaultBillingDetails(collectedDetails.toBillingDetails(checkoutSessionResponse))
             .shippingDetails(collectedDetails.toShippingDetails())
             .allowsDelayedPaymentMethods(true)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -248,6 +248,27 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
+    fun `maps Link display to embedded payment element configuration`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().linkConfiguration(
+                    PaymentElement.Configuration.LinkConfiguration().display(
+                        PaymentElement.Configuration.LinkConfiguration.Display.Never
+                    )
+                )
+            )
+            .build()
+
+        val result = factory().create(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            collectedDetails = collectedDetails(),
+        )
+
+        assertThat(result.link.display).isEqualTo(PaymentSheet.LinkConfiguration.Display.Never)
+    }
+
+    @Test
     fun `maps terms display to embedded payment element configuration`() {
         val configuration = CheckoutController.Configuration()
             .paymentElement(


### PR DESCRIPTION
# Summary

Propagate the Payment Element Link configuration into CheckoutController's embedded configuration so settings such as `Display.Never` are honored.

# Motivation

CheckoutController stored the configured Link display value, but `CheckoutEmbeddedConfigurationFactory` left the embedded configuration at its default. As a result, Link remained visible in the live embedded UI when configured with `PaymentElement.Configuration.LinkConfiguration.Display.Never`.

# Testing

- [x] Added tests
- [ ] Modified tests
- [x] Manually verified

Ran `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutEmbeddedConfigurationFactoryTest'`.

Ran `./gradlew detekt`.

Installed `:paymentsheet-example:installBaseDebug` and verified on the emulator that Link is absent when its display setting is `Never`.

# Screenshots

Not applicable. The behavior was verified from the emulator UI hierarchy; this change does not introduce new visuals.

# Changelog

Not applicable. CheckoutController is a preview API.

Committed and created by Codex.
