### PR TITLE
Move billing details connection into FormViewModel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -4,12 +4,14 @@ import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.stripe.android.paymentsheet.forms.PlaceholderHelper.connectBillingDetailsFields
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.elements.BillingAddressElement
+import com.stripe.android.uicore.elements.AddressFieldsElement
+import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.combineAsStateFlow
@@ -17,6 +19,7 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -129,6 +132,33 @@ internal class FormViewModel(
     ) { hiddenIds, textFieldControllerIds ->
         textFieldControllerIds.lastOrNull {
             !hiddenIds.contains(it)
+        }
+    }
+}
+
+private suspend fun connectBillingDetailsFields(elements: List<FormElement>) {
+    val phoneNumberElement = elements
+        .filterIsInstance<SectionElement>()
+        .flatMap { it.fields }
+        .filterIsInstance<PhoneNumberElement>()
+        .firstOrNull()
+
+    // Prefer a standalone country field because an address field's country may be hidden.
+    val countryElement = elements
+        .filterIsInstance<SectionElement>()
+        .flatMap { it.fields }
+        .filterIsInstance<CountryElement>()
+        .firstOrNull()
+        ?: elements
+            .filterIsInstance<SectionElement>()
+            .flatMap { it.fields }
+            .filterIsInstance<AddressFieldsElement>()
+            .firstOrNull()
+            ?.countryElement
+
+    countryElement?.controller?.rawFieldValue?.filterNotNull()?.collect { countryCode ->
+        if (phoneNumberElement?.controller?.getLocalNumber().isNullOrBlank()) {
+            phoneNumberElement?.controller?.countryDropdownController?.onRawValueChange(countryCode)
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/PlaceholderHelper.kt
@@ -14,13 +14,7 @@ import com.stripe.android.ui.core.elements.PhoneSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec
 import com.stripe.android.ui.core.elements.PlaceholderSpec.PlaceholderField
 import com.stripe.android.ui.core.elements.SepaMandateTextSpec
-import com.stripe.android.uicore.elements.AddressFieldsElement
-import com.stripe.android.uicore.elements.CountryElement
-import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.PhoneNumberElement
-import com.stripe.android.uicore.elements.SectionElement
-import kotlinx.coroutines.flow.filterNotNull
 
 internal object PlaceholderHelper {
     /**
@@ -177,38 +171,5 @@ internal object PlaceholderHelper {
         }
 
         else -> null
-    }
-
-    internal suspend fun connectBillingDetailsFields(elements: List<FormElement>) {
-        val phoneNumberElement: PhoneNumberElement? = elements
-            .filterIsInstance<SectionElement>()
-            .flatMap { it.fields }
-            .filterIsInstance<PhoneNumberElement>()
-            .firstOrNull()
-
-        // Look for a standalone CountryElement.
-        // Note that this should be done first, because AddressElement always has a
-        // CountryElement, but it might be hidden.
-        var countryElement = elements
-            .filterIsInstance<SectionElement>()
-            .flatMap { it.fields }
-            .filterIsInstance<CountryElement>()
-            .firstOrNull()
-
-        // If not found, look for one inside an AddressElement.
-        if (countryElement == null) {
-            countryElement = elements
-                .filterIsInstance<SectionElement>()
-                .flatMap { it.fields }
-                .filterIsInstance<AddressFieldsElement>()
-                .firstOrNull()
-                ?.countryElement
-        }
-
-        countryElement?.controller?.rawFieldValue?.filterNotNull()?.collect {
-            if (phoneNumberElement?.controller?.getLocalNumber().isNullOrBlank()) {
-                phoneNumberElement?.controller?.countryDropdownController?.onRawValueChange(it)
-            }
-        }
     }
 }


### PR DESCRIPTION
# Summary

Move the billing-country/phone-field connection helper into `FormViewModel` and remove its obsolete copy from `PlaceholderHelper`.

Committed and created by Codex.

# Motivation

Keep `FormViewModel` self-contained while isolating this change from the broader obsolete form-item-spec removal.

# Testing

- `./gradlew :paymentsheet:compileDebugKotlin`
- `./gradlew detekt`
- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots

Not applicable — this is a non-visual internal refactor.

# Changelog

Not applicable — no user-facing behavior change.
