### PR TITLE
Use strings for ECE payment method ordering

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
@@ -335,7 +335,7 @@ class ExpressCheckoutElement @Inject internal constructor(
 
         private var shippingAddressRequired: Boolean = false
         private var emailRequired: Boolean = false
-        private var paymentMethodOrder: List<PaymentMethod> = emptyList()
+        private var paymentMethodOrder: List<String> = emptyList()
         private var appearance: Appearance = Appearance()
 
         /** Sets the configuration for Link. */
@@ -371,12 +371,14 @@ class ExpressCheckoutElement @Inject internal constructor(
         /**
          * Sets the order in which express payment methods are displayed.
          *
+         * Supported values are `"google_pay"` and `"link"`.
+         *
          * By default, the Express Checkout Element uses dynamic ordering. Payment methods omitted
          * from [paymentMethodOrder] are displayed after the specified payment methods. Payment
-         * methods that are unavailable are ignored.
+         * methods that are unavailable or invalid are ignored.
          */
         fun paymentMethodOrder(
-            paymentMethodOrder: List<PaymentMethod>,
+            paymentMethodOrder: List<String>,
         ): Configuration = apply {
             this.paymentMethodOrder = paymentMethodOrder
         }
@@ -406,11 +408,11 @@ class ExpressCheckoutElement @Inject internal constructor(
             googlePayConfiguration = googlePayConfiguration.build(),
             shippingAddressRequired = shippingAddressRequired,
             emailRequired = emailRequired,
-            paymentMethodOrder = paymentMethodOrder.map { paymentMethod ->
+            paymentMethodOrder = paymentMethodOrder.mapNotNull { paymentMethod ->
                 when (paymentMethod) {
-                    is PaymentMethod.GooglePay -> PaymentMethodType.GooglePay
-                    is PaymentMethod.Link -> PaymentMethodType.Link
-                    else -> error("Unsupported payment method: ${paymentMethod::class.java.name}")
+                    "google_pay" -> PaymentMethodType.GooglePay
+                    "link" -> PaymentMethodType.Link
+                    else -> null
                 }
             },
             appearance = appearance.build(),

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ExpressCheckoutElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ExpressCheckoutElementTest.kt
@@ -86,8 +86,8 @@ internal class ExpressCheckoutElementTest {
         val state = ExpressCheckoutElement.Configuration()
             .paymentMethodOrder(
                 listOf(
-                    ExpressCheckoutElement.PaymentMethod.Link(),
-                    ExpressCheckoutElement.PaymentMethod.GooglePay(),
+                    "link",
+                    "google_pay",
                 )
             )
             .build()
@@ -96,6 +96,17 @@ internal class ExpressCheckoutElementTest {
             ExpressCheckoutElement.Configuration.PaymentMethodType.Link,
             ExpressCheckoutElement.Configuration.PaymentMethodType.GooglePay,
         ).inOrder()
+    }
+
+    @Test
+    fun `configuration ignores invalid payment methods in payment method order`() {
+        val state = ExpressCheckoutElement.Configuration()
+            .paymentMethodOrder(listOf("invalid", "link"))
+            .build()
+
+        assertThat(state.paymentMethodOrder).containsExactly(
+            ExpressCheckoutElement.Configuration.PaymentMethodType.Link,
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
@@ -103,8 +103,8 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
             configuration = ExpressCheckoutElement.Configuration()
                 .paymentMethodOrder(
                     listOf(
-                        ExpressCheckoutElement.PaymentMethod.GooglePay(),
-                        ExpressCheckoutElement.PaymentMethod.Link(),
+                        "google_pay",
+                        "link",
                     )
                 ),
         )
@@ -120,7 +120,7 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
         val availableExpressButtonTypes = create(
             availableWallets = listOf(WalletType.GooglePay, WalletType.Link),
             configuration = ExpressCheckoutElement.Configuration()
-                .paymentMethodOrder(listOf(ExpressCheckoutElement.PaymentMethod.Link())),
+                .paymentMethodOrder(listOf("link")),
         )
 
         assertThat(availableExpressButtonTypes).containsExactly(
@@ -136,8 +136,8 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
             configuration = ExpressCheckoutElement.Configuration()
                 .paymentMethodOrder(
                     listOf(
-                        ExpressCheckoutElement.PaymentMethod.GooglePay(),
-                        ExpressCheckoutElement.PaymentMethod.Link(),
+                        "google_pay",
+                        "link",
                     )
                 ),
         )


### PR DESCRIPTION
# Summary
Use strings for ECE payment method ordering

Supported values are `"google_pay"` and `"link"`; invalid values are ignored.

# Motivation
- Align the Express Checkout Element ordering API with the string-based payment method ordering APIs used elsewhere.
- Address issue where existing paymentMethodOrder API is unusable bc merchants can't construct PaymentMethod classes

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Committed and created by Codex.
