### PR TITLE
Remove orphaned iDEAL bank string

### DIFF
--- a/payments-ui-core/res/values-b+es+419/strings.xml
+++ b/payments-ui-core/res/values-b+es+419/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">El IBAN que ingresaste no es válido; \"%s\" no es un código de país admitido.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">El IBAN debe empezar con un código de país de dos letras.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banco iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Tu código BLIK está incompleto.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-ca-rES/strings.xml
+++ b/payments-ui-core/res/values-ca-rES/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">L\'IBAN no és vàlid, %s no és un codi de país compatible.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">El teu IBAN ha de començar amb un codi de país de dues lletres.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Bank iDeal</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">El codi BLIK no està complet.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-cs-rCZ/strings.xml
+++ b/payments-ui-core/res/values-cs-rCZ/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Zadané číslo IBAN je neplatné, \"%s\" není podporovaný kód země.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Číslo IBAN by mělo začínat dvěma písmeny kódu země.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banka iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Váš kód BLIK je neúplný.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-da/strings.xml
+++ b/payments-ui-core/res/values-da/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Den indtastede IBAN er ugyldig, \"%s\" er ikke en gyldig landekode.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Dit IBAN-nummer skal starte med en landekode på to bogstaver.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Din BLIK-kode er ufuldstændig.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-de/strings.xml
+++ b/payments-ui-core/res/values-de/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Die eingegebene IBAN ist ungültig. „%s“ ist kein unterstützter Ländercode.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Ihre IBAN sollte mit einem zweistelligen Ländercode beginnen.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL-Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Ihr BLIK-Code ist unvollständig.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-el-rGR/strings.xml
+++ b/payments-ui-core/res/values-el-rGR/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Ο κωδικός IBAN που εισάγατε δεν είναι έγκυρος, ο κωδικός «%s» δεν είναι υποστηριζόμενος κωδικός χώρας.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Ο κωδικός IBAN σας πρέπει να αρχίζει με έναν διψήφιο κωδικό χώρας.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Ο κωδικός σας BLIK είναι ελλιπής.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-en-rGB/strings.xml
+++ b/payments-ui-core/res/values-en-rGB/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">The IBAN you entered is invalid; \"%s\" is not a supported country code.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Your IBAN should start with a two-letter country code.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Your BLIK code is incomplete.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-es/strings.xml
+++ b/payments-ui-core/res/values-es/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">El IBAN que has introducido no es válido: %s no es un código de país admitido.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">El IBAN debe empezar con un código de país de dos letras.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banco iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Tu código BLIK no está completo.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-et-rEE/strings.xml
+++ b/payments-ui-core/res/values-et-rEE/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Sisestatud IBAN on kehtetu, \"%s\" ei ole toetatud riigikood.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Teie IBAN peab algama kahetähelise riigikoodiga.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEALi pank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Teie BLIK-kood on puudulik.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-fi/strings.xml
+++ b/payments-ui-core/res/values-fi/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Antamasi IBAN on virheellinen, \"%s\" ei ole tuettu maakoodi.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN-tilinumero alkaa kaksikirjaimisella maakoodilla.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL-pankki</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">BLIK-koodisi on puutteellinen.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-fil/strings.xml
+++ b/payments-ui-core/res/values-fil/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Ang IBAN na iniligay mo ay imbalido. \"%s\" ay di suportadong code ng bansa.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Ang iyong IBAN ay dapat magsimula sa dalawang letra na code ng bansa.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Ang iyong BLIK code ay kulang.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-fr-rCA/strings.xml
+++ b/payments-ui-core/res/values-fr-rCA/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">L\'IBAN que vous avez saisi n\'est pas valide, « %s » n\'est pas un code pays pris en charge.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Votre IBAN doit commencer par un code pays à deux lettres.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banque iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Votre code BLIK est incomplet.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-fr/strings.xml
+++ b/payments-ui-core/res/values-fr/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">L\'IBAN que vous avez saisi n\'est pas valide, « %s » n\'est pas un code pays pris en charge.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Votre IBAN doit commencer par un code pays à deux lettres.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banque iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Votre code BLIK est incomplet.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-hr/strings.xml
+++ b/payments-ui-core/res/values-hr/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Uneseni IBAN je neispravan, \"%s\" nije podržani broj države.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Vaš bi IBAN trebao započeti s kodom države od dva slova.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Vaš BLIK kod je nepotpun.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-hu/strings.xml
+++ b/payments-ui-core/res/values-hu/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">A beírt IBAN-szám érvénytelen, a(z) „%s” nem támogatott országkód.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Az IBAN-számának egy kétbetűs országkóddal kell kezdődnie.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">BLIK kódja hiányos.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-in/strings.xml
+++ b/payments-ui-core/res/values-in/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">IBAN yang Anda masukkan tidak valid. \"%s\" bukan kode negara yang didukung.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN Anda harus diawali dengan kode negara dua-huruf.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Kode BLIK Anda tidak lengkap.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-it/strings.xml
+++ b/payments-ui-core/res/values-it/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">L\'IBAN inserito non è valido; \"%s\" non è un codice di paese valido.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">L\'IBAN deve iniziare con un codice di paese di due lettere.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banca iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Il codice BLIK non è completo.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-ja/strings.xml
+++ b/payments-ui-core/res/values-ja/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">入力した IBAN が無効です。\"%s\" はサポートされている国コードではありません。</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBANコードの先頭には 2 文字の国コードを入力してください。</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL銀行</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">BLIK コードの入力に不備があります。</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-ko/strings.xml
+++ b/payments-ui-core/res/values-ko/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">입력한 IBAN이 잘못되었습니다. \"%s\"은(는) 지원되는 국가 코드가 아닙니다.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN은 두 글자의 국가 코드로 시작해야 합니다.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL 은행</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">BLIK 코드가 불완전합니다.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-lt-rLT/strings.xml
+++ b/payments-ui-core/res/values-lt-rLT/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Įvedėte neteisingą IBAN kodą, \"%s\" nėra palaikomas šalies kodas.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Jūsų IBAN turėtų prasidėti šalies kodu iš dviejų raidžių.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL bankas</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Jūsų BLIK kodas neišsamus.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-lv-rLV/strings.xml
+++ b/payments-ui-core/res/values-lv-rLV/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Ievadītais IBAN nav derīgs, \"%s\" nav atbalstīts valsts kods.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN sākumā jābūt divu burtu valsts kodam.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL banka</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Jūsu BLIK kods nav pilnīgs.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-ms-rMY/strings.xml
+++ b/payments-ui-core/res/values-ms-rMY/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">IBAN yang anda masukkan tidak sah, \"%s\" bukanlah kod negara yang disokong.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN anda harus bermula dengan kod negara dua huruf.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Bank iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Kod BLIK anda tidak lengkap.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-mt/strings.xml
+++ b/payments-ui-core/res/values-mt/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">L-IBAN li daħħalt mhux tajjeb, \"%s\" mhux pajjiż li jista\' jintuża.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">L-IBAN tiegħek għandu jibda b\'kodiċi tal-pajjiż magħmul minn żewġ ittri.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Il-Bank iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Il-kodiċi BLIK li ktibt mhux komplut.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-nb/strings.xml
+++ b/payments-ui-core/res/values-nb/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">IBAN-nummeret du la inn er ugyldig, «%s» er ikke en gyldig landskode.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN-nummeret skal starte med en tosifret landskode.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">BLIK-koden er ufullstendig.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-nl/strings.xml
+++ b/payments-ui-core/res/values-nl/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Het opgegeven IBAN-nummer is ongeldig: \"%s\" is geen ondersteunde landcode.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Het IBAN-nummer moet beginnen met een landcode van twee letters.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL-bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Je BLIK-code is onvolledig.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-pl-rPL/strings.xml
+++ b/payments-ui-core/res/values-pl-rPL/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Podany IBAN jest nieprawidłowy. „%s” nie jest prawidłowym kodem kraju.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN powinien się zaczynać od dwuliterowego kodu kraju.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Kod BLIK jest niekompletny.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-pt-rBR/strings.xml
+++ b/payments-ui-core/res/values-pt-rBR/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">O IBAN inserido é inválido, \"%s\" não foi reconhecido como código de país.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Seu IBAN deve começar com um código de país de duas letras.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banco iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Seu código BLIK está incompleto.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-pt-rPT/strings.xml
+++ b/payments-ui-core/res/values-pt-rPT/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">O IBAN que introduziu é inválido, \"%s\" não é um código de país suportado.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">O seu IBAN deve começar por um código de duas letras correspondente ao país.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banco iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">O seu código BLIK está incompleto.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-ro-rRO/strings.xml
+++ b/payments-ui-core/res/values-ro-rRO/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Codul IBAN pe care l-ați introdus nu este valid, \"%s\" nu este un cod de țară acceptat.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Codul dvs. IBAN trebuie să înceapă cu un cod de țară format din două litere.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Codul dvs. BLIK nu este complet.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-ro/strings.xml
+++ b/payments-ui-core/res/values-ro/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Codul IBAN pe care l-ați introdus nu este valid, \"%s\" nu este un cod de țară acceptat.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Codul dvs. IBAN trebuie să înceapă cu un cod de țară format din două litere.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Codul dvs. BLIK nu este complet.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-ru/strings.xml
+++ b/payments-ui-core/res/values-ru/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Введенный код IBAN ошибочен, \"%s\" – неверный код страны.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Код IBAN должен начинаться с двухбуквенного кода страны.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Банк в системе iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Ваш код BLIK неполный.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-sk-rSK/strings.xml
+++ b/payments-ui-core/res/values-sk-rSK/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Zadaný IBAN je neplatný, „%s“ nie je podporovaný kód krajiny.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Váš IBAN by mal začínať dvojpísmenovým kódom krajiny.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL banka</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Váš kód BLIK je neúplný.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-sl-rSI/strings.xml
+++ b/payments-ui-core/res/values-sl-rSI/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Vnesena koda IBAN ni veljavna. \"%s\" ni podprta koda države.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Vaša koda IBAN se mora začeti z dvomestno kodo države.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Banka iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Vaša koda BLIK ni popolna.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-sv/strings.xml
+++ b/payments-ui-core/res/values-sv/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Angivet IBAN är ogiltigt, \"%s\" är inte en giltig landskod.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Ditt IBAN ska börja med en landskod (två bokstäver).</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Din BLIK-kod är ofullständig.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-th/strings.xml
+++ b/payments-ui-core/res/values-th/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">IBAN ที่คุณป้อนไม่ถูกต้อง \"%s\" ไม่ใช่รหัสประเทศที่รองรับ</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN ควรเริ่มต้นด้วยรหัสประเทศ 2 ตัวอักษร</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">ธนาคารที่รองรับ iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">รหัส BLIK ไม่ครบถ้วน</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-tr/strings.xml
+++ b/payments-ui-core/res/values-tr/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">Girdiğiniz IBAN geçersiz. \"%s\" desteklenen bir ülke kodu değil.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN numaranız iki harfli bir ülke koduyla başlamalıdır.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">BLIK kodunuz eksik.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-vi/strings.xml
+++ b/payments-ui-core/res/values-vi/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">IBAN quý vị đã nhập không hợp lệ, \"%s\" không phải là mã quốc gia được hỗ trợ.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">IBAN của quý vị phải bắt đầu bằng mã quốc gia gồm hai chữ cái.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">Ngân hàng iDEAL</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Mã BLIK của quý vị chưa đầy đủ.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-zh-rHK/strings.xml
+++ b/payments-ui-core/res/values-zh-rHK/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">您輸入的 IBAN 無效，「%s」是不支援的國家代碼。</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">您的 IBAN 應以兩個字母的國家代碼開頭。</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL 銀行</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">您的 BLIK 代碼不完整。</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-zh-rTW/strings.xml
+++ b/payments-ui-core/res/values-zh-rTW/strings.xml
@@ -48,8 +48,6 @@
   <string name="stripe_iban_invalid_country">您輸入的 IBAN 無效，「%s」是不支援的國家代碼。</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">您的 IBAN 應以兩個字母的國家代碼開頭。</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL 銀行</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">您的 BLIK 驗證碼不完整。</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values-zh/strings.xml
+++ b/payments-ui-core/res/values-zh/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">您输入的 IBAN 无效，\"%s\" 是不支持的国家代码。</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">您的 IBAN 应以两个字母的国家代码开头。</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL 银行</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">您的 BLIK 代码不完整。</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/res/values/strings.xml
+++ b/payments-ui-core/res/values/strings.xml
@@ -52,8 +52,6 @@
   <string name="stripe_iban_invalid_country">The IBAN you entered is invalid, \"%s\" is not a supported country code.</string>
   <!-- An error message displayed when the IBAN does not start with a two-letter country code. -->
   <string name="stripe_iban_invalid_start">Your IBAN should start with a two-letter country code.</string>
-  <!-- iDEAL bank section title for iDEAL form entry. -->
-  <string name="stripe_ideal_bank">iDEAL Bank</string>
   <!-- Error message when BLIK code is invalid -->
   <string name="stripe_incomplete_blik_code">Your BLIK code is incomplete.</string>
   <!-- Error message when BLIK code is invalid -->

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SimpleDropdownConfigTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SimpleDropdownConfigTest.kt
@@ -8,20 +8,11 @@ import org.junit.Test
 
 class SimpleDropdownConfigTest {
     private val config: DropdownConfig = SimpleDropdownConfig(
-        resolvableString(R.string.stripe_ideal_bank),
+        resolvableString(R.string.stripe_payment_method_bank),
         listOf(
-            DropdownItem(displayText = "ABN AMRO", apiValue = "abn_amro"),
-            DropdownItem(displayText = "ASN Bank", apiValue = "asn_bank"),
-            DropdownItem(displayText = "Bunq", apiValue = "bunq"),
-            DropdownItem(displayText = "Handelsbanken", apiValue = "handelsbanken"),
-            DropdownItem(displayText = "ING", apiValue = "ing"),
-            DropdownItem(displayText = "Knab", apiValue = "knab"),
-            DropdownItem(displayText = "Rabobank", apiValue = "rabobank"),
-            DropdownItem(displayText = "Revolut", apiValue = "revolut"),
-            DropdownItem(displayText = "RegioBank", apiValue = "regiobank"),
-            DropdownItem(displayText = "SNS Bank (De Volksbank)", apiValue = "sns_bank"),
-            DropdownItem(displayText = "Triodos Bank", apiValue = "triodos_bank"),
-            DropdownItem(displayText = "Van Lanschot", apiValue = "van_lanschot")
+            DropdownItem(displayText = "Option A", apiValue = "option_a"),
+            DropdownItem(displayText = "Option B", apiValue = "option_b"),
+            DropdownItem(displayText = "Option C", apiValue = "option_c"),
         )
     )
 
@@ -30,25 +21,16 @@ class SimpleDropdownConfigTest {
         assertThat(config.displayItems)
             .isEqualTo(
                 listOf(
-                    "ABN AMRO",
-                    "ASN Bank",
-                    "Bunq",
-                    "Handelsbanken",
-                    "ING",
-                    "Knab",
-                    "Rabobank",
-                    "Revolut",
-                    "RegioBank",
-                    "SNS Bank (De Volksbank)",
-                    "Triodos Bank",
-                    "Van Lanschot"
+                    "Option A",
+                    "Option B",
+                    "Option C",
                 )
             )
     }
 
     @Test
     fun `Verify convert from value returns appropriate string`() {
-        assertThat(config.convertFromRaw("asn_bank"))
-            .isEqualTo("ASN Bank")
+        assertThat(config.convertFromRaw("option_b"))
+            .isEqualTo("Option B")
     }
 }


### PR DESCRIPTION
# Summary

Remove the unused `stripe_ideal_bank` resource from the base strings and all translations. Replace the stale iDEAL bank fixture in `SimpleDropdownConfigTest` with generic dropdown data.

# Motivation

Production iDEAL no longer displays a bank selector, leaving this string orphaned. The only remaining reference was test sample data unrelated to the behavior under test.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :payments-ui-core:testDebugUnitTest --tests com.stripe.android.ui.core.elements.SimpleDropdownConfigTest`

`./gradlew detekt`

No tests were ignored.

# Screenshots

| Before | After |
| ------------- | ------------- |
| Not applicable: unused resource cleanup with no production UI change. | Not applicable: unused resource cleanup with no production UI change. |

# Changelog

Not applicable: this removes an unused internal resource and stale test data without changing user-visible behavior.

Committed and created by Codex.
