### PR TITLE
Refactor billing address form elements

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/BillingAddressFormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/BillingAddressFormElementsBuilder.kt
@@ -1,11 +1,15 @@
 package com.stripe.android.lpmfoundations.luxe
 
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.ui.core.elements.AddressSpec
+import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.BillingAddressCollectionMode
 import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.additionalAutomaticTaxFieldsByCountry
+import com.stripe.android.uicore.elements.AddressElement
+import com.stripe.android.uicore.elements.AddressInputMode
+import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
@@ -57,12 +61,38 @@ internal class BillingAddressFormElementsBuilder(
     }
 
     private fun createAddressElements(): List<FormElement> {
-        return AddressSpec(
-            allowedCountryCodes = fullAddressCountryCodes,
-        ).transform(
-            initialValues = resolvedInitialValues,
-            shippingValues = arguments.shippingValues,
-            autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
+        val sameAsShippingElement = arguments.shippingValues
+            ?.get(IdentifierSpec.SameAsShipping)
+            ?.toBooleanStrictOrNull()
+            ?.let { sameAsShipping ->
+                SameAsShippingElement(
+                    identifier = IdentifierSpec.SameAsShipping,
+                    controller = SameAsShippingController(sameAsShipping),
+                )
+            }
+        val addressElement = arguments.autocompleteAddressInteractorFactory?.let { interactorFactory ->
+            AutocompleteAddressElement(
+                identifier = IdentifierSpec.BillingAddress,
+                initialValues = resolvedInitialValues,
+                countryCodes = fullAddressCountryCodes,
+                sameAsShippingElement = sameAsShippingElement,
+                shippingValuesMap = arguments.shippingValues,
+                hideCountry = false,
+                interactorFactory = interactorFactory,
+            )
+        } ?: AddressElement(
+            _identifier = IdentifierSpec.BillingAddress,
+            rawValuesMap = resolvedInitialValues,
+            countryCodes = fullAddressCountryCodes,
+            addressInputMode = AddressInputMode.NoAutocomplete(),
+            sameAsShippingElement = sameAsShippingElement,
+            shippingValuesMap = arguments.shippingValues,
+            hideCountry = false,
+        )
+
+        return listOfNotNull(
+            SectionElement.wrap(addressElement, resolvableString(R.string.stripe_billing_details)),
+            sameAsShippingElement,
         )
     }
 


### PR DESCRIPTION
# Summary
Refactor `BillingAddressFormElementsBuilder` to construct its billing address and optional same-as-shipping form elements directly, including autocomplete support.

# Motivation
Align billing-address form construction with the current address element APIs, preserving country restrictions, initial values, shipping values, and autocomplete behavior.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Ran `./gradlew detekt` successfully.

# Screenshots
Not applicable — this is an internal form-element construction refactor with no standalone visual change.

# Changelog
Not applicable — no user-facing API or release-note-worthy behavior change.

Committed and created by Codex.
