### PR TITLE
Route automatic tax Checkout Sessions through tax merchant

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
@@ -93,7 +93,12 @@ internal object CheckoutSessionDefinitions {
         key = "session.automatic_tax",
         displayName = "Automatic tax",
         defaultValue = false,
-        updateRequest = { enabled -> put("automatic_tax", enabled) },
+        updateRequest = { enabled ->
+            put("automatic_tax", enabled)
+            if (enabled) {
+                put("merchant_country_code", "us_tax")
+            }
+        },
     )
     val shippingAddressCollection = boolean(
         key = "session.shipping_address_collection",

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -28,6 +28,7 @@ class CheckoutControllerExampleRequestFactoryTest {
                 put("billing_address_collection", false)
             }
         )
+        assertThat(request.body).doesNotContainKey("merchant_country_code")
     }
 
     @Test
@@ -50,6 +51,7 @@ class CheckoutControllerExampleRequestFactoryTest {
                 put("currency", "eur")
                 put("automatic_payment_methods", true)
                 put("automatic_tax", true)
+                put("merchant_country_code", "us_tax")
                 put("shipping_address_collection", true)
                 put("billing_address_collection", true)
             }


### PR DESCRIPTION
# Summary

Routes Checkout Controller example requests with Automatic tax enabled through the playground tax-configured merchant by adding `merchant_country_code: "us_tax"`.

# Motivation

The existing `/checkout_session` backend recognizes `us_tax` and uses its tax-configured account. The example previously omitted this routing field, so Automatic tax requests used the default merchant. Automatic tax disabled requests and all other Checkout Controller behavior remain unchanged. No backend change is included.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified
- Focused `CheckoutControllerExampleRequestFactoryTest` asserts the exact enabled request, including `merchant_country_code: "us_tax"`, and explicitly asserts the field is absent when disabled.
- The path-aware pre-push hook passed `:paymentsheet-example:detekt`.

# Screenshots

| Before | After |
| ------------- | ------------- |
| Not applicable, request-only behavior | Not applicable, request-only behavior |

# Changelog

No changelog entry. This is example-only request routing and does not change SDK public behavior.

Committed and created by Codex.