### PR TITLE
Tie Connect downloads to the view lifecycle

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -47,6 +47,7 @@ import com.stripe.android.connect.webview.serialization.toJs
 import com.stripe.android.core.Logger
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerializationException
@@ -89,6 +90,8 @@ internal class StripeConnectWebView private constructor(
     @VisibleForTesting
     internal val stripeJsInterface = StripeJsInterface()
 
+    private var stripeDownloadListener: StripeDownloadListener? = null
+
     private val webViewLifecycleScope get() = findViewTreeLifecycleOwner()?.lifecycleScope
 
     private var globalLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
@@ -113,7 +116,6 @@ internal class StripeConnectWebView private constructor(
             mediaPlaybackRequiresUserGesture = false
         }
 
-        setDownloadListener(StripeDownloadListener(context))
         addJavascriptInterface(stripeJsInterface, ANDROID_JS_INTERFACE)
     }
 
@@ -161,12 +163,22 @@ internal class StripeConnectWebView private constructor(
         val activity = requireNotNull(findActivity())
         mutableContext.baseContext = activity
 
+        val lifecycleScope = requireNotNull(webViewLifecycleScope)
+        stripeDownloadListener = StripeDownloadListener(
+            context = context,
+            coroutineScope = lifecycleScope,
+            workContext = Dispatchers.IO,
+        ).also(::setDownloadListener)
+
         // Set up keyboard detection to resize the webview according to keyboard heights
         // This fixes input fields being covered by keyboard on Samsung devices.
         setupKeyboardHandling(activity)
     }
 
     override fun onDetachedFromWindow() {
+        setDownloadListener(null)
+        stripeDownloadListener = null
+
         // Clean up the global layout listener
         globalLayoutListener?.let { listener ->
             findActivity()?.window?.decorView?.viewTreeObserver?.removeOnGlobalLayoutListener(listener)

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeDownloadListener.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeDownloadListener.kt
@@ -7,16 +7,16 @@ import android.content.Context
 import android.webkit.DownloadListener
 import com.stripe.android.connect.R
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
 
 internal class StripeDownloadListener(
     private val context: Context,
     private val stripeDownloadManager: StripeDownloadManager = StripeDownloadManagerImpl(context),
     private val stripeToastManager: StripeToastManager = StripeToastManagerImpl(),
-    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    private val coroutineScope: CoroutineScope,
+    private val workContext: CoroutineContext,
 ) : DownloadListener {
 
     override fun onDownloadStart(
@@ -31,7 +31,7 @@ internal class StripeDownloadListener(
             return
         }
 
-        ioScope.launch {
+        coroutineScope.launch(workContext) {
             val downloadId = stripeDownloadManager.enqueueDownload(url, contentDisposition, mimetype)
             if (downloadId == null) {
                 showErrorToast()

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeDownloadListenerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeDownloadListenerTest.kt
@@ -4,6 +4,7 @@ import android.app.DownloadManager
 import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -32,6 +33,7 @@ class StripeDownloadListenerTest {
     }
     private val stripeToastManager: StripeToastManager = mock()
     private val testScope = TestScope()
+    private val testDispatcher = StandardTestDispatcher(testScope.testScheduler)
 
     private lateinit var stripeDownloadListener: StripeDownloadListener
 
@@ -50,13 +52,14 @@ class StripeDownloadListenerTest {
         context: Context = this.context,
         stripeDownloadManager: StripeDownloadManager = this.stripeDownloadManager,
         stripeToastManager: StripeToastManager = this.stripeToastManager,
-        ioScope: CoroutineScope = testScope,
+        coroutineScope: CoroutineScope = testScope,
     ) {
         stripeDownloadListener = StripeDownloadListener(
             context = context,
             stripeDownloadManager = stripeDownloadManager,
             stripeToastManager = stripeToastManager,
-            ioScope = ioScope,
+            coroutineScope = coroutineScope,
+            workContext = testDispatcher,
         )
     }
 


### PR DESCRIPTION
# Summary
Run Connect download monitoring in the containing lifecycle's scope and recreate the listener when the WebView is attached.

# Motivation
The listener previously owned a `SupervisorJob` scope with no lifecycle cancellation. Borrowing the view-tree lifecycle keeps work bounded without leaving a permanently cancelled listener after a temporary detach/reattach.

# Testing
- `./gradlew :connect:testDebugUnitTest`
- `./gradlew detekt`

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — no visual change.

# Changelog
Not applicable — internal lifecycle cleanup.

Committed and created by Codex.
