### PR TITLE
Disable PaymentSheet autofill for Dashboard user keys

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/PaymentConfiguration.kt
+++ b/payments-core/src/main/java/com/stripe/android/PaymentConfiguration.kt
@@ -26,6 +26,11 @@ constructor(
         return !publishableKey.startsWith("pk_test")
     }
 
+    @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+    fun isUserKey(): Boolean {
+        return ApiKeyValidator.isUserKey(publishableKey)
+    }
+
     /**
      * Manages saving and loading [PaymentConfiguration] data to SharedPreferences.
      */

--- a/payments-core/src/test/java/com/stripe/android/PaymentConfigurationTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/PaymentConfigurationTest.kt
@@ -82,4 +82,24 @@ class PaymentConfigurationTest {
             ).isLiveMode()
         ).isFalse()
     }
+
+    @Test
+    fun `isUserKey is true for live user key`() {
+        assertThat(PaymentConfiguration(publishableKey = "uk_live_123").isUserKey()).isTrue()
+    }
+
+    @Test
+    fun `isUserKey is true for test user key`() {
+        assertThat(PaymentConfiguration(publishableKey = "uk_test_123").isUserKey()).isTrue()
+    }
+
+    @Test
+    fun `isUserKey is false for live publishable key`() {
+        assertThat(PaymentConfiguration(publishableKey = "pk_live_123").isUserKey()).isFalse()
+    }
+
+    @Test
+    fun `isUserKey is false for test publishable key`() {
+        assertThat(PaymentConfiguration(publishableKey = "pk_test_123").isUserKey()).isFalse()
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsActivity.kt
@@ -44,6 +44,8 @@ internal class PaymentOptionsActivity : BaseSheetActivity<PaymentOptionsActivity
             return
         }
 
+        disableAutofillForUserKey()
+
         starterArgs.configuration.appearance.parseAppearance()
 
         if (!applicationIsTaskOwner()) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetActivity.kt
@@ -58,6 +58,8 @@ internal class PaymentSheetActivity : BaseSheetActivity<PaymentSheetResult>() {
 
         starterArgs.config.appearance.parseAppearance()
 
+        disableAutofillForUserKey()
+
         viewModel.registerForActivityResult(
             activityResultCaller = this,
             lifecycleOwner = this,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BaseSheetActivity.kt
@@ -1,8 +1,11 @@
 package com.stripe.android.paymentsheet.ui
 
+import android.os.Build
 import android.os.Bundle
+import android.view.View
 import androidx.activity.addCallback
 import androidx.appcompat.app.AppCompatActivity
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
 import com.stripe.android.paymentsheet.viewmodels.BaseSheetViewModel
@@ -15,6 +18,14 @@ internal abstract class BaseSheetActivity<ResultType> : AppCompatActivity() {
         get() = viewModel.linkHandler
 
     abstract fun setActivityResult(result: ResultType)
+
+    // User keys identify the Stripe Dashboard mobile app, where MOTO lets merchants enter a customer's card.
+    // Exclude those card details from Autofill so they cannot be saved on the merchant's device.
+    protected fun disableAutofillForUserKey() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && PaymentConfiguration.getInstance(this).isUserKey()) {
+            window.decorView.importantForAutofill = View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsActivityTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Build
+import android.view.View
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -127,6 +128,40 @@ internal class PaymentOptionsActivityTest {
             ).isEqualTo(
                 PaymentOptionsActivityResult.Canceled(null, null, listOf(), LinkAccountUpdate.Value(null))
             )
+        }
+    }
+
+    @Test
+    fun `user key excludes activity hierarchy from autofill`() {
+        PaymentConfiguration.init(context, "uk_test_123")
+
+        runActivityScenario { scenario ->
+            scenario.onActivity { activity ->
+                assertThat(activity.window.decorView.importantForAutofill)
+                    .isEqualTo(View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS)
+            }
+        }
+    }
+
+    @Test
+    fun `publishable key leaves activity hierarchy autofill importance unchanged`() {
+        runActivityScenario { scenario ->
+            scenario.onActivity { activity ->
+                assertThat(activity.window.decorView.importantForAutofill)
+                    .isEqualTo(View.IMPORTANT_FOR_AUTOFILL_AUTO)
+            }
+        }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
+    fun `user key does not access autofill APIs before Android O`() {
+        PaymentConfiguration.init(context, "uk_test_123")
+
+        runActivityScenario { scenario ->
+            scenario.onActivity { activity ->
+                assertThat(activity.isFinishing).isFalse()
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetActivityTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet
 
 import android.content.Context
 import android.os.Build
+import android.view.View
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
@@ -224,6 +225,34 @@ internal class PaymentSheetActivityTest {
             composeTestRule
                 .onNodeWithTag(BottomSheetContentTestTag)
                 .assertIsDisplayed()
+        }
+    }
+
+    @Test
+    fun `user key excludes activity hierarchy from autofill`() {
+        PaymentConfiguration.init(context, "uk_test_123")
+
+        activityScenario().launch(intent).onActivity { activity ->
+            assertThat(activity.window.decorView.importantForAutofill)
+                .isEqualTo(View.IMPORTANT_FOR_AUTOFILL_NO_EXCLUDE_DESCENDANTS)
+        }
+    }
+
+    @Test
+    fun `publishable key leaves activity hierarchy autofill importance unchanged`() {
+        activityScenario().launch(intent).onActivity { activity ->
+            assertThat(activity.window.decorView.importantForAutofill)
+                .isEqualTo(View.IMPORTANT_FOR_AUTOFILL_AUTO)
+        }
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
+    fun `user key does not access autofill APIs before Android O`() {
+        PaymentConfiguration.init(context, "uk_test_123")
+
+        activityScenario().launch(intent).onActivity { activity ->
+            assertThat(activity.isFinishing).isFalse()
         }
     }
 

--- a/stripe-core/src/main/java/com/stripe/android/core/ApiKeyValidator.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/ApiKeyValidator.kt
@@ -29,11 +29,18 @@ class ApiKeyValidator {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
+        private const val USER_KEY_PREFIX = "uk_"
+
         private val DEFAULT = ApiKeyValidator()
 
         @JvmStatic
         fun get(): ApiKeyValidator {
             return DEFAULT
+        }
+
+        @JvmStatic
+        fun isUserKey(apiKey: String): Boolean {
+            return apiKey.startsWith(USER_KEY_PREFIX)
         }
     }
 }

--- a/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
+++ b/stripe-core/src/main/java/com/stripe/android/core/networking/ApiRequest.kt
@@ -110,7 +110,7 @@ data class ApiRequest internal constructor(
         }
 
         val apiKeyIsUserKey: Boolean
-            get() = apiKey.startsWith("uk_")
+            get() = ApiKeyValidator.isUserKey(apiKey)
 
         val apiKeyIsLiveMode: Boolean
             get() = !apiKey.contains("test")

--- a/stripe-core/src/test/java/com/stripe/android/core/ApiKeyValidatorTest.kt
+++ b/stripe-core/src/test/java/com/stripe/android/core/ApiKeyValidatorTest.kt
@@ -49,4 +49,24 @@ class ApiKeyValidatorTest {
             ApiKeyValidator.get().requireValid(null)
         }
     }
+
+    @Test
+    fun `isUserKey returns true for live user key`() {
+        assertEquals(true, ApiKeyValidator.isUserKey("uk_live_123"))
+    }
+
+    @Test
+    fun `isUserKey returns true for test user key`() {
+        assertEquals(true, ApiKeyValidator.isUserKey("uk_test_123"))
+    }
+
+    @Test
+    fun `isUserKey returns false for live publishable key`() {
+        assertEquals(false, ApiKeyValidator.isUserKey("pk_live_123"))
+    }
+
+    @Test
+    fun `isUserKey returns false for test publishable key`() {
+        assertEquals(false, ApiKeyValidator.isUserKey("pk_test_123"))
+    }
 }


### PR DESCRIPTION
## Summary

- Centralizes Stripe user-key classification on the canonical `uk_` prefix
- Excludes PaymentSheet and PaymentOptions activity hierarchies from Android Autofill for Dashboard user keys on Android O and newer (previous versions don't have it)
- Preserves existing Autofill behavior for publishable keys and pre-O devices

Closes [RUN_MXMOBILE-19942](https://jira.corp.stripe.com/browse/RUN_MXMOBILE-19942)

## Testing

- Added coverage for live and test user keys and publishable keys.
- Added coverage that both PaymentSheet activity paths exclude Dashboard card entry from Autofill.
- Added coverage that publishable-key integrations retain Autofill and pre-O devices avoid unavailable Autofill APIs.
- Ran the full PaymentSheet unit test suite, static analysis, release lint, and public API checks.

| Example app (before) | Example app (after / fake API key) |
| --- | --- |
| https://github.com/user-attachments/assets/ad08e5cb-2570-4e55-b308-99dff63dd7cb | https://github.com/user-attachments/assets/39d69ab3-01b1-44c2-984e-cf8133772fb7 |

| Stripe Dashboard (current) | Stripe Dashboard (after) |
| --- | --- |
| https://github.com/user-attachments/assets/1c08e563-672e-401d-9fc2-d6dddee5aa90 | https://github.com/user-attachments/assets/f0a683f1-c3f1-4a07-8c25-898351dee91f |

Please note that "Example app (after)" won't really behave like that, I've removed the UserKey check just to be able to record the experience.