### PR TITLE
Run checkout payment element loads in parallel

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -2,13 +2,18 @@ package com.stripe.android.checkout
 
 import android.graphics.Bitmap
 import android.os.Bundle
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -52,7 +57,6 @@ internal class CheckoutStateLoader @Inject constructor(
         customerStateHolder.setCustomerState(null)
     }
 
-    @Suppress("LongMethod")
     private suspend fun commit(
         configuration: CheckoutController.Configuration.State,
         response: CheckoutSessionResponse,
@@ -82,50 +86,21 @@ internal class CheckoutStateLoader @Inject constructor(
             collectedDetails = collectedDetails,
         )
 
-        val initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(response.id, response)
-
-        val paymentElementLoaderMetadata = PaymentElementLoader.Metadata(
-            isReloadingAfterProcessDeath = false,
-            initializedViaCompose = false,
+        val loadResults = loadPaymentElements(
+            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(response.id, response),
+            embeddedConfiguration = embeddedConfig,
+            paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout.asPaymentSheet(),
+            expressCheckoutElementConfiguration = expressCheckoutElementConfiguration,
         )
-
-        val (loaderState, expressCheckoutElementLoaderState) = coroutineScope {
-            val loaderStateDeferred = async {
-                paymentElementLoader.load(
-                    initializationMode = initializationMode,
-                    integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
-                        isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
-                        configuration = embeddedConfig,
-                        paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout
-                            .asPaymentSheet(),
-                    ),
-                    metadata = paymentElementLoaderMetadata,
-                ).getOrThrow()
-            }
-            val expressCheckoutElementLoaderStateDeferred =
-                expressCheckoutElementConfiguration?.let { eceConfiguration ->
-                    async {
-                        paymentElementLoader.load(
-                            initializationMode = initializationMode,
-                            integrationConfiguration = PaymentElementLoader.Configuration.ExpressCheckoutElement(
-                                commonConfiguration = eceConfiguration,
-                            ),
-                            metadata = paymentElementLoaderMetadata,
-                        ).getOrThrow()
-                    }
-                }
-
-            loaderStateDeferred.await() to expressCheckoutElementLoaderStateDeferred?.await()
-        }
 
         // Preserve the customer's existing selection across reloads when it's still valid, rather
         // than blindly adopting the loader's recomputed selection (reuses the embedded logic). The
         // previous selection comes from the incoming state, not a separate holder.
         val selection = selectionChooser.choose(
-            paymentMethodMetadata = loaderState.paymentMethodMetadata,
-            paymentMethods = loaderState.customer?.paymentMethods,
+            paymentMethodMetadata = loadResults.paymentMethodMetadata,
+            paymentMethods = loadResults.customer?.paymentMethods,
             previousSelection = carryForward.previousSelection,
-            newSelection = loaderState.paymentSelection,
+            newSelection = loadResults.paymentSelection,
             newConfiguration = commonConfiguration,
             formSheetAction = embeddedConfig.formSheetAction,
         )
@@ -135,16 +110,66 @@ internal class CheckoutStateLoader @Inject constructor(
             checkoutSessionResponse = response,
             flagImages = flagImages,
             collectedDetails = collectedDetails,
-            paymentMethodMetadata = loaderState.paymentMethodMetadata,
-            expressCheckoutElementPaymentMethodMetadata = expressCheckoutElementLoaderState?.paymentMethodMetadata,
+            paymentMethodMetadata = loadResults.paymentMethodMetadata,
+            expressCheckoutElementPaymentMethodMetadata = loadResults.expressCheckoutElementPaymentMethodMetadata,
             embeddedConfiguration = embeddedConfig,
             paymentSelection = selection,
             temporarySelection = carryForward.temporarySelection,
             previousNewSelections = carryForward.previousNewSelections,
         )
 
-        customerStateHolder.setCustomerState(loaderState.customer)
+        customerStateHolder.setCustomerState(loadResults.customer)
     }
+
+    private suspend fun loadPaymentElements(
+        initializationMode: PaymentElementLoader.InitializationMode,
+        embeddedConfiguration: EmbeddedPaymentElement.Configuration,
+        paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+        expressCheckoutElementConfiguration: CommonConfiguration?,
+    ): LoadResults = coroutineScope {
+        val metadata = PaymentElementLoader.Metadata(
+            isReloadingAfterProcessDeath = false,
+            initializedViaCompose = false,
+        )
+        val paymentElementStateDeferred = async {
+            paymentElementLoader.load(
+                initializationMode = initializationMode,
+                integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
+                    isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
+                    configuration = embeddedConfiguration,
+                    paymentMethodLayout = paymentMethodLayout,
+                ),
+                metadata = metadata,
+            ).getOrThrow()
+        }
+        val expressCheckoutElementStateDeferred = expressCheckoutElementConfiguration?.let { configuration ->
+            async {
+                paymentElementLoader.load(
+                    initializationMode = initializationMode,
+                    integrationConfiguration = PaymentElementLoader.Configuration.ExpressCheckoutElement(
+                        commonConfiguration = configuration,
+                    ),
+                    metadata = metadata,
+                ).getOrThrow()
+            }
+        }
+
+        val paymentElementResult = paymentElementStateDeferred.await()
+        val expressCheckoutElementResult = expressCheckoutElementStateDeferred?.await()
+        LoadResults(
+            paymentMethodMetadata = paymentElementResult.paymentMethodMetadata,
+            expressCheckoutElementPaymentMethodMetadata = expressCheckoutElementResult?.paymentMethodMetadata,
+            customer = paymentElementResult.customer,
+            paymentSelection = paymentElementResult.paymentSelection,
+        )
+    }
+
+    private data class LoadResults(
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata?,
+        val customer: CustomerState?,
+        val paymentSelection: PaymentSelection?,
+    )
 
     /**
      * The fields carried from the prior state (or fresh defaults) into the next committed state, so a

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -10,6 +10,8 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -87,25 +89,34 @@ internal class CheckoutStateLoader @Inject constructor(
             initializedViaCompose = false,
         )
 
-        val loaderState = paymentElementLoader.load(
-            initializationMode = initializationMode,
-            integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
-                isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
-                configuration = embeddedConfig,
-                paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout
-                    .asPaymentSheet(),
-            ),
-            metadata = paymentElementLoaderMetadata,
-        ).getOrThrow()
-        val expressCheckoutElementLoaderState = expressCheckoutElementConfiguration?.let { eceConfiguration ->
-            paymentElementLoader.load(
-                initializationMode = initializationMode,
-                integrationConfiguration = PaymentElementLoader.Configuration.ExpressCheckoutElement(
-                    commonConfiguration = eceConfiguration,
-                ),
-                metadata = paymentElementLoaderMetadata,
-            )
-        }?.getOrThrow()
+        val (loaderState, expressCheckoutElementLoaderState) = coroutineScope {
+            val loaderStateDeferred = async {
+                paymentElementLoader.load(
+                    initializationMode = initializationMode,
+                    integrationConfiguration = PaymentElementLoader.Configuration.Embedded(
+                        isRowSelectionImmediateAction = internalRowSelectionCallback.get() != null,
+                        configuration = embeddedConfig,
+                        paymentMethodLayout = configuration.paymentElementConfiguration.paymentMethodLayout
+                            .asPaymentSheet(),
+                    ),
+                    metadata = paymentElementLoaderMetadata,
+                ).getOrThrow()
+            }
+            val expressCheckoutElementLoaderStateDeferred =
+                expressCheckoutElementConfiguration?.let { eceConfiguration ->
+                    async {
+                        paymentElementLoader.load(
+                            initializationMode = initializationMode,
+                            integrationConfiguration = PaymentElementLoader.Configuration.ExpressCheckoutElement(
+                                commonConfiguration = eceConfiguration,
+                            ),
+                            metadata = paymentElementLoaderMetadata,
+                        ).getOrThrow()
+                    }
+                }
+
+            loaderStateDeferred.await() to expressCheckoutElementLoaderStateDeferred?.await()
+        }
 
         // Preserve the customer's existing selection across reloads when it's still valid, rather
         // than blindly adopting the loader's recomputed selection (reuses the embedded logic). The

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -43,11 +43,14 @@ import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(
     CheckoutSessionPreview::class,
@@ -74,6 +77,19 @@ internal class CheckoutStateLoaderTest {
         loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
 
         assertThat(stateHolder.state?.expressCheckoutElementPaymentMethodMetadata).isNotNull()
+    }
+
+    @Test
+    fun `loadInitial loads payment element and ECE in parallel`() = runScenario(
+        paymentElementLoaderDelay = 1.seconds,
+    ) {
+        val configuration = CheckoutController.Configuration()
+            .expressCheckoutElement(ExpressCheckoutElement.Configuration())
+            .build()
+
+        loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
+
+        assertThat(testScheduler.currentTime).isEqualTo(1.seconds.inWholeMilliseconds)
     }
 
     @Test
@@ -405,6 +421,7 @@ internal class CheckoutStateLoaderTest {
         isGooglePayAvailable: Boolean = false,
         customer: CustomerState? = null,
         internalRowSelectionCallback: (() -> Unit)? = null,
+        paymentElementLoaderDelay: Duration = Duration.ZERO,
         // When null, a RecordingSelectionChooser is used. Pass a factory to exercise the real
         // DefaultEmbeddedSelectionChooser (it needs the shared SavedStateHandle to track state).
         selectionChooser: ((SavedStateHandle) -> EmbeddedSelectionChooser)? = null,
@@ -441,6 +458,7 @@ internal class CheckoutStateLoaderTest {
             shouldFail = shouldFail,
             isGooglePayAvailable = isGooglePayAvailable,
             customer = customer,
+            delay = paymentElementLoaderDelay,
         )
         val loader = CheckoutStateLoader(
             embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
@@ -460,6 +478,7 @@ internal class CheckoutStateLoaderTest {
             paymentElementLoader = paymentElementLoader,
             chooser = recordingChooser,
             imageLoader = imageLoader,
+            testScheduler = testScheduler,
         ).block()
 
         imageLoader.ensureAllEventsConsumed()
@@ -472,6 +491,7 @@ internal class CheckoutStateLoaderTest {
         val paymentElementLoader: FakePaymentElementLoader,
         val chooser: RecordingSelectionChooser,
         val imageLoader: FakeStripeImageLoader,
+        val testScheduler: TestCoroutineScheduler,
     )
 
     // Records the arguments of the most recent choose() call and returns a preconfigured selection,


### PR DESCRIPTION
# Summary
Run the Payment Element and Express Checkout Element loads concurrently in `CheckoutStateLoader`.

# Motivation
The two independent loader requests previously ran sequentially, increasing checkout initialization latency when ECE was configured.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Committed and created by Codex.
