### PR TITLE
Commit ShippingAddressElement results to Checkout state

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/AddressMapper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/AddressMapper.kt
@@ -15,6 +15,18 @@ internal fun CheckoutController.Address.State.asPaymentSheet(): PaymentSheet.Add
 )
 
 @OptIn(CheckoutSessionPreview::class)
+internal fun PaymentSheet.Address.toCheckoutAddress(): CheckoutController.Address.State? {
+    return CheckoutController.Address.State(
+        city = city,
+        country = country?.takeIf { it.isNotBlank() } ?: return null,
+        line1 = line1,
+        line2 = line2,
+        postalCode = postalCode,
+        state = state,
+    )
+}
+
+@OptIn(CheckoutSessionPreview::class)
 internal fun Address.toCheckoutAddress(): CheckoutController.Address.State? {
     return CheckoutController.Address.State(
         city = city,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -14,7 +14,6 @@ import com.stripe.android.checkout.injection.CheckoutPresenterSubcomponent
 import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
 import com.stripe.android.common.ui.DelegateDrawable
 import com.stripe.android.common.ui.PaymentElementActivityResultCaller
-import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.elements.CurrencySelectorElement
@@ -32,7 +31,6 @@ import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptions
 import com.stripe.android.uicore.image.rememberDrawablePainter
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -67,7 +65,6 @@ class CheckoutController @Inject internal constructor(
     @PaymentElementCallbackIdentifier internal val paymentElementCallbackIdentifier: String,
     private val savedState: CheckoutControllerSavedState,
     private val checkoutAnalyticsPerformer: CheckoutAnalyticsPerformer,
-    private val logger: Logger,
 ) {
     /**
      * The latest [Session] data, or `null` until [configure] has completed successfully.
@@ -178,26 +175,20 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
-    internal fun commitShippingAddress(
+    internal suspend fun commitShippingAddress(
         name: String?,
         address: Address.State,
+    ): kotlin.Result<Unit> = withCheckoutState(
+        additionalStateMutations = {
+            copy(
+                collectedDetails = collectedDetails.copy(
+                    shippingName = name,
+                    shippingAddress = address,
+                ),
+            )
+        },
     ) {
-        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            withCheckoutState(
-                additionalStateMutations = {
-                    copy(
-                        collectedDetails = collectedDetails.copy(
-                            shippingName = name,
-                            shippingAddress = address,
-                        ),
-                    )
-                },
-            ) {
-                kotlin.Result.success(checkoutSessionResponse)
-            }.onFailure { error ->
-                logger.error("Failed to commit the checkout shipping address.", error)
-            }
-        }
+        kotlin.Result.success(checkoutSessionResponse)
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -14,6 +14,7 @@ import com.stripe.android.checkout.injection.CheckoutPresenterSubcomponent
 import com.stripe.android.checkout.injection.DaggerCheckoutControllerComponent
 import com.stripe.android.common.ui.DelegateDrawable
 import com.stripe.android.common.ui.PaymentElementActivityResultCaller
+import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.StatusBarCompat
 import com.stripe.android.elements.CurrencySelectorElement
@@ -30,7 +31,9 @@ import com.stripe.android.paymentsheet.repositories.validateShippingCountry
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptions
 import com.stripe.android.uicore.image.rememberDrawablePainter
 import dev.drewhamilton.poko.Poko
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -65,6 +68,7 @@ class CheckoutController @Inject internal constructor(
     @PaymentElementCallbackIdentifier internal val paymentElementCallbackIdentifier: String,
     private val savedState: CheckoutControllerSavedState,
     private val checkoutAnalyticsPerformer: CheckoutAnalyticsPerformer,
+    private val logger: Logger,
 ) {
     /**
      * The latest [Session] data, or `null` until [configure] has completed successfully.
@@ -172,6 +176,37 @@ class CheckoutController @Inject internal constructor(
                     shippingAddress = it,
                 ),
             )
+        }
+    }
+
+    internal fun commitShippingAddress(
+        name: String?,
+        address: Address.State,
+    ) {
+        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            // Admit the mutation before the Activity result callback returns so confirmation cannot overtake it.
+            operationCoordinator.runMutation {
+                try {
+                    val state = requireNotNull(stateHolder.state) {
+                        "Cannot commit checkout shipping address before it is configured."
+                    }
+                    checkoutStateLoader.reload(
+                        state.copy(
+                            collectedDetails = state.collectedDetails.copy(
+                                shippingName = name,
+                                shippingAddress = address,
+                            ),
+                        )
+                    )
+                    kotlin.Result.success(Unit)
+                } catch (error: CancellationException) {
+                    throw error
+                } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+                    kotlin.Result.failure(error)
+                }
+            }.onFailure { error ->
+                logger.error("Failed to commit the checkout shipping address.", error)
+            }
         }
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -31,7 +31,6 @@ import com.stripe.android.paymentsheet.repositories.validateShippingCountry
 import com.stripe.android.paymentsheet.verticalmode.CurrencySelectorOptions
 import com.stripe.android.uicore.image.rememberDrawablePainter
 import dev.drewhamilton.poko.Poko
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.cancel
@@ -184,26 +183,17 @@ class CheckoutController @Inject internal constructor(
         address: Address.State,
     ) {
         viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            // Admit the mutation before the Activity result callback returns so confirmation cannot overtake it.
-            operationCoordinator.runMutation {
-                try {
-                    val state = requireNotNull(stateHolder.state) {
-                        "Cannot commit checkout shipping address before it is configured."
-                    }
-                    checkoutStateLoader.reload(
-                        state.copy(
-                            collectedDetails = state.collectedDetails.copy(
-                                shippingName = name,
-                                shippingAddress = address,
-                            ),
-                        )
+            withCheckoutState(
+                additionalStateMutations = {
+                    copy(
+                        collectedDetails = collectedDetails.copy(
+                            shippingName = name,
+                            shippingAddress = address,
+                        ),
                     )
-                    kotlin.Result.success(Unit)
-                } catch (error: CancellationException) {
-                    throw error
-                } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
-                    kotlin.Result.failure(error)
-                }
+                },
+            ) {
+                kotlin.Result.success(checkoutSessionResponse)
             }.onFailure { error ->
                 logger.error("Failed to commit the checkout shipping address.", error)
             }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -24,10 +24,12 @@ import javax.inject.Inject
 import javax.inject.Provider
 
 @OptIn(CheckoutSessionPreview::class)
-internal typealias CommitShippingAddress = suspend (
-    String?,
-    CheckoutController.Address.State,
-) -> Result<Unit>
+internal fun interface CommitShippingAddress {
+    suspend operator fun invoke(
+        name: String?,
+        address: CheckoutController.Address.State,
+    ): Result<Unit>
+}
 
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -56,7 +58,7 @@ class ShippingAddressElement internal constructor(
         lifecycleOwner = lifecycleOwner,
         paymentConfiguration = paymentConfiguration,
         coroutineScope = coroutineScope,
-        commitShippingAddress = checkoutController::commitShippingAddress,
+        commitShippingAddress = CommitShippingAddress(checkoutController::commitShippingAddress),
         stateHolder = stateHolder,
         shippingAddressElementStateHolder = shippingAddressElementStateHolder,
         errorReporter = errorReporter,
@@ -64,19 +66,27 @@ class ShippingAddressElement internal constructor(
 
     private val activityLauncher: ActivityResultLauncher<AddressElementActivityContract.Args> =
         activityResultCaller.registerForActivityResult(AddressElementActivityContract) { result ->
-            shippingAddressElementStateHolder.isPresenting = false
             when (result) {
                 is AddressLauncherResult.Succeeded -> {
-                    result.address.address?.toCheckoutAddress()?.let { address ->
+                    val address = result.address.address?.toCheckoutAddress()
+                    if (address == null) {
+                        shippingAddressElementStateHolder.isPresenting = false
+                    } else {
                         coroutineScope.launch {
-                            commitShippingAddress(
-                                result.address.name,
-                                address,
-                            )
+                            try {
+                                commitShippingAddress(
+                                    result.address.name,
+                                    address,
+                                )
+                            } finally {
+                                shippingAddressElementStateHolder.isPresenting = false
+                            }
                         }
                     }
                 }
-                is AddressLauncherResult.Canceled -> Unit
+                is AddressLauncherResult.Canceled -> {
+                    shippingAddressElementStateHolder.isPresenting = false
+                }
             }
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -23,18 +23,45 @@ import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Provider
 
+@OptIn(CheckoutSessionPreview::class)
+internal typealias CommitShippingAddress = suspend (
+    String?,
+    CheckoutController.Address.State,
+) -> Result<Unit>
+
 @CheckoutSessionPreview
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-class ShippingAddressElement @Inject internal constructor(
+class ShippingAddressElement internal constructor(
     activityResultCaller: ActivityResultCaller,
     lifecycleOwner: LifecycleOwner,
     private val paymentConfiguration: Provider<PaymentConfiguration>,
     @ViewModelScope private val coroutineScope: CoroutineScope,
-    private val checkoutController: CheckoutController,
+    private val commitShippingAddress: CommitShippingAddress,
     private val stateHolder: CheckoutControllerStateHolder,
     private val shippingAddressElementStateHolder: ShippingAddressElementStateHolder,
     private val errorReporter: ErrorReporter,
 ) {
+    @Inject
+    internal constructor(
+        activityResultCaller: ActivityResultCaller,
+        lifecycleOwner: LifecycleOwner,
+        paymentConfiguration: Provider<PaymentConfiguration>,
+        @ViewModelScope coroutineScope: CoroutineScope,
+        checkoutController: CheckoutController,
+        stateHolder: CheckoutControllerStateHolder,
+        shippingAddressElementStateHolder: ShippingAddressElementStateHolder,
+        errorReporter: ErrorReporter,
+    ) : this(
+        activityResultCaller = activityResultCaller,
+        lifecycleOwner = lifecycleOwner,
+        paymentConfiguration = paymentConfiguration,
+        coroutineScope = coroutineScope,
+        commitShippingAddress = checkoutController::commitShippingAddress,
+        stateHolder = stateHolder,
+        shippingAddressElementStateHolder = shippingAddressElementStateHolder,
+        errorReporter = errorReporter,
+    )
+
     private val activityLauncher: ActivityResultLauncher<AddressElementActivityContract.Args> =
         activityResultCaller.registerForActivityResult(AddressElementActivityContract) { result ->
             shippingAddressElementStateHolder.isPresenting = false
@@ -42,9 +69,9 @@ class ShippingAddressElement @Inject internal constructor(
                 is AddressLauncherResult.Succeeded -> {
                     result.address.address?.toCheckoutAddress()?.let { address ->
                         coroutineScope.launch {
-                            checkoutController.commitShippingAddress(
-                                name = result.address.name,
-                                address = address,
+                            commitShippingAddress(
+                                result.address.name,
+                                address,
                             )
                         }
                     }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -11,11 +11,14 @@ import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.ShippingAddressElementStateHolder
 import com.stripe.android.checkout.toCheckoutAddress
+import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Provider
@@ -26,6 +29,7 @@ class ShippingAddressElement @Inject internal constructor(
     activityResultCaller: ActivityResultCaller,
     lifecycleOwner: LifecycleOwner,
     private val paymentConfiguration: Provider<PaymentConfiguration>,
+    @ViewModelScope private val coroutineScope: CoroutineScope,
     private val checkoutController: CheckoutController,
     private val stateHolder: CheckoutControllerStateHolder,
     private val shippingAddressElementStateHolder: ShippingAddressElementStateHolder,
@@ -34,14 +38,19 @@ class ShippingAddressElement @Inject internal constructor(
     private val activityLauncher: ActivityResultLauncher<AddressElementActivityContract.Args> =
         activityResultCaller.registerForActivityResult(AddressElementActivityContract) { result ->
             shippingAddressElementStateHolder.isPresenting = false
-            val addressDetails = (result as? AddressLauncherResult.Succeeded)?.address
-                ?: return@registerForActivityResult
-            val address = addressDetails.address?.toCheckoutAddress()
-                ?: return@registerForActivityResult
-            checkoutController.commitShippingAddress(
-                name = addressDetails.name,
-                address = address,
-            )
+            when (result) {
+                is AddressLauncherResult.Succeeded -> {
+                    result.address.address?.toCheckoutAddress()?.let { address ->
+                        coroutineScope.launch {
+                            checkoutController.commitShippingAddress(
+                                name = result.address.name,
+                                address = address,
+                            )
+                        }
+                    }
+                }
+                is AddressLauncherResult.Canceled -> Unit
+            }
         }
 
     init {

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -7,12 +7,15 @@ import androidx.annotation.RestrictTo
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.ShippingAddressElementStateHolder
+import com.stripe.android.checkout.toCheckoutAddress
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
+import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Provider
@@ -23,13 +26,22 @@ class ShippingAddressElement @Inject internal constructor(
     activityResultCaller: ActivityResultCaller,
     lifecycleOwner: LifecycleOwner,
     private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val checkoutController: CheckoutController,
     private val stateHolder: CheckoutControllerStateHolder,
     private val shippingAddressElementStateHolder: ShippingAddressElementStateHolder,
     private val errorReporter: ErrorReporter,
 ) {
     private val activityLauncher: ActivityResultLauncher<AddressElementActivityContract.Args> =
-        activityResultCaller.registerForActivityResult(AddressElementActivityContract) {
+        activityResultCaller.registerForActivityResult(AddressElementActivityContract) { result ->
             shippingAddressElementStateHolder.isPresenting = false
+            val addressDetails = (result as? AddressLauncherResult.Succeeded)?.address
+                ?: return@registerForActivityResult
+            val address = addressDetails.address?.toCheckoutAddress()
+                ?: return@registerForActivityResult
+            checkoutController.commitShippingAddress(
+                name = addressDetails.name,
+                address = address,
+            )
         }
 
     init {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -33,13 +33,17 @@ import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.utils.simulateProcessDeath
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import okhttp3.mockwebserver.MockResponse
 import org.json.JSONArray
 import org.json.JSONObject
@@ -711,6 +715,71 @@ internal class CheckoutControllerTest {
         }
 
     @Test
+    fun `commitShippingAddress stores local details and reloads payment element state`() =
+        runMutationScenario(
+            assertLoadingConsumed = true,
+            useTestMainDispatcher = true,
+        ) {
+            val response = committedState().checkoutSessionResponse
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+
+            controller.commitShippingAddress(
+                name = "John",
+                address = fullAddress.build(),
+            )
+
+            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+
+            val state = committedState()
+            assertThat(state.checkoutSessionResponse).isSameInstanceAs(response)
+            assertThat(state.collectedDetails.shippingName).isEqualTo("John")
+            assertThat(state.collectedDetails.shippingAddress).isEqualTo(fullAddress.build())
+            assertThat(state.paymentMethodMetadata.shippingDetails?.name).isEqualTo("John")
+            assertThat(state.paymentMethodMetadata.shippingDetails?.address).isEqualTo(
+                fullAddress.build().asPaymentSheet()
+            )
+        }
+
+    @Test
+    fun `commitShippingAddress admits a mutation before returning`() =
+        runMutationScenario(
+            assertLoadingConsumed = true,
+            useTestMainDispatcher = true,
+        ) {
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+
+            controller.commitShippingAddress(
+                name = "John",
+                address = fullAddress.build(),
+            )
+
+            assertThat(controller.isUpdating.value).isTrue()
+            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+        }
+
+    @Test
+    fun `commitShippingAddress leaves missing state unchanged`() = runTest {
+        val controller = createController()
+
+        controller.commitShippingAddress(
+            name = "John",
+            address = Address.State(
+                city = "Denver",
+                country = "US",
+                line1 = "123 Main St",
+                line2 = null,
+                postalCode = "80202",
+                state = "CO",
+            ),
+        )
+
+        assertThat(controller.session.value).isNull()
+        assertThat(controller.isUpdating.value).isFalse()
+    }
+
+    @Test
     fun `updateBillingAddress sends tax_region and stores address when automatic tax targets billing`() =
         runMutationScenario(initModifier = automaticTaxFor("billing")) {
             networkRule.checkoutUpdate(
@@ -1232,38 +1301,48 @@ internal class CheckoutControllerTest {
         previousNewSelections: Bundle = Bundle(),
         sheetIsOpen: Boolean = false,
         assertLoadingConsumed: Boolean = false,
+        useTestMainDispatcher: Boolean = false,
         block: suspend MutationScenario.() -> Unit,
     ) = runTest {
-        networkRule.checkoutInit(
-            responseFactory = successResponseFactory(
-                jsonModifier = initModifier,
-            )
-        )
-        val savedStateHandle = SavedStateHandle()
-        val setup = createControllerSetup(savedStateHandle, DEFAULT_INTEGRATION_NAME)
-        val controller = setup.controller
-        controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
-        paymentSelection?.let(setup.stateHolder::setSelection)
-        temporarySelection?.let(setup.stateHolder::setTemporarySelection)
-        if (!previousNewSelections.isEmpty) {
-            setup.stateHolder.setPreviousNewSelections(previousNewSelections)
+        if (useTestMainDispatcher) {
+            Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
         }
-        setup.sheetStateHolder.sheetIsOpen = sheetIsOpen
-
-        turbineScope {
-            val isUpdatingTurbine = controller.isUpdating.testIn(backgroundScope)
-            block(
-                MutationScenario(
-                    controller = controller,
-                    stateHolder = setup.stateHolder,
-                    testScope = this@runTest,
-                    isUpdatingTurbine = isUpdatingTurbine,
+        try {
+            networkRule.checkoutInit(
+                responseFactory = successResponseFactory(
+                    jsonModifier = initModifier,
                 )
             )
-            if (assertLoadingConsumed) {
-                isUpdatingTurbine.ensureAllEventsConsumed()
-            } else {
-                isUpdatingTurbine.cancelAndIgnoreRemainingEvents()
+            val savedStateHandle = SavedStateHandle()
+            val setup = createControllerSetup(savedStateHandle, DEFAULT_INTEGRATION_NAME)
+            val controller = setup.controller
+            controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+            paymentSelection?.let(setup.stateHolder::setSelection)
+            temporarySelection?.let(setup.stateHolder::setTemporarySelection)
+            if (!previousNewSelections.isEmpty) {
+                setup.stateHolder.setPreviousNewSelections(previousNewSelections)
+            }
+            setup.sheetStateHolder.sheetIsOpen = sheetIsOpen
+
+            turbineScope {
+                val isUpdatingTurbine = controller.isUpdating.testIn(backgroundScope)
+                block(
+                    MutationScenario(
+                        controller = controller,
+                        stateHolder = setup.stateHolder,
+                        testScope = this@runTest,
+                        isUpdatingTurbine = isUpdatingTurbine,
+                    )
+                )
+                if (assertLoadingConsumed) {
+                    isUpdatingTurbine.ensureAllEventsConsumed()
+                } else {
+                    isUpdatingTurbine.cancelAndIgnoreRemainingEvents()
+                }
+            }
+        } finally {
+            if (useTestMainDispatcher) {
+                Dispatchers.resetMain()
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -714,10 +714,11 @@ internal class CheckoutControllerTest {
     fun `commitShippingAddress stores local details and reloads payment element state`() =
         runMutationScenario {
             val response = committedState().checkoutSessionResponse
+            val address = fullAddress.build()
 
             val result = controller.commitShippingAddress(
                 name = "John",
-                address = fullAddress.build(),
+                address = address,
             )
 
             result.getOrThrow()
@@ -725,10 +726,10 @@ internal class CheckoutControllerTest {
             val state = committedState()
             assertThat(state.checkoutSessionResponse).isSameInstanceAs(response)
             assertThat(state.collectedDetails.shippingName).isEqualTo("John")
-            assertThat(state.collectedDetails.shippingAddress).isEqualTo(fullAddress.build())
+            assertThat(state.collectedDetails.shippingAddress).isEqualTo(address)
             assertThat(state.paymentMethodMetadata.shippingDetails?.name).isEqualTo("John")
             assertThat(state.paymentMethodMetadata.shippingDetails?.address).isEqualTo(
-                fullAddress.build().asPaymentSheet()
+                address.asPaymentSheet()
             )
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -780,6 +780,26 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `commitShippingAddress does not start a mutation when a payment flow is presented`() =
+        runMutationScenario(
+            sheetIsOpen = true,
+            assertLoadingConsumed = true,
+            useTestMainDispatcher = true,
+        ) {
+            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+            val state = committedState()
+
+            controller.commitShippingAddress(
+                name = "John",
+                address = fullAddress.build(),
+            )
+
+            assertThat(controller.isUpdating.value).isFalse()
+            isUpdatingTurbine.expectNoEvents()
+            assertThat(committedState()).isSameInstanceAs(state)
+        }
+
+    @Test
     fun `updateBillingAddress sends tax_region and stores address when automatic tax targets billing`() =
         runMutationScenario(initModifier = automaticTaxFor("billing")) {
             networkRule.checkoutUpdate(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -33,17 +33,13 @@ import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.utils.simulateProcessDeath
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import okhttp3.mockwebserver.MockResponse
 import org.json.JSONArray
 import org.json.JSONObject
@@ -716,20 +712,15 @@ internal class CheckoutControllerTest {
 
     @Test
     fun `commitShippingAddress stores local details and reloads payment element state`() =
-        runMutationScenario(
-            assertLoadingConsumed = true,
-            useTestMainDispatcher = true,
-        ) {
+        runMutationScenario {
             val response = committedState().checkoutSessionResponse
-            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
 
-            controller.commitShippingAddress(
+            val result = controller.commitShippingAddress(
                 name = "John",
                 address = fullAddress.build(),
             )
 
-            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
-            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
+            result.getOrThrow()
 
             val state = committedState()
             assertThat(state.checkoutSessionResponse).isSameInstanceAs(response)
@@ -739,64 +730,6 @@ internal class CheckoutControllerTest {
             assertThat(state.paymentMethodMetadata.shippingDetails?.address).isEqualTo(
                 fullAddress.build().asPaymentSheet()
             )
-        }
-
-    @Test
-    fun `commitShippingAddress admits a mutation before returning`() =
-        runMutationScenario(
-            assertLoadingConsumed = true,
-            useTestMainDispatcher = true,
-        ) {
-            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
-
-            controller.commitShippingAddress(
-                name = "John",
-                address = fullAddress.build(),
-            )
-
-            assertThat(controller.isUpdating.value).isTrue()
-            assertThat(isUpdatingTurbine.awaitItem()).isTrue()
-            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
-        }
-
-    @Test
-    fun `commitShippingAddress leaves missing state unchanged`() = runTest {
-        val controller = createController()
-
-        controller.commitShippingAddress(
-            name = "John",
-            address = Address.State(
-                city = "Denver",
-                country = "US",
-                line1 = "123 Main St",
-                line2 = null,
-                postalCode = "80202",
-                state = "CO",
-            ),
-        )
-
-        assertThat(controller.session.value).isNull()
-        assertThat(controller.isUpdating.value).isFalse()
-    }
-
-    @Test
-    fun `commitShippingAddress does not start a mutation when a payment flow is presented`() =
-        runMutationScenario(
-            sheetIsOpen = true,
-            assertLoadingConsumed = true,
-            useTestMainDispatcher = true,
-        ) {
-            assertThat(isUpdatingTurbine.awaitItem()).isFalse()
-            val state = committedState()
-
-            controller.commitShippingAddress(
-                name = "John",
-                address = fullAddress.build(),
-            )
-
-            assertThat(controller.isUpdating.value).isFalse()
-            isUpdatingTurbine.expectNoEvents()
-            assertThat(committedState()).isSameInstanceAs(state)
         }
 
     @Test
@@ -1321,48 +1254,38 @@ internal class CheckoutControllerTest {
         previousNewSelections: Bundle = Bundle(),
         sheetIsOpen: Boolean = false,
         assertLoadingConsumed: Boolean = false,
-        useTestMainDispatcher: Boolean = false,
         block: suspend MutationScenario.() -> Unit,
     ) = runTest {
-        if (useTestMainDispatcher) {
-            Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        networkRule.checkoutInit(
+            responseFactory = successResponseFactory(
+                jsonModifier = initModifier,
+            )
+        )
+        val savedStateHandle = SavedStateHandle()
+        val setup = createControllerSetup(savedStateHandle, DEFAULT_INTEGRATION_NAME)
+        val controller = setup.controller
+        controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
+        paymentSelection?.let(setup.stateHolder::setSelection)
+        temporarySelection?.let(setup.stateHolder::setTemporarySelection)
+        if (!previousNewSelections.isEmpty) {
+            setup.stateHolder.setPreviousNewSelections(previousNewSelections)
         }
-        try {
-            networkRule.checkoutInit(
-                responseFactory = successResponseFactory(
-                    jsonModifier = initModifier,
+        setup.sheetStateHolder.sheetIsOpen = sheetIsOpen
+
+        turbineScope {
+            val isUpdatingTurbine = controller.isUpdating.testIn(backgroundScope)
+            block(
+                MutationScenario(
+                    controller = controller,
+                    stateHolder = setup.stateHolder,
+                    testScope = this@runTest,
+                    isUpdatingTurbine = isUpdatingTurbine,
                 )
             )
-            val savedStateHandle = SavedStateHandle()
-            val setup = createControllerSetup(savedStateHandle, DEFAULT_INTEGRATION_NAME)
-            val controller = setup.controller
-            controller.configure(DEFAULT_CLIENT_SECRET).getOrThrow()
-            paymentSelection?.let(setup.stateHolder::setSelection)
-            temporarySelection?.let(setup.stateHolder::setTemporarySelection)
-            if (!previousNewSelections.isEmpty) {
-                setup.stateHolder.setPreviousNewSelections(previousNewSelections)
-            }
-            setup.sheetStateHolder.sheetIsOpen = sheetIsOpen
-
-            turbineScope {
-                val isUpdatingTurbine = controller.isUpdating.testIn(backgroundScope)
-                block(
-                    MutationScenario(
-                        controller = controller,
-                        stateHolder = setup.stateHolder,
-                        testScope = this@runTest,
-                        isUpdatingTurbine = isUpdatingTurbine,
-                    )
-                )
-                if (assertLoadingConsumed) {
-                    isUpdatingTurbine.ensureAllEventsConsumed()
-                } else {
-                    isUpdatingTurbine.cancelAndIgnoreRemainingEvents()
-                }
-            }
-        } finally {
-            if (useTestMainDispatcher) {
-                Dispatchers.resetMain()
+            if (assertLoadingConsumed) {
+                isUpdatingTurbine.ensureAllEventsConsumed()
+            } else {
+                isUpdatingTurbine.cancelAndIgnoreRemainingEvents()
             }
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/elements/FakeCommitShippingAddress.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/FakeCommitShippingAddress.kt
@@ -4,16 +4,19 @@ package com.stripe.android.elements
 
 import app.cash.turbine.Turbine
 import com.stripe.android.checkout.CheckoutController
+import kotlinx.coroutines.Deferred
 
-internal class FakeCommitShippingAddress {
+internal class FakeCommitShippingAddress(
+    private val result: Deferred<Result<Unit>>,
+) : CommitShippingAddress {
     val calls = Turbine<Call>()
 
-    suspend operator fun invoke(
+    override suspend fun invoke(
         name: String?,
         address: CheckoutController.Address.State,
     ): Result<Unit> {
         calls.add(Call(name, address))
-        return Result.success(Unit)
+        return result.await()
     }
 
     fun ensureAllEventsConsumed() {

--- a/paymentsheet/src/test/java/com/stripe/android/elements/FakeCommitShippingAddress.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/FakeCommitShippingAddress.kt
@@ -1,0 +1,27 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.elements
+
+import app.cash.turbine.Turbine
+import com.stripe.android.checkout.CheckoutController
+
+internal class FakeCommitShippingAddress {
+    val calls = Turbine<Call>()
+
+    suspend operator fun invoke(
+        name: String?,
+        address: CheckoutController.Address.State,
+    ): Result<Unit> {
+        calls.add(Call(name, address))
+        return Result.success(Unit)
+    }
+
+    fun ensureAllEventsConsumed() {
+        calls.ensureAllEventsConsumed()
+    }
+
+    data class Call(
+        val name: String?,
+        val address: CheckoutController.Address.State,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -15,6 +15,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.checkout.CheckoutController
 import com.stripe.android.checkout.CheckoutControllerStateFactory
 import com.stripe.android.checkout.CheckoutControllerStateHolder
 import com.stripe.android.checkout.ShippingAddressElementStateHolder
@@ -30,6 +31,13 @@ import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import javax.inject.Provider
 
 internal class ShippingAddressElementTest {
@@ -119,22 +127,88 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `result clears presentation and ignores saved address`() = runScenario {
-        val originalState = stateHolder.state
+    fun `successful result clears presentation and commits complete address`() = runScenario {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
 
+        val addressDetails = AddressDetails(
+            name = "Jenny Rosen",
+            address = PaymentSheet.Address(
+                city = "San Francisco",
+                country = "US",
+                line1 = "510 Townsend St",
+                line2 = "Floor 2",
+                postalCode = "94103",
+                state = "CA",
+            ),
+        )
         registration.dispatch(
             AddressLauncherResult.Succeeded(
-                AddressDetails(name = "Ignored address"),
+                addressDetails,
             )
         )
 
+        val address = argumentCaptor<CheckoutController.Address.State>()
+        verify(checkoutController).commitShippingAddress(
+            name = eq(addressDetails.name),
+            address = address.capture(),
+        )
+        assertThat(address.firstValue).isEqualTo(
+            CheckoutController.Address.State(
+                city = "San Francisco",
+                country = "US",
+                line1 = "510 Townsend St",
+                line2 = "Floor 2",
+                postalCode = "94103",
+                state = "CA",
+            )
+        )
+        assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
+
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
-        assertThat(stateHolder.state).isSameInstanceAs(originalState)
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `canceled result clears presentation without committing`() = runScenario {
+        shippingAddressElement.present()
+        activityLauncher.launchCalls.awaitItem()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+
+        registration.dispatch(AddressLauncherResult.Canceled())
+
+        assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
+        verify(checkoutController, never()).commitShippingAddress(
+            name = anyOrNull(),
+            address = any(),
+        )
+    }
+
+    @Test
+    fun `malformed successful result clears presentation without committing`() = runScenario {
+        shippingAddressElement.present()
+        activityLauncher.launchCalls.awaitItem()
+        assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+
+        registration.dispatch(
+            AddressLauncherResult.Succeeded(
+                AddressDetails(
+                    name = "Missing country",
+                    address = PaymentSheet.Address(
+                        line1 = "510 Townsend St",
+                        country = " ",
+                    ),
+                )
+            )
+        )
+
+        assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
+        verify(checkoutController, never()).commitShippingAddress(
+            name = anyOrNull(),
+            address = any(),
+        )
     }
 
     @Test
@@ -183,6 +257,7 @@ internal class ShippingAddressElementTest {
             PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
         )
         val errorReporter = FakeErrorReporter()
+        val checkoutController = mock<CheckoutController>()
 
         suspend fun createElement(): ElementScenario {
             val activityResultCaller = RecordingActivityResultCaller()
@@ -191,6 +266,7 @@ internal class ShippingAddressElementTest {
                 activityResultCaller = activityResultCaller,
                 lifecycleOwner = lifecycleOwner,
                 paymentConfiguration = paymentConfiguration,
+                checkoutController = checkoutController,
                 stateHolder = stateHolder,
                 shippingAddressElementStateHolder = shippingAddressElementStateHolder,
                 errorReporter = errorReporter,
@@ -214,6 +290,7 @@ internal class ShippingAddressElementTest {
             lifecycleOwner = element.lifecycleOwner,
             stateHolder = stateHolder,
             shippingAddressElementStateHolder = shippingAddressElementStateHolder,
+            checkoutController = checkoutController,
             paymentConfiguration = paymentConfiguration,
             errorReporter = errorReporter,
             registration = element.registration,
@@ -310,6 +387,7 @@ internal class ShippingAddressElementTest {
         val lifecycleOwner: TestLifecycleOwner,
         val stateHolder: CheckoutControllerStateHolder,
         val shippingAddressElementStateHolder: ShippingAddressElementStateHolder,
+        val checkoutController: CheckoutController,
         val paymentConfiguration: RecordingProvider<PaymentConfiguration>,
         val errorReporter: FakeErrorReporter,
         val registration: Registration,

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -33,13 +33,6 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
-import org.mockito.kotlin.any
-import org.mockito.kotlin.anyOrNull
-import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
-import org.mockito.kotlin.verify
 import javax.inject.Provider
 
 internal class ShippingAddressElementTest {
@@ -150,19 +143,17 @@ internal class ShippingAddressElementTest {
             )
         )
 
-        val address = argumentCaptor<CheckoutController.Address.State>()
-        verify(checkoutController).commitShippingAddress(
-            name = eq(addressDetails.name),
-            address = address.capture(),
-        )
-        assertThat(address.firstValue).isEqualTo(
-            CheckoutController.Address.State(
-                city = "San Francisco",
-                country = "US",
-                line1 = "510 Townsend St",
-                line2 = "Floor 2",
-                postalCode = "94103",
-                state = "CA",
+        assertThat(commitShippingAddress.calls.awaitItem()).isEqualTo(
+            FakeCommitShippingAddress.Call(
+                name = addressDetails.name,
+                address = CheckoutController.Address.State(
+                    city = "San Francisco",
+                    country = "US",
+                    line1 = "510 Townsend St",
+                    line2 = "Floor 2",
+                    postalCode = "94103",
+                    state = "CA",
+                ),
             )
         )
         assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
@@ -182,10 +173,7 @@ internal class ShippingAddressElementTest {
         registration.dispatch(AddressLauncherResult.Canceled())
 
         assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
-        verify(checkoutController, never()).commitShippingAddress(
-            name = anyOrNull(),
-            address = any(),
-        )
+        commitShippingAddress.calls.expectNoEvents()
     }
 
     @Test
@@ -207,10 +195,7 @@ internal class ShippingAddressElementTest {
         )
 
         assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
-        verify(checkoutController, never()).commitShippingAddress(
-            name = anyOrNull(),
-            address = any(),
-        )
+        commitShippingAddress.calls.expectNoEvents()
     }
 
     @Test
@@ -259,7 +244,7 @@ internal class ShippingAddressElementTest {
             PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
         )
         val errorReporter = FakeErrorReporter()
-        val checkoutController = mock<CheckoutController>()
+        val commitShippingAddress = FakeCommitShippingAddress()
         val coroutineScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
 
         suspend fun createElement(): ElementScenario {
@@ -270,7 +255,7 @@ internal class ShippingAddressElementTest {
                 lifecycleOwner = lifecycleOwner,
                 paymentConfiguration = paymentConfiguration,
                 coroutineScope = coroutineScope,
-                checkoutController = checkoutController,
+                commitShippingAddress = commitShippingAddress::invoke,
                 stateHolder = stateHolder,
                 shippingAddressElementStateHolder = shippingAddressElementStateHolder,
                 errorReporter = errorReporter,
@@ -294,7 +279,7 @@ internal class ShippingAddressElementTest {
             lifecycleOwner = element.lifecycleOwner,
             stateHolder = stateHolder,
             shippingAddressElementStateHolder = shippingAddressElementStateHolder,
-            checkoutController = checkoutController,
+            commitShippingAddress = commitShippingAddress,
             paymentConfiguration = paymentConfiguration,
             errorReporter = errorReporter,
             registration = element.registration,
@@ -304,6 +289,7 @@ internal class ShippingAddressElementTest {
         element.ensureAllEventsConsumed()
         paymentConfiguration.getCalls.ensureAllEventsConsumed()
         errorReporter.ensureAllEventsConsumed()
+        commitShippingAddress.ensureAllEventsConsumed()
     }
 
     private class RecordingActivityResultCaller : ActivityResultCaller {
@@ -391,7 +377,7 @@ internal class ShippingAddressElementTest {
         val lifecycleOwner: TestLifecycleOwner,
         val stateHolder: CheckoutControllerStateHolder,
         val shippingAddressElementStateHolder: ShippingAddressElementStateHolder,
-        val checkoutController: CheckoutController,
+        val commitShippingAddress: FakeCommitShippingAddress,
         val paymentConfiguration: RecordingProvider<PaymentConfiguration>,
         val errorReporter: FakeErrorReporter,
         val registration: Registration,

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -165,6 +166,47 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
+    fun `successful result suppresses presentation until commit completes`() {
+        val commitResult = CompletableDeferred<Result<Unit>>()
+
+        runScenario(
+            configured = true,
+            commitShippingAddress = FakeCommitShippingAddress(commitResult),
+        ) {
+            shippingAddressElement.present()
+            activityLauncher.launchCalls.awaitItem()
+            assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+
+            registration.dispatch(
+                AddressLauncherResult.Succeeded(
+                    AddressDetails(
+                        name = "Jenny Rosen",
+                        address = PaymentSheet.Address(
+                            city = "San Francisco",
+                            country = "US",
+                            line1 = "510 Townsend St",
+                            postalCode = "94103",
+                            state = "CA",
+                        ),
+                    )
+                )
+            )
+            commitShippingAddress.calls.awaitItem()
+            assertThat(shippingAddressElementStateHolder.isPresenting).isTrue()
+
+            shippingAddressElement.present()
+            activityLauncher.launchCalls.expectNoEvents()
+
+            commitResult.complete(Result.success(Unit))
+            assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
+
+            shippingAddressElement.present()
+            activityLauncher.launchCalls.awaitItem()
+            assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
+        }
+    }
+
+    @Test
     fun `canceled result clears presentation without committing`() = runScenario {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
@@ -231,6 +273,18 @@ internal class ShippingAddressElementTest {
     private fun runScenario(
         configured: Boolean = true,
         block: suspend Scenario.() -> Unit,
+    ) = runScenario(
+        configured = configured,
+        commitShippingAddress = FakeCommitShippingAddress(
+            CompletableDeferred(Result.success(Unit)),
+        ),
+        block = block,
+    )
+
+    private fun runScenario(
+        configured: Boolean,
+        commitShippingAddress: FakeCommitShippingAddress,
+        block: suspend Scenario.() -> Unit,
     ) = runTest {
         val savedStateHandle = SavedStateHandle()
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(
@@ -244,7 +298,6 @@ internal class ShippingAddressElementTest {
             PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY),
         )
         val errorReporter = FakeErrorReporter()
-        val commitShippingAddress = FakeCommitShippingAddress()
         val coroutineScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
 
         suspend fun createElement(): ElementScenario {
@@ -255,7 +308,7 @@ internal class ShippingAddressElementTest {
                 lifecycleOwner = lifecycleOwner,
                 paymentConfiguration = paymentConfiguration,
                 coroutineScope = coroutineScope,
-                commitShippingAddress = commitShippingAddress::invoke,
+                commitShippingAddress = commitShippingAddress,
                 stateHolder = stateHolder,
                 shippingAddressElementStateHolder = shippingAddressElementStateHolder,
                 errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -28,6 +28,8 @@ import com.stripe.android.paymentsheet.addresselement.AddressLauncher
 import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -258,6 +260,7 @@ internal class ShippingAddressElementTest {
         )
         val errorReporter = FakeErrorReporter()
         val checkoutController = mock<CheckoutController>()
+        val coroutineScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
 
         suspend fun createElement(): ElementScenario {
             val activityResultCaller = RecordingActivityResultCaller()
@@ -266,6 +269,7 @@ internal class ShippingAddressElementTest {
                 activityResultCaller = activityResultCaller,
                 lifecycleOwner = lifecycleOwner,
                 paymentConfiguration = paymentConfiguration,
+                coroutineScope = coroutineScope,
                 checkoutController = checkoutController,
                 stateHolder = stateHolder,
                 shippingAddressElementStateHolder = shippingAddressElementStateHolder,


### PR DESCRIPTION
# Summary

Update Checkout's `ShippingAddressElement` to consume successful Address Element activity results and commit the returned name and address to local Checkout state.

```mermaid
flowchart LR
    Result["Address Element result"] --> Callback["ShippingAddressElement callback<br/>clears presentation state"]
    Callback -->|Succeeded with address and nonblank country| Scope["ViewModelScope.launch"]
    Callback -->|Canceled or unusable| Stop(["No commit"])
    Scope --> Commit["CheckoutController.commitShippingAddress"]
    Commit --> State["withCheckoutState"]
    State --> Coordinator["CheckoutOperationCoordinator"]
    Coordinator --> Reload["CheckoutStateLoader.reload"]
```

## What changed

Every result clears presentation state. A succeeded result containing an address with a nonblank country maps it to Checkout state and launches `commitShippingAddress`. Canceled and unusable results do not commit.

`commitShippingAddress` is a suspend function returning `Result<Unit>`. Through `withCheckoutState`, it serializes the mutation with other Checkout operations, re-reads the latest committed state, preserves its `CheckoutSessionResponse`, stores shipping details, and reloads Payment Element state.

The production `@Inject` constructor receives the live `CheckoutController` owned by the Checkout component and binds its `commitShippingAddress` function. A separate internal constructor accepts that function as a test seam, allowing tests to observe calls with a Turbine fake.

## What stays the same

This does not perform a Checkout Session server mutation or tax update. It does not alter the Address Element Activity contract, standalone `AddressLauncher`, confirmation code, or public API surface.

Existing confirmation code can consume the newly committed shipping details.

## Coverage

- A successful result maps and commits every supplied name and address field.
- Canceled and blank-country results clear presentation state without committing.
- The controller test verifies preserved Checkout Session response identity, stored shipping details, and reloaded Payment Element metadata.
- Element tests exercise the internal commit-function seam, not production Dagger construction.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Required CI is green for the current head, `aa1cd45365`.

# Screenshots

Not applicable. No rendering code changed.

# Notes

The callback launches the suspend commit in the Checkout component's `@ViewModelScope` without awaiting or observing its result. Commit rejection and reload failure are therefore neither surfaced nor logged by this scoped PR.

# Changelog

No changelog entry. This changes internal Checkout preview behavior without changing public API surface.

Committed and created by Codex.
