### PR TITLE
Rename payment method test fixtures

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.ui.CustomerSheetScreen
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -167,8 +167,8 @@ internal class CustomerSheetScreenshotTest {
             ),
             usBankAccountFormArguments = usBankAccountFormArguments,
             supportedPaymentMethods = listOf(
-                LpmRepositoryTestHelpers.card,
-                LpmRepositoryTestHelpers.usBankAccount,
+                SupportedPaymentMethodFixtures.card,
+                SupportedPaymentMethodFixtures.usBankAccount,
             ),
             enabled = true,
             isLiveMode = false,

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -18,7 +18,7 @@ import com.stripe.android.customersheet.data.FakeCustomerSheetSavedSelectionData
 import com.stripe.android.customersheet.utils.CustomerSheetTestHelper
 import com.stripe.android.customersheet.utils.FakeCustomerSheetLoader
 import com.stripe.android.isInstanceOf
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.CardBrand
 import com.stripe.android.model.LinkBrand
@@ -1751,7 +1751,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount
+                    SupportedPaymentMethodFixtures.usBankAccount
                 )
             )
 
@@ -1773,7 +1773,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
         viewModel.handleViewAction(
             CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                LpmRepositoryTestHelpers.usBankAccount
+                SupportedPaymentMethodFixtures.usBankAccount
             )
         )
 
@@ -1798,7 +1798,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount
+                    SupportedPaymentMethodFixtures.usBankAccount
                 )
             )
 
@@ -1818,7 +1818,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.card
+                    SupportedPaymentMethodFixtures.card
                 )
             )
 
@@ -1844,7 +1844,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount
+                    SupportedPaymentMethodFixtures.usBankAccount
                 )
             )
 
@@ -1881,7 +1881,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount
+                    SupportedPaymentMethodFixtures.usBankAccount
                 )
             )
 
@@ -1900,8 +1900,8 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     customerPaymentMethods = listOf(),
                     isGooglePayAvailable = false,
                     supportedPaymentMethods = listOf(
-                        LpmRepositoryTestHelpers.usBankAccount,
-                        LpmRepositoryTestHelpers.card,
+                        SupportedPaymentMethodFixtures.usBankAccount,
+                        SupportedPaymentMethodFixtures.card,
                     ),
                     stripeIntent = SetupIntentFixtures.SI_REQUIRES_PAYMENT_METHOD_WITH_US_BANK_ACCOUNT,
                 ),
@@ -1994,7 +1994,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount,
+                    SupportedPaymentMethodFixtures.usBankAccount,
                 )
             )
 
@@ -2062,7 +2062,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
         viewModel.handleViewAction(
             CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                LpmRepositoryTestHelpers.usBankAccount,
+                SupportedPaymentMethodFixtures.usBankAccount,
             )
         )
 
@@ -2104,7 +2104,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.card,
+                    SupportedPaymentMethodFixtures.card,
                 )
             )
 
@@ -2123,12 +2123,12 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
             workContext = testDispatcher,
             isGooglePayAvailable = false,
             customerPaymentMethods = listOf(),
-            supportedPaymentMethods = listOf(LpmRepositoryTestHelpers.usBankAccount),
+            supportedPaymentMethods = listOf(SupportedPaymentMethodFixtures.usBankAccount),
         )
 
         viewModel.handleViewAction(
             CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                LpmRepositoryTestHelpers.usBankAccount,
+                SupportedPaymentMethodFixtures.usBankAccount,
             )
         )
 
@@ -2171,7 +2171,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
         viewModel.handleViewAction(
             CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                LpmRepositoryTestHelpers.usBankAccount,
+                SupportedPaymentMethodFixtures.usBankAccount,
             )
         )
 
@@ -2225,7 +2225,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
         viewModel.handleViewAction(
             CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                LpmRepositoryTestHelpers.usBankAccount,
+                SupportedPaymentMethodFixtures.usBankAccount,
             )
         )
 
@@ -2251,7 +2251,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
         viewModel.handleViewAction(
             CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                LpmRepositoryTestHelpers.usBankAccount
+                SupportedPaymentMethodFixtures.usBankAccount
             )
         )
 
@@ -2259,11 +2259,11 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
             val viewState = awaitViewState<AddPaymentMethod>()
 
             assertThat(viewState.paymentMethodCode)
-                .isEqualTo(LpmRepositoryTestHelpers.usBankAccount.code)
+                .isEqualTo(SupportedPaymentMethodFixtures.usBankAccount.code)
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount
+                    SupportedPaymentMethodFixtures.usBankAccount
                 )
             )
 
@@ -2277,7 +2277,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
             workContext = testDispatcher,
             isGooglePayAvailable = false,
             customerPaymentMethods = listOf(),
-            supportedPaymentMethods = listOf(LpmRepositoryTestHelpers.usBankAccount),
+            supportedPaymentMethods = listOf(SupportedPaymentMethodFixtures.usBankAccount),
         )
 
         viewModel.viewState.test {
@@ -2297,7 +2297,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
         viewModel.handleViewAction(
             CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                LpmRepositoryTestHelpers.usBankAccount,
+                SupportedPaymentMethodFixtures.usBankAccount,
             )
         )
 
@@ -2312,7 +2312,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.card
+                    SupportedPaymentMethodFixtures.card
                 )
             )
 
@@ -2322,7 +2322,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount
+                    SupportedPaymentMethodFixtures.usBankAccount
                 )
             )
 
@@ -2347,7 +2347,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount
+                    SupportedPaymentMethodFixtures.usBankAccount
                 )
             )
 
@@ -2368,7 +2368,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.card
+                    SupportedPaymentMethodFixtures.card
                 )
             )
 
@@ -3403,7 +3403,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.usBankAccount
+                    SupportedPaymentMethodFixtures.usBankAccount
                 )
             )
 
@@ -3413,7 +3413,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
 
             viewModel.handleViewAction(
                 CustomerSheetViewAction.OnAddPaymentMethodItemChanged(
-                    LpmRepositoryTestHelpers.card
+                    SupportedPaymentMethodFixtures.card
                 )
             )
             viewState = awaitViewState()

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/CustomerSheetTestHelper.kt
@@ -25,8 +25,8 @@ import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentMethodLauncherContractV2
 import com.stripe.android.googlepaylauncher.InternalGooglePayPaymentMethodLauncher
 import com.stripe.android.googlepaylauncher.injection.InternalGooglePayPaymentMethodLauncherFactory
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.model.ClientAttributionMetadata
@@ -74,8 +74,8 @@ internal interface CustomerSheetTestHelper {
         ),
         cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
         supportedPaymentMethods: List<SupportedPaymentMethod> = listOf(
-            LpmRepositoryTestHelpers.card,
-            LpmRepositoryTestHelpers.usBankAccount,
+            SupportedPaymentMethodFixtures.card,
+            SupportedPaymentMethodFixtures.usBankAccount,
         ),
         savedPaymentSelection: PaymentSelection? = null,
         paymentConfiguration: PaymentConfiguration = PaymentConfiguration(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/utils/FakeCustomerSheetLoader.kt
@@ -5,8 +5,8 @@ import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetLoader
 import com.stripe.android.customersheet.CustomerSheetState
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
 import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethod
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PassiveCaptchaParams
@@ -25,8 +25,8 @@ internal class FakeCustomerSheetLoader(
     private val shouldFail: Boolean = false,
     private val customerPaymentMethods: List<PaymentMethod> = emptyList(),
     private val supportedPaymentMethods: List<SupportedPaymentMethod> = listOf(
-        LpmRepositoryTestHelpers.card,
-        LpmRepositoryTestHelpers.usBankAccount,
+        SupportedPaymentMethodFixtures.card,
+        SupportedPaymentMethodFixtures.usBankAccount,
     ),
     private val paymentSelection: PaymentSelection? = null,
     private val isGooglePayAvailable: Boolean = false,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethodFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/luxe/SupportedPaymentMethodFixtures.kt
@@ -1,10 +1,9 @@
 package com.stripe.android.lpmfoundations.luxe
 
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.ui.core.R
 
-internal object LpmRepositoryTestHelpers {
-    val card: SupportedPaymentMethod = cardFromPaymentMethodMetadata() ?: SupportedPaymentMethod(
+internal object SupportedPaymentMethodFixtures {
+    val card: SupportedPaymentMethod = SupportedPaymentMethod(
         code = "card",
         displayNameResource = R.string.stripe_paymentsheet_payment_method_card,
         iconResource = R.drawable.stripe_ic_paymentsheet_pm_card,
@@ -23,10 +22,4 @@ internal object LpmRepositoryTestHelpers {
         darkThemeIconUrl = null,
         iconRequiresTinting = true,
     )
-
-    private fun cardFromPaymentMethodMetadata(): SupportedPaymentMethod? = runCatching {
-        PaymentMethodMetadataFactory.create().supportedPaymentMethodForCode(
-            code = "card",
-        )
-    }.getOrNull()
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/manage/EmbeddedNavigatorTest.kt
@@ -6,7 +6,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.taptoadd.FakeTapToAddHelper
 import com.stripe.android.core.strings.resolvableString
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.LinkBrand
@@ -432,7 +432,7 @@ internal class EmbeddedNavigatorTest {
         val screen = createHorizontalPaymentOptionsScreen(
             interactor = FakeAddPaymentMethodInteractor(
                 initialState = FakeAddPaymentMethodInteractor.createState().copy(
-                    supportedPaymentMethods = listOf(LpmRepositoryTestHelpers.usBankAccount),
+                    supportedPaymentMethods = listOf(SupportedPaymentMethodFixtures.usBankAccount),
                 ),
             ),
         )
@@ -445,7 +445,7 @@ internal class EmbeddedNavigatorTest {
         val screen = createHorizontalPaymentOptionsScreen(
             interactor = FakeAddPaymentMethodInteractor(
                 initialState = FakeAddPaymentMethodInteractor.createState().copy(
-                    supportedPaymentMethods = listOf(LpmRepositoryTestHelpers.card),
+                    supportedPaymentMethods = listOf(SupportedPaymentMethodFixtures.card),
                 ),
             ),
         )
@@ -460,8 +460,8 @@ internal class EmbeddedNavigatorTest {
             interactor = FakeAddPaymentMethodInteractor(
                 initialState = FakeAddPaymentMethodInteractor.createState().copy(
                     supportedPaymentMethods = listOf(
-                        LpmRepositoryTestHelpers.card,
-                        LpmRepositoryTestHelpers.usBankAccount,
+                        SupportedPaymentMethodFixtures.card,
+                        SupportedPaymentMethodFixtures.usBankAccount,
                     ),
                 ),
             ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -12,7 +12,7 @@ import com.stripe.android.link.ui.inline.InlineSignupViewState
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
@@ -179,7 +179,7 @@ internal class FormHelperTest {
                 stripeIntent = PaymentIntentFixtures.PI_OFF_SESSION
             )
         ).createFormArguments(
-            paymentMethodCode = LpmRepositoryTestHelpers.card.code,
+            paymentMethodCode = SupportedPaymentMethodFixtures.card.code,
         )
 
         assertThat(observedArgs).isEqualTo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -35,7 +35,7 @@ import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.SignUpConsentAction
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.link.utils.errorMessage
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.definitions.CardDefinition
@@ -1618,7 +1618,7 @@ internal class PaymentSheetViewModelTest {
             shouldCreateAutomaticallyLaunchedCardScanFormDataHelper = false,
             paymentMethodMessagePromotionsHelper = null,
         ).createFormArguments(
-            paymentMethodCode = LpmRepositoryTestHelpers.card.code,
+            paymentMethodCode = SupportedPaymentMethodFixtures.card.code,
         )
 
         assertThat(observedArgs).isEqualTo(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormArgumentsFactoryTest.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.forms
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.lpmfoundations.luxe.LpmRepositoryTestHelpers
+import com.stripe.android.lpmfoundations.luxe.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -30,7 +30,7 @@ class FormArgumentsFactoryTest {
         config: PaymentSheet.Configuration = PaymentSheetFixtures.CONFIG_MINIMUM,
     ): FormArguments {
         return FormArgumentsFactory.create(
-            paymentMethodCode = LpmRepositoryTestHelpers.card.code,
+            paymentMethodCode = SupportedPaymentMethodFixtures.card.code,
             metadata = PaymentMethodMetadataFactory.create(
                 billingDetailsCollectionConfiguration = config.billingDetailsCollectionConfiguration,
             ),


### PR DESCRIPTION
# Summary

Renames the PaymentSheet test fixture object from `LpmRepositoryTestHelpers` to `SupportedPaymentMethodFixtures` and updates all test call sites.

Committed and created by Codex.

# Motivation

The fixture name now describes the values it provides rather than the implementation it was originally associated with, making its reuse in PaymentSheet and CustomerSheet tests clearer.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran `./gradlew detekt`.

No tests were newly ignored.

# Screenshots

Not applicable: this is a test-fixture rename with no production UI change.

# Changelog

Not applicable: this is an internal test-only refactor with no user-facing change.
