### PR TITLE
Move shipping address presentation persistence test

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerSavedStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerSavedStateTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.checkout
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.utils.simulateProcessDeath
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -78,10 +79,6 @@ internal class CheckoutControllerSavedStateTest {
         return SavedStateHandle(
             mapOf(INTEGRATION_NAME to childHandle.savedStateProvider().saveState())
         )
-    }
-
-    private fun SavedStateHandle.simulateProcessDeath(): SavedStateHandle {
-        return SavedStateHandle.createHandle(savedStateProvider().saveState(), null)
     }
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.android.utils.simulateProcessDeath
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
@@ -1127,15 +1128,6 @@ internal class CheckoutControllerTest {
                 .put("automatic_tax_address_source", source),
         )
     }
-
-    // Simulates process death by persisting the handle's registered providers into a bundle and
-    // rebuilding a fresh handle from it, the way SavedStateRegistry does across a real restart. The
-    // controller's namespaced child is then restored from that serialized state.
-    // Persisting a handle can only be done through the restricted savedStateProvider(); the same
-    // suppression the production code uses applies here.
-    @Suppress("RestrictedApi")
-    private fun SavedStateHandle.simulateProcessDeath(): SavedStateHandle =
-        SavedStateHandle.createHandle(savedStateProvider().saveState(), null)
 
     @Suppress("RestrictedApi")
     private fun parentHandleWithState(state: CheckoutControllerState): SavedStateHandle {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/ShippingAddressElementStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/ShippingAddressElementStateHolderTest.kt
@@ -1,0 +1,21 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.SavedStateHandle
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.utils.simulateProcessDeath
+import org.junit.Test
+
+internal class ShippingAddressElementStateHolderTest {
+    @Test
+    fun `presentation state survives process death`() {
+        val savedStateHandle = SavedStateHandle()
+        val stateHolder = ShippingAddressElementStateHolder(savedStateHandle)
+        stateHolder.isPresenting = true
+
+        val restoredStateHolder = ShippingAddressElementStateHolder(
+            savedStateHandle = savedStateHandle.simulateProcessDeath(),
+        )
+
+        assertThat(restoredStateHolder.isPresenting).isTrue()
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -161,19 +161,6 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `presentation state survives process death`() {
-        val savedStateHandle = SavedStateHandle()
-        val stateHolder = ShippingAddressElementStateHolder(savedStateHandle)
-        stateHolder.isPresenting = true
-
-        val restoredStateHolder = ShippingAddressElementStateHolder(
-            savedStateHandle = savedStateHandle.simulateProcessDeath(),
-        )
-
-        assertThat(restoredStateHolder.isPresenting).isTrue()
-    }
-
-    @Test
     fun `lifecycle destruction unregisters the launcher`() = runScenario {
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
@@ -328,8 +315,4 @@ internal class ShippingAddressElementTest {
         val registration: Registration,
         val createElement: suspend () -> ElementScenario,
     )
-
-    @Suppress("RestrictedApi")
-    private fun SavedStateHandle.simulateProcessDeath(): SavedStateHandle =
-        SavedStateHandle.createHandle(savedStateProvider().saveState(), null)
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/SavedStateHandleTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/SavedStateHandleTestUtils.kt
@@ -1,0 +1,8 @@
+package com.stripe.android.utils
+
+import androidx.lifecycle.SavedStateHandle
+
+// Rebuilds a handle from its saved provider state, as SavedStateRegistry does after process death.
+@Suppress("RestrictedApi")
+internal fun SavedStateHandle.simulateProcessDeath(): SavedStateHandle =
+    SavedStateHandle.createHandle(savedStateProvider().saveState(), null)


### PR DESCRIPTION
# Summary

Moves `presentation state survives process death` from `ShippingAddressElementTest` into `ShippingAddressElementStateHolderTest`.

Extracts the test-only `SavedStateHandle.simulateProcessDeath()` helper and reuses it in the two Checkout controller test classes.

# Motivation

The relocated test constructs only `ShippingAddressElementStateHolder`; it does not exercise `ShippingAddressElement` lifecycle behavior. Keeping it with the holder makes the tested ownership explicit and removes three private copies of the state-handle restoration helper.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused tests for `ShippingAddressElementStateHolderTest`, `CheckoutControllerSavedStateTest`, and `CheckoutControllerTest` pass locally.

# Screenshots

| Before | After |
| --- | --- |
| N/A, test-only change | N/A, test-only change |

# Changelog

N/A, test-only change.

Committed and created by Codex.
