### PR TITLE
Add request body prefix matcher

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -151,6 +151,12 @@ object RequestMatchers {
         }
     }
 
+    fun doesNotContainBodyPartsWithPrefix(prefix: String): RequestMatcher {
+        return ToStringRequestMatcher("doesNotContainBodyPartsWithPrefix($prefix)") { request ->
+            request.bodyParams.keys.none { it.startsWith(prefix) }
+        }
+    }
+
     fun bodyPart(name: String, value: String): RequestMatcher {
         return ToStringRequestMatcher("bodyPart($name, $value)") { request ->
             request.bodyParams[name] == value ||

--- a/network-testing/src/test/java/com/stripe/android/networktesting/RequestMatchersTest.kt
+++ b/network-testing/src/test/java/com/stripe/android/networktesting/RequestMatchersTest.kt
@@ -239,6 +239,27 @@ class RequestMatchersTest {
     }
 
     @Test
+    fun `doesNotContainBodyPartsWithPrefix rejects matching body parts`() {
+        val request = postWithFormBody(
+            "shipping[name]" to "Jenny Rosen",
+            "shipping[address][line1]" to "510 Townsend St",
+        )
+
+        val matcher = RequestMatchers.doesNotContainBodyPartsWithPrefix("shipping[")
+
+        assertThat(matcher.matches(request)).isFalse()
+    }
+
+    @Test
+    fun `doesNotContainBodyPartsWithPrefix matches when no body parts have the prefix`() {
+        val request = postWithFormBody("billing_details[name]" to "Jenny Rosen")
+
+        val matcher = RequestMatchers.doesNotContainBodyPartsWithPrefix("shipping[")
+
+        assertThat(matcher.matches(request)).isTrue()
+    }
+
+    @Test
     fun `query matches plain and pre-encoded keys`() {
         val request = getWithQuery("deferred_intent[on_behalf_of]" to "acct_123")
 


### PR DESCRIPTION
# Summary

- Add a generic request matcher that asserts no decoded form-body key begins with a given prefix.

# Motivation

Nested request maps serialize as flattened form keys. Tests need a way to assert that an entire nested namespace, such as `shipping[...]`, is absent without matching unrelated keys such as `shipping_collection`.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Unit coverage verifies that the matcher rejects a request containing both `shipping[name]` and `shipping[address][line1]`, and accepts a request with no matching keys. Detekt passed locally. CI: pending.

# Screenshots

| Before | After |
| --- | --- |
| Not applicable | Not applicable |

# Changelog

Not required. Test infrastructure only.

Committed and created by Codex.
