### PR TITLE
Migrate contact information form elements

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/ContactInformationCollectionMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/ContactInformationCollectionMode.kt
@@ -1,11 +1,19 @@
 package com.stripe.android.lpmfoundations.luxe
 
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.ui.core.elements.EmailSpec
-import com.stripe.android.ui.core.elements.NameSpec
-import com.stripe.android.ui.core.elements.PhoneSpec
+import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.PhoneNumberController
+import com.stripe.android.uicore.elements.PhoneNumberElement
+import com.stripe.android.uicore.elements.SectionElement
+import com.stripe.android.uicore.elements.SimpleTextElement
+import com.stripe.android.uicore.elements.SimpleTextFieldConfig
+import com.stripe.android.uicore.elements.SimpleTextFieldController
+import com.stripe.android.core.R as CoreR
 
 internal enum class ContactInformationCollectionMode {
     Name {
@@ -15,7 +23,20 @@ internal enum class ContactInformationCollectionMode {
 
         override fun formElement(
             initialValues: Map<IdentifierSpec, String?>
-        ): FormElement = NameSpec().transform(initialValues)
+        ): FormElement = SectionElement.wrap(
+            SimpleTextElement(
+                identifier = IdentifierSpec.Name,
+                controller = SimpleTextFieldController(
+                    textFieldConfig = SimpleTextFieldConfig(
+                        label = resolvableString(CoreR.string.stripe_address_label_full_name),
+                        capitalization = KeyboardCapitalization.Words,
+                        keyboard = KeyboardType.Text,
+                        optional = false,
+                    ),
+                    initialValue = initialValues[IdentifierSpec.Name],
+                )
+            )
+        )
     },
     Phone {
         override fun collectionMode(
@@ -24,7 +45,14 @@ internal enum class ContactInformationCollectionMode {
 
         override fun formElement(
             initialValues: Map<IdentifierSpec, String?>
-        ): FormElement = PhoneSpec().transform(initialValues)
+        ): FormElement = SectionElement.wrap(
+            PhoneNumberElement(
+                identifier = IdentifierSpec.Phone,
+                controller = PhoneNumberController.createPhoneNumberController(
+                    initialValue = initialValues[IdentifierSpec.Phone] ?: "",
+                )
+            )
+        )
     },
     Email {
         override fun collectionMode(
@@ -33,7 +61,12 @@ internal enum class ContactInformationCollectionMode {
 
         override fun formElement(
             initialValues: Map<IdentifierSpec, String?>
-        ): FormElement = EmailSpec().transform(initialValues)
+        ): FormElement = SectionElement.wrap(
+            EmailElement(
+                identifier = IdentifierSpec.Email,
+                initialValue = initialValues[IdentifierSpec.Email],
+            )
+        )
     };
 
     abstract fun collectionMode(


### PR DESCRIPTION
# Summary

Replaces the legacy name, phone, and email form-item specs with their direct UI-core elements in `ContactInformationCollectionMode`.

Committed and created by Codex.

# Motivation

This isolates the `ContactInformationCollectionMode` portion of the obsolete form-item-spec removal, so it can land independently while preserving the generated form elements.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.lpmfoundations.luxe.ContactInformationCollectionModeTest'`
- `./gradlew detekt`

# Screenshots

| Before | After |
| ------------- | ------------- |
| Not applicable: internal implementation migration. | Not applicable: no expected visual change. |

# Changelog

Not applicable: no user-facing behavior change.
