### PR TITLE
Post Connect toasts without a coroutine scope

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeToastManager.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeToastManager.kt
@@ -1,10 +1,9 @@
 package com.stripe.android.connect.webview
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.widget.Toast
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
 
 /**
  * Provides an interface for various download and file operations. Useful for mocking in tests.
@@ -13,11 +12,9 @@ internal interface StripeToastManager {
     fun showToast(context: Context, toastString: String)
 }
 
-internal class StripeToastManagerImpl(
-    private val scope: CoroutineScope = MainScope()
-) : StripeToastManager {
+internal class StripeToastManagerImpl : StripeToastManager {
     override fun showToast(context: Context, toastString: String) {
-        scope.launch {
+        Handler(Looper.getMainLooper()).post {
             Toast.makeText(context, toastString, Toast.LENGTH_LONG).show()
         }
     }


### PR DESCRIPTION
# Summary
Post Connect toast creation through the main looper instead of an independently owned `MainScope`.

# Motivation
Toast dispatch is a single main-thread action and does not need a persistent coroutine scope, which previously had no cancellation boundary.

# Testing
- `./gradlew :connect:testDebugUnitTest`
- `./gradlew detekt`

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — toast behavior is unchanged.

# Changelog
Not applicable — internal lifecycle cleanup.

Committed and created by Codex.
