### PR TITLE
Annotate Checkout Element presentation methods with MainThread

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -3,6 +3,7 @@ package com.stripe.android.elements
 import android.os.Parcelable
 import androidx.annotation.ColorInt
 import androidx.annotation.FontRes
+import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -38,6 +39,7 @@ class PaymentElement @Inject internal constructor(
     /**
      * Presents a sheet for the customer to select or manage their payment method.
      */
+    @MainThread
     fun present() {
         contentHelper.presentPaymentOptions()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -3,6 +3,7 @@ package com.stripe.android.elements
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.MainThread
 import androidx.annotation.RestrictTo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -43,6 +44,7 @@ class ShippingAddressElement @Inject internal constructor(
         )
     }
 
+    @MainThread
     fun present() {
         if (stateHolder.state == null) {
             errorReporter.report(


### PR DESCRIPTION
# Summary
Annotate Checkout Element presentation methods with `@MainThread`.

# Motivation
`PaymentElement.present()` and `ShippingAddressElement.present()` synchronously access UI, lifecycle, Activity Result, and state-holder behavior. This makes the existing caller requirement explicit for static analysis and IDE tooling with AndroidX `@MainThread`, without changing runtime behavior.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Existing focused `PaymentElementTest` and `ShippingAddressElementTest` passed. `:paymentsheet:apiDump`, `:paymentsheet:apiCheck`, `:paymentsheet:detekt`, and `git diff --check` passed. The push hook also reran `:paymentsheet:apiCheck` and `:paymentsheet:detekt` successfully.

# Screenshots
Not applicable. This is an annotation-only API contract change with no visual or runtime UI change.

# Changelog
No changelog entry. This preview API annotation documents an existing caller contract and does not change runtime behavior.

Committed and created by Codex.
