### PR TITLE
Preserve Bitrise retry test results

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -729,6 +729,13 @@ step_bundles:
           timeout: 1200
           inputs:
             - content: ./gradlew splitInstrumentationTestReportsByClass
+      - script@1:
+          title: Merge instrumentation retry results
+          is_skippable: true
+          is_always_run: true
+          timeout: 1200
+          inputs:
+            - content: python3 "$BITRISE_SOURCE_DIR/scripts/merge_instrumentation_junit_reports.py"
       - bundle::export_test_results:
           inputs:
             - test_title: $test_title

--- a/scripts/merge_instrumentation_junit_reports.py
+++ b/scripts/merge_instrumentation_junit_reports.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Merge failed intermediate instrumentation attempts into final JUnit reports."""
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import re
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+DEFAULT_RETRY_RESULTS = Path("/tmp/test_results/retry-results")
+
+
+def local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-dir",
+        type=Path,
+        default=Path(os.environ.get("BITRISE_SOURCE_DIR", ".")),
+        help="Repository containing final build/instrumentation-test-results directories.",
+    )
+    parser.add_argument(
+        "--retry-results",
+        type=Path,
+        default=Path(os.environ.get("BITRISE_RETRY_RESULTS_DIR", DEFAULT_RETRY_RESULTS)),
+        help="Directory containing retry run snapshots.",
+    )
+    parser.add_argument(
+        "--diagnostics-dir",
+        type=Path,
+        default=None,
+        help="Directory for unmatched or incomplete retry reports.",
+    )
+    return parser.parse_args()
+
+
+def suite_elements(root: ET.Element) -> list[ET.Element]:
+    root_tag = local_name(root.tag)
+    if root_tag == "testsuite":
+        return [root]
+    if root_tag == "testsuites":
+        return [element for element in root.iter() if local_name(element.tag) == "testsuite"]
+    return []
+
+
+def suite_class_name(suite: ET.Element) -> str | None:
+    for testcase in suite:
+        if local_name(testcase.tag) == "testcase" and testcase.get("classname"):
+            return testcase.get("classname")
+    return suite.get("name") or None
+
+
+def testcase_elements(suite: ET.Element) -> list[ET.Element]:
+    return [element for element in suite if local_name(element.tag) == "testcase"]
+
+
+def testcase_key(testcase: ET.Element, fallback_classname: str | None) -> tuple[str, str] | None:
+    classname = testcase.get("classname") or fallback_classname
+    name = testcase.get("name")
+    if not classname or not name:
+        return None
+    return classname, name
+
+
+def failure_elements(testcase: ET.Element) -> list[ET.Element]:
+    return [
+        element
+        for element in testcase
+        if local_name(element.tag) in {"failure", "error"}
+    ]
+
+
+@dataclass
+class EarlyFailure:
+    module: str
+    key: tuple[str, str]
+    attempt: int
+    source: Path
+    element: ET.Element
+    matched: bool = False
+
+
+@dataclass
+class MergeState:
+    warnings: dict[Path, list[str]] = field(default_factory=lambda: defaultdict(list))
+    failures: list[EarlyFailure] = field(default_factory=list)
+
+    def warn(self, source: Path, message: str) -> None:
+        self.warnings[source].append(message)
+
+
+def module_for_build_path(path: Path) -> str | None:
+    parts = path.parts
+    try:
+        build_index = parts.index("build")
+    except ValueError:
+        return None
+    module_parts = parts[:build_index]
+    attempt_indices = [
+        index
+        for index, part in enumerate(module_parts)
+        if re.fullmatch(r"attempt-\d+", part)
+    ]
+    if attempt_indices:
+        module_parts = module_parts[attempt_indices[-1] + 1 :]
+    module = Path(*module_parts)
+    return str(module) if str(module) else "."
+
+
+def attempt_number(path: Path) -> int | None:
+    for part in path.parts:
+        match = re.fullmatch(r"attempt-(\d+)", part)
+        if match:
+            return int(match.group(1))
+    return None
+
+
+def retry_xml_files(retry_results: Path) -> list[Path]:
+    if not retry_results.is_dir():
+        return []
+    paths = [
+        path
+        for run_dir in retry_results.glob("run-*")
+        for attempt_dir in run_dir.glob("attempt-*")
+        for path in attempt_dir.rglob("*.xml")
+        if path.is_file()
+    ]
+    return sorted(
+        paths,
+        key=lambda path: (
+            next(part for part in path.parts if part.startswith("run-")),
+            attempt_number(path) or 0,
+            str(path),
+        ),
+    )
+
+
+def read_early_failures(retry_results: Path, state: MergeState) -> None:
+    for path in retry_xml_files(retry_results):
+        attempt = attempt_number(path)
+        if attempt is None:
+            state.warn(path, "retry snapshot is missing an attempt number")
+            continue
+
+        try:
+            root = ET.parse(path).getroot()
+        except ET.ParseError as error:
+            state.warn(path, f"could not parse JUnit XML: {error}")
+            continue
+
+        suites = suite_elements(root)
+        if not suites:
+            state.warn(path, "XML does not contain a testsuite or testsuites root")
+            continue
+
+        relative = path.relative_to(retry_results)
+        module = module_for_build_path(relative)
+        if module is None:
+            state.warn(path, "retry result path does not identify a module")
+            continue
+
+        found_case = False
+        found_failure = False
+        for suite in suites:
+            fallback_classname = suite_class_name(suite)
+            for testcase in testcase_elements(suite):
+                found_case = True
+                failures = failure_elements(testcase)
+                if not failures:
+                    continue
+                found_failure = True
+                key = testcase_key(testcase, fallback_classname)
+                if key is None:
+                    state.warn(path, "failing testcase is missing classname or name")
+                    continue
+                for failure in failures:
+                    state.failures.append(
+                        EarlyFailure(
+                            module=module,
+                            key=key,
+                            attempt=attempt,
+                            source=path,
+                            element=copy.deepcopy(failure),
+                        )
+                    )
+
+        if not found_case:
+            state.warn(path, "JUnit report contains no testcases")
+        elif not found_failure:
+            state.warn(path, "intermediate retry report contains no failing testcases")
+
+
+def final_report_files(source_root: Path) -> list[Path]:
+    if not source_root.is_dir():
+        return []
+    return sorted(
+        path
+        for result_dir in source_root.rglob("instrumentation-test-results")
+        if result_dir.is_dir()
+        for path in result_dir.glob("*.xml")
+        if path.is_file()
+    )
+
+
+def final_status(testcase: ET.Element) -> str:
+    child_tags = {local_name(element.tag) for element in testcase}
+    if "error" in child_tags:
+        return "error"
+    if "failure" in child_tags:
+        return "failure"
+    if "skipped" in child_tags:
+        return "skipped"
+    return "pass"
+
+
+def annotation_tag(early_tag: str, final: str) -> str:
+    suffix = "Error" if early_tag == "error" else "Failure"
+    prefix = "flaky" if final == "pass" else "rerun"
+    return prefix + suffix
+
+
+def update_suite_counts(suite: ET.Element) -> None:
+    cases = testcase_elements(suite)
+    statuses = [final_status(testcase) for testcase in cases]
+    suite.set("tests", str(len(cases)))
+    suite.set("failures", str(statuses.count("failure")))
+    suite.set("errors", str(statuses.count("error")))
+    suite.set("skipped", str(statuses.count("skipped")))
+
+
+def update_testsuites_counts(root: ET.Element) -> None:
+    if local_name(root.tag) != "testsuites":
+        return
+    suites = suite_elements(root)
+    root.set("tests", str(sum(int(suite.get("tests", "0")) for suite in suites)))
+    root.set("failures", str(sum(int(suite.get("failures", "0")) for suite in suites)))
+    root.set("errors", str(sum(int(suite.get("errors", "0")) for suite in suites)))
+    root.set("skipped", str(sum(int(suite.get("skipped", "0")) for suite in suites)))
+
+
+def merge_final_report(
+    path: Path,
+    source_root: Path,
+    failures_by_key: dict[tuple[str, tuple[str, str]], list[EarlyFailure]],
+) -> int:
+    tree = ET.parse(path)
+    root = tree.getroot()
+    relative = path.relative_to(source_root)
+    module = module_for_build_path(relative)
+    if module is None:
+        return 0
+
+    annotations = 0
+    for suite in suite_elements(root):
+        fallback_classname = suite_class_name(suite)
+        for testcase in testcase_elements(suite):
+            key = testcase_key(testcase, fallback_classname)
+            if key is None:
+                continue
+            early_failures = failures_by_key.get((module, key), [])
+            if not early_failures:
+                continue
+            current_status = final_status(testcase)
+            if current_status == "skipped":
+                continue
+            for early_failure in early_failures:
+                annotated = copy.deepcopy(early_failure.element)
+                annotated.tag = annotation_tag(local_name(annotated.tag), current_status)
+                testcase.append(annotated)
+                early_failure.matched = True
+                annotations += 1
+        update_suite_counts(suite)
+    update_testsuites_counts(root)
+    if annotations:
+        ET.indent(tree, space="  ")
+        tree.write(path, encoding="utf-8", xml_declaration=True)
+    return annotations
+
+
+def copy_diagnostics(
+    retry_results: Path,
+    diagnostics_dir: Path,
+    state: MergeState,
+) -> None:
+    for source, reasons in state.warnings.items():
+        try:
+            relative = source.relative_to(retry_results)
+        except ValueError:
+            relative = Path(source.name)
+        destination = diagnostics_dir / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        warning_file = destination.with_name(destination.name + ".warning.txt")
+        warning_file.write_text("\n".join(reasons) + "\n", encoding="utf-8")
+        for reason in reasons:
+            print(f"Warning: {source}: {reason}", file=sys.stderr)
+
+
+def merge_reports(
+    source_root: Path,
+    retry_results: Path,
+    diagnostics_dir: Path | None = None,
+) -> int:
+    source_root = source_root.resolve()
+    retry_results = retry_results.resolve()
+    if diagnostics_dir is None:
+        diagnostics_dir = retry_results.parent / "retry-diagnostics"
+    diagnostics_dir = diagnostics_dir.resolve()
+
+    state = MergeState()
+    read_early_failures(retry_results, state)
+    failures_by_key: dict[tuple[str, tuple[str, str]], list[EarlyFailure]] = defaultdict(list)
+    for failure in state.failures:
+        failures_by_key[(failure.module, failure.key)].append(failure)
+
+    annotations = 0
+    for path in final_report_files(source_root):
+        try:
+            annotations += merge_final_report(path, source_root, failures_by_key)
+        except (ET.ParseError, ValueError) as error:
+            state.warn(path, f"could not update final JUnit XML: {error}")
+
+    for failure in state.failures:
+        if not failure.matched:
+            state.warn(
+                failure.source,
+                f"no final testcase matched {failure.key[0]}#{failure.key[1]} from attempt {failure.attempt}",
+            )
+
+    if state.warnings:
+        copy_diagnostics(retry_results, diagnostics_dir, state)
+    if state.failures:
+        print(f"Merged {annotations} intermediate instrumentation result(s).")
+    elif not retry_results.is_dir():
+        print(f"No retry result snapshots found at {retry_results}.")
+    return annotations
+
+
+def main() -> None:
+    args = parse_args()
+    merge_reports(args.source_dir, args.retry_results, args.diagnostics_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/retry_with_emulator_cleanup.sh
+++ b/scripts/retry_with_emulator_cleanup.sh
@@ -6,6 +6,53 @@
 OUTPUT_LOG=$(mktemp)
 trap 'rm -f "$OUTPUT_LOG"' EXIT
 
+SOURCE_DIR="${BITRISE_SOURCE_DIR:-.}"
+SOURCE_DIR=$(cd "$SOURCE_DIR" && pwd)
+RETRY_RESULTS_DIR="${BITRISE_RETRY_RESULTS_DIR:-/tmp/test_results/retry-results}"
+RETRY_RUN_DIR=""
+
+# Gradle emits this line after a test task has produced its JUnit failure report.
+# Keep the detector narrow so compilation, setup, and emulator failures are not
+# treated as test failures.
+function is_gradle_test_failure {
+  local log_file="$1"
+  grep -qF "There were failing tests." "$log_file"
+}
+
+function capture_attempt_results {
+  local attempt="$1"
+
+  if [ ! -d "$SOURCE_DIR" ]; then
+    echo "Cannot capture retry results because source directory is missing: $SOURCE_DIR" >&2
+    return 0
+  fi
+
+  if [ -z "$RETRY_RUN_DIR" ]; then
+    mkdir -p "$RETRY_RESULTS_DIR"
+    RETRY_RUN_DIR=$(mktemp -d "$RETRY_RESULTS_DIR/run-XXXXXX")
+  fi
+
+  local attempt_dir="$RETRY_RUN_DIR/attempt-$attempt"
+  local captured=0
+  while IFS= read -r -d '' result_dir; do
+    local relative="${result_dir#"$SOURCE_DIR"/}"
+    local destination="$attempt_dir/$relative"
+    mkdir -p "$(dirname "$destination")"
+    cp -R "$result_dir" "$destination"
+    captured=$((captured + 1))
+    echo "Captured retry $attempt results: $relative"
+  done < <(
+    find "$SOURCE_DIR" -type d \( \
+      -path '*/build/outputs/androidTest-results/connected' -o \
+      -path '*/build/outputs/androidTest-results/managedDevice' \
+    \) -print0
+  )
+
+  if [ "$captured" -eq 0 ]; then
+    echo "No instrumentation result directories found after retry $attempt."
+  fi
+}
+
 function clear_corrupted_orchestrator_cache {
   if [ -f "$OUTPUT_LOG" ] && grep -qE "Failed to install split APK|Invalid File.*orchestrator" "$OUTPUT_LOG"; then
     echo "Detected orchestrator APK installation failure. Clearing corrupted cache..."
@@ -47,6 +94,7 @@ function retry {
     fi
     count=$(($count + 1))
     if [ $count -lt $retries ]; then
+      capture_attempt_results "$count"
       echo "Retry $count/$retries exited $exit. Checking for known failures..."
       clear_corrupted_orchestrator_cache
       echo "Checking emulator health..."

--- a/scripts/test_merge_instrumentation_junit_reports.py
+++ b/scripts/test_merge_instrumentation_junit_reports.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from merge_instrumentation_junit_reports import merge_reports
+
+
+FINAL_ROOT = """<testsuite name="suite" tests="{tests}" failures="{failures}" errors="{errors}" skipped="0">
+  {cases}
+</testsuite>"""
+RETRY_ROOT = """<testsuite name="suite">
+  {cases}
+</testsuite>"""
+
+
+def testcase(name: str, classname: str = "com.example.RetryTest", result: str = "") -> str:
+    child = {
+        "failure": '<failure type="AssertionError">first failure</failure>',
+        "error": '<error type="RuntimeException">first error</error>',
+        "skipped": "<skipped />",
+    }.get(result, "")
+    return f'<testcase classname="{classname}" name="{name}" time="0.1">{child}</testcase>'
+
+
+class InstrumentationJUnitMergeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp_dir.name) / "repo"
+        self.retry = Path(self.temp_dir.name) / "retry-results"
+        self.final_dir = self.root / "paymentsheet" / "build" / "instrumentation-test-results"
+        self.retry_dir = self.retry / "run-1" / "attempt-1" / "paymentsheet" / "build" / "outputs" / "androidTest-results" / "managedDevice"
+        self.final_dir.mkdir(parents=True)
+        self.retry_dir.mkdir(parents=True)
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def write_final(self, name: str, cases: str, tests: int = 1, failures: int = 0, errors: int = 0) -> Path:
+        path = self.final_dir / f"TEST-{name}.xml"
+        path.write_text(
+            FINAL_ROOT.format(tests=tests, failures=failures, errors=errors, cases=cases),
+            encoding="utf-8",
+        )
+        return path
+
+    def write_retry(self, name: str, cases: str, device: str = "device-1") -> Path:
+        path = self.retry_dir / device / f"TEST-{name}.xml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(RETRY_ROOT.format(cases=cases), encoding="utf-8")
+        return path
+
+    def read_final(self, path: Path) -> ET.Element:
+        return ET.parse(path).getroot()
+
+    def test_fail_then_pass_is_flaky_and_remains_green(self) -> None:
+        final = self.write_final("RetryTest", testcase("testFlaky"))
+        self.write_retry("RetryTest", testcase("testFlaky", result="failure"))
+
+        merge_reports(self.root, self.retry)
+
+        root = self.read_final(final)
+        case = root.find("testcase")
+        self.assertIsNotNone(case)
+        self.assertIsNotNone(case.find("flakyFailure"))
+        self.assertIsNone(case.find("failure"))
+        self.assertEqual("0", root.get("failures"))
+        self.assertEqual("1", root.get("tests"))
+
+    def test_repeated_failure_keeps_final_failure_and_rerun_failures(self) -> None:
+        final = self.write_final("RetryTest", testcase("testAlwaysFails", result="failure"), failures=1)
+        self.write_retry("RetryTest", testcase("testAlwaysFails", result="failure"))
+        second = self.retry / "run-1" / "attempt-2" / "paymentsheet" / "build" / "outputs" / "androidTest-results" / "managedDevice"
+        second.mkdir(parents=True)
+        (second / "TEST-RetryTest.xml").write_text(
+            RETRY_ROOT.format(cases=testcase("testAlwaysFails", result="failure")),
+            encoding="utf-8",
+        )
+
+        merge_reports(self.root, self.retry)
+
+        root = self.read_final(final)
+        case = root.find("testcase")
+        self.assertEqual(1, len(case.findall("failure")))
+        self.assertEqual(2, len(case.findall("rerunFailure")))
+        self.assertEqual("1", root.get("failures"))
+
+    def test_error_then_pass_uses_flaky_error(self) -> None:
+        final = self.write_final("RetryTest", testcase("testError"))
+        self.write_retry("RetryTest", testcase("testError", result="error"))
+
+        merge_reports(self.root, self.retry)
+
+        case = self.read_final(final).find("testcase")
+        self.assertIsNotNone(case.find("flakyError"))
+        self.assertIsNone(case.find("error"))
+
+    def test_parameterized_name_is_matched_exactly(self) -> None:
+        parameterized_name = "testCard[US, Visa]"
+        final = self.write_final("RetryTest", testcase(parameterized_name))
+        self.write_retry("RetryTest", testcase(parameterized_name, result="failure"))
+
+        merge_reports(self.root, self.retry)
+
+        case = self.read_final(final).find("testcase")
+        self.assertIsNotNone(case.find("flakyFailure"))
+        self.assertEqual(parameterized_name, case.get("name"))
+
+    def test_multi_device_reports_are_merged_by_class_and_name(self) -> None:
+        first = self.write_final("FirstTest", testcase("testOne", "com.example.FirstTest"))
+        second = self.final_dir / "TEST-com_example_SecondTest.xml"
+        second.write_text(
+            FINAL_ROOT.format(
+                tests=1,
+                failures=0,
+                errors=0,
+                cases=testcase("testTwo", "com.example.SecondTest"),
+            ),
+            encoding="utf-8",
+        )
+        self.write_retry("FirstTest", testcase("testOne", "com.example.FirstTest", "failure"), "device-1")
+        self.write_retry("SecondTest", testcase("testTwo", "com.example.SecondTest", "error"), "device-2")
+
+        merge_reports(self.root, self.retry)
+
+        self.assertIsNotNone(self.read_final(first).find("testcase/flakyFailure"))
+        self.assertIsNotNone(self.read_final(second).find("testcase/flakyError"))
+
+    def test_unmatched_and_incomplete_reports_become_diagnostics(self) -> None:
+        final = self.write_final("RetryTest", testcase("testKnown"))
+        unmatched = self.write_retry("RetryTest", testcase("testMissing", result="failure"))
+        incomplete = self.retry_dir / "broken.xml"
+        incomplete.write_text("<testsuite><testcase", encoding="utf-8")
+        stderr = io.StringIO()
+
+        with contextlib.redirect_stderr(stderr):
+            merge_reports(self.root, self.retry)
+
+        self.assertIsNone(self.read_final(final).find("testcase/flakyFailure"))
+        diagnostics = self.retry.parent / "retry-diagnostics"
+        self.assertTrue((diagnostics / unmatched.relative_to(self.retry)).is_file())
+        self.assertTrue((diagnostics / incomplete.relative_to(self.retry)).is_file())
+        self.assertIn("no final testcase matched", stderr.getvalue())
+        self.assertIn("could not parse JUnit XML", stderr.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Summary

Preserve failed test cases from intermediate Bitrise retry attempts in the final instrumentation JUnit reports.

# Motivation

The retry wrapper exposes every attempt in the console, but the next Gradle attempt can overwrite the previous JUnit output before Bitrise Test Reports reads it. A test that fails once and then passes therefore appears only as green final output, without structured evidence that it was flaky.

# What changed

- Snapshot connected and managed-device instrumentation result directories before each non-final retry under `/tmp/test_results/retry-results/run-*/attempt-*`.
- Run a merger after the existing `splitInstrumentationTestReportsByClass` step. It matches attempts by the exact `classname` and `name` pair, including parameterized names.
- Add `flakyFailure` or `flakyError` to a recovered final testcase. Add `rerunFailure` or `rerunError` alongside a final failure or error.
- Recalculate suite counts from the final direct result elements, so recovered tests remain green and repeated failures remain failed.
- Keep malformed, incomplete, or unmatched early reports as artifact diagnostics with warnings instead of fabricating structured testcases.

# What stays the same

- Existing retry count, cleanup ordering, and retry timing remain unchanged on the default wrapper path.
- The seven existing instrumentation and PaymentSheet E2E wrapper callers keep their existing invocation contract.
- No SDK runtime behavior, public API, or changelog entry is changed. Maestro report merging remains separate.

# Coverage

The fixture suite covers failure recovery, repeated failure, error recovery, exact parameterized names, multi-device report paths, and unmatched or incomplete XML diagnostics.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Local checks passed on the stacked child head: both Python suites passed with 6 tests each, Python compilation passed, `bash -n` passed, shellcheck passed, `bitrise validate` passed with Bitrise CLI 2.43.3, and `git diff --check` passed. CI will run for this draft PR.

# Screenshots

Not applicable. This changes CI result collection only.

# Changelog

No user-facing SDK change. No changelog entry is required.

Committed and created by Codex.
