### PR TITLE
Use factory to create OTP elements

### DIFF
--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPSpec.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/OTPSpec.kt
@@ -2,8 +2,6 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.uicore.elements.IdentifierSpec
-import com.stripe.android.uicore.elements.OTPController
-import com.stripe.android.uicore.elements.OTPElement
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 
@@ -13,11 +11,4 @@ import kotlinx.serialization.Serializable
 data object OTPSpec : FormItemSpec() {
     override val apiPath: IdentifierSpec
         get() = IdentifierSpec.Generic("otp")
-
-    fun transform(): OTPElement {
-        return OTPElement(
-            identifier = apiPath,
-            controller = OTPController()
-        )
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationDialog.kt
@@ -22,8 +22,8 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.link.theme.LinkTheme
 import com.stripe.android.model.LinkBrand
-import com.stripe.android.ui.core.elements.OTPSpec
 import com.stripe.android.uicore.elements.OTPElement
+import com.stripe.android.uicore.elements.OTPElementFactory
 import com.stripe.android.uicore.utils.collectAsState
 
 @Composable
@@ -137,7 +137,7 @@ fun VerificationDialogPreview() {
                     allowLogout = true,
                     linkBrand = LinkBrand.Link,
                 ),
-                otpElement = OTPSpec.transform(),
+                otpElement = OTPElementFactory.create(),
                 onBack = {},
                 onChangeEmailClick = {},
                 onResendCodeClick = {},

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.link.theme.DefaultLinkTheme
 import com.stripe.android.model.LinkBrand
-import com.stripe.android.ui.core.elements.OTPSpec
+import com.stripe.android.uicore.elements.OTPElementFactory
 import com.stripe.android.uicore.utils.collectAsState
 
 @Composable
@@ -49,7 +49,7 @@ fun VerificationPreview() {
                     allowLogout = true,
                     linkBrand = LinkBrand.Link,
                 ),
-                otpElement = OTPSpec.transform(),
+                otpElement = OTPElementFactory.create(),
                 onBack = {},
                 onChangeEmailClick = {},
                 onResendCodeClick = {},

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationViewModel.kt
@@ -23,7 +23,7 @@ import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.link.utils.errorMessage
 import com.stripe.android.model.ConsumerSessionRefresh
 import com.stripe.android.model.LinkBrand
-import com.stripe.android.ui.core.elements.OTPSpec
+import com.stripe.android.uicore.elements.OTPElementFactory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -71,7 +71,7 @@ internal class VerificationViewModel @Inject constructor(
     )
     val viewState: StateFlow<VerificationViewState> = _viewState
 
-    val otpElement = OTPSpec.transform()
+    val otpElement = OTPElementFactory.create()
 
     private val otpCode: StateFlow<String?> =
         otpElement.otpCompleteFlow.stateIn(viewModelScope, SharingStarted.Lazily, null)

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/DefaultLinkInlineInteractor.kt
@@ -18,7 +18,7 @@ import com.stripe.android.link.utils.errorMessage
 import com.stripe.android.link.verification.VerificationState.Render2FA
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.flowcontroller.DefaultFlowController.Companion.WALLETS_BUTTON_LINK_LAUNCHER
-import com.stripe.android.ui.core.elements.OTPSpec
+import com.stripe.android.uicore.elements.OTPElementFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -39,7 +39,7 @@ internal class DefaultLinkInlineInteractor @Inject constructor(
     private val linkEventsReporter: LinkEventsReporter
 ) : LinkInlineInteractor {
 
-    override val otpElement = OTPSpec.transform()
+    override val otpElement = OTPElementFactory.create()
 
     override val state: StateFlow<LinkInlineState> = savedStateHandle.getStateFlow(
         key = LINK_EMBEDDED_STATE_KEY,

--- a/paymentsheet/src/main/java/com/stripe/android/link/verification/NoOpLinkInlineInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/verification/NoOpLinkInlineInteractor.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.link.verification
 
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.ui.core.elements.OTPSpec
 import com.stripe.android.uicore.elements.OTPElement
+import com.stripe.android.uicore.elements.OTPElementFactory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -16,7 +16,7 @@ internal class NoOpLinkInlineInteractor : LinkInlineInteractor {
             verificationState = VerificationState.RenderButton,
         )
     )
-    override val otpElement: OTPElement = OTPSpec.transform()
+    override val otpElement: OTPElement = OTPElementFactory.create()
 
     override fun setup(paymentMethodMetadata: PaymentMethodMetadata) {
         // No-op implementation

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/luxe/TransformSpecToElements.kt
@@ -28,6 +28,7 @@ import com.stripe.android.ui.core.elements.SimpleTextSpec
 import com.stripe.android.ui.core.elements.StaticTextSpec
 import com.stripe.android.uicore.elements.FormElement
 import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.OTPElementFactory
 
 /**
  * Transform a [LayoutSpec] data object into an Element, which
@@ -57,7 +58,7 @@ internal class TransformSpecToElements(
                 is AffirmTextSpec -> listOf(spec.transform())
                 is EmptyFormSpec -> listOf(EmptyFormElement())
                 is MandateTextSpec -> listOf(spec.transform(arguments.merchantName))
-                is OTPSpec -> listOf(spec.transform())
+                is OTPSpec -> listOf(OTPElementFactory.create())
                 is NameSpec -> listOf(spec.transform(arguments.initialValues))
                 is EmailSpec -> listOf(spec.transform(arguments.initialValues))
                 is PhoneSpec -> listOf(spec.transform(arguments.initialValues))

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/verification/VerificationScreenshotTest.kt
@@ -5,8 +5,8 @@ import com.stripe.android.link.ui.LinkScreenshotSurface
 import com.stripe.android.model.ConsentUi
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.screenshottesting.PaparazziRule
-import com.stripe.android.ui.core.elements.OTPSpec
 import com.stripe.android.uicore.elements.OTPElement
+import com.stripe.android.uicore.elements.OTPElementFactory
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -70,7 +70,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationScreenWithOTPNotFilled",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(content = ""),
+                        otpElement = otpElementWithContent(content = ""),
                         state = VerificationViewState(
                             requestFocus = false,
                             redactedPhoneNumber = "(•••) ••• ••91",
@@ -89,7 +89,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationScreenWithOTPFilled",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(),
+                        otpElement = otpElementWithContent(),
                         state = VerificationViewState(
                             requestFocus = false,
                             redactedPhoneNumber = "(•••) ••• ••91",
@@ -108,7 +108,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationScreenWithOTPFilledAndProcessing",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(),
+                        otpElement = otpElementWithContent(),
                         state = VerificationViewState(
                             isProcessing = true,
                             requestFocus = false,
@@ -127,7 +127,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationScreenWithOTPFilledAndSendingNewCode",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(),
+                        otpElement = otpElementWithContent(),
                         state = VerificationViewState(
                             isSendingNewCode = true,
                             requestFocus = false,
@@ -146,7 +146,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationScreenWithOTPFilledAndErrorMessage",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(),
+                        otpElement = otpElementWithContent(),
                         state = VerificationViewState(
                             isSendingNewCode = false,
                             requestFocus = false,
@@ -165,7 +165,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationDialogWithOTPNotFilled",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(content = ""),
+                        otpElement = otpElementWithContent(content = ""),
                         state = VerificationViewState(
                             requestFocus = false,
                             redactedPhoneNumber = "(•••) ••• ••91",
@@ -184,7 +184,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationDialogWithOTPFilled",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(),
+                        otpElement = otpElementWithContent(),
                         state = VerificationViewState(
                             requestFocus = false,
                             redactedPhoneNumber = "(•••) ••• ••91",
@@ -203,7 +203,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationDialogWithOTPFilledAndErrorMessage",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(),
+                        otpElement = otpElementWithContent(),
                         state = VerificationViewState(
                             isSendingNewCode = false,
                             requestFocus = false,
@@ -222,7 +222,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationScreenProcessingWebAuth",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(content = ""),
+                        otpElement = otpElementWithContent(content = ""),
                         state = VerificationViewState(
                             isProcessingWebAuth = true,
                             isDialog = false,
@@ -243,7 +243,7 @@ internal class VerificationScreenshotTest(
                 TestCase(
                     name = "VerificationDialogProcessingWebAuth",
                     content = TestCase.Content(
-                        otpElement = otpSpecWithContent(content = ""),
+                        otpElement = otpElementWithContent(content = ""),
                         state = VerificationViewState(
                             isProcessingWebAuth = true,
                             isDialog = true,
@@ -264,10 +264,10 @@ internal class VerificationScreenshotTest(
             )
         }
 
-        private fun otpSpecWithContent(content: String = "555555"): OTPElement {
-            val spec = OTPSpec.transform()
-            spec.controller.onAutofillDigit(content)
-            return spec
+        private fun otpElementWithContent(content: String = "555555"): OTPElement {
+            val element = OTPElementFactory.create()
+            element.controller.onAutofillDigit(content)
+            return element
         }
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementFactory.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementFactory.kt
@@ -1,0 +1,13 @@
+package com.stripe.android.uicore.elements
+
+import androidx.annotation.RestrictTo
+
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+object OTPElementFactory {
+    fun create(): OTPElement {
+        return OTPElement(
+            identifier = IdentifierSpec.Generic("otp"),
+            controller = OTPController(),
+        )
+    }
+}


### PR DESCRIPTION
# Summary

- Add `OTPElementFactory` as the single construction path for OTP elements.
- Replace `OTPSpec.transform()` call sites and keep `OTPSpec` focused on serialized form metadata.
- Update the verification screenshot fixture to construct OTP elements through the factory.

Committed and created by Codex.

# Motivation

OTP element construction should not require a form spec. A dedicated factory separates runtime element creation from the serialized `OTPSpec` representation and lets Link verification surfaces create the element directly.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :stripe-ui-core:compileDebugKotlin :payments-ui-core:compileDebugKotlin :paymentsheet:compileDebugKotlin :paymentsheet:testDebugUnitTest --tests "com.stripe.android.link.ui.verification.VerificationScreenshotTest"`
- `./gradlew detekt`

No tests were newly ignored.

# Screenshots

Not applicable; this is an internal construction refactor with no visual changes.

# Changelog

Not applicable; this change does not alter the public API or user-visible behavior.
