### PR TITLE
Add playground API configuration setting

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/PaymentSheetPlaygroundViewModel.kt
@@ -55,6 +55,7 @@ import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundCon
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettingDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
 import com.stripe.android.paymentsheet.example.playground.settings.ShippingAddressSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.UseApiConfigurationSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.countryCode
 import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
 import com.stripe.android.paymentsheet.model.PaymentOption
@@ -282,10 +283,12 @@ internal class PaymentSheetPlaygroundViewModel(
 
                         // Init PaymentConfiguration with the publishable key returned from the backend,
                         // which will be used on all Stripe API calls
-                        PaymentConfiguration.init(
-                            getApplication(),
-                            response.publishableKey
-                        )
+                        if (!UseApiConfigurationSettingsDefinition.isEnabled(playgroundState.snapshot)) {
+                            PaymentConfiguration.init(
+                                getApplication(),
+                                response.publishableKey
+                            )
+                        }
 
                         if (playgroundState.isNewCustomer) {
                             playgroundSettingsFlow.value?.let { settings ->
@@ -353,10 +356,15 @@ internal class PaymentSheetPlaygroundViewModel(
 
                 // Init PaymentConfiguration with the publishable key returned from the backend,
                 // which will be used on all Stripe API calls
-                PaymentConfiguration.init(
-                    getApplication(),
-                    response.publishableKey
-                )
+                val useApiConfiguration = playgroundSettingsFlow.value
+                    ?.snapshot()
+                    ?.let(UseApiConfigurationSettingsDefinition::isEnabled) == true
+                if (!useApiConfiguration) {
+                    PaymentConfiguration.init(
+                        getApplication(),
+                        response.publishableKey
+                    )
+                }
 
                 if (isNewCustomer) {
                     playgroundSettingsFlow.value?.let { settings ->

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/embedded/EmbeddedExampleActivity.kt
@@ -19,7 +19,10 @@ import androidx.compose.material.Button
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -27,12 +30,16 @@ import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.core.requests.suspendable
 import com.github.kittinunf.result.Result
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.rememberEmbeddedPaymentElement
 import com.stripe.android.paymentsheet.CreateIntentResult
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.example.R
+import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
+import com.stripe.android.paymentsheet.example.playground.settings.UseApiConfigurationSettingsDefinition
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutRequest
 import com.stripe.android.paymentsheet.example.samples.networking.ExampleCheckoutResponse
 import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
@@ -44,17 +51,25 @@ internal class EmbeddedExampleActivity : AppCompatActivity() {
         supportActionBar?.title = getString(R.string.embedded_example_title)
 
         setContent {
-            CheckoutScreen()
+            val useApiConfiguration = remember {
+                val snapshot = PlaygroundSettings.createFromSharedPreferences(applicationContext).snapshot()
+                UseApiConfigurationSettingsDefinition.isEnabled(snapshot)
+            }
+            CheckoutScreen(useApiConfiguration)
         }
     }
 }
 
 @Composable
-fun CheckoutScreen() {
+@OptIn(ApiConfigurationPreview::class)
+fun CheckoutScreen(useApiConfiguration: Boolean = false) {
     val context = LocalContext.current.applicationContext
+    var prefetchedCheckout by remember { mutableStateOf<CheckoutResult?>(null) }
     val embeddedBuilder = remember {
         EmbeddedPaymentElement.Builder(
-            createIntentCallback = { _, _ -> checkout(context) },
+            createIntentCallback = { _, _ ->
+                (prefetchedCheckout ?: checkout(context, initializePaymentConfiguration = true)).createIntentResult
+            },
             resultCallback = { result -> handlePaymentResult(context, result) },
         )
     }
@@ -62,6 +77,15 @@ fun CheckoutScreen() {
     val embeddedPaymentElement = rememberEmbeddedPaymentElement(embeddedBuilder)
 
     LaunchedEffect(embeddedPaymentElement) {
+        val checkoutResult = if (useApiConfiguration) {
+            checkout(context, initializePaymentConfiguration = false).also {
+                prefetchedCheckout = it
+            }
+        } else {
+            null
+        }
+        val configurationBuilder = EmbeddedPaymentElement.Configuration.Builder("Powdur")
+        checkoutResult?.apiConfiguration?.let(configurationBuilder::apiConfiguration)
         val configureResult = embeddedPaymentElement.configure(
             intentConfiguration = PaymentSheet.IntentConfiguration(
                 mode = PaymentSheet.IntentConfiguration.Mode.Payment(
@@ -70,7 +94,7 @@ fun CheckoutScreen() {
                 ),
                 // Optional intent configuration options...
             ),
-            configuration = EmbeddedPaymentElement.Configuration.Builder("Powdur").build()
+            configuration = configurationBuilder.build()
         )
         if (configureResult is EmbeddedPaymentElement.ConfigureResult.Failed) {
             Toast.makeText(context, configureResult.error.message, Toast.LENGTH_LONG).show()
@@ -101,7 +125,10 @@ fun CheckoutScreen() {
     }
 }
 
-private suspend fun checkout(context: Context): CreateIntentResult {
+private suspend fun checkout(
+    context: Context,
+    initializePaymentConfiguration: Boolean,
+): CheckoutResult {
     val request = ExampleCheckoutRequest(
         hotDogCount = 1,
         saladCount = 1,
@@ -115,17 +142,30 @@ private suspend fun checkout(context: Context): CreateIntentResult {
         .awaitModel(ExampleCheckoutResponse.serializer())
     return when (apiResult) {
         is Result.Success -> {
-            PaymentConfiguration.init(
-                context = context,
-                publishableKey = apiResult.value.publishableKey,
+            if (initializePaymentConfiguration) {
+                PaymentConfiguration.init(
+                    context = context,
+                    publishableKey = apiResult.value.publishableKey,
+                )
+            }
+            CheckoutResult(
+                createIntentResult = CreateIntentResult.Success(apiResult.value.paymentIntent),
+                apiConfiguration = ApiConfiguration(apiResult.value.publishableKey),
             )
-            CreateIntentResult.Success(apiResult.value.paymentIntent)
         }
         is Result.Failure -> {
-            CreateIntentResult.Failure(apiResult.error)
+            CheckoutResult(
+                createIntentResult = CreateIntentResult.Failure(apiResult.error),
+                apiConfiguration = null,
+            )
         }
     }
 }
+
+private data class CheckoutResult(
+    val createIntentResult: CreateIntentResult,
+    val apiConfiguration: ApiConfiguration?,
+)
 
 private fun handlePaymentResult(context: Context, result: EmbeddedPaymentElement.Result) {
     when (result) {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/PlaygroundRequester.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/network/PlaygroundRequester.kt
@@ -14,6 +14,9 @@ import com.stripe.android.paymentsheet.example.playground.model.CheckoutResponse
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerSettingsDefinition
 import com.stripe.android.paymentsheet.example.playground.settings.CustomerType
 import com.stripe.android.paymentsheet.example.playground.settings.PlaygroundSettings
+import com.stripe.android.paymentsheet.example.playground.settings.ResolvedApiConfiguration
+import com.stripe.android.paymentsheet.example.playground.settings.ResolvedApiConfigurationSettingsDefinition
+import com.stripe.android.paymentsheet.example.playground.settings.UseApiConfigurationSettingsDefinition
 import com.stripe.android.paymentsheet.example.samples.networking.awaitModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -47,15 +50,21 @@ internal class PlaygroundRequester(
 
                 // Init PaymentConfiguration with the publishable key returned from the backend,
                 // which will be used on all Stripe API calls
-                withContext(Dispatchers.IO) {
-                    PaymentConfiguration.init(
-                        applicationContext,
-                        checkoutResponse.publishableKey,
-                    )
+                if (!UseApiConfigurationSettingsDefinition.isEnabled(playgroundSettings)) {
+                    withContext(Dispatchers.IO) {
+                        PaymentConfiguration.init(
+                            applicationContext,
+                            checkoutResponse.publishableKey,
+                        )
+                    }
                 }
 
                 val customerId = checkoutResponse.customerId
                 val updatedSettings = playgroundSettings.playgroundSettings()
+                updatedSettings[ResolvedApiConfigurationSettingsDefinition] = ResolvedApiConfiguration(
+                    publishableKey = checkoutResponse.publishableKey,
+                    stripeAccountId = null,
+                )
                 val currentCustomerType = playgroundSettings[CustomerSettingsDefinition]
                 if (
                     (currentCustomerType == CustomerType.NEW || currentCustomerType == CustomerType.RETURNING) &&

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/PlaygroundSettings.kt
@@ -1,4 +1,4 @@
-@file:OptIn(LinkControllerPreview::class)
+@file:OptIn(ApiConfigurationPreview::class, LinkControllerPreview::class)
 
 package com.stripe.android.paymentsheet.example.playground.settings
 
@@ -8,7 +8,9 @@ import android.os.Parcelable
 import android.util.Log
 import androidx.compose.runtime.Stable
 import androidx.core.content.edit
+import com.stripe.android.ApiConfigurationPreview
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkController
@@ -143,6 +145,9 @@ internal class PlaygroundSettings private constructor(
             appSettings: Settings,
         ): PaymentSheet.Configuration {
             val builder = PaymentSheet.Configuration.Builder("Example, Inc.")
+            if (this[UseApiConfigurationSettingsDefinition]) {
+                builder.apiConfiguration(apiConfiguration())
+            }
             val paymentSheetConfigurationData =
                 PlaygroundSettingDefinition.PaymentSheetConfigurationData(builder)
             settings.filter { (definition, _) ->
@@ -172,6 +177,9 @@ internal class PlaygroundSettings private constructor(
             playgroundState: PlaygroundState.Payment
         ): EmbeddedPaymentElement.Configuration {
             val builder = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
+            if (this[UseApiConfigurationSettingsDefinition]) {
+                builder.apiConfiguration(apiConfiguration())
+            }
             val embeddedConfigurationData = PlaygroundSettingDefinition.EmbeddedConfigurationData(builder)
             settings.filter { (definition, _) ->
                 definition.applicable(configurationData, settings)
@@ -300,6 +308,15 @@ internal class PlaygroundSettings private constructor(
                 settingDefinition.configure(builder, value)
             }
             return builder.build()
+        }
+
+        private fun apiConfiguration(): ApiConfiguration {
+            val resolved = this[ResolvedApiConfigurationSettingsDefinition]
+            return ApiConfiguration(
+                requireNotNull(resolved.publishableKey) {
+                    "No publishable key was resolved for ApiConfiguration."
+                }
+            ).stripeAccountId(resolved.stripeAccountId)
         }
 
         fun customerEphemeralKeyRequest(): CustomerEphemeralKeyRequest {
@@ -573,6 +590,7 @@ internal class PlaygroundSettings private constructor(
             CaptureMethodSettingsDefinition,
             FeatureFlagSettingsDefinition(FeatureFlags.enableNfcScanning),
             FeatureFlagSettingsDefinition(FeatureFlags.disableNfcScanningSecurity),
+            UseApiConfigurationSettingsDefinition,
         )
 
         private val nonUiSettingDefinitions: List<PlaygroundSettingDefinition<*>> = listOf(
@@ -580,6 +598,7 @@ internal class PlaygroundSettings private constructor(
             CustomEndpointDefinition,
             ShippingAddressSettingsDefinition,
             ConfirmationTokenSettingsDefinition,
+            ResolvedApiConfigurationSettingsDefinition,
         )
 
         private val allSettingDefinitions: List<PlaygroundSettingDefinition<*>> =

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ResolvedApiConfigurationSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/ResolvedApiConfigurationSettingsDefinition.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+internal object ResolvedApiConfigurationSettingsDefinition :
+    PlaygroundSettingDefinition<ResolvedApiConfiguration>,
+    PlaygroundSettingDefinition.Saveable<ResolvedApiConfiguration> {
+    override val key: String = "resolvedApiConfiguration"
+    override val defaultValue: ResolvedApiConfiguration = ResolvedApiConfiguration()
+    override val saveToSharedPreferences: Boolean = false
+
+    override fun convertToString(value: ResolvedApiConfiguration): String {
+        return Json.encodeToString(ResolvedApiConfiguration.serializer(), value)
+    }
+
+    override fun convertToValue(value: String): ResolvedApiConfiguration {
+        return Json.decodeFromString(ResolvedApiConfiguration.serializer(), value)
+    }
+}
+
+@Serializable
+internal data class ResolvedApiConfiguration(
+    val publishableKey: String? = null,
+    val stripeAccountId: String? = null,
+)

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/UseApiConfigurationSettingsDefinition.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/settings/UseApiConfigurationSettingsDefinition.kt
@@ -1,0 +1,26 @@
+package com.stripe.android.paymentsheet.example.playground.settings
+
+internal object UseApiConfigurationSettingsDefinition : BooleanSettingsDefinition(
+    key = "useApiConfiguration",
+    displayName = "Use ApiConfiguration",
+    defaultValue = true,
+) {
+    fun isEnabled(snapshot: PlaygroundSettings.Snapshot): Boolean {
+        return snapshot[this] && supports(snapshot.configurationData)
+    }
+
+    override fun applicable(
+        configurationData: PlaygroundConfigurationData,
+        settings: Map<PlaygroundSettingDefinition<*>, Any?>,
+    ): Boolean {
+        return supports(configurationData)
+    }
+
+    private fun supports(configurationData: PlaygroundConfigurationData): Boolean {
+        return configurationData.integrationType in setOf(
+            PlaygroundConfigurationData.IntegrationType.PaymentSheet,
+            PlaygroundConfigurationData.IntegrationType.FlowController,
+            PlaygroundConfigurationData.IntegrationType.Embedded,
+        )
+    }
+}

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
@@ -68,6 +68,5 @@ internal object ApiConfigurationTestTypeProvider : TestParameterValuesProvider()
     ): List<ApiConfigurationTestType> = listOf(
         ApiConfigurationTestType.PaymentConfigurationOnly,
         ApiConfigurationTestType.ApiConfigurationOnly,
-        ApiConfigurationTestType.ApiConfigurationOverridesPaymentConfiguration,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -1140,8 +1140,9 @@ class PaymentSheet internal constructor(
              * When not set, the payment element uses the credentials initialized through
              * [com.stripe.android.PaymentConfiguration].
              */
+            @ApiConfigurationPreview
             @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-            internal fun apiConfiguration(apiConfiguration: ApiConfiguration) = apply {
+            fun apiConfiguration(apiConfiguration: ApiConfiguration) = apply {
                 this.apiConfiguration = apiConfiguration.build()
             }
 


### PR DESCRIPTION
# Summary

Add a "Use ApiConfiguration" playground setting for PaymentSheet, FlowController, and Embedded Payment Element.

When enabled, the playground stores the publishable key and optional Stripe account ID returned by the backend and supplies them through each integration configuration instead of initializing process-wide `PaymentConfiguration`. The standalone Embedded example also resolves credentials before configuration and reuses its prefetched intent result during confirmation.

Expose the preview `PaymentSheet.Configuration.Builder.apiConfiguration()` entry point so PaymentSheet and FlowController can opt into per-instance credentials alongside Embedded Payment Element.

Committed and created by Codex.

# Motivation

The playground should exercise API-configuration-only integrations and verify that PaymentSheet, FlowController, and Embedded Payment Element do not depend on global `PaymentConfiguration` initialization.

Keeping the resolved credential pair in the playground snapshot preserves it across Activity recreation while ensuring each payment-element instance owns the credentials selected by its backend response.

# Testing
- [ ] Added tests
- [x] Modified tests
- [x] Manually verified

# Screenshots

Not applicable — playground configuration behavior only.

# Changelog
