### PR TITLE
Omit addressless Checkout shipping at confirmation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptor.kt
@@ -241,7 +241,7 @@ internal class CheckoutSessionConfirmationInterceptor @AssistedInject constructo
 }
 
 private fun ShippingInformation?.toCheckoutSessionShipping(): ConfirmCheckoutSessionParams.Shipping? {
-    return this?.let {
+    return this?.takeIf { it.address?.toParamMap()?.isNotEmpty() == true }?.let {
         ConfirmCheckoutSessionParams.Shipping(
             name = it.name,
             address = it.address,
@@ -250,7 +250,7 @@ private fun ShippingInformation?.toCheckoutSessionShipping(): ConfirmCheckoutSes
 }
 
 private fun ConfirmPaymentIntentParams.Shipping?.toCheckoutSessionShipping(): ConfirmCheckoutSessionParams.Shipping? {
-    return this?.let {
+    return this?.takeIf { it.getAddress().toParamMap().isNotEmpty() }?.let {
         ConfirmCheckoutSessionParams.Shipping(
             name = it.getName(),
             address = it.getAddress(),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -455,6 +455,18 @@ class CheckoutSessionConfirmationInterceptorTest {
     }
 
     @Test
+    fun `intercept with new payment method omits empty controller shipping`() = runScenario {
+        networkRule.checkoutConfirm(
+            not(hasBodyPart("shipping[name]")),
+            not(hasBodyPart("shipping[address][line1]")),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        interceptNewPm(shippingValues = EMPTY_CONTROLLER_SHIPPING)
+    }
+
+    @Test
     fun `intercept with saved payment method falls back to controller shipping`() = runScenario {
         networkRule.checkoutConfirm(
             bodyPart("shipping[name]", "Controller Shipping"),
@@ -470,6 +482,39 @@ class CheckoutSessionConfirmationInterceptorTest {
         }
 
         interceptSavedPm(shippingValues = CONTROLLER_SHIPPING)
+    }
+
+    @Test
+    fun `intercept with saved payment method omits empty controller shipping`() = runScenario {
+        networkRule.checkoutConfirm(
+            not(hasBodyPart("shipping[name]")),
+            not(hasBodyPart("shipping[address][line1]")),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        interceptSavedPm(shippingValues = EMPTY_CONTROLLER_SHIPPING)
+    }
+
+    @Test
+    fun `intercept with saved payment method falls back from addressless option shipping`() = runScenario {
+        networkRule.checkoutConfirm(
+            bodyPart("shipping[name]", "Controller Shipping"),
+            bodyPart("shipping[address][line1]", "123 Controller Street"),
+            bodyPart("shipping[address][line2]", "Unit 4"),
+            bodyPart("shipping[address][city]", "Controller City"),
+            bodyPart("shipping[address][state]", "NY"),
+            bodyPart("shipping[address][postal_code]", "10001"),
+            bodyPart("shipping[address][country]", "CA"),
+            not(hasBodyPart("shipping[phone]")),
+        ) { response ->
+            response.testBodyFromFile("checkout-session-confirm.json")
+        }
+
+        interceptSavedPm(
+            shippingInformation = ADDRESSLESS_SHIPPING_INFORMATION,
+            shippingValues = CONTROLLER_SHIPPING,
+        )
     }
 
     @Test
@@ -655,6 +700,16 @@ class CheckoutSessionConfirmationInterceptorTest {
             ),
             name = "Controller Shipping",
             phone = "1-800-555-0000",
+        )
+
+        val EMPTY_CONTROLLER_SHIPPING = ConfirmPaymentIntentParams.Shipping(
+            address = Address(),
+            name = "",
+        )
+
+        val ADDRESSLESS_SHIPPING_INFORMATION = ShippingInformation(
+            address = Address(),
+            name = "Option Shipping",
         )
 
         val SAVE_ENABLED_CUSTOMER_METADATA = PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA.copy(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.PaymentAnalyticsRequestFactory
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.doesNotContainBodyPartsWithPrefix
 import com.stripe.android.networktesting.RequestMatchers.hasBodyPart
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.testBodyFromFile
@@ -457,8 +458,7 @@ class CheckoutSessionConfirmationInterceptorTest {
     @Test
     fun `intercept with new payment method omits empty controller shipping`() = runScenario {
         networkRule.checkoutConfirm(
-            not(hasBodyPart("shipping[name]")),
-            not(hasBodyPart("shipping[address][line1]")),
+            doesNotContainBodyPartsWithPrefix("shipping["),
         ) { response ->
             response.testBodyFromFile("checkout-session-confirm.json")
         }
@@ -487,8 +487,7 @@ class CheckoutSessionConfirmationInterceptorTest {
     @Test
     fun `intercept with saved payment method omits empty controller shipping`() = runScenario {
         networkRule.checkoutConfirm(
-            not(hasBodyPart("shipping[name]")),
-            not(hasBodyPart("shipping[address][line1]")),
+            doesNotContainBodyPartsWithPrefix("shipping["),
         ) { response ->
             response.testBodyFromFile("checkout-session-confirm.json")
         }


### PR DESCRIPTION
# Summary

- Omit Checkout confirmation shipping when its address has no serialized fields.
- Preserve whole-source shipping precedence: valid saved-option shipping wins; otherwise valid controller shipping is used.

# Motivation

An empty Checkout state can produce `Shipping(name = "", address = Address())`. The confirmation conversion sent `shipping[name]=""` despite having no address fields. Confirmation now omits shipping for that state.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Focused interceptor coverage verifies empty controller shipping is omitted for new and saved methods, and addressless saved-option shipping falls back to complete controller shipping. Existing coverage retains valid controller shipping, valid saved-option precedence, phone omission, and no-source omission.

The focused interceptor test, API compatibility check, and detekt passed locally. CI: pending.

# Screenshots

| Before | After |
| --- | --- |
| Not applicable | Not applicable |

# Changelog

Not required. No public API or user-visible UI change.

Committed and created by Codex.
