### PR TITLE
Fix Paparazzi regional resolution

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -257,6 +257,7 @@ ext.testLibs = [
         okhttpMockWebServer  : "com.squareup.okhttp3:mockwebserver:${versions.okhttp}",
         okhttpTls            : "com.squareup.okhttp3:okhttp-tls:${versions.okhttp}",
         robolectric          : "org.robolectric:robolectric:${versions.robolectric}",
+        sdkCommon            : "com.android.tools:sdk-common:32.3.2",
         testOrchestrator     : "androidx.test:orchestrator:${versions.androidTestOrchestrator}",
         testParameterInjector: "com.google.testparameterinjector:test-parameter-injector:${versions.testParameterInjector}",
         turbine              : "app.cash.turbine:turbine:${versions.turbine}",

--- a/screenshot-testing/build.gradle
+++ b/screenshot-testing/build.gradle
@@ -22,6 +22,9 @@ dependencies {
 
     implementation testLibs.kotlin.reflect
 
+    // Remove once Paparazzi bundles the upstream locale-selection fix.
+    api testLibs.sdkCommon
+
     // Implemented here instead of using plugin which implements with testImplementation
     api("app.cash.paparazzi:paparazzi:${versions.paparazzi}") {
         exclude group: 'jakarta.activation'


### PR DESCRIPTION
# Summary

Pins the Paparazzi test fixture's `com.android.tools:sdk-common` dependency to 32.3.2.

# Motivation

Paparazzi's currently bundled `sdk-common` version does not include the upstream locale-selection fix, causing regional screenshot resolution issues. This test-only pin preserves the current AGP and Paparazzi versions and is documented for removal once Paparazzi bundles the fix.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified: `./gradlew :paymentsheet:dependencies --configuration debugUnitTestRuntimeClasspath` resolves `sdk-common` to 32.3.2.
- [x] `./gradlew detekt`

# Screenshots

Not applicable — this is a test-only dependency-resolution change with no UI changes.

# Changelog

Not applicable — this does not affect the published SDK.

Committed and created by Codex.
