### PR TITLE
Update Checkout billing tax region internally

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -192,16 +192,25 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
-    internal suspend fun updateBillingAddress(
-        name: String?,
+    /**
+     * Updates the billing tax region when this Checkout Session uses billing for automatic tax.
+     *
+     * This does not change the billing details shown in payment UI. Billing details collected by
+     * Payment Element continue to update the tax region during confirmation.
+     *
+     * @param address The billing address used to calculate automatic tax.
+     */
+    suspend fun updateBillingTaxRegionIfNecessary(
         address: Address,
-    ): kotlin.Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.BILLING, address) {
-        copy(
-            collectedDetails = collectedDetails.copy(
-                billingName = name,
-                billingAddress = it,
-            ),
-        )
+    ): kotlin.Result<Unit> {
+        val builtAddress = address.build()
+        return withCheckoutState {
+            checkoutSessionTaxRegionUpdater.updateServerStateIfNeeded(
+                checkoutSessionResponse = checkoutSessionResponse,
+                addressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+                address = builtAddress,
+            )
+        }
     }
 
     /**
@@ -247,10 +256,12 @@ class CheckoutController @Inject internal constructor(
 
     /**
      * Runs a mutation against the checkout session, serializing it behind the operation coordinator
-     * so mutations run in sequence. [block] produces the updated [CheckoutSessionResponse]; the
-     * result is folded into a new [CheckoutControllerState] (with any [additionalStateMutations]
-     * applied) and handed to [checkoutStateLoader] to reload the payment element and atomically
-     * commit the new state.
+     * so mutations run in sequence. [block] produces the updated [CheckoutSessionResponse]. If it
+     * returns the currently committed response, the original state is retained; otherwise the
+     * response is copied into a new [CheckoutControllerState]. [additionalStateMutations] is then
+     * applied, and the resulting state is handed to [checkoutStateLoader] to reload the payment
+     * element and atomically commit it when it differs from the original state. A successful
+     * no-change mutation therefore completes without reloading the payment element.
      *
      * Returns [kotlin.Result.failure] if the session hasn't been configured yet or a payment flow is
      * currently presented.
@@ -274,12 +285,17 @@ class CheckoutController @Inject internal constructor(
                 // build on each other's results rather than a stale snapshot.
                 val state = requireNotNull(stateHolder.state)
                 val response = state.block(state.checkoutSessionResponse.id).getOrThrow()
-                val newState = state
-                    .copy(checkoutSessionResponse = response)
-                    .additionalStateMutations()
-                // reload resolves flag images (reusing newState's carried-over cache) and commits
-                // the fully reloaded state to the holder.
-                checkoutStateLoader.reload(newState)
+                val stateWithResponse = if (response === state.checkoutSessionResponse) {
+                    state
+                } else {
+                    state.copy(checkoutSessionResponse = response)
+                }
+                val newState = stateWithResponse.additionalStateMutations()
+                if (newState !== state) {
+                    // Reload resolves flag images (reusing newState's carried-over cache) and
+                    // commits the fully reloaded state to the holder.
+                    checkoutStateLoader.reload(newState)
+                }
             }
         }
     }
@@ -971,7 +987,7 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
-     * Builder for an address passed to [updateShippingAddress] and [updateBillingAddress].
+     * Builder for an address passed to [updateShippingAddress] and [updateBillingTaxRegionIfNecessary].
      */
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -200,7 +200,7 @@ class CheckoutController @Inject internal constructor(
      *
      * @param address The billing address used to calculate automatic tax.
      */
-    suspend fun updateBillingTaxRegionIfNecessary(
+    internal suspend fun updateBillingTaxRegionIfNecessary(
         address: Address,
     ): kotlin.Result<Unit> {
         val builtAddress = address.build()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -711,66 +711,68 @@ internal class CheckoutControllerTest {
         }
 
     @Test
-    fun `updateBillingAddress sends tax_region and stores address when automatic tax targets billing`() =
+    fun `updateBillingTaxRegionIfNecessary sends tax_region and reloads when automatic tax targets billing`() =
         runMutationScenario(initModifier = automaticTaxFor("billing")) {
             networkRule.checkoutUpdate(
                 bodyPart("tax_region[country]", "US"),
                 bodyPart("tax_region[city]", "Denver"),
                 bodyPart("tax_region[postal_code]", "80202"),
                 bodyPart("elements_session_client[is_aggregation_expected]", "true"),
-                responseFactory = successResponseFactory(automaticTaxFor("billing")),
+                responseFactory = successResponseFactory(
+                    combine(
+                        automaticTaxFor("billing"),
+                        { json -> json.put("total_summary", totalSummaryJson(due = 5099)) },
+                    ),
+                ),
             )
 
-            val result = controller.updateBillingAddress(
-                name = "Jane",
-                address = fullAddress,
-            )
+            val result = controller.updateBillingTaxRegionIfNecessary(fullAddress)
 
             result.getOrThrow()
-            val state = committedState()
-            assertThat(state.collectedDetails.billingName).isEqualTo("Jane")
-            assertThat(state.collectedDetails.billingAddress).isEqualTo(fullAddress.build())
+            assertThat(controller.session.value?.totalSummary?.totalDueToday).isEqualTo(5099)
         }
 
     @Test
-    fun `updateBillingAddress does not send tax_region when automatic tax targets shipping`() =
+    fun `updateBillingTaxRegionIfNecessary is a no-op when automatic tax targets shipping`() =
         runMutationScenario(initModifier = automaticTaxFor("shipping")) {
-            // Automatic tax targets shipping, so a billing address update stays local: no request.
-            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
+            val sessionBeforeUpdate = requireNotNull(controller.session.value)
+            val stateBeforeUpdate = committedState()
+
+            val result = controller.updateBillingTaxRegionIfNecessary(fullAddress)
 
             result.getOrThrow()
-            val state = committedState()
-            assertThat(state.collectedDetails.billingName).isEqualTo("Jane")
-            assertThat(state.collectedDetails.billingAddress).isEqualTo(fullAddress.build())
+            assertThat(controller.session.value).isEqualTo(sessionBeforeUpdate)
+            assertThat(committedState()).isSameInstanceAs(stateBeforeUpdate)
         }
 
     @Test
-    fun `updateBillingAddress stores address without a network call when automatic tax is disabled`() =
+    fun `updateBillingTaxRegionIfNecessary is a no-op when automatic tax is disabled`() =
         runMutationScenario {
-            // No checkoutUpdate is enqueued: with automatic tax off, the address is stored locally
-            // and the payment element is reloaded from the existing response, firing no request.
-            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
+            val sessionBeforeUpdate = requireNotNull(controller.session.value)
+            val stateBeforeUpdate = committedState()
+
+            val result = controller.updateBillingTaxRegionIfNecessary(fullAddress)
 
             result.getOrThrow()
-            val state = committedState()
-            assertThat(state.collectedDetails.billingName).isEqualTo("Jane")
-            assertThat(state.collectedDetails.billingAddress).isEqualTo(fullAddress.build())
+            assertThat(controller.session.value).isEqualTo(sessionBeforeUpdate)
+            assertThat(committedState()).isSameInstanceAs(stateBeforeUpdate)
         }
 
     @Test
-    fun `updateBillingAddress does not store address on failure`() =
+    fun `updateBillingTaxRegionIfNecessary preserves committed state on server failure`() =
         runMutationScenario(initModifier = automaticTaxFor("billing")) {
             networkRule.checkoutUpdate { response ->
                 response.setResponseCode(400)
                 response.setBody("""{"error": {"message": "Invalid address"}}""")
             }
+            val sessionBeforeUpdate = requireNotNull(controller.session.value)
+            val stateBeforeUpdate = committedState()
 
-            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
+            val result = controller.updateBillingTaxRegionIfNecessary(fullAddress)
 
             assertThat(result.isFailure).isTrue()
-            val state = committedState()
-            assertThat(state.collectedDetails.billingName).isNull()
-            assertThat(state.collectedDetails.billingAddress).isNull()
+            assertThat(controller.session.value).isEqualTo(sessionBeforeUpdate)
+            assertThat(committedState()).isSameInstanceAs(stateBeforeUpdate)
         }
 
     @Test
@@ -1042,12 +1044,9 @@ internal class CheckoutControllerTest {
         }
 
     @Test
-    fun `updateBillingAddress is not gated by allowedShippingCountries`() =
+    fun `updateBillingTaxRegionIfNecessary is not gated by allowedShippingCountries`() =
         runMutationScenario(initModifier = allowedShippingCountries(listOf("US"))) {
-            val result = controller.updateBillingAddress(
-                name = null,
-                address = Address().country("DE"),
-            )
+            val result = controller.updateBillingTaxRegionIfNecessary(Address().country("DE"))
 
             assertThat(result.isSuccess).isTrue()
         }


### PR DESCRIPTION
# Summary

Replaces unused internal `CheckoutController.updateBillingAddress(name, address)` with internal `updateBillingTaxRegionIfNecessary(address)`.

The helper sends `tax_region` through the existing Checkout mutation path only when automatic tax uses billing as its tax-address source. It is not merchant-callable API. `updateShippingAddress` is unchanged.

# Motivation

Keep automatic-tax coordination in Checkout while leaving Payment Element billing-detail collection and confirmation-time tax updates unchanged.

The response/state identity guard skips a Payment Element reload when the updater returns the original response for a successful no-op.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused controller coverage verifies billing-source tax-region requests and reloads, tax-disabled and shipping-source no-ops, failed-request state preservation, and independence from shipping-country validation. Existing updater tests verify request serialization and exact response identity for no-op paths.

# Screenshots

Not applicable. No visual changes.

# Changelog

No changelog entry. Checkout Session remains private preview.

Committed and created by Codex.
