### PR TITLE
Remove unused payments-ui-core JSON dependency

### DIFF
--- a/payments-ui-core/build.gradle
+++ b/payments-ui-core/build.gradle
@@ -48,7 +48,6 @@ dependencies {
     testImplementation testLibs.androidx.composeUi
     testImplementation testLibs.hamcrest
     testImplementation testLibs.junit
-    testImplementation testLibs.json
     testImplementation testLibs.kotlin.annotations
     testImplementation testLibs.kotlin.coroutines
     testImplementation testLibs.kotlin.junit


### PR DESCRIPTION
# Summary
Remove the unused `org.json:json` test dependency from `payments-ui-core`.

# Motivation
`payments-ui-core` no longer contains any `org.json` usages, so keeping the test dependency adds an unnecessary artifact to the module's test classpath.

# Testing
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

Verified that `payments-ui-core` contains no references to `org.json` classes or imports.

Ran:
- `./gradlew :payments-ui-core:testDebugUnitTest`
- `./gradlew detekt`

Ignored tests: None.

# Screenshots
Not applicable; this dependency cleanup does not change UI.

# Changelog
Not applicable; this internal build cleanup does not affect SDK behavior or public APIs.

Committed and created by Codex.
