### PR TITLE
Show pending tax state in Checkout example

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutContent.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutContent.kt
@@ -4,8 +4,6 @@ package com.stripe.android.paymentsheet.example.playground.checkout
 
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -26,8 +24,6 @@ internal fun CheckoutContent(
     onRemovePromotionCode: () -> Unit,
     onUpdateEmail: (String) -> Unit,
 ) {
-    Text(text = "Tax status: ${session.tax.status}", style = MaterialTheme.typography.h6)
-    Spacer(Modifier.height(16.dp))
     LineItemsSection(session)
     TotalSummarySection(session)
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutSummary.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutSummary.kt
@@ -7,14 +7,19 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.uicore.format.CurrencyFormatter
+
+internal const val PENDING_TAX_TEST_TAG = "pending_tax"
 
 @Composable
 internal fun LineItemsSection(session: Session) {
@@ -47,14 +52,45 @@ internal fun TotalSummarySection(session: Session) {
                 if (shipping.amount == 0L) "Free" else formatAmount(shipping.amount, session.currency),
             )
         }
-        summary.taxAmounts.forEach { tax ->
-            SummaryRow(
-                if (tax.inclusive) "${tax.displayName} (included)" else tax.displayName,
-                formatAmount(tax.amount, session.currency),
-            )
+        TaxSummaryRows(taxStatus = session.tax.status) {
+            summary.taxAmounts.forEach { tax ->
+                SummaryRow(
+                    if (tax.inclusive) "${tax.displayName} (included)" else tax.displayName,
+                    formatAmount(tax.amount, session.currency),
+                )
+            }
         }
         Divider(modifier = Modifier.padding(vertical = 8.dp))
         SummaryRow("Total", formatAmount(summary.totalDueToday, session.currency))
+    }
+}
+
+@Composable
+internal fun TaxSummaryRows(
+    taxStatus: Session.Tax.Status,
+    calculatedTaxRows: @Composable () -> Unit,
+) {
+    val pendingMessage = when (taxStatus) {
+        Session.Tax.Status.RequiresShippingAddress -> "Enter shipping address to calculate"
+        Session.Tax.Status.RequiresBillingAddress -> "Enter billing address to calculate"
+        Session.Tax.Status.Ready,
+        Session.Tax.Status.Unknown -> null
+    }
+
+    if (pendingMessage != null) {
+        val color = MaterialTheme.colors.onSurface.copy(alpha = ContentAlpha.medium)
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics(mergeDescendants = true) {}
+                .testTag(PENDING_TAX_TEST_TAG),
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(text = "Tax", color = color)
+            Text(text = pendingMessage, style = MaterialTheme.typography.caption, color = color)
+        }
+    } else {
+        calculatedTaxRows()
     }
 }
 

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutSummaryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutSummaryTest.kt
@@ -1,0 +1,96 @@
+@file:OptIn(
+    com.stripe.android.paymentelement.CheckoutSessionPreview::class,
+    kotlinx.coroutines.ExperimentalCoroutinesApi::class,
+)
+
+package com.stripe.android.paymentsheet.example.playground.checkout
+
+import androidx.compose.material.Text
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import com.stripe.android.checkout.CheckoutController.Session
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutSummaryTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+
+    @Test
+    fun `shipping address required shows pending tax message`() = runScenario(
+        taxStatus = Session.Tax.Status.RequiresShippingAddress,
+    ) {
+        page.pendingTax.assertIsDisplayed()
+        page.pendingTax.assertTextContains("Tax")
+        page.pendingTax.assertTextContains("Enter shipping address to calculate")
+        page.calculatedTax.assertDoesNotExist()
+    }
+
+    @Test
+    fun `billing address required shows pending tax message`() = runScenario(
+        taxStatus = Session.Tax.Status.RequiresBillingAddress,
+    ) {
+        page.pendingTax.assertIsDisplayed()
+        page.pendingTax.assertTextContains("Tax")
+        page.pendingTax.assertTextContains("Enter billing address to calculate")
+        page.calculatedTax.assertDoesNotExist()
+    }
+
+    @Test
+    fun `ready tax shows calculated tax rows`() = runScenario(
+        taxStatus = Session.Tax.Status.Ready,
+    ) {
+        page.pendingTax.assertDoesNotExist()
+        page.calculatedTax.assertIsDisplayed()
+    }
+
+    @Test
+    fun `unknown tax shows calculated tax rows`() = runScenario(
+        taxStatus = Session.Tax.Status.Unknown,
+    ) {
+        page.pendingTax.assertDoesNotExist()
+        page.calculatedTax.assertIsDisplayed()
+    }
+
+    private fun runScenario(
+        taxStatus: Session.Tax.Status,
+        block: Scenario.() -> Unit,
+    ) {
+        composeRule.setContent {
+            TaxSummaryRows(taxStatus = taxStatus) {
+                Text(CALCULATED_TAX_TEXT)
+            }
+        }
+
+        block(Scenario(page = CheckoutSummaryPage(composeRule)))
+    }
+
+    private data class Scenario(
+        val page: CheckoutSummaryPage,
+    )
+}
+
+private class CheckoutSummaryPage(
+    composeRule: ComposeContentTestRule,
+) {
+    val pendingTax = composeRule.onNodeWithTag(PENDING_TAX_TEST_TAG)
+    val calculatedTax = composeRule.onNodeWithText(CALCULATED_TAX_TEXT)
+}
+
+private const val CALCULATED_TAX_TEXT = "Calculated tax"


### PR DESCRIPTION
# Summary

Render pending automatic tax in the CheckoutController playground order summary. Sessions that require a shipping or billing address now show the corresponding calculation prompt and suppress calculated tax rows until tax is ready.

Committed and created by Codex.

# Motivation

The Android playground displayed the raw tax status above the checkout content but did not represent pending tax in the order summary. This brings the example in line with stripe-ios and gives the customer an actionable explanation for why tax has not been calculated.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Added Compose coverage for shipping-address, billing-address, ready, and unknown tax states.

Validated with:

- `./gradlew :paymentsheet-example:testBaseDebugUnitTest :paymentsheet-example:assembleBaseDebug`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not included. The pending and calculated rendering branches are covered by Robolectric Compose tests; no Android emulator screenshot was captured.

# Changelog

Not applicable. This only changes the internal example playground and does not affect the SDK API or merchant-facing behavior.
