### PR TITLE
Add checkout settings import and export

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -35,6 +35,8 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
         CheckoutControllerExampleViewModel.factory
     }
 
+    private val settingsImportExport = SettingsImportExport(this) { viewModel.settings }
+
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -109,6 +111,18 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                             } else {
                                 null
                             },
+                            actions = {
+                                if (
+                                    status is CheckoutControllerExampleViewModel.Status.Settings &&
+                                    navigationPath.isEmpty()
+                                ) {
+                                    SettingsOverflowMenu(
+                                        onImport = settingsImportExport::importSettings,
+                                        onExport = settingsImportExport::exportSettings,
+                                        onReset = viewModel.settings::reset,
+                                    )
+                                }
+                            },
                         )
                         if (status is CheckoutControllerExampleViewModel.Status.Settings) {
                             SearchSettingsField(
@@ -164,7 +178,6 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                                     canStart = settingValues.isNotEmpty() &&
                                         viewModel.settings.validationErrors().isEmpty(),
                                     onStart = viewModel::start,
-                                    onReset = viewModel.settings::reset,
                                 )
                             }
                         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SettingsActions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SettingsActions.kt
@@ -2,16 +2,24 @@ package com.stripe.android.paymentsheet.example.playground.checkout
 
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.Button
+import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
-import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 
 @Composable
 internal fun SettingsActions(
     canStart: Boolean,
     onStart: () -> Unit,
-    onReset: () -> Unit,
 ) {
     Button(
         onClick = onStart,
@@ -20,7 +28,56 @@ internal fun SettingsActions(
     ) {
         Text("Create Checkout Session")
     }
-    TextButton(onClick = onReset, modifier = Modifier.fillMaxWidth()) {
-        Text("Reset to defaults")
+}
+
+@Composable
+internal fun SettingsOverflowMenu(
+    onImport: () -> Unit,
+    onExport: () -> Unit,
+    onReset: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    IconButton(
+        onClick = { expanded = true },
+        modifier = Modifier.semantics { contentDescription = "More options" },
+    ) {
+        Text("⋮", style = MaterialTheme.typography.h5)
+    }
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { expanded = false },
+    ) {
+        SettingsDropdownMenuItem(
+            text = "Import settings from JSON",
+            onClick = onImport,
+            onDismiss = { expanded = false },
+        )
+        SettingsDropdownMenuItem(
+            text = "Export settings as JSON",
+            onClick = onExport,
+            onDismiss = { expanded = false },
+        )
+        SettingsDropdownMenuItem(
+            text = "Reset to defaults",
+            onClick = onReset,
+            onDismiss = { expanded = false },
+        )
+    }
+}
+
+@Composable
+private fun SettingsDropdownMenuItem(
+    text: String,
+    onClick: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    DropdownMenuItem(
+        onClick = {
+            onDismiss()
+            onClick()
+        },
+    ) {
+        Text(text)
     }
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SettingsImportExport.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SettingsImportExport.kt
@@ -1,0 +1,60 @@
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettings
+
+internal class SettingsImportExport(
+    private val activity: AppCompatActivity,
+    private val settings: () -> CheckoutPlaygroundSettings,
+) {
+    private val importLauncher = activity.registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        uri ?: return@registerForActivityResult
+
+        runCatching {
+            activity.contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+                ?: error("Unable to read the selected file")
+        }.fold(
+            onSuccess = { json ->
+                settings().importJson(json).fold(
+                    onSuccess = { showToast("Settings imported") },
+                    onFailure = { error -> showToast("Could not import settings: ${error.message}") },
+                )
+            },
+            onFailure = { error -> showToast("Could not read settings: ${error.message}") },
+        )
+    }
+
+    private val exportLauncher = activity.registerForActivityResult(
+        ActivityResultContracts.CreateDocument(JSON_MIME_TYPE)
+    ) { uri ->
+        uri ?: return@registerForActivityResult
+
+        runCatching {
+            activity.contentResolver.openOutputStream(uri)?.bufferedWriter()?.use { writer ->
+                writer.write(settings().asJsonString())
+            } ?: error("Unable to write the selected file")
+        }.fold(
+            onSuccess = { showToast("Settings exported") },
+            onFailure = { error -> showToast("Could not export settings: ${error.message}") },
+        )
+    }
+
+    fun importSettings() {
+        importLauncher.launch(arrayOf(JSON_MIME_TYPE, "text/plain"))
+    }
+
+    fun exportSettings() {
+        exportLauncher.launch(DEFAULT_SETTINGS_FILE_NAME)
+    }
+
+    private fun showToast(message: String) {
+        Toast.makeText(activity, message, Toast.LENGTH_LONG).show()
+    }
+
+    private companion object {
+        const val JSON_MIME_TYPE = "application/json"
+        const val DEFAULT_SETTINGS_FILE_NAME = "checkout-settings.json"
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.example.playground.checkout.settings
 
 import android.content.Context
+import android.util.Log
 import androidx.core.content.edit
 import com.stripe.android.paymentsheet.example.Settings
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -16,6 +17,7 @@ internal class CheckoutPlaygroundSettings private constructor(
     defaultValues: Map<String, String>,
     initialValues: Map<String, String>,
     initialReturningCustomerId: String?,
+    private val logWarning: (String) -> Unit,
     private val persist: (Map<String, String>) -> Unit,
     private val persistReturningCustomerId: (String?) -> Unit,
 ) : CheckoutPlaygroundSettingValues {
@@ -77,10 +79,31 @@ internal class CheckoutPlaygroundSettings private constructor(
     }
 
     fun asJsonString(): String {
-        return Json.encodeToString(
+        return Json { prettyPrint = true }.encodeToString(
             MapSerializer(String.serializer(), String.serializer()),
             _values.value.serialized(),
         )
+    }
+
+    fun importJson(json: String): Result<Unit> = runCatching {
+        val importedValues = decodeValuesOrThrow(json)
+        val unknownKeys = importedValues.keys - definitionsByKey.keys
+        if (unknownKeys.isNotEmpty()) {
+            logWarning("Ignoring unknown settings: ${unknownKeys.sorted().joinToString()}")
+        }
+
+        val invalidSettings = importedValues.mapNotNull { (key, value) ->
+            definitionsByKey[key]?.validationError(value)?.let { key to it }
+        }
+        require(invalidSettings.isEmpty()) {
+            invalidSettings.joinToString(
+                prefix = "Invalid settings: ",
+                transform = { (key, error) -> "$key ($error)" },
+            )
+        }
+
+        _values.value = currentDefaults() + importedValues.sanitized()
+        persist(_values.value.serialized())
     }
 
     private fun Map<String, String>.sanitized(): Map<CheckoutPlaygroundSettingDefinition.Value<*>, String> {
@@ -110,6 +133,7 @@ internal class CheckoutPlaygroundSettings private constructor(
         private const val PREFERENCES_KEY = "settings_v1"
         private const val RETURNING_CUSTOMER_ID_KEY = "returning_customer_id"
         private const val RETURNING_CUSTOMER = "returning"
+        private const val TAG = "CheckoutSettings"
 
         fun create(context: Context): CheckoutPlaygroundSettings {
             val preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
@@ -121,6 +145,7 @@ internal class CheckoutPlaygroundSettings private constructor(
                 ),
                 initialValues = values,
                 initialReturningCustomerId = preferences.getString(RETURNING_CUSTOMER_ID_KEY, null),
+                logWarning = { message -> Log.w(TAG, message) },
                 persist = { updatedValues ->
                     preferences.edit {
                         putString(
@@ -152,6 +177,7 @@ internal class CheckoutPlaygroundSettings private constructor(
                 defaultValues = emptyMap(),
                 initialValues = json?.let(::decodeValues).orEmpty(),
                 initialReturningCustomerId = null,
+                logWarning = {},
                 persist = {},
                 persistReturningCustomerId = {},
             )
@@ -166,6 +192,7 @@ internal class CheckoutPlaygroundSettings private constructor(
                 defaultValues = mapOf(CheckoutPlaygroundDefinitions.session.backendUrl.key to defaultBackendUrl),
                 initialValues = json?.let(::decodeValues).orEmpty(),
                 initialReturningCustomerId = null,
+                logWarning = {},
                 persist = {},
                 persistReturningCustomerId = {},
             )
@@ -173,12 +200,16 @@ internal class CheckoutPlaygroundSettings private constructor(
 
         private fun decodeValues(json: String): Map<String, String> {
             return try {
-                Json.decodeFromString(MapSerializer(String.serializer(), String.serializer()), json)
+                decodeValuesOrThrow(json)
             } catch (_: SerializationException) {
                 emptyMap()
             } catch (_: IllegalArgumentException) {
                 emptyMap()
             }
+        }
+
+        private fun decodeValuesOrThrow(json: String): Map<String, String> {
+            return Json.decodeFromString(MapSerializer(String.serializer(), String.serializer()), json)
         }
     }
 }

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
@@ -117,6 +117,56 @@ class CheckoutPlaygroundSettingsTest {
     }
 
     @Test
+    fun `import replaces current settings`() = runScenario {
+        val currency = CheckoutPlaygroundDefinitions.session.currency
+        val paymentMethodSave = CheckoutPlaygroundDefinitions.session.paymentMethodSave
+        settings.updateSerialized(currency, "eur")
+        settings.update(paymentMethodSave, false)
+        val exportedJson = settings.asJsonString()
+        settings.updateSerialized(currency, "usd")
+        settings.update(paymentMethodSave, true)
+
+        val result = settings.importJson(exportedJson)
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(settings.serializedValue(currency)).isEqualTo("eur")
+        assertThat(settings[paymentMethodSave]).isFalse()
+    }
+
+    @Test
+    fun `malformed import does not change current settings`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.session.currency
+        settings.updateSerialized(definition, "eur")
+
+        val result = settings.importJson("not json")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(settings.serializedValue(definition)).isEqualTo("eur")
+    }
+
+    @Test
+    fun `import ignores unknown setting`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.session.currency
+        settings.updateSerialized(definition, "usd")
+
+        val result = settings.importJson("""{"unknown":"value","session.currency":"eur"}""")
+
+        assertThat(result.isSuccess).isTrue()
+        assertThat(settings.serializedValue(definition)).isEqualTo("eur")
+    }
+
+    @Test
+    fun `import with invalid setting does not change current settings`() = runScenario {
+        val definition = CheckoutPlaygroundDefinitions.Controller.currencySelector.appearance.scale
+        settings.update(definition, 1.25f)
+
+        val result = settings.importJson("""{"currency.appearance.scale":"not-a-number"}""")
+
+        assertThat(result.isFailure).isTrue()
+        assertThat(settings[definition]).isEqualTo(1.25f)
+    }
+
+    @Test
     fun `new customer is saved as returning customer`() = runScenario {
         settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
 


### PR DESCRIPTION
# Summary
Add JSON import and export actions to the CheckoutController playground settings screen. Exports include every effective setting in a readable file, while imports validate and persist the configuration atomically.

Committed and created by Codex.

# Motivation
Agents and developers need a portable representation of the active checkout playground configuration so they can inspect, share, and reproduce the same settings.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet-example:testBaseDebugUnitTest --tests 'com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettingsTest'`
- `./gradlew detekt`

# Screenshots
Not applicable — this adds text actions to the developer playground and was not manually exercised on a device.

# Changelog
Not applicable — this is an internal example-app utility and does not change the public SDK.
