### PR TITLE
Source Checkout billing defaults from configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCollectedDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCollectedDetails.kt
@@ -10,7 +10,5 @@ import kotlinx.parcelize.Parcelize
 internal data class CheckoutCollectedDetails(
     val email: String?,
     val shippingName: String? = null,
-    val billingName: String? = null,
     val shippingAddress: Address.State? = null,
-    val billingAddress: Address.State? = null,
 ) : Parcelable

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -86,7 +86,10 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         customer = ConfigurationDefaults.customer,
         googlePay = googlePayConfiguration,
         link = linkConfiguration,
-        defaultBillingDetails = collectedDetails.toBillingDetails(checkoutSessionResponse),
+        defaultBillingDetails = configuration.toBillingDetails(
+            checkoutSessionResponse = checkoutSessionResponse,
+            collectedEmail = collectedDetails.email,
+        ),
         shippingDetails = collectedDetails.toShippingDetails(),
         allowsDelayedPaymentMethods = true,
         allowsPaymentMethodsRequiringShippingAddress = true,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
@@ -50,18 +50,14 @@ internal fun CheckoutController.Configuration.State.toPaymentElementGooglePayCon
     }
 
 @OptIn(CheckoutSessionPreview::class)
-internal fun CheckoutCollectedDetails.toBillingDetails(
+internal fun CheckoutController.Configuration.State.toBillingDetails(
     checkoutSessionResponse: CheckoutSessionResponse,
+    collectedEmail: String?,
 ): PaymentSheet.BillingDetails = PaymentSheet.BillingDetails(
-    address = billingAddress?.asPaymentSheet(),
-    email = resolveEmail(checkoutSessionResponse),
-    name = billingName,
+    address = defaults.billingDetails?.address?.asPaymentSheet(),
+    email = collectedEmail ?: checkoutSessionResponse.customerEmail,
+    name = defaults.billingDetails?.name,
 )
-
-@OptIn(CheckoutSessionPreview::class)
-internal fun CheckoutCollectedDetails.resolveEmail(
-    response: CheckoutSessionResponse,
-): String? = email ?: response.customerEmail
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutCollectedDetails.toShippingDetails(): AddressDetails = AddressDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -33,7 +33,12 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             .appearance(configuration.paymentElementConfiguration.appearance.asPaymentSheet())
             .googlePay(configuration.toExpressCheckoutElementGooglePayConfiguration(checkoutSessionResponse))
             .link(configuration.paymentElementConfiguration.linkConfiguration.asPaymentSheet())
-            .defaultBillingDetails(collectedDetails.toBillingDetails(checkoutSessionResponse))
+            .defaultBillingDetails(
+                configuration.toBillingDetails(
+                    checkoutSessionResponse = checkoutSessionResponse,
+                    collectedEmail = collectedDetails.email,
+                ),
+            )
             .shippingDetails(collectedDetails.toShippingDetails())
             .allowsDelayedPaymentMethods(true)
             .allowsPaymentMethodsRequiringShippingAddress(true)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -205,8 +205,6 @@ private fun CheckoutController.Configuration.State.asInitialCollectedDetails(): 
     return CheckoutCollectedDetails(
         email = defaults.email,
         shippingName = defaults.shippingDetails?.name,
-        billingName = defaults.billingDetails?.name,
         shippingAddress = defaults.shippingDetails?.address,
-        billingAddress = defaults.billingDetails?.address,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -47,8 +47,6 @@ internal class CheckoutCommonConfigurationFactoryTest {
             requiresBillingAddress = true,
         )
         val collectedDetails = collectedDetails(
-            billingName = "Jane Billing",
-            billingAddress = address(),
             shippingName = "John Shipping",
             shippingAddress = address(),
         )
@@ -305,6 +303,53 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
+    fun `maps configured billing defaults to payment element and express checkout element`() {
+        val configuration = CheckoutController.Configuration()
+            .defaults(
+                CheckoutController.Configuration.Defaults().billingDetails(
+                    CheckoutController.Configuration.Defaults.ContactDetails()
+                        .name("Jane Billing")
+                        .address(
+                            CheckoutController.Address()
+                                .city("Denver")
+                                .country("US")
+                                .line1("123 Main St")
+                                .line2("Apt 4")
+                                .postalCode("80202")
+                                .state("CO"),
+                        ),
+                ),
+            )
+            .expressCheckoutElement(ExpressCheckoutElement.Configuration())
+            .build()
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(customerEmail = "checkout@example.com")
+        val collectedDetails = collectedDetails()
+
+        val paymentElementDefaults = factory().createForPaymentElement(
+            configuration = configuration,
+            checkoutSessionResponse = checkoutSessionResponse,
+            collectedDetails = collectedDetails,
+        ).defaultBillingDetails
+        val expressCheckoutElementDefaults = requireNotNull(
+            factory().createForExpressCheckoutElement(
+                configuration = configuration,
+                checkoutSessionResponse = checkoutSessionResponse,
+                collectedDetails = collectedDetails,
+            ),
+        ).defaultBillingDetails
+
+        assertThat(expressCheckoutElementDefaults).isEqualTo(paymentElementDefaults)
+        assertThat(paymentElementDefaults?.email).isEqualTo("checkout@example.com")
+        assertThat(paymentElementDefaults?.name).isEqualTo("Jane Billing")
+        assertThat(paymentElementDefaults?.address?.city).isEqualTo("Denver")
+        assertThat(paymentElementDefaults?.address?.country).isEqualTo("US")
+        assertThat(paymentElementDefaults?.address?.line1).isEqualTo("123 Main St")
+        assertThat(paymentElementDefaults?.address?.line2).isEqualTo("Apt 4")
+        assertThat(paymentElementDefaults?.address?.postalCode).isEqualTo("80202")
+        assertThat(paymentElementDefaults?.address?.state).isEqualTo("CO")
+    }
+
+    @Test
     fun `maps terms display to common configuration`() {
         val configuration = CheckoutController.Configuration()
             .paymentElement(
@@ -400,7 +445,7 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
-    fun `sources the collected billing email over the checkout session customer email`() {
+    fun `sources the collected email over the checkout session customer email`() {
         val result = factory().create(
             configuration = controllerConfiguration(),
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(customerEmail = "checkout@example.com"),
@@ -494,16 +539,12 @@ internal class CheckoutCommonConfigurationFactoryTest {
     private fun collectedDetails(
         email: String? = null,
         shippingName: String? = null,
-        billingName: String? = null,
         shippingAddress: Address.State? = null,
-        billingAddress: Address.State? = null,
     ): CheckoutCollectedDetails {
         return CheckoutCollectedDetails(
             email = email,
             shippingName = shippingName,
-            billingName = billingName,
             shippingAddress = shippingAddress,
-            billingAddress = billingAddress,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -166,7 +166,7 @@ internal class CheckoutControllerTest {
     ) {
         result.getOrThrow()
 
-        val billingAddress = requireNotNull(committedState?.collectedDetails?.billingAddress)
+        val billingAddress = requireNotNull(committedState?.embeddedConfiguration?.defaultBillingDetails?.address)
         assertThat(billingAddress.city).isEqualTo("San Francisco")
         assertThat(billingAddress.country).isEqualTo("US")
         assertThat(billingAddress.line1).isEqualTo("510 Townsend St")
@@ -606,6 +606,8 @@ internal class CheckoutControllerTest {
 
         result.getOrThrow()
         assertThat(controller.session.value?.email).isEqualTo("checkout@example.com")
+        assertThat(committedState().embeddedConfiguration.defaultBillingDetails?.email)
+            .isEqualTo("checkout@example.com")
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -275,7 +275,7 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
-    fun `sources the collected billing email over the checkout session customer email`() {
+    fun `sources the collected email over the checkout session customer email`() {
         val result = factory().create(
             configuration = controllerConfiguration(),
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(customerEmail = "checkout@example.com"),
@@ -286,24 +286,31 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
-    fun `populates billing details from the session data`() {
+    fun `populates billing details from configuration defaults`() {
         val result = factory().create(
-            configuration = controllerConfiguration(),
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
-            collectedDetails = collectedDetails(
-                billingName = "Jane Billing",
-                billingAddress = Address.State(
-                    city = "Denver",
-                    country = "US",
-                    line1 = "123 Main St",
-                    line2 = "Apt 4",
-                    postalCode = "80202",
-                    state = "CO",
-                ),
-            ),
+            configuration = CheckoutController.Configuration()
+                .defaults(
+                    CheckoutController.Configuration.Defaults().billingDetails(
+                        CheckoutController.Configuration.Defaults.ContactDetails()
+                            .name("Jane Billing")
+                            .address(
+                                CheckoutController.Address()
+                                    .city("Denver")
+                                    .country("US")
+                                    .line1("123 Main St")
+                                    .line2("Apt 4")
+                                    .postalCode("80202")
+                                    .state("CO"),
+                            ),
+                    ),
+                )
+                .build(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(customerEmail = "checkout@example.com"),
+            collectedDetails = collectedDetails(),
         )
 
         val billingDetails = requireNotNull(result.defaultBillingDetails)
+        assertThat(billingDetails.email).isEqualTo("checkout@example.com")
         assertThat(billingDetails.name).isEqualTo("Jane Billing")
         val address = requireNotNull(billingDetails.address)
         assertThat(address.city).isEqualTo("Denver")
@@ -377,16 +384,12 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     private fun collectedDetails(
         email: String? = null,
         shippingName: String? = null,
-        billingName: String? = null,
         shippingAddress: Address.State? = null,
-        billingAddress: Address.State? = null,
     ): CheckoutCollectedDetails {
         return CheckoutCollectedDetails(
             email = email,
             shippingName = shippingName,
-            billingName = billingName,
             shippingAddress = shippingAddress,
-            billingAddress = billingAddress,
         )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -144,59 +144,29 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
-    fun `loadInitial seeds collected details with the defaults billing address`() = runScenario {
-        val address = CheckoutController.Address()
-            .city(" San Francisco ")
-            .country(" US ")
-            .line1(" 510 Townsend St ")
-            .postalCode(" 94103 ")
-            .state(" CA ")
-
-        loader.loadInitial(
-            configuration = CheckoutController.Configuration()
-                .defaults(
-                    CheckoutController.Configuration.Defaults()
-                        .billingDetails(
-                            CheckoutController.Configuration.Defaults.ContactDetails().address(address),
-                        ),
-                )
-                .build(),
-            checkoutSessionResponse = response(),
-        )
-
-        val billingAddress = requireNotNull(stateHolder.state?.collectedDetails?.billingAddress)
-        assertThat(billingAddress.city).isEqualTo("San Francisco")
-        assertThat(billingAddress.country).isEqualTo("US")
-        assertThat(billingAddress.line1).isEqualTo("510 Townsend St")
-        assertThat(billingAddress.postalCode).isEqualTo("94103")
-        assertThat(billingAddress.state).isEqualTo("CA")
-        assertThat(stateHolder.state?.embeddedConfiguration?.defaultBillingDetails?.address?.postalCode)
-            .isEqualTo("94103")
-    }
-
-    @Test
-    fun `loadInitial seeds collected details from configuration defaults`() = runScenario {
+    fun `loadInitial keeps only mutable configuration defaults in collected details`() = runScenario {
         val configuration = CheckoutController.Configuration()
             .defaults(
                 CheckoutController.Configuration.Defaults()
-                    .billingDetails(
-                        CheckoutController.Configuration.Defaults.ContactDetails()
-                            .name("Jane Billing")
-                            .address(CheckoutController.Address().country("US").city("Denver")),
-                    )
                     .shippingDetails(
-                        CheckoutController.Configuration.Defaults.ContactDetails().name("John Shipping"),
-                    ),
+                        CheckoutController.Configuration.Defaults.ContactDetails()
+                            .name("John Shipping")
+                            .address(CheckoutController.Address().country("US").city("Seattle")),
+                    )
+                    .email("prefill@example.com"),
             )
             .build()
 
         loader.loadInitial(configuration = configuration, checkoutSessionResponse = response())
 
         val collected = requireNotNull(stateHolder.state).collectedDetails
-        assertThat(collected.billingName).isEqualTo("Jane Billing")
-        assertThat(collected.billingAddress?.country).isEqualTo("US")
-        assertThat(collected.billingAddress?.city).isEqualTo("Denver")
-        assertThat(collected.shippingName).isEqualTo("John Shipping")
+        assertThat(collected).isEqualTo(
+            CheckoutCollectedDetails(
+                email = "prefill@example.com",
+                shippingName = "John Shipping",
+                shippingAddress = CheckoutController.Address().country("US").city("Seattle").build(),
+            ),
+        )
     }
 
     @Test


### PR DESCRIPTION
# Summary

Removes `billingName` and `billingAddress` from mutable `CheckoutCollectedDetails`.

Configured billing name and address now flow directly from Checkout configuration into Payment Element, Embedded Payment Element, and Express Checkout Element defaults. Collected email and shipping details remain mutable.

# Motivation

The billing tax-region API does not update payment UI billing details. Configuration therefore remains the owner of billing defaults, without copying them through mutable collected state.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Factory tests verify complete billing-default mapping for all three payment UI integrations. Loader and controller tests verify initial configuration wiring and preservation of mutable email and shipping state.

# Screenshots

Not applicable. No intended visual change.

# Changelog

No changelog entry. Checkout Session remains private preview.

Committed and created by Codex.
