### PR TITLE
Rename IdentifierSpec to FormFieldId

### DIFF
--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationPreviewParameterProvider.kt
@@ -6,7 +6,7 @@ import com.stripe.android.financialconnections.presentation.Async.Fail
 import com.stripe.android.financialconnections.presentation.Async.Loading
 import com.stripe.android.financialconnections.presentation.Async.Success
 import com.stripe.android.financialconnections.presentation.Async.Uninitialized
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 
@@ -52,7 +52,7 @@ internal class NetworkingLinkVerificationPreviewParameterProvider :
             email = "theLargestEmailYoulleverseeThatCouldBreakALayout@email.com",
             phoneNumber = "12345678",
             otpElement = OTPElement(
-                IdentifierSpec.Generic("otp"),
+                FormFieldId.Generic("otp"),
                 OTPController()
             ),
             consumerSessionClientSecret = "12345678",

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkinglinkverification/NetworkingLinkVerificationViewModel.kt
@@ -32,7 +32,7 @@ import com.stripe.android.financialconnections.presentation.FinancialConnections
 import com.stripe.android.financialconnections.repository.ConsumerSessionProvider
 import com.stripe.android.financialconnections.utils.error
 import com.stripe.android.model.ConsumerSession
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import com.stripe.android.uicore.navigation.NavigationManager
@@ -92,7 +92,7 @@ internal class NetworkingLinkVerificationViewModel @AssistedInject constructor(
         initialInstitution = initialInstitution,
         consumerSessionClientSecret = consumerSession.clientSecret,
         otpElement = OTPElement(
-            IdentifierSpec.Generic("otp"),
+            FormFieldId.Generic("otp"),
             OTPController()
         )
     )

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationPreviewParameterProvider.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationPreviewParameterProvider.kt
@@ -6,7 +6,7 @@ import com.stripe.android.financialconnections.presentation.Async.Fail
 import com.stripe.android.financialconnections.presentation.Async.Loading
 import com.stripe.android.financialconnections.presentation.Async.Success
 import com.stripe.android.financialconnections.presentation.Async.Uninitialized
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 
@@ -59,7 +59,7 @@ internal class NetworkingSaveToLinkVerificationPreviewParameterProvider :
         email = "theLargestEmailYoulleverseeThatCouldBreakALayout@email.com",
         phoneNumber = "12345678",
         otpElement = OTPElement(
-            IdentifierSpec.Generic("otp"),
+            FormFieldId.Generic("otp"),
             OTPController()
         ),
         showNotNowButton = false,

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModel.kt
@@ -32,7 +32,7 @@ import com.stripe.android.financialconnections.presentation.FinancialConnections
 import com.stripe.android.financialconnections.repository.AttachedPaymentAccountRepository
 import com.stripe.android.financialconnections.repository.ConsumerSessionProvider
 import com.stripe.android.financialconnections.utils.error
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import com.stripe.android.uicore.navigation.NavigationManager
@@ -78,7 +78,7 @@ internal class NetworkingSaveToLinkVerificationViewModel @AssistedInject constru
                 phoneNumber = consumerSession.phoneNumber,
                 consumerSessionClientSecret = consumerSession.clientSecret,
                 otpElement = OTPElement(
-                    IdentifierSpec.Generic("otp"),
+                    FormFieldId.Generic("otp"),
                     OTPController()
                 )
             )

--- a/identity-example/src/main/java/com/stripe/android/identity/example/ui/RequirePhoneVerificationUI.kt
+++ b/identity-example/src/main/java/com/stripe/android/identity/example/ui/RequirePhoneVerificationUI.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.unit.dp
 import com.stripe.android.identity.example.R
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
@@ -67,12 +67,12 @@ internal fun RequirePhoneVerificationUI(
                 enabled = true,
                 element = SectionElement.wrap(
                     PhoneNumberElement(
-                        identifier = IdentifierSpec.Phone,
+                        identifier = FormFieldId.Phone,
                         controller = phoneController
                     )
                 ),
                 hiddenIdentifiers = emptySet(),
-                lastTextFieldIdentifier = IdentifierSpec.Phone,
+                lastTextFieldIdentifier = FormFieldId.Phone,
             )
         }
     }

--- a/identity/src/main/java/com/stripe/android/identity/ui/AddressSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/AddressSection.kt
@@ -22,7 +22,7 @@ import com.stripe.android.uicore.address.transformToElementList
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PostalCodeConfig
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionElementUI
@@ -58,7 +58,7 @@ internal fun AddressSection(
             requireNotNull(selectedCountryCode)
         )
     }
-    val countryElement = remember { CountryElement(IdentifierSpec.Country, controller) }
+    val countryElement = remember { CountryElement(FormFieldId.Country, controller) }
     val sectionList = remember(selectedCountryCode) {
         mutableListOf<SectionFieldElement>(countryElement).also {
             it.addAll(addressDetailSectionElements)
@@ -79,14 +79,14 @@ internal fun AddressSection(
             val addressMap = formFieldValues.toMap()
             if (isValidAddress(addressMap)) {
                 RequiredInternationalAddress(
-                    line1 = addressMap[IdentifierSpec.Line1]?.value!!,
-                    line2 = addressMap[IdentifierSpec.Line2]?.value.takeIf {
+                    line1 = addressMap[FormFieldId.Line1]?.value!!,
+                    line2 = addressMap[FormFieldId.Line2]?.value.takeIf {
                         it?.isNotEmpty() == true
                     },
-                    city = addressMap[IdentifierSpec.City]?.value!!,
-                    postalCode = addressMap[IdentifierSpec.PostalCode]?.value!!,
-                    state = addressMap[IdentifierSpec.State]?.value,
-                    country = addressMap[IdentifierSpec.Country]?.value!!,
+                    city = addressMap[FormFieldId.City]?.value!!,
+                    postalCode = addressMap[FormFieldId.PostalCode]?.value!!,
+                    state = addressMap[FormFieldId.State]?.value,
+                    country = addressMap[FormFieldId.Country]?.value!!,
                 )
             } else {
                 null
@@ -117,7 +117,7 @@ private fun AddressSectionContent(
     enabled: Boolean,
     addressNotListedText: String,
     sectionElement: SectionElement,
-    textIdentifiers: List<IdentifierSpec>,
+    textIdentifiers: List<FormFieldId>,
     onAddressNotListedClick: () -> Unit
 ) {
     SectionElementUI(
@@ -140,14 +140,14 @@ private fun AddressSectionContent(
     }
 }
 
-private fun isValidAddress(addressMap: Map<IdentifierSpec, FormFieldEntry>): Boolean {
+private fun isValidAddress(addressMap: Map<FormFieldId, FormFieldEntry>): Boolean {
     addressMap.forEach { (spec, entry) ->
         if (REQUIRED_FIELDS.contains(spec) && entry.value.isNullOrBlank()) {
             return false
         }
     }
-    val country = addressMap[IdentifierSpec.Country]?.value
-    val postal = addressMap[IdentifierSpec.PostalCode]?.value
+    val country = addressMap[FormFieldId.Country]?.value
+    val postal = addressMap[FormFieldId.PostalCode]?.value
     if (country == null || postal == null) {
         return false
     }
@@ -161,11 +161,11 @@ private fun isValidAddress(addressMap: Map<IdentifierSpec, FormFieldEntry>): Boo
 }
 
 private val REQUIRED_FIELDS = listOf(
-    IdentifierSpec.Line1,
-    IdentifierSpec.City,
-    IdentifierSpec.PostalCode,
-    IdentifierSpec.State,
-    IdentifierSpec.Country
+    FormFieldId.Line1,
+    FormFieldId.City,
+    FormFieldId.PostalCode,
+    FormFieldId.State,
+    FormFieldId.Country
 )
 
 internal const val ADDRESS_COUNTRY_NOT_LISTED_BUTTON_TAG = "IdNumberSectionCountryNotListed"

--- a/identity/src/main/java/com/stripe/android/identity/ui/DOBSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/DOBSection.kt
@@ -19,7 +19,7 @@ import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.DobParam
 import com.stripe.android.identity.networking.models.DobParam.Companion.toDob
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionElementUI
 import com.stripe.android.uicore.elements.SimpleTextElement
@@ -56,7 +56,7 @@ internal fun DOBSection(
     val dobSectionElement = remember {
         SectionElement.wrap(
             sectionFieldElement = SimpleTextElement(
-                identifier = IdentifierSpec.Generic(DOB_SPEC),
+                identifier = FormFieldId.Generic(DOB_SPEC),
                 controller = dateController
             ),
             label = resolvableString(R.string.stripe_dob)

--- a/identity/src/main/java/com/stripe/android/identity/ui/IDNumberSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/IDNumberSection.kt
@@ -27,7 +27,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionElementUI
 import com.stripe.android.uicore.elements.SimpleTextElement
@@ -56,7 +56,7 @@ internal fun IDNumberSection(
             )
         )
     }
-    val countryElement = remember { CountryElement(IdentifierSpec.Country, controller) }
+    val countryElement = remember { CountryElement(FormFieldId.Country, controller) }
     val usElement = remember {
         SimpleTextElement(
             identifier = US_SPEC,
@@ -313,13 +313,13 @@ private object BRVisualTransformation : VisualTransformation {
 }
 
 internal const val US_CODE = "US"
-internal val US_SPEC = IdentifierSpec.Generic("USSpec")
+internal val US_SPEC = FormFieldId.Generic("USSpec")
 internal const val US_ID_PLACEHOLDER = "***-**-1234"
 internal const val US_ID_PLACEHOLDER_PREFIX = "***-**-"
 internal const val SINGAPORE_CODE = "SG"
 internal const val BRAZIL_ID_PLACEHOLDER = "000.000.000-00"
 internal const val BRAZIL_CODE = "BR"
-internal val BRAZIL_SPEC = IdentifierSpec.Generic("BRSpec")
+internal val BRAZIL_SPEC = FormFieldId.Generic("BRSpec")
 internal const val SINGAPORE_ID_PLACEHOLDER = "S1234567A"
-internal val SINGAPORE_SPEC = IdentifierSpec.Generic("SingaporeSpec")
+internal val SINGAPORE_SPEC = FormFieldId.Generic("SingaporeSpec")
 internal const val ID_NUMBER_COUNTRY_NOT_LISTED_BUTTON_TAG = "IdNumberSectionCountryNotListed"

--- a/identity/src/main/java/com/stripe/android/identity/ui/NameSection.kt
+++ b/identity/src/main/java/com/stripe/android/identity/ui/NameSection.kt
@@ -11,7 +11,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.identity.R
 import com.stripe.android.identity.networking.Resource
 import com.stripe.android.identity.networking.models.NameParam
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionElementUI
 import com.stripe.android.uicore.elements.SimpleTextElement
@@ -42,11 +42,11 @@ internal fun NameSection(
         SectionElement.wrap(
             sectionFieldElements = listOf(
                 SimpleTextElement(
-                    identifier = IdentifierSpec.Generic(FIRST_NAME_SPEC),
+                    identifier = FormFieldId.Generic(FIRST_NAME_SPEC),
                     controller = firstNameController
                 ),
                 SimpleTextElement(
-                    identifier = IdentifierSpec.Generic(LAST_NAME_SPEC),
+                    identifier = FormFieldId.Generic(LAST_NAME_SPEC),
                     controller = lastNameController
                 )
             ),

--- a/identity/src/main/java/com/stripe/android/identity/viewmodel/OTPViewModel.kt
+++ b/identity/src/main/java/com/stripe/android/identity/viewmodel/OTPViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.stripe.android.identity.IdentityVerificationSheetContract
 import com.stripe.android.identity.networking.IdentityRepository
 import com.stripe.android.identity.networking.models.VerificationPageData
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,7 +40,7 @@ internal class OTPViewModel(
 
     val otpElement =
         OTPElement(
-            identifier = IdentifierSpec.Generic(OTP),
+            identifier = FormFieldId.Generic(OTP),
             controller = OTPController()
         )
 

--- a/identity/src/test/java/com/stripe/android/identity/ui/OTPScreenTest.kt
+++ b/identity/src/test/java/com/stripe/android/identity/ui/OTPScreenTest.kt
@@ -28,7 +28,7 @@ import com.stripe.android.identity.viewmodel.IdentityViewModel
 import com.stripe.android.identity.viewmodel.OTPViewModel
 import com.stripe.android.identity.viewmodel.OTPViewState
 import com.stripe.android.testing.createComposeCleanupRule
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -102,7 +102,7 @@ class OTPScreenTest {
     private val mockOtpViewModel = mock<OTPViewModel> {
         on { viewState } doReturn otpViewState
         on { otpElement } doReturn OTPElement(
-            identifier = IdentifierSpec.Generic(OTPViewModel.OTP),
+            identifier = FormFieldId.Generic(OTPViewModel.OTP),
             controller = OTPController()
         )
     }

--- a/payments-ui-core/detekt-baseline.xml
+++ b/payments-ui-core/detekt-baseline.xml
@@ -2,8 +2,8 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ConstructorParameterNaming:CardNumberElement.kt:CardNumberElement$val _identifier: IdentifierSpec</ID>
-    <ID>ConstructorParameterNaming:CvcElement.kt:CvcElement$val _identifier: IdentifierSpec</ID>
+    <ID>ConstructorParameterNaming:CardNumberElement.kt:CardNumberElement$val _identifier: FormFieldId</ID>
+    <ID>ConstructorParameterNaming:CvcElement.kt:CvcElement$val _identifier: FormFieldId</ID>
     <ID>CyclomaticComplexMethod:TransformGoogleToStripeAddress.kt:@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun Place.transformGoogleToStripeAddress: com.stripe.android.model.Address</ID>
     <ID>ForbiddenComment:Menu.kt:// TODO: Make sure this gets the rounded corner values</ID>
     <ID>LongMethod:Menu.kt:@Suppress("ModifierParameter") @Composable internal fun DropdownMenuContent</ID>

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverter.kt
@@ -10,7 +10,7 @@ import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.ParameterDestination
 import com.stripe.android.uicore.forms.FormFieldEntry
 
@@ -24,7 +24,7 @@ class FieldValuesToParamsMapConverter {
          * This function will convert fieldValuePairs to PaymentMethodCreateParams.
          */
         fun transformToPaymentMethodCreateParams(
-            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+            fieldValuePairs: Map<FormFieldId, FormFieldEntry>,
             code: PaymentMethodCode,
             requiresMandate: Boolean,
             allowRedisplay: PaymentMethod.AllowRedisplay? = null,
@@ -33,7 +33,7 @@ class FieldValuesToParamsMapConverter {
             val fieldValuePairsForCreateParams = fieldValuePairs.filter { entry ->
                 entry.key.destination == ParameterDestination.Api.Params
             }.filterNot { entry ->
-                entry.key == IdentifierSpec.SaveForFutureUse || entry.key == IdentifierSpec.CardBrand
+                entry.key == FormFieldId.SaveForFutureUse || entry.key == FormFieldId.CardBrand
             }
             return transformToParamsMap(
                 fieldValuePairsForCreateParams,
@@ -55,13 +55,13 @@ class FieldValuesToParamsMapConverter {
         }
 
         private fun createBillingDetails(
-            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+            fieldValuePairs: Map<FormFieldId, FormFieldEntry>,
         ): PaymentMethod.BillingDetails? {
             val billingDetails = PaymentMethod.BillingDetails.Builder()
 
-            billingDetails.setName(fieldValuePairs[IdentifierSpec.Name]?.value)
-            billingDetails.setEmail(fieldValuePairs[IdentifierSpec.Email]?.value)
-            billingDetails.setPhone(fieldValuePairs[IdentifierSpec.Phone]?.value)
+            billingDetails.setName(fieldValuePairs[FormFieldId.Name]?.value)
+            billingDetails.setEmail(fieldValuePairs[FormFieldId.Email]?.value)
+            billingDetails.setPhone(fieldValuePairs[FormFieldId.Phone]?.value)
             billingDetails.setAddress(createAddress(fieldValuePairs))
 
             val builtBillingDetails = billingDetails.build()
@@ -73,16 +73,16 @@ class FieldValuesToParamsMapConverter {
         }
 
         private fun createAddress(
-            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+            fieldValuePairs: Map<FormFieldId, FormFieldEntry>,
         ): Address {
             val address = Address.Builder()
 
-            address.setLine1(fieldValuePairs[IdentifierSpec.Line1]?.value)
-            address.setLine2(fieldValuePairs[IdentifierSpec.Line2]?.value)
-            address.setCity(fieldValuePairs[IdentifierSpec.City]?.value)
-            address.setState(fieldValuePairs[IdentifierSpec.State]?.value)
-            address.setCountry(fieldValuePairs[IdentifierSpec.Country]?.value)
-            address.setPostalCode(fieldValuePairs[IdentifierSpec.PostalCode]?.value)
+            address.setLine1(fieldValuePairs[FormFieldId.Line1]?.value)
+            address.setLine2(fieldValuePairs[FormFieldId.Line2]?.value)
+            address.setCity(fieldValuePairs[FormFieldId.City]?.value)
+            address.setState(fieldValuePairs[FormFieldId.State]?.value)
+            address.setCountry(fieldValuePairs[FormFieldId.Country]?.value)
+            address.setPostalCode(fieldValuePairs[FormFieldId.PostalCode]?.value)
 
             return address.build()
         }
@@ -93,7 +93,7 @@ class FieldValuesToParamsMapConverter {
         @Suppress("ReturnCount")
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun transformToPaymentMethodOptionsParams(
-            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+            fieldValuePairs: Map<FormFieldId, FormFieldEntry>,
             code: PaymentMethodCode,
             setupFutureUsage: ConfirmPaymentIntentParams.SetupFutureUsage? = null
         ): PaymentMethodOptionsParams? {
@@ -107,13 +107,13 @@ class FieldValuesToParamsMapConverter {
                     )
                 }
                 PaymentMethod.Type.Blik.code -> {
-                    val blikCode = fieldValuePairsForOptions[IdentifierSpec.BlikCode]?.value
+                    val blikCode = fieldValuePairsForOptions[FormFieldId.BlikCode]?.value
                     blikCode?.let {
                         PaymentMethodOptionsParams.Blik(it)
                     }
                 }
                 PaymentMethod.Type.Konbini.code -> {
-                    val confirmationNumber = fieldValuePairsForOptions[IdentifierSpec.KonbiniConfirmationNumber]?.value
+                    val confirmationNumber = fieldValuePairsForOptions[FormFieldId.KonbiniConfirmationNumber]?.value
                     confirmationNumber?.let {
                         PaymentMethodOptionsParams.Konbini(confirmationNumber)
                     }
@@ -134,7 +134,7 @@ class FieldValuesToParamsMapConverter {
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
         fun transformToPaymentMethodExtraParams(
-            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+            fieldValuePairs: Map<FormFieldId, FormFieldEntry>,
             code: PaymentMethodCode,
         ): PaymentMethodExtraParams? {
             val fieldValuePairsForExtras = fieldValuePairs.filter { entry ->
@@ -142,25 +142,25 @@ class FieldValuesToParamsMapConverter {
             }
             return when (code) {
                 PaymentMethod.Type.BacsDebit.code -> PaymentMethodExtraParams.BacsDebit(
-                    confirmed = fieldValuePairsForExtras[IdentifierSpec.BacsDebitConfirmed]?.value?.toBoolean()
+                    confirmed = fieldValuePairsForExtras[FormFieldId.BacsDebitConfirmed]?.value?.toBoolean()
                 )
                 PaymentMethod.Type.Card.code -> PaymentMethodExtraParams.Card(
                     setAsDefault =
-                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean(),
-                    phoneNumberCountry = fieldValuePairsForExtras[IdentifierSpec.PhoneNumberCountry]?.value,
-                    fromValidatedScan = fieldValuePairsForExtras[IdentifierSpec.CardValidatedScan]?.value?.toBoolean(),
+                    fieldValuePairsForExtras[FormFieldId.SetAsDefaultPaymentMethod]?.value?.toBoolean(),
+                    phoneNumberCountry = fieldValuePairsForExtras[FormFieldId.PhoneNumberCountry]?.value,
+                    fromValidatedScan = fieldValuePairsForExtras[FormFieldId.CardValidatedScan]?.value?.toBoolean(),
                 )
                 PaymentMethod.Type.Link.code -> PaymentMethodExtraParams.Link(
                     setAsDefault =
-                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
+                    fieldValuePairsForExtras[FormFieldId.SetAsDefaultPaymentMethod]?.value?.toBoolean()
                 )
                 PaymentMethod.Type.USBankAccount.code -> PaymentMethodExtraParams.USBankAccount(
                     setAsDefault =
-                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
+                    fieldValuePairsForExtras[FormFieldId.SetAsDefaultPaymentMethod]?.value?.toBoolean()
                 )
                 PaymentMethod.Type.SepaDebit.code -> PaymentMethodExtraParams.SepaDebit(
                     setAsDefault =
-                    fieldValuePairsForExtras[IdentifierSpec.SetAsDefaultPaymentMethod]?.value?.toBoolean()
+                    fieldValuePairsForExtras[FormFieldId.SetAsDefaultPaymentMethod]?.value?.toBoolean()
                 )
                 else -> null
             }
@@ -171,10 +171,10 @@ class FieldValuesToParamsMapConverter {
          * according to their keys.
          *
          * @param: formFieldValues: These are the fields and their values and based on the algorithm of this function
-         * will be put into a map according to the IdentifierSpec keys.
+         * will be put into a map according to the FormFieldId keys.
          */
         private fun transformToParamsMap(
-            fieldValuePairs: Map<IdentifierSpec, FormFieldEntry>,
+            fieldValuePairs: Map<FormFieldId, FormFieldEntry>,
             code: PaymentMethodCode
         ): MutableMap<String, Any?> {
             val destMap = mutableMapOf<String, Any?>()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/FormUI.kt
@@ -35,7 +35,7 @@ import com.stripe.android.uicore.LocalSectionSpacing
 import com.stripe.android.uicore.elements.CheckboxFieldElement
 import com.stripe.android.uicore.elements.CheckboxFieldUI
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPElement
 import com.stripe.android.uicore.elements.OTPElementUI
 import com.stripe.android.uicore.elements.SameAsShippingElement
@@ -48,10 +48,10 @@ import kotlinx.coroutines.flow.StateFlow
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun FormUI(
-    hiddenIdentifiersFlow: StateFlow<Set<IdentifierSpec>>,
+    hiddenIdentifiersFlow: StateFlow<Set<FormFieldId>>,
     enabledFlow: StateFlow<Boolean>,
     elementsFlow: StateFlow<List<FormElement>>,
-    lastTextFieldIdentifierFlow: StateFlow<IdentifierSpec?>,
+    lastTextFieldIdentifierFlow: StateFlow<FormFieldId?>,
     modifier: Modifier = Modifier
 ) {
     val hiddenIdentifiers by hiddenIdentifiersFlow.collectAsState()
@@ -71,10 +71,10 @@ fun FormUI(
 @Composable
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun FormUI(
-    hiddenIdentifiers: Set<IdentifierSpec>,
+    hiddenIdentifiers: Set<FormFieldId>,
     enabled: Boolean,
     elements: List<FormElement>,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    lastTextFieldIdentifier: FormFieldId?,
     modifier: Modifier = Modifier
 ) {
     val sectionSpacing = LocalSectionSpacing.current
@@ -111,8 +111,8 @@ private fun FormUIElement(
     maxIndex: Int,
     enabled: Boolean,
     hasVerticalCustomSpacing: Boolean,
-    hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    hiddenIdentifiers: Set<FormFieldId>,
+    lastTextFieldIdentifier: FormFieldId?,
 ) {
     when (element) {
         is SectionElement -> SectionElementUI(

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AffirmHeaderElement.kt
@@ -4,19 +4,19 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AffirmHeaderElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: Controller? = null
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElement.kt
@@ -7,21 +7,21 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AfterpayClearpayHeaderElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: Controller? = null,
     val currency: String?
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 
     val infoUrl: String

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AuBecsDebitMandateTextElement.kt
@@ -5,7 +5,7 @@ import com.stripe.android.R
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.InputController
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -18,7 +18,7 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AuBecsDebitMandateTextElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     val merchantName: String?,
     override val controller: InputController? = null
 ) : FormElement {
@@ -26,6 +26,6 @@ data class AuBecsDebitMandateTextElement(
     override val mandateText: ResolvableString =
         resolvableString(id = R.string.stripe_au_becs_mandate, merchantName ?: "")
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingFields.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/AutomaticTaxBillingFields.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 /**
  * Billing address fields required in addition to country for automatic tax calculation.
@@ -10,15 +10,15 @@ import com.stripe.android.uicore.elements.IdentifierSpec
  * Source: https://docs.stripe.com/tax/customer-locations
  */
 @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-val additionalAutomaticTaxFieldsByCountry: Map<String, Set<IdentifierSpec>> = mapOf(
-    "CA" to setOf(IdentifierSpec.PostalCode),
-    "GB" to setOf(IdentifierSpec.PostalCode),
-    "IN" to setOf(IdentifierSpec.PostalCode),
-    "PR" to setOf(IdentifierSpec.Line1, IdentifierSpec.City, IdentifierSpec.PostalCode),
-    "US" to setOf(IdentifierSpec.Line1, IdentifierSpec.City, IdentifierSpec.State, IdentifierSpec.PostalCode),
+val additionalAutomaticTaxFieldsByCountry: Map<String, Set<FormFieldId>> = mapOf(
+    "CA" to setOf(FormFieldId.PostalCode),
+    "GB" to setOf(FormFieldId.PostalCode),
+    "IN" to setOf(FormFieldId.PostalCode),
+    "PR" to setOf(FormFieldId.Line1, FormFieldId.City, FormFieldId.PostalCode),
+    "US" to setOf(FormFieldId.Line1, FormFieldId.City, FormFieldId.State, FormFieldId.PostalCode),
 )
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-fun automaticTaxRequiredFields(countryCode: String): Set<IdentifierSpec> {
+fun automaticTaxRequiredFields(countryCode: String): Set<FormFieldId> {
     return additionalAutomaticTaxFieldsByCountry[countryCode].orEmpty()
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BillingAddressElement.kt
@@ -18,7 +18,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionFieldComposable
@@ -39,7 +39,7 @@ sealed interface BillingAddressCollectionMode {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     data class Country(
-        val additionalFieldsByCountry: Map<String, Set<IdentifierSpec>>,
+        val additionalFieldsByCountry: Map<String, Set<FormFieldId>>,
     ) : BillingAddressCollectionMode
 }
 
@@ -54,7 +54,7 @@ fun cardBillingAddressCollectionMode(
         BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic -> {
             val additionalFieldsByCountry = buildMap {
                 listOf("US", "GB", "CA").forEach { countryCode ->
-                    put(countryCode, setOf(IdentifierSpec.PostalCode))
+                    put(countryCode, setOf(FormFieldId.PostalCode))
                 }
                 if (requiresBillingAddressForAutomaticTax) {
                     additionalAutomaticTaxFieldsByCountry.forEach { (countryCode, fields) ->
@@ -72,16 +72,16 @@ fun cardBillingAddressCollectionMode(
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class BillingAddressElement(
-    override val identifier: IdentifierSpec,
-    rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
+    override val identifier: FormFieldId,
+    rawValuesMap: Map<FormFieldId, String?> = emptyMap(),
     countryCodes: Set<String> = emptySet(),
     countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),
-        rawValuesMap[IdentifierSpec.Country]
+        rawValuesMap[FormFieldId.Country]
     ),
     autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
     sameAsShippingElement: SameAsShippingElement?,
-    shippingValuesMap: Map<IdentifierSpec, String?>?,
+    shippingValuesMap: Map<FormFieldId, String?>?,
     private val addressCollectionMode: BillingAddressCollectionMode,
     private val collectionConfiguration: BillingDetailsCollectionConfiguration =
         BillingDetailsCollectionConfiguration(),
@@ -132,7 +132,7 @@ class BillingAddressElement(
                 emailConfig = emailConfig,
             ),
             countryElement = CountryElement(
-                identifier = IdentifierSpec.Country,
+                identifier = FormFieldId.Country,
                 controller = countryDropdownFieldController,
             ),
             shippingValuesMap = shippingValuesMap,
@@ -177,8 +177,8 @@ class BillingAddressElement(
                 enabled: Boolean,
                 field: SectionFieldElement,
                 modifier: Modifier,
-                hiddenIdentifiers: Set<IdentifierSpec>,
-                lastTextFieldIdentifier: IdentifierSpec?
+                hiddenIdentifiers: Set<FormFieldId>,
+                lastTextFieldIdentifier: FormFieldId?
             ) {
                 if (addressElementSectionController is SectionFieldComposable) {
                     addressElementSectionController.ComposeUI(
@@ -198,13 +198,13 @@ class BillingAddressElement(
 
     // Save for future use puts this in the controller rather than element
     // card and achv2 uses save for future use
-    val hiddenIdentifiers: StateFlow<Set<IdentifierSpec>> =
+    val hiddenIdentifiers: StateFlow<Set<FormFieldId>> =
         countryDropdownFieldController.rawFieldValue.mapAsStateFlow { countryCode ->
             when (val mode = addressCollectionMode) {
                 BillingAddressCollectionMode.Never -> {
                     FieldType.entries
                         .filterNot { it == FieldType.Name }
-                        .map { it.identifierSpec }
+                        .map { it.formFieldId }
                         .toSet()
                 }
                 BillingAddressCollectionMode.Full -> {
@@ -215,8 +215,8 @@ class BillingAddressElement(
                     FieldType.entries
                         // Filtering name causes the field to be hidden even outside
                         // of this form.
-                        .filterNot { it == FieldType.Name || it.identifierSpec in shownFields }
-                        .map { it.identifierSpec }
+                        .filterNot { it == FieldType.Name || it.formFieldId in shownFields }
+                        .map { it.formFieldId }
                         .toSet()
                 }
             }
@@ -231,7 +231,7 @@ class BillingAddressElement(
     override fun sectionFieldErrorController(): SectionFieldValidationController =
         cardBillingAddressElementSectionErrorController
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) = addressElement.setRawValue(rawValuesMap)
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) = addressElement.setRawValue(rawValuesMap)
 
     override fun getTextFieldIdentifiers() = addressElement.getTextFieldIdentifiers()
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BlikElement.kt
@@ -2,7 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.InputController
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 class BlikElement(
-    override val identifier: IdentifierSpec = IdentifierSpec.BlikCode,
+    override val identifier: FormFieldId = FormFieldId.BlikCode,
     override val controller: InputController = SimpleTextFieldController(
         textFieldConfig = BlikConfig()
     )
@@ -20,7 +20,7 @@ class BlikElement(
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
         return controller.formFieldValue.mapAsStateFlow { entry ->
             listOf(identifier to entry)
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElement.kt
@@ -3,7 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -13,7 +13,7 @@ import com.stripe.android.view.BecsDebitBanks
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class BsbElement(
-    private val identifierSpec: IdentifierSpec,
+    private val formFieldId: FormFieldId,
     initialValue: String?
 ) : FormElement {
     private val banks = BecsDebitBanks()
@@ -22,8 +22,8 @@ class BsbElement(
         textFieldConfig = BsbConfig(banks),
         initialValue = initialValue,
     )
-    override val identifier: IdentifierSpec
-        get() = identifierSpec
+    override val identifier: FormFieldId
+        get() = formFieldId
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/BsbElementUI.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.Section
 import com.stripe.android.uicore.elements.TextField
 import com.stripe.android.uicore.stripeColors
@@ -19,7 +19,7 @@ import com.stripe.android.uicore.utils.collectAsState
 fun BsbElementUI(
     enabled: Boolean,
     element: BsbElement,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    lastTextFieldIdentifier: FormFieldId?,
     modifier: Modifier = Modifier,
 ) {
     val validationMessage by element.controller.validationMessage.collectAsState()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsController.kt
@@ -16,7 +16,7 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.DefaultFieldValidationMessageComparator
 import com.stripe.android.uicore.elements.FieldValidationMessageComparator
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowController
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionFieldComposable
@@ -36,7 +36,7 @@ import kotlin.coroutines.CoroutineContext
 
 internal class CardDetailsController(
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
-    initialValues: Map<IdentifierSpec, String?>,
+    initialValues: Map<FormFieldId, String?>,
     coroutineScope: CoroutineScope,
     collectName: Boolean = false,
     cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
@@ -53,10 +53,10 @@ internal class CardDetailsController(
     dateConfig: TextFieldConfig = DateConfig(),
     private val validationMessageComparator: FieldValidationMessageComparator = DefaultFieldValidationMessageComparator
 ) : SectionFieldValidationController, SectionFieldComposable {
-    private val initialCardNumber = initialValues[IdentifierSpec.CardNumber]
+    private val initialCardNumber = initialValues[FormFieldId.CardNumber]
 
     val cardPillElement = MutableStateFlow(
-        if (initialValues[IdentifierSpec.CardValidatedScan].toBoolean() && initialCardNumber != null) {
+        if (initialValues[FormFieldId.CardValidatedScan].toBoolean() && initialCardNumber != null) {
             CardPillElement(
                 controller = CardPillController(
                     cardNumber = initialCardNumber,
@@ -76,9 +76,9 @@ internal class CardDetailsController(
                     capitalization = KeyboardCapitalization.Words,
                     keyboard = androidx.compose.ui.text.input.KeyboardType.Text
                 ),
-                initialValue = initialValues[IdentifierSpec.Name],
+                initialValue = initialValues[FormFieldId.Name],
             ),
-            identifier = IdentifierSpec.Name,
+            identifier = FormFieldId.Name,
         )
     } else {
         null
@@ -86,7 +86,7 @@ internal class CardDetailsController(
 
     val label: Int? = null
     val numberElement = CardNumberElement(
-        IdentifierSpec.CardNumber,
+        FormFieldId.CardNumber,
         DefaultCardNumberController(
             coroutineScope = coroutineScope,
             cardTextFieldConfig = cardDetailsTextFieldConfig,
@@ -98,7 +98,7 @@ internal class CardDetailsController(
                 is CardBrandChoiceEligibility.Eligible -> CardBrandChoiceConfig.Eligible(
                     preferredBrands = cbcEligibility.preferredNetworks,
                     initialBrand = initialValues[
-                        IdentifierSpec.PreferredCardBrand
+                        FormFieldId.PreferredCardBrand
                     ]?.let { value ->
                         CardBrand.fromCode(value)
                     }
@@ -111,20 +111,20 @@ internal class CardDetailsController(
     )
 
     val cvcElement = CvcElement(
-        IdentifierSpec.CardCvc,
+        FormFieldId.CardCvc,
         CvcController(
             cvcTextFieldConfig,
             numberElement.controller.cardBrandFlow,
-            initialValue = initialValues[IdentifierSpec.CardCvc]
+            initialValue = initialValues[FormFieldId.CardCvc]
         )
     )
 
     val expirationDateElement = SimpleTextElement(
-        IdentifierSpec.Generic("date"),
+        FormFieldId.Generic("date"),
         SimpleTextFieldController(
             textFieldConfig = dateConfig,
-            initialValue = initialValues[IdentifierSpec.CardExpMonth] +
-                initialValues[IdentifierSpec.CardExpYear]?.takeLast(2),
+            initialValue = initialValues[FormFieldId.CardExpMonth] +
+                initialValues[FormFieldId.CardExpYear]?.takeLast(2),
             overrideContentDescriptionProvider = ::formatExpirationDateForAccessibility
         )
     )
@@ -185,7 +185,7 @@ internal class CardDetailsController(
 
                 add(
                     RowElement(
-                        IdentifierSpec.Generic("card_details_row"),
+                        FormFieldId.Generic("card_details_row"),
                         fields,
                         RowController(fields)
                     )
@@ -218,8 +218,8 @@ internal class CardDetailsController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         CardDetailsElementUI(
             enabled,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElement.kt
@@ -10,7 +10,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.CardDetailsUtil.getExpiryMonthFormFieldEntry
 import com.stripe.android.ui.core.elements.CardDetailsUtil.getExpiryYearFormFieldEntry
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionFieldValidationController
 import com.stripe.android.uicore.elements.SectionMultiFieldElement
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -25,9 +25,9 @@ import kotlinx.coroutines.flow.StateFlow
  * card number, expiration date, and CVC.
  */
 internal class CardDetailsElement(
-    identifier: IdentifierSpec,
+    identifier: FormFieldId,
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
-    initialValues: Map<IdentifierSpec, String?>,
+    initialValues: Map<FormFieldId, String?>,
     coroutineScope: CoroutineScope,
     collectName: Boolean = false,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
@@ -50,23 +50,23 @@ internal class CardDetailsElement(
     override fun sectionFieldErrorController(): SectionFieldValidationController =
         controller
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         // Nothing from FormArguments to populate
     }
 
-    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
+    override fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> =
         stateFlowOf(
             listOfNotNull(
                 controller.nameElement?.identifier,
                 controller.numberElement.identifier,
                 controller.expirationDateElement.identifier,
                 controller.cvcElement.identifier,
-                IdentifierSpec.CardBrand,
-                IdentifierSpec.PreferredCardBrand.takeIf { cbcEligibility is CardBrandChoiceEligibility.Eligible },
+                FormFieldId.CardBrand,
+                FormFieldId.PreferredCardBrand.takeIf { cbcEligibility is CardBrandChoiceEligibility.Eligible },
             )
         )
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
         val flows = buildList {
             if (controller.nameElement != null) {
                 add(
@@ -87,13 +87,13 @@ internal class CardDetailsElement(
             )
             add(
                 controller.numberElement.controller.cardBrandFlow.mapAsStateFlow {
-                    IdentifierSpec.CardBrand to FormFieldEntry(it.code, true)
+                    FormFieldId.CardBrand to FormFieldEntry(it.code, true)
                 }
             )
             if (cbcEligibility is CardBrandChoiceEligibility.Eligible) {
                 add(
                     controller.numberElement.controller.selectedCardBrandFlow.mapAsStateFlow { brand ->
-                        IdentifierSpec.PreferredCardBrand to FormFieldEntry(
+                        FormFieldId.PreferredCardBrand to FormFieldEntry(
                             value = brand.code.takeUnless { brand == CardBrand.Unknown },
                             isComplete = true
                         )
@@ -102,12 +102,12 @@ internal class CardDetailsElement(
             }
             add(
                 controller.expirationDateElement.controller.formFieldValue.mapAsStateFlow {
-                    IdentifierSpec.CardExpMonth to getExpiryMonthFormFieldEntry(it)
+                    FormFieldId.CardExpMonth to getExpiryMonthFormFieldEntry(it)
                 }
             )
             add(
                 controller.expirationDateElement.controller.formFieldValue.mapAsStateFlow {
-                    IdentifierSpec.CardExpYear to getExpiryYearFormFieldEntry(it)
+                    FormFieldId.CardExpYear to getExpiryYearFormFieldEntry(it)
                 }
             )
 
@@ -115,7 +115,7 @@ internal class CardDetailsElement(
                 controller.cardPillElement.mapAsStateFlow { element ->
                     val hasCardPill = element != null
 
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry(hasCardPill.toString(), true)
+                    FormFieldId.CardValidatedScan to FormFieldEntry(hasCardPill.toString(), true)
                 }
             )
         }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsElementUI.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionFieldElementUI
 import com.stripe.android.uicore.stripeColors
 import com.stripe.android.uicore.stripeShapes
@@ -16,8 +16,8 @@ import com.stripe.android.uicore.utils.collectAsState
 internal fun CardDetailsElementUI(
     enabled: Boolean,
     controller: CardDetailsController,
-    hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    hiddenIdentifiers: Set<FormFieldId>,
+    lastTextFieldIdentifier: FormFieldId?,
     modifier: Modifier = Modifier,
 ) {
     val fields by controller.fields.collectAsState()

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionController.kt
@@ -7,7 +7,7 @@ import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionFieldValidationController
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.CoroutineScope
@@ -15,7 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardDetailsSectionController(
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
-    initialValues: Map<IdentifierSpec, String?>,
+    initialValues: Map<FormFieldId, String?>,
     coroutineScope: CoroutineScope,
     collectName: Boolean = false,
     cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
@@ -24,7 +24,7 @@ class CardDetailsSectionController(
     val cardDetailsAction: CardDetailsAction? = null,
 ) : SectionFieldValidationController {
     internal val cardDetailsElement = CardDetailsElement(
-        IdentifierSpec.Generic("card_detail"),
+        FormFieldId.Generic("card_detail"),
         cardAccountRangeRepositoryFactory,
         initialValues,
         coroutineScope,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElement.kt
@@ -8,7 +8,7 @@ import com.stripe.android.cards.CardAccountRangeRepository
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -16,13 +16,13 @@ import kotlinx.coroutines.flow.StateFlow
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CardDetailsSectionElement(
     cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
-    initialValues: Map<IdentifierSpec, String?>,
+    initialValues: Map<FormFieldId, String?>,
     coroutineScope: CoroutineScope,
     private val collectName: Boolean = false,
     private val cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
     private val cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
     private val cardFundingFilter: CardFundingFilter,
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     private val cardDetailsAction: CardDetailsAction? = null,
     override val controller: CardDetailsSectionController = CardDetailsSectionController(
         coroutineScope = coroutineScope,
@@ -38,10 +38,10 @@ class CardDetailsSectionElement(
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         controller.cardDetailsElement.getFormFieldValueFlow()
 
-    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
+    override fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> =
         controller.cardDetailsElement.getTextFieldIdentifiers()
 
     override fun onValidationStateChanged(isValidating: Boolean) {

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUI.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.stripe.android.ui.core.R
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.H6Text
-import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.SectionController
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionElementUI
@@ -27,8 +27,8 @@ import com.stripe.android.uicore.utils.collectAsState
 fun CardDetailsSectionElementUI(
     enabled: Boolean,
     controller: CardDetailsSectionController,
-    hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    hiddenIdentifiers: Set<FormFieldId>,
+    lastTextFieldIdentifier: FormFieldId?,
     modifier: Modifier = Modifier,
 ) {
     Column(modifier) {
@@ -39,7 +39,7 @@ fun CardDetailsSectionElementUI(
         SectionElementUI(
             enabled = enabled,
             element = SectionElement(
-                IdentifierSpec.Generic("credit_details"),
+                FormFieldId.Generic("credit_details"),
                 listOf(controller.cardDetailsElement),
                 SectionController(
                     null,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsUtil.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardDetailsUtil.kt
@@ -1,17 +1,17 @@
 package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.convertTo4DigitDate
 import com.stripe.android.uicore.forms.FormFieldEntry
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 object CardDetailsUtil {
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-    fun createExpiryDateFormFieldValues(entry: FormFieldEntry): Map<IdentifierSpec, FormFieldEntry> {
+    fun createExpiryDateFormFieldValues(entry: FormFieldEntry): Map<FormFieldId, FormFieldEntry> {
         return mapOf(
-            IdentifierSpec.CardExpMonth to getExpiryMonthFormFieldEntry(entry),
-            IdentifierSpec.CardExpYear to getExpiryYearFormFieldEntry(entry)
+            FormFieldId.CardExpMonth to getExpiryMonthFormFieldEntry(entry),
+            FormFieldId.CardExpYear to getExpiryYearFormFieldEntry(entry)
         )
     }
 

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberController.kt
@@ -32,7 +32,7 @@ import com.stripe.android.ui.core.elements.events.LocalAnalyticsEventReporter
 import com.stripe.android.ui.core.elements.events.LocalCardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.TextFieldController
 import com.stripe.android.uicore.elements.TextFieldIcon
@@ -325,8 +325,8 @@ internal class DefaultCardNumberController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         val reporter = LocalCardNumberCompletedEventReporter.current
         val disallowedBrandReporter = LocalCardBrandDisallowedReporter.current

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardNumberElement.kt
@@ -1,17 +1,17 @@
 package com.stripe.android.ui.core.elements
 
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 
 internal data class CardNumberElement(
-    val _identifier: IdentifierSpec,
+    val _identifier: FormFieldId,
     override val controller: CardNumberController
 ) : SectionSingleFieldElement(_identifier) {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         // Nothing from FormArguments to populate
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardPillElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CardPillElement.kt
@@ -41,7 +41,7 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.FormInsets
 import com.stripe.android.uicore.LocalTextFieldInsets
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionFieldComposable
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.SectionFieldValidationController
@@ -54,20 +54,20 @@ import com.stripe.android.R as PaymentsCoreR
 internal class CardPillElement(
     val controller: CardPillController,
 ) : SectionFieldElement {
-    override val identifier: IdentifierSpec = IdentifierSpec.Generic("card_scanned_pill")
+    override val identifier: FormFieldId = FormFieldId.Generic("card_scanned_pill")
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 
     override fun sectionFieldErrorController(): SectionFieldValidationController = controller
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         // No-op
     }
 
-    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
+    override fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> =
         stateFlowOf(emptyList())
 
     override fun onValidationStateChanged(isValidating: Boolean) {
@@ -90,8 +90,8 @@ internal class CardPillController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?,
     ) {
         CardPillElementUI(
             enabled = enabled,

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcController.kt
@@ -19,7 +19,7 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.TextField
 import com.stripe.android.uicore.elements.TextFieldController
@@ -157,8 +157,8 @@ class CvcController constructor(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?,
     ) {
         val isInspectionMode = LocalInspectionMode.current
         val focusRequester = remember { FocusRequester() }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/CvcElement.kt
@@ -2,18 +2,18 @@ package com.stripe.android.ui.core.elements
 
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class CvcElement(
-    val _identifier: IdentifierSpec,
+    val _identifier: FormFieldId,
     override val controller: CvcController
 ) : SectionSingleFieldElement(_identifier) {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         // Nothing from FormArguments to populate
     }
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/IbanElement.kt
@@ -1,12 +1,12 @@
 package com.stripe.android.ui.core.elements
 
 import com.stripe.android.core.strings.ResolvableString
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.TextFieldController
 
 internal data class IbanElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: TextFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/MandateTextElement.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.unit.dp
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.InputController
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class MandateTextElement(
-    override val identifier: IdentifierSpec = IdentifierSpec.Generic("mandate"),
+    override val identifier: FormFieldId = FormFieldId.Generic("mandate"),
     val stringResId: Int,
     val args: List<String>,
     val topPadding: Dp = 8.dp,
@@ -23,6 +23,6 @@ data class MandateTextElement(
     override val allowsUserInteraction: Boolean = false
     override val mandateText: ResolvableString = resolvableString(stringResId, *args.toTypedArray())
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PaymentMethodMessageHeaderElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/PaymentMethodMessageHeaderElement.kt
@@ -5,19 +5,19 @@ import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class PaymentMethodMessageHeaderElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: Controller? = null,
     val promotion: PaymentMethodMessagePromotion
 ) : FormElement {
     override val allowsUserInteraction: Boolean = false
     override val mandateText: ResolvableString? = null
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RenderableFormElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/RenderableFormElement.kt
@@ -5,11 +5,11 @@ import androidx.compose.runtime.Composable
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 abstract class RenderableFormElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val allowsUserInteraction: Boolean,
 ) : FormElement {
     override val controller: Controller? = null
@@ -18,7 +18,7 @@ abstract class RenderableFormElement(
     @Composable
     abstract fun ComposeUI(
         enabled: Boolean,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?,
     )
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SaveForFutureUseElement.kt
@@ -3,7 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -25,9 +25,9 @@ data class SaveForFutureUseElement(
         initialValue
     )
 
-    override val identifier: IdentifierSpec = IdentifierSpec.SaveForFutureUse
+    override val identifier: FormFieldId = FormFieldId.SaveForFutureUse
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         controller.formFieldValue.mapAsStateFlow {
             listOf(
                 identifier to it

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SetAsDefaultPaymentMethodElement.kt
@@ -3,7 +3,7 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -25,7 +25,7 @@ data class SetAsDefaultPaymentMethodElement(
         it && !setAsDefaultMatchesSaveForFutureUse
     }
 
-    override val identifier: IdentifierSpec = IdentifierSpec.SetAsDefaultPaymentMethod
+    override val identifier: FormFieldId = FormFieldId.SetAsDefaultPaymentMethod
 
     override val controller: SetAsDefaultPaymentMethodController = SetAsDefaultPaymentMethodController(
         setAsDefaultPaymentMethodInitialValue = initialValue,
@@ -36,7 +36,7 @@ data class SetAsDefaultPaymentMethodElement(
 
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         controller.formFieldValue.mapAsStateFlow {
             listOf(
                 identifier to it

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/SimpleDropdownElement.kt
@@ -3,12 +3,12 @@ package com.stripe.android.ui.core.elements
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SimpleDropdownElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: DropdownFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextElement.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/StaticTextElement.kt
@@ -4,7 +4,7 @@ import androidx.annotation.RestrictTo
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.InputController
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -17,12 +17,12 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class StaticTextElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     val text: ResolvableString,
     override val controller: InputController? = null
 ) : FormElement {
     constructor(
-        identifier: IdentifierSpec,
+        identifier: FormFieldId,
         stringResId: Int,
         controller: InputController? = null
     ) : this(
@@ -34,6 +34,6 @@ data class StaticTextElement(
     override val allowsUserInteraction: Boolean = false
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         stateFlowOf(emptyList())
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/ConvertToFormValuesMap.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/forms/ConvertToFormValuesMap.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.ui.core.forms
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
-fun convertToFormValuesMap(paramMap: Map<String, Any?>): Map<IdentifierSpec, String?> {
-    val mutableMap = mutableMapOf<IdentifierSpec, String?>()
+fun convertToFormValuesMap(paramMap: Map<String, Any?>): Map<FormFieldId, String?> {
+    val mutableMap = mutableMapOf<FormFieldId, String?>()
     addPath(paramMap, "", mutableMap)
     return mutableMap
 }
@@ -14,15 +14,15 @@ fun convertToFormValuesMap(paramMap: Map<String, Any?>): Map<IdentifierSpec, Str
 private fun addPath(
     paramMap: Map<String, Any?>,
     path: String,
-    output: MutableMap<IdentifierSpec, String?>
+    output: MutableMap<FormFieldId, String?>
 ) {
     for (entry in paramMap.entries) {
         when (entry.value) {
             null -> {
-                output[IdentifierSpec.get(addPathKey(path, entry.key))] = null
+                output[FormFieldId.get(addPathKey(path, entry.key))] = null
             }
             is String -> {
-                output[IdentifierSpec.get(addPathKey(path, entry.key))] = entry.value as String
+                output[FormFieldId.get(addPathKey(path, entry.key))] = entry.value as String
             }
             is Map<*, *> -> {
                 addPath(entry.value as Map<String, Any>, addPathKey(path, entry.key), output)

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/FieldValuesToParamsMapConverterTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodSelectionFlow
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter.Companion.addPath
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter.Companion.getKeys
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import org.junit.Test
 
@@ -18,7 +18,7 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(
                 mapOf(
-                    IdentifierSpec.Generic("ideal[bank]") to FormFieldEntry(
+                    FormFieldId.Generic("ideal[bank]") to FormFieldEntry(
                         "abn_amro",
                         true
                     )
@@ -48,15 +48,15 @@ class FieldValuesToParamsMapConverterTest {
     fun `test function`() {
         val map: MutableMap<String, Any?> = mutableMapOf("type" to "card")
         mapOf(
-            IdentifierSpec.Name to FormFieldEntry(
+            FormFieldId.Name to FormFieldEntry(
                 "joe",
                 true
             ),
-            IdentifierSpec.Email to FormFieldEntry(
+            FormFieldId.Email to FormFieldEntry(
                 "joe@gmail.com",
                 true
             ),
-            IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+            FormFieldId.Generic("billing_details[address][country]") to FormFieldEntry(
                 "US",
                 true
             )
@@ -86,19 +86,19 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
+                    FormFieldId.Name to FormFieldEntry(
                         name,
                         true
                     ),
-                    IdentifierSpec.Email to FormFieldEntry(
+                    FormFieldId.Email to FormFieldEntry(
                         email,
                         true
                     ),
-                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                    FormFieldId.Generic("billing_details[address][country]") to FormFieldEntry(
                         country,
                         true
                     ),
-                    IdentifierSpec.Line1 to FormFieldEntry(
+                    FormFieldId.Line1 to FormFieldEntry(
                         line1,
                         true
                     )
@@ -160,23 +160,23 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
+                    FormFieldId.Name to FormFieldEntry(
                         "joe",
                         true
                     ),
-                    IdentifierSpec.Email to FormFieldEntry(
+                    FormFieldId.Email to FormFieldEntry(
                         "joe@gmail.com",
                         true
                     ),
-                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                    FormFieldId.Generic("billing_details[address][country]") to FormFieldEntry(
                         "US",
                         true
                     ),
-                    IdentifierSpec.Line1 to FormFieldEntry(
+                    FormFieldId.Line1 to FormFieldEntry(
                         "123 Main Street",
                         true
                     ),
-                    IdentifierSpec.BlikCode to FormFieldEntry(
+                    FormFieldId.BlikCode to FormFieldEntry(
                         "example_blik_code",
                         true,
                     )
@@ -188,7 +188,7 @@ class FieldValuesToParamsMapConverterTest {
 
         assertThat(
             paymentMethodParams.toParamMap()
-        ).doesNotContainKey(IdentifierSpec.BlikCode)
+        ).doesNotContainKey(FormFieldId.BlikCode)
     }
 
     @Test
@@ -196,27 +196,27 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
+                    FormFieldId.Name to FormFieldEntry(
                         "joe",
                         true
                     ),
-                    IdentifierSpec.Email to FormFieldEntry(
+                    FormFieldId.Email to FormFieldEntry(
                         "joe@gmail.com",
                         true
                     ),
-                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                    FormFieldId.Generic("billing_details[address][country]") to FormFieldEntry(
                         "US",
                         true
                     ),
-                    IdentifierSpec.Line1 to FormFieldEntry(
+                    FormFieldId.Line1 to FormFieldEntry(
                         "123 Main Street",
                         true
                     ),
-                    IdentifierSpec.SaveForFutureUse to FormFieldEntry(
+                    FormFieldId.SaveForFutureUse to FormFieldEntry(
                         "true",
                         true,
                     ),
-                    IdentifierSpec.CardBrand to FormFieldEntry(
+                    FormFieldId.CardBrand to FormFieldEntry(
                         "visa",
                         true,
                     )
@@ -238,11 +238,11 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodExtraParams(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
+                    FormFieldId.Name to FormFieldEntry(
                         "joe",
                         true
                     ),
-                    IdentifierSpec.BacsDebitConfirmed to FormFieldEntry(
+                    FormFieldId.BacsDebitConfirmed to FormFieldEntry(
                         "true",
                         true
                     )
@@ -260,11 +260,11 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodCreateParams(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
+                    FormFieldId.Name to FormFieldEntry(
                         "joe",
                         true
                     ),
-                    IdentifierSpec.SameAsShipping to FormFieldEntry(
+                    FormFieldId.SameAsShipping to FormFieldEntry(
                         "true",
                         true
                     )
@@ -319,23 +319,23 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodOptionsParams(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
+                    FormFieldId.Name to FormFieldEntry(
                         "joe",
                         true
                     ),
-                    IdentifierSpec.Email to FormFieldEntry(
+                    FormFieldId.Email to FormFieldEntry(
                         "joe@gmail.com",
                         true
                     ),
-                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                    FormFieldId.Generic("billing_details[address][country]") to FormFieldEntry(
                         "US",
                         true
                     ),
-                    IdentifierSpec.Line1 to FormFieldEntry(
+                    FormFieldId.Line1 to FormFieldEntry(
                         "123 Main Street",
                         true
                     ),
-                    IdentifierSpec.BlikCode to FormFieldEntry(
+                    FormFieldId.BlikCode to FormFieldEntry(
                         "example_blik_code",
                         true,
                     )
@@ -356,19 +356,19 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodOptionsParams(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
+                    FormFieldId.Name to FormFieldEntry(
                         "joe",
                         true
                     ),
-                    IdentifierSpec.Email to FormFieldEntry(
+                    FormFieldId.Email to FormFieldEntry(
                         "joe@gmail.com",
                         true
                     ),
-                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                    FormFieldId.Generic("billing_details[address][country]") to FormFieldEntry(
                         "US",
                         true
                     ),
-                    IdentifierSpec.Line1 to FormFieldEntry(
+                    FormFieldId.Line1 to FormFieldEntry(
                         "123 Main Street",
                         true
                     ),
@@ -387,23 +387,23 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodOptionsParams(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(
+                    FormFieldId.Name to FormFieldEntry(
                         "joe",
                         true
                     ),
-                    IdentifierSpec.Email to FormFieldEntry(
+                    FormFieldId.Email to FormFieldEntry(
                         "joe@gmail.com",
                         true
                     ),
-                    IdentifierSpec.Generic("billing_details[address][country]") to FormFieldEntry(
+                    FormFieldId.Generic("billing_details[address][country]") to FormFieldEntry(
                         "US",
                         true
                     ),
-                    IdentifierSpec.Line1 to FormFieldEntry(
+                    FormFieldId.Line1 to FormFieldEntry(
                         "123 Main Street",
                         true
                     ),
-                    IdentifierSpec.KonbiniConfirmationNumber to FormFieldEntry(
+                    FormFieldId.KonbiniConfirmationNumber to FormFieldEntry(
                         "example_confirmation_number",
                         true,
                     )
@@ -452,7 +452,7 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodExtraParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodExtraParams(
                 mapOf(
-                    IdentifierSpec.SetAsDefaultPaymentMethod to FormFieldEntry(
+                    FormFieldId.SetAsDefaultPaymentMethod to FormFieldEntry(
                         "true",
                         true
                     ),
@@ -487,7 +487,7 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodExtraParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodExtraParams(
                 mapOf(
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry(
+                    FormFieldId.CardValidatedScan to FormFieldEntry(
                         "true",
                         true
                     ),
@@ -510,7 +510,7 @@ class FieldValuesToParamsMapConverterTest {
         val paymentMethodExtraParams = FieldValuesToParamsMapConverter
             .transformToPaymentMethodExtraParams(
                 mapOf(
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry(
+                    FormFieldId.CardValidatedScan to FormFieldEntry(
                         "false",
                         true
                     ),
@@ -581,7 +581,7 @@ class FieldValuesToParamsMapConverterTest {
 
     private companion object {
         val fieldValuePairs = mapOf(
-            IdentifierSpec.Generic("ideal[bank]") to FormFieldEntry(
+            FormFieldId.Generic("ideal[bank]") to FormFieldEntry(
                 "abn_amro",
                 true
             )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressControllerTest.kt
@@ -5,7 +5,7 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.uicore.elements.AddressController
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.EmailElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -29,11 +29,11 @@ class AddressControllerTest {
     private val sectionFieldElementFlow = MutableStateFlow(
         listOf(
             EmailElement(
-                IdentifierSpec.Email,
+                FormFieldId.Email,
                 controller = emailController
             ),
             IbanElement(
-                IdentifierSpec.Generic("sepa_debit[iban]"),
+                FormFieldId.Generic("sepa_debit[iban]"),
                 ibanController
             )
         )

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AddressElementTest.kt
@@ -10,7 +10,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
@@ -35,7 +35,7 @@ import com.stripe.android.uicore.R as UiCoreR
 @RunWith(RobolectricTestRunner::class)
 class AddressElementTest {
     private val countryElement = CountryElement(
-        IdentifierSpec.Country,
+        FormFieldId.Country,
         DropdownFieldController(
             CountryConfig(setOf("US", "CA"))
         )
@@ -46,7 +46,7 @@ class AddressElementTest {
         runBlocking {
             // ZZ does not have state and US does
             val addressElement = AddressElement(
-                IdentifierSpec.Generic("address"),
+                FormFieldId.Generic("address"),
                 countryElement = countryElement,
                 sameAsShippingElement = null,
                 shippingValuesMap = null
@@ -82,7 +82,7 @@ class AddressElementTest {
     @Test
     fun `verify flow of form field values`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -99,7 +99,7 @@ class AddressElementTest {
 
         // Verify
         var firstForFieldValues = formFieldValueFlow.first()
-        assertThat(firstForFieldValues.toMap()[IdentifierSpec.PostalCode])
+        assertThat(firstForFieldValues.toMap()[FormFieldId.PostalCode])
             .isEqualTo(
                 FormFieldEntry("999", false)
             )
@@ -113,7 +113,7 @@ class AddressElementTest {
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
 
         firstForFieldValues = formFieldValueFlow.first()
-        assertThat(firstForFieldValues.toMap()[IdentifierSpec.PostalCode])
+        assertThat(firstForFieldValues.toMap()[FormFieldId.PostalCode])
             .isEqualTo(
                 FormFieldEntry("A1B2C3", true)
             )
@@ -122,7 +122,7 @@ class AddressElementTest {
     @Test
     fun `changing country updates the fields`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             sameAsShippingElement = null,
             shippingValuesMap = null
@@ -147,9 +147,9 @@ class AddressElementTest {
     @Test
     fun `changing country rebuilds form values`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             rawValuesMap = mapOf(
-                IdentifierSpec.Country to "US",
+                FormFieldId.Country to "US",
             ),
             countryCodes = setOf("US", "BS"),
             sameAsShippingElement = null,
@@ -157,30 +157,30 @@ class AddressElementTest {
         )
         val formFieldValueFlow = addressElement.getFormFieldValueFlow()
         val usValues = mapOf(
-            IdentifierSpec.PostalCode to "10001",
-            IdentifierSpec.State to "NY",
+            FormFieldId.PostalCode to "10001",
+            FormFieldId.State to "NY",
         )
         addressElement.fields.value
-            .filterNot { it.identifier == IdentifierSpec.Country }
+            .filterNot { it.identifier == FormFieldId.Country }
             .forEach { it.setRawValue(usValues) }
 
         val initialFormValues = formFieldValueFlow.value.toMap()
-        assertThat(initialFormValues).containsKey(IdentifierSpec.PostalCode)
-        assertThat(initialFormValues).containsKey(IdentifierSpec.State)
-        assertThat(initialFormValues[IdentifierSpec.PostalCode]?.value).isEqualTo("10001")
-        assertThat(initialFormValues[IdentifierSpec.State]?.value).isEqualTo("NY")
+        assertThat(initialFormValues).containsKey(FormFieldId.PostalCode)
+        assertThat(initialFormValues).containsKey(FormFieldId.State)
+        assertThat(initialFormValues[FormFieldId.PostalCode]?.value).isEqualTo("10001")
+        assertThat(initialFormValues[FormFieldId.State]?.value).isEqualTo("NY")
 
         addressElement.countryElement.controller.onRawValueChange("BS")
 
         val bahamasValues = formFieldValueFlow.value.toMap()
-        assertThat(bahamasValues).doesNotContainKey(IdentifierSpec.PostalCode)
-        assertThat(bahamasValues[IdentifierSpec.State]?.value).isEmpty()
+        assertThat(bahamasValues).doesNotContainKey(FormFieldId.PostalCode)
+        assertThat(bahamasValues[FormFieldId.State]?.value).isEmpty()
     }
 
     @Test
     fun `condensed address element should have name and phone number fields when required`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = null,
@@ -193,18 +193,18 @@ class AddressElementTest {
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isTrue()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isTrue()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Email)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Name)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Phone)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Email)).isTrue()
     }
 
     @Test
     fun `hidden name & phone number field is not shown`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = null,
@@ -217,18 +217,18 @@ class AddressElementTest {
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isFalse()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isFalse()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Email)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Name)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Phone)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Email)).isFalse()
     }
 
     @Test
     fun `optional name & phone number field is shown`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = null,
@@ -241,12 +241,12 @@ class AddressElementTest {
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isTrue()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isTrue()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Email)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Name)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Phone)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Email)).isTrue()
     }
 
     @Test
@@ -256,8 +256,8 @@ class AddressElementTest {
         val phoneNumberWithoutCountryCode = "8008675309"
         val addressElement = createAddressElement(
             initialValues = mapOf(
-                IdentifierSpec.Phone to phoneNumberCountryCode + phoneNumberWithoutCountryCode,
-                IdentifierSpec.Country to countryCode
+                FormFieldId.Phone to phoneNumberCountryCode + phoneNumberWithoutCountryCode,
+                FormFieldId.Country to countryCode
             )
         )
 
@@ -274,8 +274,8 @@ class AddressElementTest {
         val phoneNumberWithoutCountryCode = "8008675309"
         val addressElement = createAddressElement(
             initialValues = mapOf(
-                IdentifierSpec.Phone to phoneNumberCountryCode + phoneNumberWithoutCountryCode,
-                IdentifierSpec.Country to countryCode
+                FormFieldId.Phone to phoneNumberCountryCode + phoneNumberWithoutCountryCode,
+                FormFieldId.Country to countryCode
             )
         )
 
@@ -288,7 +288,7 @@ class AddressElementTest {
     @Test
     fun `expanded address element should have name and phone number fields when required`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 googleApiKey = null,
@@ -301,18 +301,18 @@ class AddressElementTest {
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isTrue()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isTrue()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Email)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Name)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Phone)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Email)).isTrue()
     }
 
     @Test
     fun `expanded shipping address element should hide name and phone number when state is hidden`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 googleApiKey = null,
@@ -325,18 +325,18 @@ class AddressElementTest {
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isFalse()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isFalse()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Email)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Name)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Phone)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Email)).isFalse()
     }
 
     @Test
     fun `expanded shipping address element should show phone number when state is optional`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 googleApiKey = null,
@@ -349,50 +349,50 @@ class AddressElementTest {
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.Phone)).isTrue()
     }
 
     @Test
     fun `normal address element should not have name, email, and phone number fields`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.NoAutocomplete(),
             sameAsShippingElement = null,
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.Name)).isFalse()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Phone)).isFalse()
-        assertThat(identifierSpecs.contains(IdentifierSpec.Email)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Name)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Phone)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.Email)).isFalse()
     }
 
     @Test
     fun `normal address element should not have one line address element`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.NoAutocomplete(),
             sameAsShippingElement = null,
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.OneLineAddress)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.OneLineAddress)).isFalse()
     }
 
     @Test
     fun `condensed shipping address element should have one line address element`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = "some key",
@@ -405,16 +405,16 @@ class AddressElementTest {
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.OneLineAddress)).isTrue()
+        assertThat(formFieldIds.contains(FormFieldId.OneLineAddress)).isTrue()
     }
 
     @Test
     fun `AddressElement should not have OneLineAddress when places is unavailable`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = "some key",
@@ -427,10 +427,10 @@ class AddressElementTest {
             shippingValuesMap = null,
             isPlacesAvailable = false,
         )
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.OneLineAddress)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.OneLineAddress)).isFalse()
     }
 
     @Test
@@ -439,9 +439,9 @@ class AddressElementTest {
             CountryConfig(setOf("US", "CA", "JP"))
         )
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = CountryElement(
-                identifier = IdentifierSpec.Country,
+                identifier = FormFieldId.Country,
                 controller = countryDropdownFieldController,
             ),
             addressInputMode = AddressInputMode.AutocompleteCondensed(
@@ -457,7 +457,7 @@ class AddressElementTest {
         )
         countryDropdownFieldController.onValueChange(1)
 
-        val trailingIcon = addressElement.trailingIconFor(IdentifierSpec.Line1)
+        val trailingIcon = addressElement.trailingIconFor(FormFieldId.Line1)
         assertThat(trailingIcon).isNull()
     }
 
@@ -468,9 +468,9 @@ class AddressElementTest {
         )
         val onNavigationCounter = AtomicInteger(0)
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = CountryElement(
-                identifier = IdentifierSpec.Country,
+                identifier = FormFieldId.Country,
                 controller = countryDropdownFieldController,
             ),
             addressInputMode = AddressInputMode.AutocompleteExpanded(
@@ -486,10 +486,10 @@ class AddressElementTest {
         )
         countryDropdownFieldController.onValueChange(1)
 
-        val line1TrailingIcon = addressElement.trailingIconFor(IdentifierSpec.Line1)
+        val line1TrailingIcon = addressElement.trailingIconFor(FormFieldId.Line1)
         assertThat(line1TrailingIcon?.contentDescription)
             .isEqualTo(UiCoreR.string.stripe_address_search_content_description)
-        assertThat(addressElement.trailingIconFor(IdentifierSpec.Line2)).isNull()
+        assertThat(addressElement.trailingIconFor(FormFieldId.Line2)).isNull()
 
         line1TrailingIcon?.onClick?.invoke()
         assertThat(onNavigationCounter.get()).isEqualTo(1)
@@ -499,7 +499,7 @@ class AddressElementTest {
     fun `when google api key not supplied, condensed shipping address element is not one line address element`() =
         runTest {
             val addressElement = AddressElement(
-                IdentifierSpec.Generic("address"),
+                FormFieldId.Generic("address"),
                 countryElement = countryElement,
                 addressInputMode = AddressInputMode.AutocompleteCondensed(
                     googleApiKey = null,
@@ -512,16 +512,16 @@ class AddressElementTest {
                 shippingValuesMap = null
             )
 
-            val identifierSpecs = addressElement.fields.first().map {
+            val formFieldIds = addressElement.fields.first().map {
                 it.identifier
             }
-            assertThat(identifierSpecs.contains(IdentifierSpec.OneLineAddress)).isFalse()
+            assertThat(formFieldIds.contains(FormFieldId.OneLineAddress)).isFalse()
         }
 
     @Test
     fun `expanded shipping address element should not have one line address element`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteExpanded(
                 googleApiKey = null,
@@ -534,28 +534,28 @@ class AddressElementTest {
             shippingValuesMap = null
         )
 
-        val identifierSpecs = addressElement.fields.first().map {
+        val formFieldIds = addressElement.fields.first().map {
             it.identifier
         }
-        assertThat(identifierSpecs.contains(IdentifierSpec.OneLineAddress)).isFalse()
+        assertThat(formFieldIds.contains(FormFieldId.OneLineAddress)).isFalse()
     }
 
     @Test
     fun `when same as shipping is enabled billing address is the same as shipping`() = runTest {
         val sameAsShippingElement = SameAsShippingElement(
-            IdentifierSpec.SameAsShipping,
+            FormFieldId.SameAsShipping,
             SameAsShippingController(false)
         )
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             mapOf(
-                IdentifierSpec.Country to "CA"
+                FormFieldId.Country to "CA"
             ),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.NoAutocomplete(),
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = mapOf(
-                IdentifierSpec.Country to "US"
+                FormFieldId.Country to "US"
             )
         )
 
@@ -570,7 +570,7 @@ class AddressElementTest {
 
         assertThat(country()).isEqualTo("CA")
 
-        sameAsShippingElement.setRawValue(mapOf(IdentifierSpec.SameAsShipping to "true"))
+        sameAsShippingElement.setRawValue(mapOf(FormFieldId.SameAsShipping to "true"))
 
         assertThat(country()).isEqualTo("US")
     }
@@ -578,9 +578,9 @@ class AddressElementTest {
     @Test
     fun `when phone number is required, should not be complete until fully entered`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             mapOf(
-                IdentifierSpec.Country to "CA"
+                FormFieldId.Country to "CA"
             ),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.NoAutocomplete(
@@ -605,9 +605,9 @@ class AddressElementTest {
     @Test
     fun `on validating, should update all internal fields of validation state`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             mapOf(
-                IdentifierSpec.Country to "CA"
+                FormFieldId.Country to "CA"
             ),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.NoAutocomplete(
@@ -620,24 +620,24 @@ class AddressElementTest {
         addressElement.fields.test {
             val fields = awaitItem()
 
-            fields.element(IdentifierSpec.Country).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.Line1).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.Line2).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.State).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.PostalCode).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.City).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.Country).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.Line1).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.Line2).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.State).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.PostalCode).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.City).errorTest(fieldValidationMessage = null)
 
             addressElement.onValidationStateChanged(true)
 
-            fields.element(IdentifierSpec.Country).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.Line1)
+            fields.element(FormFieldId.Country).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.Line1)
                 .errorTest(fieldValidationMessage = FieldValidationMessage.Error(R.string.stripe_blank_and_required))
-            fields.element(IdentifierSpec.Line2).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.State)
+            fields.element(FormFieldId.Line2).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.State)
                 .errorTest(fieldValidationMessage = FieldValidationMessage.Error(R.string.stripe_blank_and_required))
-            fields.element(IdentifierSpec.PostalCode)
+            fields.element(FormFieldId.PostalCode)
                 .errorTest(fieldValidationMessage = FieldValidationMessage.Error(R.string.stripe_blank_and_required))
-            fields.element(IdentifierSpec.City)
+            fields.element(FormFieldId.City)
                 .errorTest(fieldValidationMessage = FieldValidationMessage.Error(R.string.stripe_blank_and_required))
         }
     }
@@ -645,7 +645,7 @@ class AddressElementTest {
     @Test
     fun `name element filters out emojis`() = runTest {
         val addressElement = AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
                 googleApiKey = null,
@@ -659,7 +659,7 @@ class AddressElementTest {
         )
 
         val nameElement = addressElement.fields.first()
-            .find { it.identifier == IdentifierSpec.Name } as? SimpleTextElement
+            .find { it.identifier == FormFieldId.Name } as? SimpleTextElement
 
         assertThat(nameElement).isNotNull()
 
@@ -676,9 +676,9 @@ class AddressElementTest {
         assertThat(nameController.fieldValue.first()).isEqualTo("Bob  Jones")
     }
 
-    private fun createAddressElement(initialValues: Map<IdentifierSpec, String>): AddressElement {
+    private fun createAddressElement(initialValues: Map<FormFieldId, String>): AddressElement {
         return AddressElement(
-            IdentifierSpec.Generic("address"),
+            FormFieldId.Generic("address"),
             rawValuesMap = initialValues,
             countryElement = countryElement,
             addressInputMode = AddressInputMode.AutocompleteCondensed(
@@ -704,16 +704,16 @@ private suspend fun Flow<List<SectionFieldElement>>.postalCodeController(): Text
             listOf(element)
         }
     }.flatten().find { element ->
-        element.identifier == IdentifierSpec.PostalCode
+        element.identifier == FormFieldId.PostalCode
     }
 
     return (element as SimpleTextElement).controller
 }
 
 private suspend fun AddressElement.trailingIconFor(
-    identifierSpec: IdentifierSpec
+    formFieldId: FormFieldId
 ): TextFieldIcon.Trailing? {
-    val fieldForSpec = fields.first().first { it.identifier == identifierSpec }
+    val fieldForSpec = fields.first().first { it.identifier == formFieldId }
     val controllerForSpec = (fieldForSpec as SimpleTextElement).controller
     val trailingIcon = (controllerForSpec as SimpleTextFieldController).textFieldConfig.trailingIcon
     return trailingIcon.value as? TextFieldIcon.Trailing?

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/AfterpayClearpayHeaderElementTest.kt
@@ -6,7 +6,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isCashappAfterpay
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement.Companion.isClearpay
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,7 +22,7 @@ class AfterpayClearpayHeaderElementTest {
     @Test
     fun `Verify label is correct`() {
         val element = AfterpayClearpayHeaderElement(
-            IdentifierSpec.Generic("test"),
+            FormFieldId.Generic("test"),
             currency = "EUR",
         )
 
@@ -34,7 +34,7 @@ class AfterpayClearpayHeaderElementTest {
     @Test
     fun `Verify infoUrl is correct`() {
         val element = AfterpayClearpayHeaderElement(
-            IdentifierSpec.Generic("test"),
+            FormFieldId.Generic("test"),
             currency = "EUR",
         )
 
@@ -46,7 +46,7 @@ class AfterpayClearpayHeaderElementTest {
     fun `Verify infoUrl is updated as locale changes`() {
         localeRule.setTemporarily(Locale.UK)
         val element = AfterpayClearpayHeaderElement(
-            IdentifierSpec.Generic("test"),
+            FormFieldId.Generic("test"),
             currency = "GBP",
         )
 
@@ -62,7 +62,7 @@ class AfterpayClearpayHeaderElementTest {
     fun `Verify infoUrl is localized for GB`() {
         localeRule.setTemporarily(Locale.UK)
         val element = AfterpayClearpayHeaderElement(
-            IdentifierSpec.Generic("test"),
+            FormFieldId.Generic("test"),
             currency = "GBP",
         )
 
@@ -74,7 +74,7 @@ class AfterpayClearpayHeaderElementTest {
     fun `Verify infoUrl is localized for France`() {
         localeRule.setTemporarily(Locale.FRANCE)
         val element = AfterpayClearpayHeaderElement(
-            IdentifierSpec.Generic("test"),
+            FormFieldId.Generic("test"),
             currency = "EUR",
         )
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BsbElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/BsbElementTest.kt
@@ -2,7 +2,7 @@ package com.stripe.android.ui.core.elements
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -11,7 +11,7 @@ class BsbElementTest {
     @Test
     fun `default banks include server bank prefixes`() = runTest {
         val element = BsbElement(
-            identifierSpec = IdentifierSpec.Generic("au_becs_debit[bsb_number]"),
+            formFieldId = FormFieldId.Generic("au_becs_debit[bsb_number]"),
             initialValue = null,
         )
 
@@ -25,7 +25,7 @@ class BsbElementTest {
     @Test
     fun `most specific bank prefix determines bank name`() = runTest {
         val element = BsbElement(
-            identifierSpec = IdentifierSpec.Generic("au_becs_debit[bsb_number]"),
+            formFieldId = FormFieldId.Generic("au_becs_debit[bsb_number]"),
             initialValue = null,
         )
 
@@ -38,9 +38,9 @@ class BsbElementTest {
 
     @Test
     fun `controller updates bank name and complete form entry`() = runTest {
-        val identifier = IdentifierSpec.Generic("au_becs_debit[bsb_number]")
+        val identifier = FormFieldId.Generic("au_becs_debit[bsb_number]")
         val element = BsbElement(
-            identifierSpec = identifier,
+            formFieldId = identifier,
             initialValue = null,
         )
 

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardBillingAddressElementTest.kt
@@ -10,7 +10,7 @@ import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.utils.isInstanceOf
@@ -19,9 +19,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
-private val ALL_ADDRESS_FIELDS: Set<IdentifierSpec> = FieldType.entries
+private val ALL_ADDRESS_FIELDS: Set<FormFieldId> = FieldType.entries
     .filterNot { it == FieldType.Name }
-    .map { it.identifierSpec }
+    .map { it.formFieldId }
     .toSet()
 
 @RunWith(RobolectricTestRunner::class)
@@ -35,7 +35,7 @@ internal class CardBillingAddressElementTest {
     fun `Verify that when US is selected postal is not hidden`() = runTest {
         cardBillingElement.hiddenIdentifiers.test {
             dropdownFieldController.onRawValueChange("US")
-            expectMostRecentItem().verifyFieldsShown(IdentifierSpec.PostalCode)
+            expectMostRecentItem().verifyFieldsShown(FormFieldId.PostalCode)
         }
     }
 
@@ -43,7 +43,7 @@ internal class CardBillingAddressElementTest {
     fun `Verify that when GB is selected postal is not hidden`() = runTest {
         cardBillingElement.hiddenIdentifiers.test {
             dropdownFieldController.onRawValueChange("GB")
-            expectMostRecentItem().verifyFieldsShown(IdentifierSpec.PostalCode)
+            expectMostRecentItem().verifyFieldsShown(FormFieldId.PostalCode)
         }
     }
 
@@ -51,7 +51,7 @@ internal class CardBillingAddressElementTest {
     fun `Verify that when CA is selected postal is not hidden`() = runTest {
         cardBillingElement.hiddenIdentifiers.test {
             dropdownFieldController.onRawValueChange("CA")
-            expectMostRecentItem().verifyFieldsShown(IdentifierSpec.PostalCode)
+            expectMostRecentItem().verifyFieldsShown(FormFieldId.PostalCode)
         }
     }
 
@@ -82,7 +82,7 @@ internal class CardBillingAddressElementTest {
         element.hiddenIdentifiers.test {
             // IN has no AVS default fields, but requires a postal code for automatic tax.
             dropdownFieldController.onRawValueChange("IN")
-            expectMostRecentItem().verifyFieldsShown(IdentifierSpec.PostalCode)
+            expectMostRecentItem().verifyFieldsShown(FormFieldId.PostalCode)
         }
     }
 
@@ -93,9 +93,9 @@ internal class CardBillingAddressElementTest {
         element.hiddenIdentifiers.test {
             dropdownFieldController.onRawValueChange("PR")
             expectMostRecentItem().verifyFieldsShown(
-                IdentifierSpec.Line1,
-                IdentifierSpec.City,
-                IdentifierSpec.PostalCode,
+                FormFieldId.Line1,
+                FormFieldId.City,
+                FormFieldId.PostalCode,
             )
         }
     }
@@ -107,10 +107,10 @@ internal class CardBillingAddressElementTest {
         element.hiddenIdentifiers.test {
             dropdownFieldController.onRawValueChange("US")
             expectMostRecentItem().verifyFieldsShown(
-                IdentifierSpec.Line1,
-                IdentifierSpec.City,
-                IdentifierSpec.State,
-                IdentifierSpec.PostalCode,
+                FormFieldId.Line1,
+                FormFieldId.City,
+                FormFieldId.State,
+                FormFieldId.PostalCode,
             )
         }
     }
@@ -248,7 +248,7 @@ internal class CardBillingAddressElementTest {
                 .value
                 .fieldsFlowable
                 .value
-                .findField(IdentifierSpec.PostalCode)
+                .findField(FormFieldId.PostalCode)
 
             assertThat(postalCodeField).isNotNull()
 
@@ -256,7 +256,7 @@ internal class CardBillingAddressElementTest {
 
             nonNullPostalCodeField.setRawValue(
                 mapOf(
-                    IdentifierSpec.PostalCode to "99999"
+                    FormFieldId.PostalCode to "99999"
                 )
             )
 
@@ -264,14 +264,14 @@ internal class CardBillingAddressElementTest {
         }
     }
 
-    private fun List<SectionFieldElement>.findField(identifierSpec: IdentifierSpec): SectionFieldElement? {
+    private fun List<SectionFieldElement>.findField(formFieldId: FormFieldId): SectionFieldElement? {
         for (element in this) {
             when (element) {
-                is RowElement -> element.fields.findField(identifierSpec)?.let {
+                is RowElement -> element.fields.findField(formFieldId)?.let {
                     return it
                 }
                 else -> element.takeIf {
-                    it.identifier == identifierSpec
+                    it.identifier == formFieldId
                 }?.let {
                     return it
                 }
@@ -286,7 +286,7 @@ internal class CardBillingAddressElementTest {
      * set - rather than which are hidden, since that's what a human reviewing a test failure
      * actually wants to check against the expected UX.
      */
-    private fun Set<IdentifierSpec>.verifyFieldsShown(vararg shownFields: IdentifierSpec) {
+    private fun Set<FormFieldId>.verifyFieldsShown(vararg shownFields: FormFieldId) {
         Truth.assertThat(ALL_ADDRESS_FIELDS - this).containsExactlyElementsIn(shownFields.toSet())
     }
 
@@ -308,7 +308,7 @@ internal class CardBillingAddressElementTest {
         addressCollectionMode: BillingAddressCollectionMode,
     ): BillingAddressElement {
         return BillingAddressElement(
-            identifier = IdentifierSpec.Generic("billing_element"),
+            identifier = FormFieldId.Generic("billing_element"),
             rawValuesMap = emptyMap(),
             countryCodes = emptySet(),
             countryDropdownFieldController = dropdownFieldController,
@@ -336,11 +336,11 @@ internal class CardBillingAddressElementTest {
         val addressFields = addressController.fieldsFlowable.value
 
         val hasEmail = addressFields.any { field ->
-            field.identifier == IdentifierSpec.Email
+            field.identifier == FormFieldId.Email
         }
 
         val hasPhone = addressFields.any { field ->
-            field.identifier == IdentifierSpec.Phone
+            field.identifier == FormFieldId.Phone
         }
 
         block(hasEmail, hasPhone)
@@ -362,11 +362,11 @@ internal class CardBillingAddressElementTest {
         val addressFields = addressController.fieldsFlowable.value
 
         val hasEmail = addressFields.any { field ->
-            field.identifier == IdentifierSpec.Email
+            field.identifier == FormFieldId.Email
         }
 
         val hasPhone = addressFields.any { field ->
-            field.identifier == IdentifierSpec.Phone
+            field.identifier == FormFieldId.Phone
         }
 
         block(hasEmail, hasPhone)
@@ -378,7 +378,7 @@ internal class CardBillingAddressElementTest {
     ) = runTest {
         block(
             BillingAddressElement(
-                identifier = IdentifierSpec.Generic("billing_element"),
+                identifier = FormFieldId.Generic("billing_element"),
                 rawValuesMap = emptyMap(),
                 countryCodes = emptySet(),
                 countryDropdownFieldController = dropdownFieldController,

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsControllerTest.kt
@@ -29,7 +29,7 @@ import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventR
 import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.FieldValidationMessage
 import com.stripe.android.uicore.elements.FieldValidationMessageComparator
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.TextFieldConfig
 import com.stripe.android.uicore.elements.TextFieldState
@@ -129,8 +129,8 @@ class CardDetailsControllerTest {
         runTest {
             val cardController = cardDetailsController(
                 initialValues = mapOf(
-                    IdentifierSpec.CardNumber to "4000002500001001",
-                    IdentifierSpec.PreferredCardBrand to CardBrand.CartesBancaires.code
+                    FormFieldId.CardNumber to "4000002500001001",
+                    FormFieldId.PreferredCardBrand to CardBrand.CartesBancaires.code
                 ),
                 cbcEligibility = CardBrandChoiceEligibility.Eligible(listOf())
             )
@@ -172,10 +172,10 @@ class CardDetailsControllerTest {
     fun `When new card overwrites existing card, fields properly filled in`() = runTest {
         val cardController = cardDetailsController(
             initialValues = mapOf(
-                IdentifierSpec.CardNumber to "4242424242424242",
-                IdentifierSpec.CardExpYear to "2042",
-                IdentifierSpec.CardExpMonth to "2",
-                IdentifierSpec.CardCvc to "123",
+                FormFieldId.CardNumber to "4242424242424242",
+                FormFieldId.CardExpYear to "2042",
+                FormFieldId.CardExpMonth to "2",
+                FormFieldId.CardCvc to "123",
             )
         )
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
@@ -207,10 +207,10 @@ class CardDetailsControllerTest {
     fun `When new card scanned with invalid expiry date, should not use invalid date`() = runTest {
         val cardController = cardDetailsController(
             initialValues = mapOf(
-                IdentifierSpec.CardNumber to "4242424242424242",
-                IdentifierSpec.CardExpYear to "2042",
-                IdentifierSpec.CardExpMonth to "2",
-                IdentifierSpec.CardCvc to "123",
+                FormFieldId.CardNumber to "4242424242424242",
+                FormFieldId.CardExpYear to "2042",
+                FormFieldId.CardExpMonth to "2",
+                FormFieldId.CardCvc to "123",
             )
         )
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
@@ -258,10 +258,10 @@ class CardDetailsControllerTest {
     fun `When initialized with validated scan and card number, card pill is shown`() = runTest {
         val cardController = cardDetailsController(
             initialValues = mapOf(
-                IdentifierSpec.CardNumber to "4242424242424242",
-                IdentifierSpec.CardValidatedScan to "true",
-                IdentifierSpec.CardExpMonth to "06",
-                IdentifierSpec.CardExpYear to "2030",
+                FormFieldId.CardNumber to "4242424242424242",
+                FormFieldId.CardValidatedScan to "true",
+                FormFieldId.CardExpMonth to "06",
+                FormFieldId.CardExpYear to "2030",
             )
         )
 
@@ -285,7 +285,7 @@ class CardDetailsControllerTest {
     fun `When initialized with validated scan but no card number, card pill is not shown`() = runTest {
         val cardController = cardDetailsController(
             initialValues = mapOf(
-                IdentifierSpec.CardValidatedScan to "true",
+                FormFieldId.CardValidatedScan to "true",
             )
         )
         idleLooper()
@@ -308,8 +308,8 @@ class CardDetailsControllerTest {
     fun `When initialized with validated scan false, card pill is not shown`() = runTest {
         val cardController = cardDetailsController(
             initialValues = mapOf(
-                IdentifierSpec.CardNumber to "4242424242424242",
-                IdentifierSpec.CardValidatedScan to "false",
+                FormFieldId.CardNumber to "4242424242424242",
+                FormFieldId.CardValidatedScan to "false",
             )
         )
         idleLooper()
@@ -420,10 +420,10 @@ class CardDetailsControllerTest {
     fun `When new card scanned with no expiry date, should clear date`() = runTest {
         val cardController = cardDetailsController(
             initialValues = mapOf(
-                IdentifierSpec.CardNumber to "4242424242424242",
-                IdentifierSpec.CardExpYear to "2042",
-                IdentifierSpec.CardExpMonth to "2",
-                IdentifierSpec.CardCvc to "123",
+                FormFieldId.CardNumber to "4242424242424242",
+                FormFieldId.CardExpYear to "2042",
+                FormFieldId.CardExpMonth to "2",
+                FormFieldId.CardCvc to "123",
             )
         )
         assertThat(cardController.numberElement.controller.rawFieldValue.value)
@@ -496,7 +496,7 @@ class CardDetailsControllerTest {
                     cardController.ComposeUI(
                         enabled = true,
                         field = CardDetailsElement(
-                            identifier = IdentifierSpec.Generic("card_details"),
+                            identifier = FormFieldId.Generic("card_details"),
                             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
                             initialValues = mapOf(),
                             coroutineScope = coroutineScope,
@@ -513,7 +513,7 @@ class CardDetailsControllerTest {
     }
 
     private fun cardDetailsController(
-        initialValues: Map<IdentifierSpec, String?> = emptyMap(),
+        initialValues: Map<FormFieldId, String?> = emptyMap(),
         cbcEligibility: CardBrandChoiceEligibility = CardBrandChoiceEligibility.Ineligible,
         cardBrandFilter: CardBrandFilter = DefaultCardBrandFilter,
         cardDetailsTextFieldConfig: CardNumberTextFieldConfig = CardNumberConfig(

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsElementTest.kt
@@ -11,7 +11,7 @@ import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.TextFieldIcon
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.CoroutineScope
@@ -53,7 +53,7 @@ class CardDetailsElementTest {
             workContext = testDispatcher,
         )
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = emptyMap(),
@@ -68,12 +68,12 @@ class CardDetailsElementTest {
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("321", true),
-                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4242424242424242", true),
+                    FormFieldId.CardCvc to FormFieldEntry("321", true),
+                    FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("01", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -82,12 +82,12 @@ class CardDetailsElementTest {
     @Test
     fun `test view only form field values returned and expiration date parsing`() = runTest {
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = mapOf(
-                IdentifierSpec.CardNumber to "4242424242424242",
-                IdentifierSpec.CardBrand to CardBrand.Visa.code
+                FormFieldId.CardNumber to "4242424242424242",
+                FormFieldId.CardBrand to CardBrand.Visa.code
             )
         )
 
@@ -98,12 +98,12 @@ class CardDetailsElementTest {
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("321", true),
-                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("12", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4242424242424242", true),
+                    FormFieldId.CardCvc to FormFieldEntry("321", true),
+                    FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("12", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -120,7 +120,7 @@ class CardDetailsElementTest {
             workContext = testDispatcher,
         )
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = emptyMap(),
@@ -137,13 +137,13 @@ class CardDetailsElementTest {
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.Name to FormFieldEntry("Jane Doe", true),
-                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("321", true),
-                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
+                    FormFieldId.Name to FormFieldEntry("Jane Doe", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4242424242424242", true),
+                    FormFieldId.CardCvc to FormFieldEntry("321", true),
+                    FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("01", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -163,7 +163,7 @@ class CardDetailsElementTest {
         )
 
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = emptyMap(),
@@ -181,14 +181,14 @@ class CardDetailsElementTest {
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.Name to FormFieldEntry("Jane Doe", true),
-                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("321", true),
-                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                    IdentifierSpec.PreferredCardBrand to FormFieldEntry(null, true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
+                    FormFieldId.Name to FormFieldEntry("Jane Doe", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4242424242424242", true),
+                    FormFieldId.CardCvc to FormFieldEntry("321", true),
+                    FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                    FormFieldId.PreferredCardBrand to FormFieldEntry(null, true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("01", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -208,7 +208,7 @@ class CardDetailsElementTest {
         )
 
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = emptyMap(),
@@ -233,14 +233,14 @@ class CardDetailsElementTest {
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.Name to FormFieldEntry("Jane Doe", true),
-                    IdentifierSpec.CardNumber to FormFieldEntry("4000002500001001", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("321", true),
-                    IdentifierSpec.PreferredCardBrand to FormFieldEntry("cartes_bancaires", true),
-                    IdentifierSpec.CardBrand to FormFieldEntry("cartes_bancaires", true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
+                    FormFieldId.Name to FormFieldEntry("Jane Doe", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4000002500001001", true),
+                    FormFieldId.CardCvc to FormFieldEntry("321", true),
+                    FormFieldId.PreferredCardBrand to FormFieldEntry("cartes_bancaires", true),
+                    FormFieldId.CardBrand to FormFieldEntry("cartes_bancaires", true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("01", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -260,7 +260,7 @@ class CardDetailsElementTest {
         )
 
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = emptyMap(),
@@ -278,14 +278,14 @@ class CardDetailsElementTest {
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.Name to FormFieldEntry("Jane Doe", true),
-                    IdentifierSpec.CardNumber to FormFieldEntry("4000002500001001", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("321", true),
-                    IdentifierSpec.PreferredCardBrand to FormFieldEntry("cartes_bancaires", true),
-                    IdentifierSpec.CardBrand to FormFieldEntry("cartes_bancaires", true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
+                    FormFieldId.Name to FormFieldEntry("Jane Doe", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4000002500001001", true),
+                    FormFieldId.CardCvc to FormFieldEntry("321", true),
+                    FormFieldId.PreferredCardBrand to FormFieldEntry("cartes_bancaires", true),
+                    FormFieldId.CardBrand to FormFieldEntry("cartes_bancaires", true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("01", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -301,7 +301,7 @@ class CardDetailsElementTest {
             workContext = testDispatcher,
         )
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = emptyMap(),
@@ -319,12 +319,12 @@ class CardDetailsElementTest {
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("", false),
-                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("01", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4242424242424242", true),
+                    FormFieldId.CardCvc to FormFieldEntry("", false),
+                    FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("01", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("false", true),
                 )
             )
         }
@@ -333,26 +333,26 @@ class CardDetailsElementTest {
     @Test
     fun `test form field values include validated scan when initialized with card pill`() = runTest {
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = mapOf(
-                IdentifierSpec.CardNumber to "4242424242424242",
-                IdentifierSpec.CardValidatedScan to "true",
-                IdentifierSpec.CardExpMonth to "06",
-                IdentifierSpec.CardExpYear to "2030",
+                FormFieldId.CardNumber to "4242424242424242",
+                FormFieldId.CardValidatedScan to "true",
+                FormFieldId.CardExpMonth to "06",
+                FormFieldId.CardExpYear to "2030",
             ),
         )
 
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("", false),
-                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("06", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("true", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4242424242424242", true),
+                    FormFieldId.CardCvc to FormFieldEntry("", false),
+                    FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("06", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("true", true),
                 )
             )
         }
@@ -370,7 +370,7 @@ class CardDetailsElementTest {
         )
 
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = repositoryFactory,
             coroutineScope = coroutineScope,
             initialValues = emptyMap(),
@@ -388,12 +388,12 @@ class CardDetailsElementTest {
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.CardNumber to FormFieldEntry("4242424242424242", true),
-                    IdentifierSpec.CardCvc to FormFieldEntry("", false),
-                    IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                    IdentifierSpec.CardExpMonth to FormFieldEntry("06", true),
-                    IdentifierSpec.CardExpYear to FormFieldEntry("2030", true),
-                    IdentifierSpec.CardValidatedScan to FormFieldEntry("true", true),
+                    FormFieldId.CardNumber to FormFieldEntry("4242424242424242", true),
+                    FormFieldId.CardCvc to FormFieldEntry("", false),
+                    FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                    FormFieldId.CardExpMonth to FormFieldEntry("06", true),
+                    FormFieldId.CardExpYear to FormFieldEntry("2030", true),
+                    FormFieldId.CardValidatedScan to FormFieldEntry("true", true),
                 )
             )
         }
@@ -402,10 +402,10 @@ class CardDetailsElementTest {
     @Test
     fun `test form field values clear validated scan when card pill is dismissed`() = runTest {
         val initialValues = mapOf(
-            IdentifierSpec.CardNumber to "4242424242424242",
-            IdentifierSpec.CardValidatedScan to "true",
-            IdentifierSpec.CardExpMonth to "06",
-            IdentifierSpec.CardExpYear to "2030",
+            FormFieldId.CardNumber to "4242424242424242",
+            FormFieldId.CardValidatedScan to "true",
+            FormFieldId.CardExpMonth to "06",
+            FormFieldId.CardExpYear to "2030",
         )
         val repositoryFactory = DefaultCardAccountRangeRepositoryFactory(context)
         val cardController = CardDetailsController(
@@ -416,7 +416,7 @@ class CardDetailsElementTest {
             workContext = testDispatcher,
         )
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = repositoryFactory,
             coroutineScope = coroutineScope,
             initialValues = initialValues,
@@ -425,19 +425,19 @@ class CardDetailsElementTest {
 
         cardDetailsElement.getFormFieldValueFlow().test {
             assertThat(awaitItem())
-                .contains(IdentifierSpec.CardValidatedScan to FormFieldEntry("true", true))
+                .contains(FormFieldId.CardValidatedScan to FormFieldEntry("true", true))
 
             cardController.cardPillElement.value = null
 
             assertThat(awaitItem())
-                .contains(IdentifierSpec.CardValidatedScan to FormFieldEntry("false", true),)
+                .contains(FormFieldId.CardValidatedScan to FormFieldEntry("false", true),)
         }
     }
 
     @Test
     fun `test when validating, all fields show errors as expected`() = runTest {
         val cardDetailsElement = CardDetailsElement(
-            IdentifierSpec.Generic("card_details"),
+            FormFieldId.Generic("card_details"),
             cardAccountRangeRepositoryFactory = DefaultCardAccountRangeRepositoryFactory(context),
             coroutineScope = coroutineScope,
             initialValues = emptyMap(),

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardDetailsSectionElementUITest.kt
@@ -14,7 +14,7 @@ import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.runner.RunWith
@@ -101,7 +101,7 @@ internal class CardDetailsSectionElementUITest {
                     enabled = true,
                     controller = controller,
                     hiddenIdentifiers = emptySet(),
-                    lastTextFieldIdentifier = IdentifierSpec.PostalCode
+                    lastTextFieldIdentifier = FormFieldId.PostalCode
                 )
             }
         }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/CardNumberControllerTest.kt
@@ -34,7 +34,7 @@ import com.stripe.android.ui.core.elements.events.CardNumberCompletedEventReport
 import com.stripe.android.ui.core.elements.events.LocalAnalyticsEventReporter
 import com.stripe.android.ui.core.elements.events.LocalCardBrandDisallowedReporter
 import com.stripe.android.ui.core.elements.events.LocalCardNumberCompletedEventReporter
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
 import com.stripe.android.uicore.elements.SimpleTextFieldController
@@ -585,7 +585,7 @@ internal class CardNumberControllerTest {
                 cardNumberController.ComposeUI(
                     enabled = true,
                     field = SimpleTextElement(
-                        identifier = IdentifierSpec.Name,
+                        identifier = FormFieldId.Name,
                         controller = SimpleTextFieldController(
                             textFieldConfig = SimpleTextFieldConfig(
                                 resolvableString(value = "Card number")
@@ -620,7 +620,7 @@ internal class CardNumberControllerTest {
                 cardNumberController.ComposeUI(
                     enabled = true,
                     field = SimpleTextElement(
-                        identifier = IdentifierSpec.Name,
+                        identifier = FormFieldId.Name,
                         controller = SimpleTextFieldController(
                             textFieldConfig = SimpleTextFieldConfig(
                                 resolvableString(value = "Card number")
@@ -692,7 +692,7 @@ internal class CardNumberControllerTest {
                 cardNumberController.ComposeUI(
                     enabled = true,
                     field = SimpleTextElement(
-                        identifier = IdentifierSpec.Name,
+                        identifier = FormFieldId.Name,
                         controller = SimpleTextFieldController(
                             textFieldConfig = SimpleTextFieldConfig(
                                 label = "Card number".resolvableString
@@ -756,7 +756,7 @@ internal class CardNumberControllerTest {
                 cardNumberController.ComposeUI(
                     enabled = true,
                     field = SimpleTextElement(
-                        identifier = IdentifierSpec.Name,
+                        identifier = FormFieldId.Name,
                         controller = SimpleTextFieldController(
                             textFieldConfig = SimpleTextFieldConfig(
                                 resolvableString(value = "Card number")

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SectionFieldElementTestUtils.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/SectionFieldElementTestUtils.kt
@@ -3,7 +3,7 @@ package com.stripe.android.ui.core.elements
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 
@@ -20,21 +20,21 @@ internal suspend fun SectionFieldElement.errorTest(fieldValidationMessage: Field
     }
 }
 
-internal fun List<SectionFieldElement>.element(identifierSpec: IdentifierSpec): SectionFieldElement {
-    val element = nullableElement(identifierSpec)
+internal fun List<SectionFieldElement>.element(formFieldId: FormFieldId): SectionFieldElement {
+    val element = nullableElement(formFieldId)
 
     assertThat(element).isNotNull()
 
     return requireNotNull(element)
 }
 
-private fun List<SectionFieldElement>.nullableElement(identifierSpec: IdentifierSpec): SectionFieldElement? {
+private fun List<SectionFieldElement>.nullableElement(formFieldId: FormFieldId): SectionFieldElement? {
     for (element in this) {
         if (element is RowElement) {
-            element.fields.nullableElement(identifierSpec)?.let {
+            element.fields.nullableElement(formFieldId)?.let {
                 return it
             }
-        } else if (element.identifier == identifierSpec) {
+        } else if (element.identifier == formFieldId) {
             return element
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/common/spms/CvcFormHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/spms/CvcFormHelper.kt
@@ -11,7 +11,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -54,7 +54,7 @@ internal class DefaultCvcFormHelper(
     )
 
     private val cvcElement = CvcElement(
-        _identifier = IdentifierSpec.CardCvc,
+        _identifier = FormFieldId.CardCvc,
         controller = cvcController
     )
 

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationBody.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/verification/VerificationBody.kt
@@ -53,7 +53,7 @@ import com.stripe.android.model.ConsentUi
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.SectionStyle
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import com.stripe.android.uicore.elements.OTPElementColors
@@ -421,7 +421,7 @@ private fun Preview() {
                         )
                     ),
                     otpElement = OTPElement(
-                        identifier = IdentifierSpec.Generic("otp"),
+                        identifier = FormFieldId.Generic("otp"),
                         controller = OTPController(),
                     ),
                     onBack = {},

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/LinkInline2FASection.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/LinkInline2FASection.kt
@@ -39,7 +39,7 @@ import com.stripe.android.model.DisplayablePaymentDetails
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.uicore.SectionStyle
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import com.stripe.android.uicore.elements.OTPElementColors
@@ -220,7 +220,7 @@ private fun Title(
 @Composable
 private fun LinkEmbeddedOtpSectionDefaultPreview() {
     val otpElement = OTPElement(
-        identifier = IdentifierSpec.Generic("otp"),
+        identifier = FormFieldId.Generic("otp"),
         controller = OTPController()
     )
 
@@ -249,7 +249,7 @@ private fun LinkEmbeddedOtpSectionDefaultPreview() {
 @Composable
 private fun LinkEmbeddedOtpSectionDefaultCardPreview() {
     val otpElement = OTPElement(
-        identifier = IdentifierSpec.Generic("otp"),
+        identifier = FormFieldId.Generic("otp"),
         controller = OTPController()
     )
 
@@ -282,7 +282,7 @@ private fun LinkEmbeddedOtpSectionDefaultCardPreview() {
 @Composable
 private fun LinkEmbeddedOtpSectionDefaultBankPreview() {
     val otpElement = OTPElement(
-        identifier = IdentifierSpec.Generic("otp"),
+        identifier = FormFieldId.Generic("otp"),
         controller = OTPController()
     )
 
@@ -315,7 +315,7 @@ private fun LinkEmbeddedOtpSectionDefaultBankPreview() {
 @Composable
 private fun LinkEmbeddedOtpSectionProcessingPreview() {
     val otpElement = OTPElement(
-        identifier = IdentifierSpec.Generic("otp"),
+        identifier = FormFieldId.Generic("otp"),
         controller = OTPController().apply {
             onValueChanged(0, "123456")
         }
@@ -350,7 +350,7 @@ private fun LinkEmbeddedOtpSectionProcessingPreview() {
 @Composable
 private fun LinkEmbeddedOtpSectionErrorPreview() {
     val otpElement = OTPElement(
-        identifier = IdentifierSpec.Generic("otp"),
+        identifier = FormFieldId.Generic("otp"),
         controller = OTPController().apply {
             onValueChanged(0, "123")
         }

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletScreen.kt
@@ -74,7 +74,7 @@ import com.stripe.android.payments.financialconnections.getIntentBuilder
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowController
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionElement
@@ -806,7 +806,7 @@ internal fun CardDetailsRecollectionForm(
             if (isCardExpired) {
                 add(
                     element = SimpleTextElement(
-                        identifier = IdentifierSpec.Generic("date"),
+                        identifier = FormFieldId.Generic("date"),
                         controller = expiryDateController
                     )
                 )
@@ -814,14 +814,14 @@ internal fun CardDetailsRecollectionForm(
 
             add(
                 element = CvcElement(
-                    _identifier = IdentifierSpec.CardCvc,
+                    _identifier = FormFieldId.CardCvc,
                     controller = cvcController
                 )
             )
         }
 
         RowElement(
-            _identifier = IdentifierSpec.Generic(paymentDetails.id),
+            _identifier = FormFieldId.Generic(paymentDetails.id),
             fields = rowFields,
             controller = RowController(rowFields)
         )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/BillingAddressFormElementsBuilder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/BillingAddressFormElementsBuilder.kt
@@ -14,7 +14,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
@@ -51,7 +51,7 @@ internal class BillingAddressFormElementsBuilder(
     private fun createCountryElement(requirement: CountryRequirement): FormElement {
         return SectionElement.wrap(
             CountryElement(
-                identifier = IdentifierSpec.Country,
+                identifier = FormFieldId.Country,
                 controller = DropdownFieldController(
                     config = CountryConfig(requirement.allowedCountryCodes),
                     initialValue = requirement.initialValue,
@@ -62,17 +62,17 @@ internal class BillingAddressFormElementsBuilder(
 
     private fun createAddressElements(): List<FormElement> {
         val sameAsShippingElement = arguments.shippingValues
-            ?.get(IdentifierSpec.SameAsShipping)
+            ?.get(FormFieldId.SameAsShipping)
             ?.toBooleanStrictOrNull()
             ?.let { sameAsShipping ->
                 SameAsShippingElement(
-                    identifier = IdentifierSpec.SameAsShipping,
+                    identifier = FormFieldId.SameAsShipping,
                     controller = SameAsShippingController(sameAsShipping),
                 )
             }
         val addressElement = arguments.autocompleteAddressInteractorFactory?.let { interactorFactory ->
             AutocompleteAddressElement(
-                identifier = IdentifierSpec.BillingAddress,
+                identifier = FormFieldId.BillingAddress,
                 initialValues = resolvedInitialValues,
                 countryCodes = fullAddressCountryCodes,
                 sameAsShippingElement = sameAsShippingElement,
@@ -81,7 +81,7 @@ internal class BillingAddressFormElementsBuilder(
                 interactorFactory = interactorFactory,
             )
         } ?: AddressElement(
-            _identifier = IdentifierSpec.BillingAddress,
+            _identifier = FormFieldId.BillingAddress,
             rawValuesMap = resolvedInitialValues,
             countryCodes = fullAddressCountryCodes,
             addressInputMode = AddressInputMode.NoAutocomplete(),
@@ -98,16 +98,16 @@ internal class BillingAddressFormElementsBuilder(
 
     private fun createAutomaticTaxBillingAddressElements(): List<FormElement> {
         val sameAsShippingElement = arguments.shippingValues
-            ?.get(IdentifierSpec.SameAsShipping)
+            ?.get(FormFieldId.SameAsShipping)
             ?.toBooleanStrictOrNull()
             ?.let { sameAsShipping ->
                 SameAsShippingElement(
-                    identifier = IdentifierSpec.SameAsShipping,
+                    identifier = FormFieldId.SameAsShipping,
                     controller = SameAsShippingController(sameAsShipping),
                 )
             }
         val billingAddressElement = BillingAddressElement(
-            identifier = IdentifierSpec.BillingAddress,
+            identifier = FormFieldId.BillingAddress,
             rawValuesMap = resolvedInitialValues,
             countryCodes = automaticTaxCountryCodes,
             autocompleteAddressInteractorFactory = arguments.autocompleteAddressInteractorFactory,
@@ -129,7 +129,7 @@ internal data class CountryRequirement(
     val allowedCountryCodes: Set<String>,
     val initialValue: String?,
 ) {
-    fun applyTo(initialValues: Map<IdentifierSpec, String?>): Map<IdentifierSpec, String?> {
-        return initialValues + (IdentifierSpec.Country to initialValue)
+    fun applyTo(initialValues: Map<FormFieldId, String?>): Map<FormFieldId, String?> {
+        return initialValues + (FormFieldId.Country to initialValue)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/ContactInformationCollectionMode.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/ContactInformationCollectionMode.kt
@@ -6,7 +6,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
@@ -22,10 +22,10 @@ internal enum class ContactInformationCollectionMode {
         ): PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = configuration.name
 
         override fun formElement(
-            initialValues: Map<IdentifierSpec, String?>
+            initialValues: Map<FormFieldId, String?>
         ): FormElement = SectionElement.wrap(
             SimpleTextElement(
-                identifier = IdentifierSpec.Name,
+                identifier = FormFieldId.Name,
                 controller = SimpleTextFieldController(
                     textFieldConfig = SimpleTextFieldConfig(
                         label = resolvableString(CoreR.string.stripe_address_label_full_name),
@@ -33,7 +33,7 @@ internal enum class ContactInformationCollectionMode {
                         keyboard = KeyboardType.Text,
                         optional = false,
                     ),
-                    initialValue = initialValues[IdentifierSpec.Name],
+                    initialValue = initialValues[FormFieldId.Name],
                 )
             )
         )
@@ -44,12 +44,12 @@ internal enum class ContactInformationCollectionMode {
         ): PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = configuration.phone
 
         override fun formElement(
-            initialValues: Map<IdentifierSpec, String?>
+            initialValues: Map<FormFieldId, String?>
         ): FormElement = SectionElement.wrap(
             PhoneNumberElement(
-                identifier = IdentifierSpec.Phone,
+                identifier = FormFieldId.Phone,
                 controller = PhoneNumberController.createPhoneNumberController(
-                    initialValue = initialValues[IdentifierSpec.Phone] ?: "",
+                    initialValue = initialValues[FormFieldId.Phone] ?: "",
                 )
             )
         )
@@ -60,11 +60,11 @@ internal enum class ContactInformationCollectionMode {
         ): PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = configuration.email
 
         override fun formElement(
-            initialValues: Map<IdentifierSpec, String?>
+            initialValues: Map<FormFieldId, String?>
         ): FormElement = SectionElement.wrap(
             EmailElement(
-                identifier = IdentifierSpec.Email,
-                initialValue = initialValues[IdentifierSpec.Email],
+                identifier = FormFieldId.Email,
+                initialValue = initialValues[FormFieldId.Email],
             )
         )
     };
@@ -73,7 +73,7 @@ internal enum class ContactInformationCollectionMode {
         configuration: PaymentSheet.BillingDetailsCollectionConfiguration
     ): PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode
 
-    abstract fun formElement(initialValues: Map<IdentifierSpec, String?>): FormElement
+    abstract fun formElement(initialValues: Map<FormFieldId, String?>): FormElement
 
     fun isAllowed(configuration: PaymentSheet.BillingDetailsCollectionConfiguration): Boolean {
         val collectionMode = collectionMode(configuration = configuration)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/InitialValuesFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/InitialValuesFactory.kt
@@ -4,7 +4,7 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.forms.convertToFormValuesMap
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.ParameterDestination
 
 internal object InitialValuesFactory {
@@ -12,7 +12,7 @@ internal object InitialValuesFactory {
         defaultBillingDetails: PaymentSheet.BillingDetails?,
         paymentMethodCreateParams: PaymentMethodCreateParams?,
         paymentMethodExtraParams: PaymentMethodExtraParams?
-    ): Map<IdentifierSpec, String?> {
+    ): Map<FormFieldId, String?> {
         val initialValues = paymentMethodCreateParams?.let {
             convertToFormValuesMap(it.toParamMap())
         } ?: emptyMap()
@@ -24,15 +24,15 @@ internal object InitialValuesFactory {
         } ?: emptyMap()
 
         return mapOf(
-            IdentifierSpec.Name to defaultBillingDetails?.name,
-            IdentifierSpec.Email to defaultBillingDetails?.email,
-            IdentifierSpec.Phone to defaultBillingDetails?.phone,
-            IdentifierSpec.Line1 to defaultBillingDetails?.address?.line1,
-            IdentifierSpec.Line2 to defaultBillingDetails?.address?.line2,
-            IdentifierSpec.City to defaultBillingDetails?.address?.city,
-            IdentifierSpec.State to defaultBillingDetails?.address?.state,
-            IdentifierSpec.Country to defaultBillingDetails?.address?.country,
-            IdentifierSpec.PostalCode to defaultBillingDetails?.address?.postalCode
+            FormFieldId.Name to defaultBillingDetails?.name,
+            FormFieldId.Email to defaultBillingDetails?.email,
+            FormFieldId.Phone to defaultBillingDetails?.phone,
+            FormFieldId.Line1 to defaultBillingDetails?.address?.line1,
+            FormFieldId.Line2 to defaultBillingDetails?.address?.line2,
+            FormFieldId.City to defaultBillingDetails?.address?.city,
+            FormFieldId.State to defaultBillingDetails?.address?.state,
+            FormFieldId.Country to defaultBillingDetails?.address?.country,
+            FormFieldId.PostalCode to defaultBillingDetails?.address?.postalCode
         ).plus(initialValues).plus(initialExtras)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/SaveForFutureUseHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/SaveForFutureUseHelper.kt
@@ -11,7 +11,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 internal fun isSaveForFutureUseValueChangeable(
     code: PaymentMethodCode,
@@ -89,6 +89,6 @@ private fun getSetAsDefaultInitialValueFromArguments(
     arguments: UiDefinitionFactory.Arguments
 ): Boolean {
     return arguments.initialValues.entries.firstOrNull {
-        it.key.v1.contains(IdentifierSpec.SetAsDefaultPaymentMethod.v1)
+        it.key.v1.contains(FormFieldId.SetAsDefaultPaymentMethod.v1)
     }?.value?.toBoolean() ?: false
 }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionFactory.kt
@@ -27,7 +27,7 @@ import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormData
 import com.stripe.android.ui.core.elements.FORM_ELEMENT_SET_DEFAULT_MATCHES_SAVE_FOR_FUTURE_DEFAULT_VALUE
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import kotlinx.coroutines.CoroutineScope
 
 internal sealed interface UiDefinitionFactory {
@@ -50,9 +50,9 @@ internal sealed interface UiDefinitionFactory {
         val coroutineScope: CoroutineScope,
         val cardAccountRangeRepositoryFactory: CardAccountRangeRepository.Factory,
         val linkConfigurationCoordinator: LinkConfigurationCoordinator?,
-        val initialValues: Map<IdentifierSpec, String?>,
+        val initialValues: Map<FormFieldId, String?>,
         val initialLinkUserInput: UserInput?,
-        val shippingValues: Map<IdentifierSpec, String?>?,
+        val shippingValues: Map<FormFieldId, String?>?,
         val saveForFutureUseInitialValue: Boolean,
         val merchantName: String,
         val cbcEligibility: CardBrandChoiceEligibility,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmDefinition.kt
@@ -10,7 +10,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.elements.AffirmHeaderElement
 import com.stripe.android.ui.core.elements.PaymentMethodMessageHeaderElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.R as StripeR
 import com.stripe.android.ui.core.R as UiCoreR
 
@@ -54,12 +54,12 @@ private object AffirmUiDefinitionFactory : UiDefinitionFactory.Simple() {
         )
         val header = if (message != null) {
             PaymentMethodMessageHeaderElement(
-                identifier = IdentifierSpec.Generic("affirm_promotion"),
+                identifier = FormFieldId.Generic("affirm_promotion"),
                 promotion = message
             )
         } else {
             AffirmHeaderElement(
-                identifier = IdentifierSpec.Generic("affirm_header")
+                identifier = FormFieldId.Generic("affirm_header")
             )
         }
         builder.header(header)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayDefinition.kt
@@ -13,7 +13,7 @@ import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.currency
 import com.stripe.android.ui.core.elements.AfterpayClearpayHeaderElement
 import com.stripe.android.ui.core.elements.PaymentMethodMessageHeaderElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.ui.core.R as UiCoreR
 
 internal object AfterpayClearpayDefinition : PaymentMethodDefinition {
@@ -69,12 +69,12 @@ private object AfterpayClearpayUiDefinitionFactory : UiDefinitionFactory.Simple(
 
         val header = if (promotion != null) {
             PaymentMethodMessageHeaderElement(
-                identifier = IdentifierSpec.Generic("afterpay_promotion"),
+                identifier = FormFieldId.Generic("afterpay_promotion"),
                 promotion = promotion
             )
         } else {
             AfterpayClearpayHeaderElement(
-                identifier = IdentifierSpec.Generic("afterpay_header"),
+                identifier = FormFieldId.Generic("afterpay_header"),
                 currency = metadata.stripeIntent.currency
             )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayDefinition.kt
@@ -9,7 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.MandateTextElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 internal object AmazonPayDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.AmazonPay
@@ -47,7 +47,7 @@ private object AmazonPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
         if (AmazonPayDefinition.requiresMandate(metadata)) {
             builder.footer(
                 MandateTextElement(
-                    identifier = IdentifierSpec.Generic("mandate"),
+                    identifier = FormFieldId.Generic("mandate"),
                     stringResId = R.string.stripe_amazon_pay_mandate,
                     args = listOf(arguments.merchantName)
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitDefinition.kt
@@ -15,7 +15,7 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.AuBankAccountNumberConfig
 import com.stripe.android.ui.core.elements.AuBecsDebitMandateTextElement
 import com.stripe.android.ui.core.elements.BsbElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
@@ -41,8 +41,8 @@ internal object AuBecsDebitDefinition : PaymentMethodDefinition {
 }
 
 private object AuBecsDebitUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    private val bsbNumberIdentifier = IdentifierSpec.Generic("au_becs_debit[bsb_number]")
-    private val accountNumberIdentifier = IdentifierSpec.Generic("au_becs_debit[account_number]")
+    private val bsbNumberIdentifier = FormFieldId.Generic("au_becs_debit[bsb_number]")
+    private val accountNumberIdentifier = FormFieldId.Generic("au_becs_debit[account_number]")
 
     override fun createSupportedPaymentMethod(
         metadata: PaymentMethodMetadata,
@@ -66,7 +66,7 @@ private object AuBecsDebitUiDefinitionFactory : UiDefinitionFactory.Simple() {
                 type = ContactInformationCollectionMode.Name,
                 formElement = SectionElement.wrap(
                     SimpleTextElement(
-                        identifier = IdentifierSpec.Name,
+                        identifier = FormFieldId.Name,
                         controller = SimpleTextFieldController(
                             textFieldConfig = SimpleTextFieldConfig(
                                 label = StripeR.string.stripe_au_becs_account_name.resolvableString,
@@ -74,7 +74,7 @@ private object AuBecsDebitUiDefinitionFactory : UiDefinitionFactory.Simple() {
                                 keyboard = KeyboardType.Text,
                                 optional = false,
                             ),
-                            initialValue = arguments.initialValues[IdentifierSpec.Name],
+                            initialValue = arguments.initialValues[FormFieldId.Name],
                         ),
                     ),
                 ),
@@ -84,7 +84,7 @@ private object AuBecsDebitUiDefinitionFactory : UiDefinitionFactory.Simple() {
             .overrideContactInformationPosition(ContactInformationCollectionMode.Phone)
             .element(
                 BsbElement(
-                    identifierSpec = bsbNumberIdentifier,
+                    formFieldId = bsbNumberIdentifier,
                     initialValue = arguments.initialValues[bsbNumberIdentifier],
                 )
             )
@@ -103,7 +103,7 @@ private object AuBecsDebitUiDefinitionFactory : UiDefinitionFactory.Simple() {
                 if (metadata.mandateAllowed(AuBecsDebitDefinition.type)) {
                     footer(
                         AuBecsDebitMandateTextElement(
-                            identifier = IdentifierSpec.Generic("au_becs_mandate"),
+                            identifier = FormFieldId.Generic("au_becs_mandate"),
                             merchantName = arguments.merchantName,
                         )
                     )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitDefinition.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.elements.BacsDebitAccountNumberConfig
 import com.stripe.android.ui.core.elements.BacsDebitSortCodeConfig
 import com.stripe.android.uicore.elements.CheckboxFieldController
 import com.stripe.android.uicore.elements.CheckboxFieldElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
@@ -38,8 +38,8 @@ internal object BacsDebitDefinition : PaymentMethodDefinition {
 }
 
 private object BacsDebitUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    private val sortCodeIdentifier = IdentifierSpec.Generic("bacs_debit[sort_code]")
-    private val accountNumberIdentifier = IdentifierSpec.Generic("bacs_debit[account_number]")
+    private val sortCodeIdentifier = FormFieldId.Generic("bacs_debit[sort_code]")
+    private val accountNumberIdentifier = FormFieldId.Generic("bacs_debit[account_number]")
 
     override fun createSupportedPaymentMethod(
         metadata: PaymentMethodMetadata,
@@ -92,14 +92,14 @@ private object BacsDebitUiDefinitionFactory : UiDefinitionFactory.Simple() {
                 if (metadata.mandateAllowed(BacsDebitDefinition.type)) {
                     footer(
                         CheckboxFieldElement(
-                            identifier = IdentifierSpec.BacsDebitConfirmed,
+                            identifier = FormFieldId.BacsDebitConfirmed,
                             controller = CheckboxFieldController(
                                 labelResource = CheckboxFieldController.LabelResource(
                                     R.string.stripe_bacs_confirm_mandate_label,
                                     arguments.merchantName,
                                 ),
                                 debugTag = "BACS_MANDATE_CHECKBOX",
-                                initialValue = arguments.initialValues[IdentifierSpec.BacsDebitConfirmed].toBoolean(),
+                                initialValue = arguments.initialValues[FormFieldId.BacsDebitConfirmed].toBoolean(),
                             ),
                         )
                     )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinition.kt
@@ -10,7 +10,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.BlikConfig
 import com.stripe.android.ui.core.elements.BlikElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
 
@@ -48,7 +48,7 @@ private object BlikUiDefinitionFactory : UiDefinitionFactory.Simple() {
         val blikElement = BlikElement(
             controller = SimpleTextFieldController(
                 textFieldConfig = BlikConfig(),
-                initialValue = arguments.initialValues[IdentifierSpec.BlikCode],
+                initialValue = arguments.initialValues[FormFieldId.BlikCode],
             ),
         )
         builder.element(SectionElement.wrap(blikElement))

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoDefinition.kt
@@ -12,7 +12,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
@@ -49,16 +49,16 @@ private object BoletoUiDefinitionFactory : UiDefinitionFactory.Simple() {
         arguments: UiDefinitionFactory.Arguments,
         builder: FormElementsBuilder
     ) {
-        val taxIdElementIdentifierSpec = IdentifierSpec.Generic("boleto[tax_id]")
+        val taxIdElementFormFieldId = FormFieldId.Generic("boleto[tax_id]")
         val taxIdElement = SimpleTextElement(
-            taxIdElementIdentifierSpec,
+            taxIdElementFormFieldId,
             SimpleTextFieldController(
                 SimpleTextFieldConfig(
                     label = resolvableString(R.string.stripe_boleto_tax_id_label),
                     capitalization = KeyboardCapitalization.None,
                     keyboard = KeyboardType.Ascii,
                 ),
-                initialValue = arguments.initialValues[taxIdElementIdentifierSpec],
+                initialValue = arguments.initialValues[taxIdElementFormFieldId],
             )
         )
 

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardDefinition.kt
@@ -37,7 +37,7 @@ import com.stripe.android.ui.core.elements.RenderableFormElement
 import com.stripe.android.ui.core.elements.cardBillingAddressCollectionMode
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SameAsShippingController
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
@@ -127,7 +127,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                     coroutineScope = arguments.coroutineScope,
                     cardAccountRangeRepositoryFactory = arguments.cardAccountRangeRepositoryFactory,
                     initialValues = arguments.initialValues,
-                    identifier = IdentifierSpec.Generic("card_details"),
+                    identifier = FormFieldId.Generic("card_details"),
                     collectName = billingDetailsCollectionConfiguration.collectsName,
                     cbcEligibility = arguments.cbcEligibility,
                     cardBrandFilter = arguments.cardBrandFilter,
@@ -177,7 +177,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
                 val linkBrand = metadata.linkState?.configuration?.linkBrand ?: return@buildList
                 add(
                     CombinedLinkMandateElement(
-                        identifier = IdentifierSpec.Generic("card_mandate"),
+                        identifier = FormFieldId.Generic("card_mandate"),
                         merchantName = metadata.merchantName,
                         linkBrand = linkBrand,
                         signupMode = signupMode,
@@ -189,7 +189,7 @@ private object CardUiDefinitionFactory : UiDefinitionFactory.Custom {
             } else if (metadata.hasIntentToSetup(CardDefinition.type.code) && mandateAllowed) {
                 add(
                     MandateTextElement(
-                        identifier = IdentifierSpec.Generic("card_mandate"),
+                        identifier = FormFieldId.Generic("card_mandate"),
                         stringResId = PaymentSheetR.string.stripe_paymentsheet_card_mandate,
                         topPadding = when {
                             signupMode == LinkSignupMode.AlongsideSaveForFutureUse -> 0.dp
@@ -274,21 +274,21 @@ private fun cardBillingElements(
     allowedCountries: Set<String>,
     collectionConfiguration: BillingDetailsCollectionConfiguration,
     autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
-    initialValues: Map<IdentifierSpec, String?>,
-    shippingValues: Map<IdentifierSpec, String?>?,
+    initialValues: Map<FormFieldId, String?>,
+    shippingValues: Map<FormFieldId, String?>?,
     requiresBillingAddressForAutomaticTax: Boolean,
 ): List<FormElement> {
     val sameAsShippingElement =
-        shippingValues?.get(IdentifierSpec.SameAsShipping)
+        shippingValues?.get(FormFieldId.SameAsShipping)
             ?.toBooleanStrictOrNull()
             ?.let {
                 SameAsShippingElement(
-                    identifier = IdentifierSpec.SameAsShipping,
+                    identifier = FormFieldId.SameAsShipping,
                     controller = SameAsShippingController(it)
                 )
             }
     val addressElement = BillingAddressElement(
-        IdentifierSpec.Generic("credit_billing"),
+        FormFieldId.Generic("credit_billing"),
         countryCodes = allowedCountries,
         rawValuesMap = initialValues,
         sameAsShippingElement = sameAsShippingElement,
@@ -319,7 +319,7 @@ private fun cardBillingElements(
 }
 
 internal class CombinedLinkMandateElement(
-    identifier: IdentifierSpec,
+    identifier: FormFieldId,
     signupMode: LinkSignupMode?,
     canChangeSaveForFutureUse: Boolean,
     private val merchantName: String,
@@ -330,7 +330,7 @@ internal class CombinedLinkMandateElement(
     allowsUserInteraction = false,
     identifier = identifier
 ) {
-    override fun getFormFieldValueFlow() = stateFlowOf(emptyList<Pair<IdentifierSpec, FormFieldEntry>>())
+    override fun getFormFieldValueFlow() = stateFlowOf(emptyList<Pair<FormFieldId, FormFieldEntry>>())
 
     private val topPadding = when {
         signupMode == LinkSignupMode.AlongsideSaveForFutureUse -> 0.dp
@@ -342,8 +342,8 @@ internal class CombinedLinkMandateElement(
     @Composable
     override fun ComposeUI(
         enabled: Boolean,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         val linkState by linkSignupStateFlow.collectAsState()
         Mandate(

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayDefinition.kt
@@ -9,7 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.MandateTextElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 internal object CashAppPayDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.CashAppPay
@@ -45,7 +45,7 @@ private object CashAppPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
         if (CashAppPayDefinition.requiresMandate(metadata)) {
             builder.footer(
                 MandateTextElement(
-                    identifier = IdentifierSpec.Generic("cashapp_mandate"),
+                    identifier = FormFieldId.Generic("cashapp_mandate"),
                     stringResId = R.string.stripe_cash_app_pay_mandate,
                     args = listOf(arguments.merchantName, arguments.merchantName)
                 )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CustomPaymentMethodUiDefinitionFactory.kt
@@ -7,7 +7,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.DisplayableCustomPaymentM
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.ui.core.elements.StaticTextElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 internal class CustomPaymentMethodUiDefinitionFactory(
     private val displayableCustomPaymentMethod: DisplayableCustomPaymentMethod
@@ -35,7 +35,7 @@ internal class CustomPaymentMethodUiDefinitionFactory(
         displayableCustomPaymentMethod.subtitle?.let { subtitle ->
             builder.header(
                 StaticTextElement(
-                    identifier = IdentifierSpec.Generic("CustomPaymentMethodHeader"),
+                    identifier = FormFieldId.Generic("CustomPaymentMethodHeader"),
                     text = subtitle,
                 )
             )

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsDefinition.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.elements.DropdownItem
 import com.stripe.android.ui.core.elements.SimpleDropdownConfig
 import com.stripe.android.ui.core.elements.SimpleDropdownElement
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 
 internal object EpsDefinition : PaymentMethodDefinition {
@@ -36,7 +36,7 @@ internal object EpsDefinition : PaymentMethodDefinition {
 }
 
 private object EpsUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    private val epsIdentifier = IdentifierSpec.Generic("eps[bank]")
+    private val epsIdentifier = FormFieldId.Generic("eps[bank]")
 
     override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = EpsDefinition,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxDefinition.kt
@@ -13,7 +13,7 @@ import com.stripe.android.ui.core.elements.DropdownItem
 import com.stripe.android.ui.core.elements.SimpleDropdownConfig
 import com.stripe.android.ui.core.elements.SimpleDropdownElement
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 
 internal object FpxDefinition : PaymentMethodDefinition {
@@ -35,7 +35,7 @@ internal object FpxDefinition : PaymentMethodDefinition {
 }
 
 private object FpxUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    private val fpsIdentifier = IdentifierSpec.Generic("fpx[bank]")
+    private val fpsIdentifier = FormFieldId.Generic("fpx[bank]")
 
     override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = FpxDefinition,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinition.kt
@@ -17,7 +17,7 @@ import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.PaymentMethodMessageHeaderElement
 import com.stripe.android.ui.core.elements.StaticTextElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 internal object KlarnaDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Klarna
@@ -63,7 +63,7 @@ private object KlarnaUiDefinitionFactory : UiDefinitionFactory.Simple() {
             .overrideContactInformationPosition(ContactInformationCollectionMode.Phone)
             .requireCountry(
                 allowedCountryCodes = metadata.billingDetailsCollectionConfiguration.allowedBillingCountries,
-                initialValue = arguments.initialValues[IdentifierSpec.Country],
+                initialValue = arguments.initialValues[FormFieldId.Country],
             )
             .apply {
                 if (KlarnaDefinition.requiresMandate(metadata)) {
@@ -87,12 +87,12 @@ private object KlarnaUiDefinitionFactory : UiDefinitionFactory.Simple() {
         )
         return if (message != null) {
             PaymentMethodMessageHeaderElement(
-                identifier = IdentifierSpec.Generic("klarna_promotion"),
+                identifier = FormFieldId.Generic("klarna_promotion"),
                 promotion = message
             )
         } else {
             StaticTextElement(
-                identifier = IdentifierSpec.Generic("klarna_header_text"),
+                identifier = FormFieldId.Generic("klarna_header_text"),
                 stringResId = R.string.stripe_klarna_buy_now_pay_later
             )
         }
@@ -120,13 +120,13 @@ private object KlarnaRemovedFormUiDefinitionFactory : UiDefinitionFactory.Simple
             builder
                 .header(
                     StaticTextElement(
-                        IdentifierSpec.Generic("klarna_header_text"),
+                        FormFieldId.Generic("klarna_header_text"),
                         stringResId = R.string.stripe_klarna_buy_now_pay_later
                     )
                 )
                 .requireCountry(
                     allowedCountryCodes = arguments.billingDetailsCollectionConfiguration.allowedBillingCountries,
-                    initialValue = arguments.initialValues[IdentifierSpec.Country]
+                    initialValue = arguments.initialValues[FormFieldId.Country]
                         ?: metadata.stripeIntent.countryCode,
                 )
         }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniDefinition.kt
@@ -12,7 +12,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
@@ -51,7 +51,7 @@ private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple() {
         builder: FormElementsBuilder,
     ) {
         val confirmationNumberElement = SimpleTextElement(
-            identifier = IdentifierSpec.KonbiniConfirmationNumber,
+            identifier = FormFieldId.KonbiniConfirmationNumber,
             controller = SimpleTextFieldController(
                 textFieldConfig = SimpleTextFieldConfig(
                     label = resolvableString(R.string.stripe_konbini_confirmation_number_label),
@@ -59,7 +59,7 @@ private object KonbiniUiDefinitionFactory : UiDefinitionFactory.Simple() {
                     keyboard = KeyboardType.Phone,
                     optional = true,
                 ),
-                initialValue = arguments.initialValues[IdentifierSpec.KonbiniConfirmationNumber],
+                initialValue = arguments.initialValues[FormFieldId.KonbiniConfirmationNumber],
             ),
         )
         builder

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/NaverPayDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/NaverPayDefinition.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.ui.core.elements.SimpleDropdownConfig
 import com.stripe.android.ui.core.elements.SimpleDropdownElement
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 
 internal object NaverPayDefinition : PaymentMethodDefinition {
@@ -36,7 +36,7 @@ internal object NaverPayDefinition : PaymentMethodDefinition {
 }
 
 private object NaverPayUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    private val fundingIdentifier = IdentifierSpec.Generic("naver_pay[funding]")
+    private val fundingIdentifier = FormFieldId.Generic("naver_pay[funding]")
 
     override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = NaverPayDefinition,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24Definition.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.elements.DropdownItem
 import com.stripe.android.ui.core.elements.SimpleDropdownConfig
 import com.stripe.android.ui.core.elements.SimpleDropdownElement
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 
 internal object P24Definition : PaymentMethodDefinition {
@@ -36,7 +36,7 @@ internal object P24Definition : PaymentMethodDefinition {
 }
 
 private object P24UiDefinitionFactory : UiDefinitionFactory.Simple() {
-    private val p24BankIdentifier = IdentifierSpec.Generic("p24[bank]")
+    private val p24BankIdentifier = FormFieldId.Generic("p24[bank]")
 
     override fun createSupportedPaymentMethod(metadata: PaymentMethodMetadata) = SupportedPaymentMethod(
         paymentMethodDefinition = P24Definition,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitDefinition.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.IbanConfig
 import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
@@ -39,7 +39,7 @@ internal object SepaDebitDefinition : PaymentMethodDefinition {
 }
 
 private object SepaDebitUiDefinitionFactory : UiDefinitionFactory.Simple() {
-    private val ibanIdentifier = IdentifierSpec.Generic("sepa_debit[iban]")
+    private val ibanIdentifier = FormFieldId.Generic("sepa_debit[iban]")
 
     override fun buildFormElements(
         metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroDefinition.kt
@@ -9,7 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.R
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 internal object WeroDefinition : PaymentMethodDefinition {
     override val type: PaymentMethod.Type = PaymentMethod.Type.Wero
@@ -45,7 +45,7 @@ private object WeroUiDefinitionFactory : UiDefinitionFactory.Simple() {
         builder
             .requireCountry(
                 allowedCountryCodes = setOf("DE", "BE", "FR"),
-                initialValue = arguments.initialValues[IdentifierSpec.Country],
+                initialValue = arguments.initialValues[FormFieldId.Country],
             )
             .overrideContactInformationPosition(ContactInformationCollectionMode.Name)
             .overrideContactInformationPosition(ContactInformationCollectionMode.Email)

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/link/LinkFormElement.kt
@@ -12,7 +12,7 @@ import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.ui.core.elements.RenderableFormElement
 import com.stripe.android.uicore.LocalSectionSpacing
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.StateFlow
@@ -26,17 +26,17 @@ internal class LinkFormElement(
     private val previousLinkSignupCheckboxSelection: Boolean?,
 ) : RenderableFormElement(
     allowsUserInteraction = true,
-    identifier = IdentifierSpec.Generic("link_form")
+    identifier = FormFieldId.Generic("link_form")
 ) {
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
         return stateFlowOf(listOf())
     }
 
     @Composable
     override fun ComposeUI(
         enabled: Boolean,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?,
     ) {
         val modifier = Modifier.run {
             if (LocalSectionSpacing.current == null) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressDetails.kt
@@ -4,7 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import dev.drewhamilton.poko.Poko
 import kotlinx.parcelize.Parcelize
 
@@ -36,22 +36,22 @@ class AddressDetails(
 
 internal fun AddressDetails.toIdentifierMap(
     billingDetails: PaymentSheet.BillingDetails? = null
-): Map<IdentifierSpec, String?> {
+): Map<FormFieldId, String?> {
     return if (billingDetails == null || !billingDetails.isFilledOut()) {
         mapOf(
-            IdentifierSpec.Name to name,
-            IdentifierSpec.Line1 to address?.line1,
-            IdentifierSpec.Line2 to address?.line2,
-            IdentifierSpec.City to address?.city,
-            IdentifierSpec.State to address?.state,
-            IdentifierSpec.PostalCode to address?.postalCode,
-            IdentifierSpec.Country to address?.country,
-            IdentifierSpec.Phone to phoneNumber
+            FormFieldId.Name to name,
+            FormFieldId.Line1 to address?.line1,
+            FormFieldId.Line2 to address?.line2,
+            FormFieldId.City to address?.city,
+            FormFieldId.State to address?.state,
+            FormFieldId.PostalCode to address?.postalCode,
+            FormFieldId.Country to address?.country,
+            FormFieldId.Phone to phoneNumber
         )
             .plus(billingDetails?.address?.toIdentifierMap() ?: emptyMap())
             .plus(
                 mapOf(
-                    IdentifierSpec.SameAsShipping to isCheckboxSelected?.toString()
+                    FormFieldId.SameAsShipping to isCheckboxSelected?.toString()
                 ).takeIf { isCheckboxSelected != null } ?: emptyMap()
             )
     } else {
@@ -59,14 +59,14 @@ internal fun AddressDetails.toIdentifierMap(
     }
 }
 
-internal fun PaymentSheet.Address.toIdentifierMap(): Map<IdentifierSpec, String?> {
+internal fun PaymentSheet.Address.toIdentifierMap(): Map<FormFieldId, String?> {
     return mapOf(
-        IdentifierSpec.Line1 to line1,
-        IdentifierSpec.Line2 to line2,
-        IdentifierSpec.City to city,
-        IdentifierSpec.State to state,
-        IdentifierSpec.PostalCode to postalCode,
-        IdentifierSpec.Country to country,
+        FormFieldId.Line1 to line1,
+        FormFieldId.Line2 to line2,
+        FormFieldId.City to city,
+        FormFieldId.State to state,
+        FormFieldId.PostalCode to postalCode,
+        FormFieldId.Country to country,
     )
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormController.kt
@@ -5,17 +5,17 @@ import com.stripe.android.uicore.elements.AddressFieldConfiguration
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.utils.mapAsStateFlow
 
 internal class AddressFormController(
-    val initialValues: Map<IdentifierSpec, String?>,
+    val initialValues: Map<FormFieldId, String?>,
     val config: AddressLauncher.Configuration?,
     val interactor: AutocompleteAddressInteractor,
 ) {
     private val autocompleteAddressElement = AutocompleteAddressElement(
-        identifier = IdentifierSpec.Generic("address"),
+        identifier = FormFieldId.Generic("address"),
         initialValues = initialValues,
         countryCodes = config?.allowedCountries ?: CountryUtils.supportedBillingCountries,
         nameConfig = AddressFieldConfiguration.REQUIRED,
@@ -47,5 +47,5 @@ internal class AddressFormController(
         }
         .toMap()
 
-    fun setRawValues(values: Map<IdentifierSpec, String?>) = autocompleteAddressElement.setRawValue(values)
+    fun setRawValues(values: Map<FormFieldId, String?>) = autocompleteAddressElement.setRawValue(values)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormatParser.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressFormatParser.kt
@@ -4,14 +4,14 @@ import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AddressFieldConfiguration
 import com.stripe.android.uicore.elements.AddressInputMode
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 internal class AddressFormatParser(
     private val config: AddressLauncher.Configuration?
 ) {
     fun parse(
         values: AddressDetails,
-    ): Map<IdentifierSpec, String?> {
+    ): Map<FormFieldId, String?> {
         val addressElement = createAddressElement(values)
 
         return addressElement.getFormFieldValueFlow().value.toMap().mapValues {
@@ -23,7 +23,7 @@ internal class AddressFormatParser(
         values: AddressDetails,
     ): AddressElement {
         return AddressElement(
-            _identifier = IdentifierSpec.Generic("address"),
+            _identifier = FormFieldId.Generic("address"),
             rawValuesMap = values.toIdentifierMap(),
             countryCodes = config?.allowedCountries ?: CountryUtils.supportedBillingCountries,
             addressInputMode = AddressInputMode.NoAutocomplete(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteController.kt
@@ -5,7 +5,7 @@ import com.stripe.android.model.Address
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
@@ -83,7 +83,7 @@ internal class InlineAutocompleteController(
                                 AutocompleteAddressInteractor.InlinePredictionsState.Idle
                             eventListenerProvider()?.invoke(
                                 AutocompleteAddressInteractor.Event.OnValues(
-                                    mapOf(IdentifierSpec.Country to c)
+                                    mapOf(FormFieldId.Country to c)
                                 )
                             )
                             return@collectLatest
@@ -99,7 +99,7 @@ internal class InlineAutocompleteController(
                         if (countryChanged && activationState != ActivationState.Inactive) {
                             eventListenerProvider()?.invoke(
                                 AutocompleteAddressInteractor.Event.OnValues(
-                                    mapOf(IdentifierSpec.Country to c)
+                                    mapOf(FormFieldId.Country to c)
                                 )
                             )
                         }
@@ -144,12 +144,12 @@ internal class InlineAutocompleteController(
         eventListenerProvider()?.invoke(
             AutocompleteAddressInteractor.Event.OnExpandForm(
                 mapOf(
-                    IdentifierSpec.Line1 to address.line1,
-                    IdentifierSpec.Line2 to address.line2,
-                    IdentifierSpec.City to address.city,
-                    IdentifierSpec.State to address.state,
-                    IdentifierSpec.PostalCode to address.postalCode,
-                    IdentifierSpec.Country to address.country,
+                    FormFieldId.Line1 to address.line1,
+                    FormFieldId.Line2 to address.line2,
+                    FormFieldId.City to address.city,
+                    FormFieldId.State to address.state,
+                    FormFieldId.PostalCode to address.postalCode,
+                    FormFieldId.Country to address.country,
                 )
             )
         )
@@ -266,9 +266,9 @@ internal class InlineAutocompleteController(
     }
 
     private fun emitExpandForm(query: String?, country: String?) {
-        val values = buildMap<IdentifierSpec, String?> {
-            query?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Line1, it) }
-            country?.takeIf { it.isNotBlank() }?.let { put(IdentifierSpec.Country, it) }
+        val values = buildMap<FormFieldId, String?> {
+            query?.takeIf { it.isNotBlank() }?.let { put(FormFieldId.Line1, it) }
+            country?.takeIf { it.isNotBlank() }?.let { put(FormFieldId.Country, it) }
         }.takeIf { it.isNotEmpty() }
 
         eventListenerProvider()?.invoke(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -11,7 +11,7 @@ import com.stripe.android.paymentsheet.injection.AddressElementViewModelModule
 import com.stripe.android.paymentsheet.injection.InputAddressViewModelSubcomponent
 import com.stripe.android.ui.core.elements.autocomplete.PlacesClientProxy
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -57,7 +57,7 @@ internal class InputAddressViewModel @Inject constructor(
         }
     )
 
-    private var previousUserInput: Map<IdentifierSpec, String?>? = if (initialInputsAreTheSame) {
+    private var previousUserInput: Map<FormFieldId, String?>? = if (initialInputsAreTheSame) {
         null
     } else {
         initialShippingAddress
@@ -190,21 +190,21 @@ internal class InputAddressViewModel @Inject constructor(
         val formValues = addressFormController.getCurrentFormValues()
 
         return AddressDetails(
-            name = formValues[IdentifierSpec.Name]?.value,
+            name = formValues[FormFieldId.Name]?.value,
             address = PaymentSheet.Address(
-                city = formValues[IdentifierSpec.City]?.value,
-                country = formValues[IdentifierSpec.Country]?.value,
-                line1 = formValues[IdentifierSpec.Line1]?.value,
-                line2 = formValues[IdentifierSpec.Line2]?.value,
-                postalCode = formValues[IdentifierSpec.PostalCode]?.value,
-                state = formValues[IdentifierSpec.State]?.value
+                city = formValues[FormFieldId.City]?.value,
+                country = formValues[FormFieldId.Country]?.value,
+                line1 = formValues[FormFieldId.Line1]?.value,
+                line2 = formValues[FormFieldId.Line2]?.value,
+                postalCode = formValues[FormFieldId.PostalCode]?.value,
+                state = formValues[FormFieldId.State]?.value
             ),
-            phoneNumber = formValues[IdentifierSpec.Phone]?.value
+            phoneNumber = formValues[FormFieldId.Phone]?.value
         )
     }
 
     fun clickPrimaryButton(
-        completedFormValues: Map<IdentifierSpec, FormFieldEntry>?,
+        completedFormValues: Map<FormFieldId, FormFieldEntry>?,
         checkboxChecked: Boolean
     ) {
         if (completedFormValues == null) {
@@ -214,16 +214,16 @@ internal class InputAddressViewModel @Inject constructor(
         _formEnabled.value = false
         dismissWithAddress(
             AddressDetails(
-                name = completedFormValues?.get(IdentifierSpec.Name)?.value,
+                name = completedFormValues?.get(FormFieldId.Name)?.value,
                 address = PaymentSheet.Address(
-                    city = completedFormValues?.get(IdentifierSpec.City)?.value,
-                    country = completedFormValues?.get(IdentifierSpec.Country)?.value,
-                    line1 = completedFormValues?.get(IdentifierSpec.Line1)?.value,
-                    line2 = completedFormValues?.get(IdentifierSpec.Line2)?.value,
-                    postalCode = completedFormValues?.get(IdentifierSpec.PostalCode)?.value,
-                    state = completedFormValues?.get(IdentifierSpec.State)?.value
+                    city = completedFormValues?.get(FormFieldId.City)?.value,
+                    country = completedFormValues?.get(FormFieldId.Country)?.value,
+                    line1 = completedFormValues?.get(FormFieldId.Line1)?.value,
+                    line2 = completedFormValues?.get(FormFieldId.Line2)?.value,
+                    postalCode = completedFormValues?.get(FormFieldId.PostalCode)?.value,
+                    state = completedFormValues?.get(FormFieldId.State)?.value
                 ),
-                phoneNumber = completedFormValues?.get(IdentifierSpec.Phone)?.value,
+                phoneNumber = completedFormValues?.get(FormFieldId.Phone)?.value,
                 isCheckboxSelected = checkboxChecked
             )
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilter.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.forms
 
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
@@ -12,10 +12,10 @@ import kotlinx.coroutines.flow.combine
  * the list of form elements into a [FormFieldValues].
  */
 internal class CompleteFormFieldValueFilter(
-    private val currentFieldValueMap: Flow<Map<IdentifierSpec, FormFieldEntry>>,
-    private val hiddenIdentifiers: Flow<Set<IdentifierSpec>>,
+    private val currentFieldValueMap: Flow<Map<FormFieldId, FormFieldEntry>>,
+    private val hiddenIdentifiers: Flow<Set<FormFieldId>>,
     private val userRequestedReuse: Flow<PaymentSelection.CustomerRequestedSave>,
-    private val defaultValues: Map<IdentifierSpec, String>,
+    private val defaultValues: Map<FormFieldId, String>,
 ) {
     /**
      * This flow does not emit any value until all form field values are complete, then it emits an
@@ -35,10 +35,10 @@ internal class CompleteFormFieldValueFilter(
     }
 
     private fun filterFlow(
-        idFieldSnapshotMap: Map<IdentifierSpec, FormFieldEntry>,
-        hiddenIdentifiers: Set<IdentifierSpec>,
+        idFieldSnapshotMap: Map<FormFieldId, FormFieldEntry>,
+        hiddenIdentifiers: Set<FormFieldId>,
         userRequestedReuse: PaymentSelection.CustomerRequestedSave,
-        defaultValues: Map<IdentifierSpec, String>,
+        defaultValues: Map<FormFieldId, String>,
     ): FormFieldValues? {
         // This will run twice in a row when the save for future use state changes: once for the
         // saveController changing and once for the the hidden fields changing

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormFieldValues.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormFieldValues.kt
@@ -1,13 +1,13 @@
 package com.stripe.android.paymentsheet.forms
 
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 
 /**
- * The identifier here comes from the form element (section, static text, etc)
+ * The field ID comes from the form element (section, static text, etc).
  */
 internal data class FormFieldValues(
-    val fieldValuePairs: Map<IdentifierSpec, FormFieldEntry> = mapOf(),
+    val fieldValuePairs: Map<FormFieldId, FormFieldEntry> = mapOf(),
     val userRequestedReuse: PaymentSelection.CustomerRequestedSave
 )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/forms/FormViewModel.kt
@@ -10,7 +10,7 @@ import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.uicore.elements.AddressFieldsElement
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
@@ -66,7 +66,7 @@ internal class FormViewModel(
         .filterIsInstance<BillingAddressElement>()
         .firstOrNull()
 
-    private var externalHiddenIdentifiers = MutableStateFlow(emptySet<IdentifierSpec>())
+    private var externalHiddenIdentifiers = MutableStateFlow(emptySet<FormFieldId>())
 
     init {
         viewModelScope.launch {
@@ -75,8 +75,8 @@ internal class FormViewModel(
     }
 
     @VisibleForTesting
-    internal fun addHiddenIdentifiers(identifierSpecs: Set<IdentifierSpec>) {
-        externalHiddenIdentifiers.value = identifierSpecs
+    internal fun addHiddenIdentifiers(formFieldIds: Set<FormFieldId>) {
+        externalHiddenIdentifiers.value = formFieldIds
     }
 
     internal val hiddenIdentifiers = combineAsStateFlow(
@@ -88,7 +88,7 @@ internal class FormViewModel(
 
     // This will convert the save for future use value into a CustomerRequestedSave operation
     private val userRequestedReuse = currentFieldValues().map { currentFieldValues ->
-        currentFieldValues.filter { it.first == IdentifierSpec.SaveForFutureUse }
+        currentFieldValues.filter { it.first == FormFieldId.SaveForFutureUse }
             .map { it.second.value.toBoolean() }
             .map { saveForFutureUse ->
                 if (saveForFutureUse) {
@@ -108,7 +108,7 @@ internal class FormViewModel(
             formArguments.defaultFormValues,
         ).filterFlow()
 
-    private fun currentFieldValues(): Flow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    private fun currentFieldValues(): Flow<List<Pair<FormFieldId, FormFieldEntry>>> {
         return if (elements.isEmpty()) {
             flowOf(emptyList())
         } else {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/FormArguments.kt
@@ -8,7 +8,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 
 internal data class FormArguments(
@@ -24,18 +24,18 @@ internal data class FormArguments(
         PaymentSheet.BillingDetailsCollectionConfiguration(),
 ) {
     val defaultFormValues by lazy {
-        mutableMapOf<IdentifierSpec, String>().apply {
+        mutableMapOf<FormFieldId, String>().apply {
             if (billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod) {
                 billingDetails?.let { billingDetails ->
-                    billingDetails.name?.let { this[IdentifierSpec.Name] = it }
-                    billingDetails.email?.let { this[IdentifierSpec.Email] = it }
-                    billingDetails.phone?.let { this[IdentifierSpec.Phone] = it }
-                    billingDetails.address?.line1?.let { this[IdentifierSpec.Companion.Line1] = it }
-                    billingDetails.address?.line2?.let { this[IdentifierSpec.Companion.Line2] = it }
-                    billingDetails.address?.city?.let { this[IdentifierSpec.Companion.City] = it }
-                    billingDetails.address?.state?.let { this[IdentifierSpec.Companion.State] = it }
-                    billingDetails.address?.postalCode?.let { this[IdentifierSpec.Companion.PostalCode] = it }
-                    billingDetails.address?.country?.let { this[IdentifierSpec.Companion.Country] = it }
+                    billingDetails.name?.let { this[FormFieldId.Name] = it }
+                    billingDetails.email?.let { this[FormFieldId.Email] = it }
+                    billingDetails.phone?.let { this[FormFieldId.Phone] = it }
+                    billingDetails.address?.line1?.let { this[FormFieldId.Companion.Line1] = it }
+                    billingDetails.address?.line2?.let { this[FormFieldId.Companion.Line2] = it }
+                    billingDetails.address?.city?.let { this[FormFieldId.Companion.City] = it }
+                    billingDetails.address?.state?.let { this[FormFieldId.Companion.State] = it }
+                    billingDetails.address?.postalCode?.let { this[FormFieldId.Companion.PostalCode] = it }
+                    billingDetails.address?.country?.let { this[FormFieldId.Companion.Country] = it }
                 }
             }
         }.toMap()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -48,8 +48,8 @@ import com.stripe.android.uicore.IconStyle
 import com.stripe.android.uicore.LocalIconStyle
 import com.stripe.android.uicore.elements.AddressController
 import com.stripe.android.uicore.elements.AddressElementUI
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.H6Text
-import com.stripe.android.uicore.elements.IdentifierSpec
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.PhoneNumberElementUI
 import com.stripe.android.uicore.elements.SameAsShippingElement
@@ -148,7 +148,7 @@ internal fun BankAccountForm(
     emailController: TextFieldController,
     phoneController: PhoneNumberController,
     addressController: AddressController,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    lastTextFieldIdentifier: FormFieldId?,
     sameAsShippingElement: SameAsShippingElement?,
     saveForFutureUseElement: SaveForFutureUseElement,
     setAsDefaultPaymentMethodElement: SetAsDefaultPaymentMethodElement?,
@@ -215,7 +215,7 @@ private fun BillingDetailsForm(
     emailController: TextFieldController,
     phoneController: PhoneNumberController,
     addressController: AddressController,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    lastTextFieldIdentifier: FormFieldId?,
     sameAsShippingElement: SameAsShippingElement?,
 ) {
     Column(
@@ -271,7 +271,7 @@ private fun BillingDetailsForm(
                     TextField(
                         textFieldController = emailController,
                         enabled = enabled,
-                        imeAction = if (lastTextFieldIdentifier == IdentifierSpec.Email) {
+                        imeAction = if (lastTextFieldIdentifier == FormFieldId.Email) {
                             ImeAction.Done
                         } else {
                             ImeAction.Next
@@ -284,7 +284,7 @@ private fun BillingDetailsForm(
             PhoneSection(
                 enabled = enabled,
                 phoneController = phoneController,
-                imeAction = if (lastTextFieldIdentifier == IdentifierSpec.Phone) {
+                imeAction = if (lastTextFieldIdentifier == FormFieldId.Phone) {
                     ImeAction.Done
                 } else {
                     ImeAction.Next
@@ -337,7 +337,7 @@ private fun PhoneSection(
 private fun AddressSection(
     enabled: Boolean,
     addressController: AddressController,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    lastTextFieldIdentifier: FormFieldId?,
     sameAsShippingElement: SameAsShippingElement?,
     modifier: Modifier = Modifier,
 ) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -52,7 +52,7 @@ import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.EmailConfig
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.SameAsShippingController
@@ -145,11 +145,11 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     }
 
     private val lastNonAddressTextFieldIdentifier = if (collectingPhone) {
-        IdentifierSpec.Phone
+        FormFieldId.Phone
     } else if (collectingEmail) {
-        IdentifierSpec.Email
+        FormFieldId.Email
     } else if (collectingName) {
-        IdentifierSpec.Name
+        FormFieldId.Name
     } else {
         null
     }
@@ -173,18 +173,18 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
     val sameAsShippingElement = args.formArgs.shippingDetails
         ?.toIdentifierMap(defaultBillingDetails)
-        ?.get(IdentifierSpec.SameAsShipping)
+        ?.get(FormFieldId.SameAsShipping)
         ?.toBooleanStrictOrNull()
         ?.let {
             SameAsShippingElement(
-                identifier = IdentifierSpec.SameAsShipping,
+                identifier = FormFieldId.SameAsShipping,
                 controller = SameAsShippingController(it)
             )
         }
 
     private val autocompleteAddressElement = autocompleteAddressInteractorFactory?.let {
         AutocompleteAddressElement(
-            identifier = IdentifierSpec.Generic("billing_details[address]"),
+            identifier = FormFieldId.Generic("billing_details[address]"),
             initialValues = defaultAddress?.asFormFieldValues() ?: emptyMap(),
             countryCodes = collectionConfiguration.allowedBillingCountries,
             sameAsShippingElement = sameAsShippingElement,
@@ -194,7 +194,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     }
 
     val addressElement = autocompleteAddressElement ?: AddressElement(
-        _identifier = IdentifierSpec.Generic("billing_details[address]"),
+        _identifier = FormFieldId.Generic("billing_details[address]"),
         rawValuesMap = defaultAddress?.asFormFieldValues() ?: emptyMap(),
         countryCodes = collectionConfiguration.allowedBillingCountries,
         sameAsShippingElement = sameAsShippingElement,
@@ -212,7 +212,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         }
     }
 
-    val lastTextFieldIdentifier: StateFlow<IdentifierSpec?> = if (collectingAddress) {
+    val lastTextFieldIdentifier: StateFlow<FormFieldId?> = if (collectingAddress) {
         addressElement.getTextFieldIdentifiers().mapAsStateFlow {
             it.lastOrNull() ?: lastNonAddressTextFieldIdentifier
         }
@@ -881,23 +881,23 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
     }
 }
 
-internal fun Address.asFormFieldValues(): Map<IdentifierSpec, String?> = mapOf(
-    IdentifierSpec.Line1 to line1,
-    IdentifierSpec.Line2 to line2,
-    IdentifierSpec.City to city,
-    IdentifierSpec.State to state,
-    IdentifierSpec.Country to country,
-    IdentifierSpec.PostalCode to postalCode,
+internal fun Address.asFormFieldValues(): Map<FormFieldId, String?> = mapOf(
+    FormFieldId.Line1 to line1,
+    FormFieldId.Line2 to line2,
+    FormFieldId.City to city,
+    FormFieldId.State to state,
+    FormFieldId.Country to country,
+    FormFieldId.PostalCode to postalCode,
 )
 
-internal fun Address.Companion.fromFormFieldValues(formFieldValues: Map<IdentifierSpec, String?>) =
+internal fun Address.Companion.fromFormFieldValues(formFieldValues: Map<FormFieldId, String?>) =
     Address(
-        line1 = formFieldValues[IdentifierSpec.Line1],
-        line2 = formFieldValues[IdentifierSpec.Line2],
-        city = formFieldValues[IdentifierSpec.City],
-        state = formFieldValues[IdentifierSpec.State],
-        country = formFieldValues[IdentifierSpec.Country],
-        postalCode = formFieldValues[IdentifierSpec.PostalCode],
+        line1 = formFieldValues[FormFieldId.Line1],
+        line2 = formFieldValues[FormFieldId.Line2],
+        city = formFieldValues[FormFieldId.City],
+        state = formFieldValues[FormFieldId.State],
+        country = formFieldValues[FormFieldId.Country],
+        postalCode = formFieldValues[FormFieldId.PostalCode],
     )
 
 internal fun PaymentSheet.Address.asAddressModel() =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodAutomaticTaxBillingDetails.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentMethodAutomaticTaxBillingDetails.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentsheet.state
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.elements.automaticTaxRequiredFields
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 internal fun PaymentMethod.hasSufficientBillingDetailsForAutomaticTax(): Boolean {
     val address = billingDetails?.address ?: return false
@@ -14,12 +14,12 @@ internal fun PaymentMethod.hasSufficientBillingDetailsForAutomaticTax(): Boolean
     }
 }
 
-private fun IdentifierSpec.addressValue(address: Address): String? {
+private fun FormFieldId.addressValue(address: Address): String? {
     return when (this) {
-        IdentifierSpec.Line1 -> address.line1
-        IdentifierSpec.City -> address.city
-        IdentifierSpec.State -> address.state
-        IdentifierSpec.PostalCode -> address.postalCode
+        FormFieldId.Line1 -> address.line1
+        FormFieldId.City -> address.city
+        FormFieldId.State -> address.state
+        FormFieldId.PostalCode -> address.postalCode
         else -> null
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/AddPaymentMethod.kt
@@ -20,7 +20,7 @@ import com.stripe.android.paymentsheet.forms.FormFieldValues
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.getSetupFutureUseValue
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.utils.collectAsState
 
 @Composable
@@ -128,7 +128,7 @@ internal fun FormFieldValues.transformToPaymentSelection(
             paymentMethodOptionsParams = options,
             paymentMethodCreateParams = params,
             paymentMethodExtraParams = extras,
-            brand = CardBrand.fromCode(fieldValuePairs[IdentifierSpec.CardBrand]?.value),
+            brand = CardBrand.fromCode(fieldValuePairs[FormFieldId.CardBrand]?.value),
             customerRequestedSave = userRequestedReuse,
             linkInput = inlineSignupViewState?.userInput?.takeIf {
                 inlineSignupViewState.useLink

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/BillingDetailsForm.kt
@@ -9,7 +9,7 @@ import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.cardBillingAddressCollectionMode
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
@@ -32,7 +32,7 @@ internal class BillingDetailsForm(
 ) {
     val nameElement: SimpleTextElement? = if (nameCollection == NameCollection.OutsideBillingDetailsForm) {
         SimpleTextElement(
-            identifier = IdentifierSpec.Name,
+            identifier = FormFieldId.Name,
             controller = NameConfig.createController(billingDetails?.name)
         )
     } else {
@@ -40,7 +40,7 @@ internal class BillingDetailsForm(
     }
 
     private val cardBillingAddressElement: BillingAddressElement = BillingAddressElement(
-        identifier = IdentifierSpec.BillingAddress,
+        identifier = FormFieldId.BillingAddress,
         sameAsShippingElement = null,
         shippingValuesMap = null,
         countryCodes = allowedBillingCountries,
@@ -86,20 +86,20 @@ internal class BillingDetailsForm(
         ) { nameFormFields, addressFormFields, hiddenIdentifiers ->
             val name = when (nameCollection) {
                 NameCollection.InBillingDetailsForm ->
-                    addressFormFields.valueOrNull(IdentifierSpec.Name, hiddenIdentifiers)
+                    addressFormFields.valueOrNull(FormFieldId.Name, hiddenIdentifiers)
                 NameCollection.OutsideBillingDetailsForm ->
-                    nameFormFields.find { it.first == IdentifierSpec.Name }?.second
+                    nameFormFields.find { it.first == FormFieldId.Name }?.second
                 NameCollection.Disabled -> null
             }
 
-            val email = addressFormFields.valueOrNull(IdentifierSpec.Email, hiddenIdentifiers)
-            val phone = addressFormFields.valueOrNull(IdentifierSpec.Phone, hiddenIdentifiers)
-            val line1 = addressFormFields.valueOrNull(IdentifierSpec.Line1, hiddenIdentifiers)
-            val line2 = addressFormFields.valueOrNull(IdentifierSpec.Line2, hiddenIdentifiers)
-            val city = addressFormFields.valueOrNull(IdentifierSpec.City, hiddenIdentifiers)
-            val postalCode = addressFormFields.valueOrNull(IdentifierSpec.PostalCode, hiddenIdentifiers)
-            val country = addressFormFields.valueOrNull(IdentifierSpec.Country, hiddenIdentifiers)
-            val state = addressFormFields.valueOrNull(IdentifierSpec.State, hiddenIdentifiers)
+            val email = addressFormFields.valueOrNull(FormFieldId.Email, hiddenIdentifiers)
+            val phone = addressFormFields.valueOrNull(FormFieldId.Phone, hiddenIdentifiers)
+            val line1 = addressFormFields.valueOrNull(FormFieldId.Line1, hiddenIdentifiers)
+            val line2 = addressFormFields.valueOrNull(FormFieldId.Line2, hiddenIdentifiers)
+            val city = addressFormFields.valueOrNull(FormFieldId.City, hiddenIdentifiers)
+            val postalCode = addressFormFields.valueOrNull(FormFieldId.PostalCode, hiddenIdentifiers)
+            val country = addressFormFields.valueOrNull(FormFieldId.Country, hiddenIdentifiers)
+            val state = addressFormFields.valueOrNull(FormFieldId.State, hiddenIdentifiers)
             BillingDetailsFormState(
                 name = name,
                 email = email,
@@ -114,35 +114,35 @@ internal class BillingDetailsForm(
         }.flowOn(Dispatchers.Main)
     }
 
-    private fun List<Pair<IdentifierSpec, FormFieldEntry>>.valueOrNull(
-        identifierSpec: IdentifierSpec,
-        hiddenIdentifiers: Set<IdentifierSpec>
+    private fun List<Pair<FormFieldId, FormFieldEntry>>.valueOrNull(
+        formFieldId: FormFieldId,
+        hiddenIdentifiers: Set<FormFieldId>
     ): FormFieldEntry? {
-        if (hiddenIdentifiers.contains(identifierSpec)) return null
+        if (hiddenIdentifiers.contains(formFieldId)) return null
         return firstOrNull {
-            it.first == identifierSpec
+            it.first == formFieldId
         }?.second
     }
 
     private fun rawAddressValues(
         billingDetails: PaymentMethod.BillingDetails?,
-    ): Map<IdentifierSpec, String?> {
+    ): Map<FormFieldId, String?> {
         val address = billingDetails?.address
 
         return listOfNotNull(
-            (IdentifierSpec.Name to billingDetails?.name).takeIf {
+            (FormFieldId.Name to billingDetails?.name).takeIf {
                 nameCollection == NameCollection.InBillingDetailsForm
             },
-            IdentifierSpec.Line1 to address?.line1,
-            IdentifierSpec.Line2 to address?.line2,
-            IdentifierSpec.State to address?.state,
-            IdentifierSpec.City to address?.city,
-            IdentifierSpec.Country to address?.country,
-            IdentifierSpec.PostalCode to address?.postalCode,
-            (IdentifierSpec.Email to billingDetails?.email).takeIf {
+            FormFieldId.Line1 to address?.line1,
+            FormFieldId.Line2 to address?.line2,
+            FormFieldId.State to address?.state,
+            FormFieldId.City to address?.city,
+            FormFieldId.Country to address?.country,
+            FormFieldId.PostalCode to address?.postalCode,
+            (FormFieldId.Email to billingDetails?.email).takeIf {
                 collectEmail
             },
-            (IdentifierSpec.Phone to billingDetails?.phone).takeIf {
+            (FormFieldId.Phone to billingDetails?.phone).takeIf {
                 collectPhone
             },
         ).toMap()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/CardDetailsUI.kt
@@ -33,7 +33,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.model.CardBrand
 import com.stripe.android.paymentsheet.ui.EditCardDetailsInteractor.ViewAction
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.Section
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.elements.SectionFieldElementUI
@@ -53,7 +53,7 @@ internal fun CardDetailsEditUI(
     val state by editCardDetailsInteractor.state.collectAsState()
     val dividerHeight = remember { mutableStateOf(0.dp) }
 
-    val hiddenBillingDetailsFields: State<Set<IdentifierSpec>>? = state.billingDetailsForm
+    val hiddenBillingDetailsFields: State<Set<FormFieldId>>? = state.billingDetailsForm
         ?.hiddenElements
         ?.collectAsState()
 
@@ -100,7 +100,7 @@ private fun CardDetailsFormUI(
     paymentMethodIcon: Int,
     onBrandChoiceChanged: (CardBrandChoice) -> Unit,
     dividerHeight: MutableState<Dp>,
-    hiddenBillingDetailsFields: State<Set<IdentifierSpec>>?,
+    hiddenBillingDetailsFields: State<Set<FormFieldId>>?,
     onExpDateChanged: (String) -> Unit,
     nameElementForCardSection: SectionFieldElement?,
 ) {
@@ -182,8 +182,8 @@ private fun rememberValidationMessage(
  * Checks if the billing details form has any fields that are focusable.
  */
 @Composable
-private fun Set<IdentifierSpec>.hasFocusableFields(): Boolean = listOf(
-    IdentifierSpec.PostalCode
+private fun Set<FormFieldId>.hasFocusableFields(): Boolean = listOf(
+    FormFieldId.PostalCode
 ).none { contains(it) }
 
 @Composable

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryDateState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/ExpiryDateState.kt
@@ -4,7 +4,7 @@ import androidx.compose.runtime.Immutable
 import com.stripe.android.ui.core.elements.CardDetailsUtil
 import com.stripe.android.uicore.elements.DateConfig
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.TextFieldState
 import com.stripe.android.uicore.elements.TextFieldStateConstants
 import com.stripe.android.uicore.elements.canAcceptInput
@@ -36,14 +36,14 @@ internal data class ExpiryDateState(
 
     val expiryMonth: Int?
         get() = formFieldValues?.toIntOrNull(
-            key = IdentifierSpec.CardExpMonth,
+            key = FormFieldId.CardExpMonth,
             min = JANUARY,
             max = DECEMBER,
         )
 
     val expiryYear: Int?
         get() = formFieldValues?.toIntOrNull(
-            key = IdentifierSpec.CardExpYear,
+            key = FormFieldId.CardExpYear,
             min = YEAR_2000,
             max = YEAR_2100,
         )
@@ -71,8 +71,8 @@ internal data class ExpiryDateState(
         return copy(text = proposedValue)
     }
 
-    private fun Map<IdentifierSpec, FormFieldEntry>.toIntOrNull(
-        key: IdentifierSpec,
+    private fun Map<FormFieldId, FormFieldEntry>.toIntOrNull(
+        key: FormFieldId,
         min: Int,
         max: Int
     ): Int? {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/PaymentMethodForm.kt
@@ -11,7 +11,7 @@ import com.stripe.android.paymentsheet.forms.FormViewModel
 import com.stripe.android.paymentsheet.paymentdatacollection.FormArguments
 import com.stripe.android.ui.core.FormUI
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.utils.collectAsState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -57,9 +57,9 @@ internal fun PaymentMethodForm(
     enabled: Boolean,
     onFormFieldValuesChanged: (FormFieldValues?) -> Unit,
     completeFormValues: Flow<FormFieldValues?>,
-    hiddenIdentifiers: Set<IdentifierSpec>,
+    hiddenIdentifiers: Set<FormFieldId>,
     elements: List<FormElement>,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    lastTextFieldIdentifier: FormFieldId?,
     modifier: Modifier = Modifier,
 ) {
     LaunchedEffect(paymentMethodCode) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/SavedPaymentMethodTabLayoutUI.kt
@@ -60,7 +60,7 @@ import com.stripe.android.paymentsheet.toPaymentSelection
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
 import com.stripe.android.uicore.DefaultStripeTheme
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionCard
 import com.stripe.android.uicore.elements.SectionValidationMessage
 import com.stripe.android.uicore.getOuterFormInsets
@@ -618,7 +618,7 @@ internal fun CvcRecollectionField(
     val controller by cvcControllerFlow.collectAsState()
     val validationMessage by controller.validationMessage.collectAsState()
     val element = CvcElement(
-        IdentifierSpec(),
+        FormFieldId(),
         controller
     )
     val focusRequester = remember { FocusRequester() }

--- a/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultSavedPaymentMethodLinkFormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/spms/DefaultSavedPaymentMethodLinkFormHelperTest.kt
@@ -17,7 +17,7 @@ import com.stripe.android.link.ui.inline.UserInput
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import kotlinx.coroutines.flow.StateFlow
@@ -277,7 +277,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
         )
 
         object FakeElement : FormElement {
-            override val identifier: IdentifierSpec
+            override val identifier: FormFieldId
                 get() = throw IllegalStateException("Should not be retrieved!")
 
             override val controller: Controller
@@ -289,7 +289,7 @@ internal class DefaultSavedPaymentMethodLinkFormHelperTest {
             override val mandateText: ResolvableString
                 get() = throw IllegalStateException("Should not be retrieved!")
 
-            override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+            override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
                 throw IllegalStateException("Should not be called!")
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/DefaultTapToAddCardAddedInteractorTest.kt
@@ -20,7 +20,7 @@ import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.testing.PaymentMethodFactory.update
 import com.stripe.android.uicore.elements.Controller
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -262,7 +262,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
     }
 
     private object FakeFormElement : FormElement {
-        override val identifier: IdentifierSpec
+        override val identifier: FormFieldId
             get() = throw IllegalStateException("Should not be retrieved!")
 
         override val controller: Controller
@@ -271,7 +271,7 @@ internal class DefaultTapToAddCardAddedInteractorTest {
         override val allowsUserInteraction: Boolean = true
         override val mandateText: ResolvableString? = null
 
-        override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+        override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
             return stateFlowOf(emptyList())
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/FakeTapToAddConfirmationInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/ui/FakeTapToAddConfirmationInteractor.kt
@@ -10,7 +10,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.ui.core.elements.CvcController
 import com.stripe.android.ui.core.elements.CvcElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -85,7 +85,7 @@ internal class FakeTapToAddConfirmationInteractor(
             initialValue = initialValue,
         )
         val cvcElement = CvcElement(
-            _identifier = IdentifierSpec.CardCvc,
+            _identifier = FormFieldId.CardCvc,
             controller = cvcController,
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetViewModelTest.kt
@@ -55,7 +55,7 @@ import com.stripe.android.ui.core.elements.BillingAddressElement
 import com.stripe.android.ui.core.elements.CardDetailsSectionController
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.BankFormScreenStateFactory
@@ -950,7 +950,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                 CustomerSheetViewAction.OnFormFieldValuesCompleted(
                     formFieldValues = FormFieldValues(
                         fieldValuePairs = mapOf(
-                            IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
+                            FormFieldId.Generic("test") to FormFieldEntry("test", true)
                         ),
                         userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
                     )
@@ -2446,7 +2446,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                 CustomerSheetViewAction.OnFormFieldValuesCompleted(
                     formFieldValues = FormFieldValues(
                         fieldValuePairs = mapOf(
-                            IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
+                            FormFieldId.Generic("test") to FormFieldEntry("test", true)
                         ),
                         userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
                     )
@@ -2661,7 +2661,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                     CustomerSheetViewAction.OnFormFieldValuesCompleted(
                         formFieldValues = FormFieldValues(
                             fieldValuePairs = mapOf(
-                                IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
+                                FormFieldId.Generic("test") to FormFieldEntry("test", true)
                             ),
                             userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
                         )
@@ -3451,7 +3451,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
                 CustomerSheetViewAction.OnFormFieldValuesCompleted(
                     formFieldValues = FormFieldValues(
                         fieldValuePairs = mapOf(
-                            IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
+                            FormFieldId.Generic("test") to FormFieldEntry("test", true)
                         ),
                         userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
                     )
@@ -3752,7 +3752,7 @@ class CustomerSheetViewModelTest : CustomerSheetTestHelper {
     private companion object {
         val TEST_FORM_VALUES = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("test") to FormFieldEntry("test", true)
+                FormFieldId.Generic("test") to FormFieldEntry("test", true)
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/repositories/LinkApiRepositoryTest.kt
@@ -27,7 +27,7 @@ import com.stripe.android.repository.ConsumersApiService
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.LocaleTestRule
 import com.stripe.android.ui.core.FieldValuesToParamsMapConverter
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
@@ -497,31 +497,31 @@ class LinkApiRepositoryTest {
             )
         val formValues = newLinkPaymentDetails.buildFormValues()
         assertThat(formValues).containsEntry(
-            IdentifierSpec.get("type"),
+            FormFieldId.get("type"),
             "card"
         )
         assertThat(formValues).containsEntry(
-            IdentifierSpec.CardNumber,
+            FormFieldId.CardNumber,
             "5555555555554444"
         )
         assertThat(formValues).containsEntry(
-            IdentifierSpec.CardCvc,
+            FormFieldId.CardCvc,
             "123"
         )
         assertThat(formValues).containsEntry(
-            IdentifierSpec.CardExpMonth,
+            FormFieldId.CardExpMonth,
             "12"
         )
         assertThat(formValues).containsEntry(
-            IdentifierSpec.CardExpYear,
+            FormFieldId.CardExpYear,
             "2050"
         )
         assertThat(formValues).containsEntry(
-            IdentifierSpec.Country,
+            FormFieldId.Country,
             "US"
         )
         assertThat(formValues).containsEntry(
-            IdentifierSpec.PostalCode,
+            FormFieldId.PostalCode,
             "12345"
         )
     }
@@ -1045,14 +1045,14 @@ class LinkApiRepositoryTest {
     private val cardPaymentMethodCreateParams =
         FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
             mapOf(
-                IdentifierSpec.CardNumber to FormFieldEntry("5555555555554444", true),
-                IdentifierSpec.CardCvc to FormFieldEntry("123", true),
-                IdentifierSpec.CardExpMonth to FormFieldEntry("12", true),
-                IdentifierSpec.CardExpYear to FormFieldEntry("2050", true),
-                IdentifierSpec.Email to FormFieldEntry("jenny@example.com", true),
-                IdentifierSpec.Name to FormFieldEntry("Jenny Rosen", true),
-                IdentifierSpec.Country to FormFieldEntry("US", true),
-                IdentifierSpec.PostalCode to FormFieldEntry("12345", true),
+                FormFieldId.CardNumber to FormFieldEntry("5555555555554444", true),
+                FormFieldId.CardCvc to FormFieldEntry("123", true),
+                FormFieldId.CardExpMonth to FormFieldEntry("12", true),
+                FormFieldId.CardExpYear to FormFieldEntry("2050", true),
+                FormFieldId.Email to FormFieldEntry("jenny@example.com", true),
+                FormFieldId.Name to FormFieldEntry("Jenny Rosen", true),
+                FormFieldId.Country to FormFieldEntry("US", true),
+                FormFieldId.PostalCode to FormFieldEntry("12345", true),
             ),
             "card",
             false,
@@ -1062,10 +1062,10 @@ class LinkApiRepositoryTest {
     private val cardPaymentMethodCreateParamsWithoutBillingAddress =
         FieldValuesToParamsMapConverter.transformToPaymentMethodCreateParams(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardNumber to FormFieldEntry("5555555555554444", true),
-                IdentifierSpec.CardCvc to FormFieldEntry("123", true),
-                IdentifierSpec.CardExpMonth to FormFieldEntry("12", true),
-                IdentifierSpec.CardExpYear to FormFieldEntry("2050", true),
+                FormFieldId.CardNumber to FormFieldEntry("5555555555554444", true),
+                FormFieldId.CardCvc to FormFieldEntry("123", true),
+                FormFieldId.CardExpMonth to FormFieldEntry("12", true),
+                FormFieldId.CardExpYear to FormFieldEntry("2050", true),
             ),
             code = "card",
             requiresMandate = false,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/paymentmethod/PaymentMethodViewModelTest.kt
@@ -29,7 +29,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.ui.core.elements.CardDetailsSectionElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.Dispatchers
@@ -120,7 +120,7 @@ class PaymentMethodViewModelTest {
 
         viewModel.formValuesChanged(
             formValues = FormFieldValues(
-                fieldValuePairs = mapOf(IdentifierSpec.CardCvc to FormFieldEntry("111")),
+                fieldValuePairs = mapOf(FormFieldId.CardCvc to FormFieldEntry("111")),
                 userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/updatecard/UpdateCardScreenViewModelTest.kt
@@ -22,7 +22,7 @@ import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import com.stripe.android.ui.core.elements.BillingAddressElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.navigation.NavigationManager
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -177,7 +177,7 @@ class UpdateCardScreenViewModelTest {
                     val addressFields = cardBillingAddressElement.addressController.value.fieldsFlowable.value
 
                     val doesNotHavePhoneElement = addressFields.none { element ->
-                        element.identifier == IdentifierSpec.Phone
+                        element.identifier == FormFieldId.Phone
                     }
 
                     assertThat(doesNotHavePhoneElement).isTrue()
@@ -223,7 +223,7 @@ class UpdateCardScreenViewModelTest {
                     val addressFields = cardBillingAddressElement.addressController.value.fieldsFlowable.value
 
                     val hasPhoneElement = addressFields.any { element ->
-                        element.identifier == IdentifierSpec.Phone
+                        element.identifier == FormFieldId.Phone
                     }
 
                     assertThat(hasPhoneElement).isTrue()
@@ -269,12 +269,12 @@ class UpdateCardScreenViewModelTest {
                     val addressFields = cardBillingAddressElement.addressController.value.fieldsFlowable.value
 
                     val hasCountryElement = addressFields.any {
-                        it.identifier == IdentifierSpec.Country
+                        it.identifier == FormFieldId.Country
                     }
 
                     val hasPostalCodeElement = addressFields.any {
                         it is RowElement && it.fields.any {
-                            it.identifier == IdentifierSpec.PostalCode
+                            it.identifier == FormFieldId.PostalCode
                         }
                     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/LinkInline2FASectionScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/LinkInline2FASectionScreenshotTest.kt
@@ -12,7 +12,7 @@ import com.stripe.android.screenshottesting.FontSize
 import com.stripe.android.screenshottesting.PaparazziRule
 import com.stripe.android.screenshottesting.SystemAppearance
 import com.stripe.android.testing.LocaleTestRule
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import org.junit.Rule
@@ -34,7 +34,7 @@ class LinkInline2FASectionScreenshotTest {
     @Test
     fun testDefault() {
         val otpElement = OTPElement(
-            identifier = IdentifierSpec.Generic("otp"),
+            identifier = FormFieldId.Generic("otp"),
             controller = OTPController()
         )
 
@@ -64,7 +64,7 @@ class LinkInline2FASectionScreenshotTest {
     @Test
     fun testWithPaymentDetailsMastercard() {
         val otpElement = OTPElement(
-            identifier = IdentifierSpec.Generic("otp"),
+            identifier = FormFieldId.Generic("otp"),
             controller = OTPController()
         )
 
@@ -102,7 +102,7 @@ class LinkInline2FASectionScreenshotTest {
     @Test
     fun testWithPaymentDetailsBank() {
         val otpElement = OTPElement(
-            identifier = IdentifierSpec.Generic("otp"),
+            identifier = FormFieldId.Generic("otp"),
             controller = OTPController()
         )
 
@@ -140,7 +140,7 @@ class LinkInline2FASectionScreenshotTest {
     @Test
     fun testProcessingState() {
         val otpElement = OTPElement(
-            identifier = IdentifierSpec.Generic("otp"),
+            identifier = FormFieldId.Generic("otp"),
             controller = OTPController().apply {
                 onValueChanged(0, "123456")
             }
@@ -180,7 +180,7 @@ class LinkInline2FASectionScreenshotTest {
     @Test
     fun testErrorState() {
         val otpElement = OTPElement(
-            identifier = IdentifierSpec.Generic("otp"),
+            identifier = FormFieldId.Generic("otp"),
             controller = OTPController().apply {
                 onValueChanged(0, "123")
             }

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/LinkInline2FASectionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/LinkInline2FASectionTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.link.ui.verification.VERIFICATION_HEADER_IMAGE_TAG
 import com.stripe.android.link.ui.verification.VerificationViewState
 import com.stripe.android.model.LinkBrand
 import com.stripe.android.testing.createComposeCleanupRule
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.OTPController
 import com.stripe.android.uicore.elements.OTPElement
 import org.junit.Rule
@@ -44,7 +44,7 @@ internal class LinkInline2FASectionTest {
                     linkBrand = LinkBrand.Onelink,
                 ),
                 otpElement = OTPElement(
-                    identifier = IdentifierSpec.Generic("otp"),
+                    identifier = FormFieldId.Generic("otp"),
                     controller = OTPController(),
                 ),
                 onResend = {},

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/BillingAddressFormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/BillingAddressFormElementsBuilderTest.kt
@@ -18,7 +18,7 @@ import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SameAsShippingElement
 import com.stripe.android.uicore.elements.SectionElement
 import kotlinx.coroutines.CoroutineScope
@@ -67,16 +67,16 @@ class BillingAddressFormElementsBuilderTest {
                     allowedCountries = setOf("US"),
                 ),
                 requiresBillingAddressForAutomaticTax = true,
-                initialValues = mapOf(IdentifierSpec.Country to "US"),
+                initialValues = mapOf(FormFieldId.Country to "US"),
             ),
         ).build().billingAddressElement()
 
-        assertThat(billingAddressElement.hiddenIdentifiers.value).contains(IdentifierSpec.Line2)
+        assertThat(billingAddressElement.hiddenIdentifiers.value).contains(FormFieldId.Line2)
         assertThat(billingAddressElement.hiddenIdentifiers.value).containsNoneOf(
-            IdentifierSpec.Line1,
-            IdentifierSpec.City,
-            IdentifierSpec.State,
-            IdentifierSpec.PostalCode,
+            FormFieldId.Line1,
+            FormFieldId.City,
+            FormFieldId.State,
+            FormFieldId.PostalCode,
         )
     }
 
@@ -148,7 +148,7 @@ class BillingAddressFormElementsBuilderTest {
     fun `country requirement overrides full address countries and initial country`() {
         val addressElement = billingAddressFormElementsBuilder(
             arguments = arguments(
-                initialValues = mapOf(IdentifierSpec.Country to "US"),
+                initialValues = mapOf(FormFieldId.Country to "US"),
             ),
             requireBillingAddressCollection = true,
             fallbackCountryCodes = setOf("US"),
@@ -169,7 +169,7 @@ class BillingAddressFormElementsBuilderTest {
     fun `country requirement explicit null overrides full address initial country`() {
         val addressElement = billingAddressFormElementsBuilder(
             arguments = arguments(
-                initialValues = mapOf(IdentifierSpec.Country to "US"),
+                initialValues = mapOf(FormFieldId.Country to "US"),
             ),
             requireBillingAddressCollection = true,
             fallbackCountryCodes = setOf("US"),
@@ -190,7 +190,7 @@ class BillingAddressFormElementsBuilderTest {
                     allowedCountries = setOf("US"),
                 ),
                 requiresBillingAddressForAutomaticTax = true,
-                initialValues = mapOf(IdentifierSpec.Country to "US"),
+                initialValues = mapOf(FormFieldId.Country to "US"),
             ),
             countryRequirement = CountryRequirement(
                 allowedCountryCodes = setOf("DE", "FR"),
@@ -212,7 +212,7 @@ class BillingAddressFormElementsBuilderTest {
                 billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(
                     allowedCountries = setOf("US"),
                 ),
-                initialValues = mapOf(IdentifierSpec.Country to "CA"),
+                initialValues = mapOf(FormFieldId.Country to "CA"),
             ),
             requireBillingAddressCollection = true,
             fallbackCountryCodes = setOf("CA"),
@@ -241,7 +241,7 @@ class BillingAddressFormElementsBuilderTest {
                     allowedCountries = setOf("US", "CA"),
                 ),
                 requiresBillingAddressForAutomaticTax = true,
-                initialValues = mapOf(IdentifierSpec.Country to "CA"),
+                initialValues = mapOf(FormFieldId.Country to "CA"),
             ),
             fallbackCountryCodes = setOf("BS"),
         ).build().billingAddressElement().countryElement
@@ -259,7 +259,7 @@ class BillingAddressFormElementsBuilderTest {
             arguments = arguments(
                 billingDetailsCollectionConfiguration = automaticAddressConfiguration(),
                 requiresBillingAddressForAutomaticTax = true,
-                shippingValues = mapOf(IdentifierSpec.SameAsShipping to "true"),
+                shippingValues = mapOf(FormFieldId.SameAsShipping to "true"),
             ),
         ).build()
 
@@ -333,8 +333,8 @@ class BillingAddressFormElementsBuilderTest {
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
             PaymentSheet.BillingDetailsCollectionConfiguration(),
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
-        initialValues: Map<IdentifierSpec, String?> = emptyMap(),
-        shippingValues: Map<IdentifierSpec, String?>? = emptyMap(),
+        initialValues: Map<FormFieldId, String?> = emptyMap(),
+        shippingValues: Map<FormFieldId, String?>? = emptyMap(),
         requiresBillingAddressForAutomaticTax: Boolean = false,
     ): UiDefinitionFactory.Arguments {
         val context = ApplicationProvider.getApplicationContext<Application>()

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/FormElementsBuilderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/FormElementsBuilderTest.kt
@@ -18,7 +18,7 @@ import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SectionFieldElement
@@ -57,9 +57,9 @@ class FormElementsBuilderTest {
     @Test
     fun `build orders fields correctly`() {
         val formElements = formElementsBuilder(arguments())
-            .element(testElement(IdentifierSpec(v1 = "element")))
-            .header(testElement(IdentifierSpec(v1 = "header")))
-            .footer(testElement(IdentifierSpec(v1 = "footer")))
+            .element(testElement(FormFieldId(v1 = "element")))
+            .header(testElement(FormFieldId(v1 = "header")))
+            .footer(testElement(FormFieldId(v1 = "footer")))
             .requireBillingAddressIfAllowed()
             .requireContactInformationIfAllowed(ContactInformationCollectionMode.Name)
             .build()
@@ -74,8 +74,8 @@ class FormElementsBuilderTest {
     @Test
     fun `build orders country requirement after ordinary elements and before footers`() {
         val formElements = formElementsBuilder(arguments())
-            .element(testElement(IdentifierSpec(v1 = "element")))
-            .footer(testElement(IdentifierSpec(v1 = "footer")))
+            .element(testElement(FormFieldId(v1 = "element")))
+            .footer(testElement(FormFieldId(v1 = "footer")))
             .requireCountry(
                 allowedCountryCodes = setOf("US", "CA"),
                 initialValue = "US",
@@ -96,8 +96,8 @@ class FormElementsBuilderTest {
                 requiresBillingAddressForAutomaticTax = true,
             ),
         )
-            .element(testElement(IdentifierSpec.Generic("element")))
-            .footer(testElement(IdentifierSpec.Generic("footer")))
+            .element(testElement(FormFieldId.Generic("element")))
+            .footer(testElement(FormFieldId.Generic("footer")))
             .build()
 
         assertThat(formElements.map { it.identifier.v1 }).containsExactly(
@@ -130,12 +130,12 @@ class FormElementsBuilderTest {
     @Test
     fun `build returns fields in the order they were added`() {
         val formElements = formElementsBuilder(arguments())
-            .element(testElement(IdentifierSpec(v1 = "element1")))
-            .element(testElement(IdentifierSpec(v1 = "element2")))
-            .footer(testElement(IdentifierSpec(v1 = "footer1")))
-            .footer(testElement(IdentifierSpec(v1 = "footer2")))
-            .header(testElement(IdentifierSpec(v1 = "header1")))
-            .header(testElement(IdentifierSpec(v1 = "header2")))
+            .element(testElement(FormFieldId(v1 = "element1")))
+            .element(testElement(FormFieldId(v1 = "element2")))
+            .footer(testElement(FormFieldId(v1 = "footer1")))
+            .footer(testElement(FormFieldId(v1 = "footer2")))
+            .header(testElement(FormFieldId(v1 = "header1")))
+            .header(testElement(FormFieldId(v1 = "header2")))
             .build()
         assertThat(formElements).hasSize(6)
         assertThat(formElements[0].identifier.v1).isEqualTo("header1")
@@ -154,7 +154,7 @@ class FormElementsBuilderTest {
             )
         )
         val formElements = formElementsBuilder(arguments)
-            .element(testElement(IdentifierSpec(v1 = "element")))
+            .element(testElement(FormFieldId(v1 = "element")))
             .ignoreBillingAddressRequirements()
             .build()
         assertThat(formElements).hasSize(1)
@@ -171,7 +171,7 @@ class FormElementsBuilderTest {
             )
         )
         val formElements = formElementsBuilder(arguments)
-            .element(testElement(IdentifierSpec(v1 = "element")))
+            .element(testElement(FormFieldId(v1 = "element")))
             .ignoreContactInformationRequirements()
             .build()
         assertThat(formElements).hasSize(1)
@@ -258,7 +258,7 @@ class FormElementsBuilderTest {
         return formElements[position] as SectionElement
     }
 
-    private fun testElement(identifier: IdentifierSpec): FormElement {
+    private fun testElement(identifier: FormFieldId): FormElement {
         return StaticTextElement(
             identifier = identifier,
             text = resolvableString("Test element"),
@@ -269,8 +269,8 @@ class FormElementsBuilderTest {
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration =
             PaymentSheet.BillingDetailsCollectionConfiguration(),
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
-        initialValues: Map<IdentifierSpec, String?> = emptyMap(),
-        shippingValues: Map<IdentifierSpec, String?>? = emptyMap(),
+        initialValues: Map<FormFieldId, String?> = emptyMap(),
+        shippingValues: Map<FormFieldId, String?>? = emptyMap(),
         requiresBillingAddressForAutomaticTax: Boolean = false,
     ): UiDefinitionFactory.Arguments {
         val context = ApplicationProvider.getApplicationContext<Application>()

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/InitialValuesFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/InitialValuesFactoryTest.kt
@@ -7,7 +7,7 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import org.junit.Test
 
 class InitialValuesFactoryTest {
@@ -64,20 +64,20 @@ class InitialValuesFactoryTest {
             paymentMethodExtraParams = null,
         )
 
-        assertThat(initialValues).containsEntry(IdentifierSpec.Name, "Jenny Rosen")
-        assertThat(initialValues).containsEntry(IdentifierSpec.Email, "jenny.rosen@example.com")
-        assertThat(initialValues).containsEntry(IdentifierSpec.Phone, "1-800-555-1234")
-        assertThat(initialValues).containsEntry(IdentifierSpec.Line1, "1234 Main St")
-        assertThat(initialValues).containsEntry(IdentifierSpec.Line2, null)
-        assertThat(initialValues).containsEntry(IdentifierSpec.City, "Berlin")
-        assertThat(initialValues).containsEntry(IdentifierSpec.State, "Capital")
-        assertThat(initialValues).containsEntry(IdentifierSpec.PostalCode, "10787")
-        assertThat(initialValues).containsEntry(IdentifierSpec.Country, "DE")
-        assertThat(initialValues).containsEntry(IdentifierSpec.Generic("type"), "card")
-        assertThat(initialValues).containsEntry(IdentifierSpec.CardNumber, "4242424242424242")
-        assertThat(initialValues).containsEntry(IdentifierSpec.CardExpMonth, "1")
-        assertThat(initialValues).containsEntry(IdentifierSpec.CardExpYear, "2024")
-        assertThat(initialValues).containsEntry(IdentifierSpec.CardCvc, "111")
+        assertThat(initialValues).containsEntry(FormFieldId.Name, "Jenny Rosen")
+        assertThat(initialValues).containsEntry(FormFieldId.Email, "jenny.rosen@example.com")
+        assertThat(initialValues).containsEntry(FormFieldId.Phone, "1-800-555-1234")
+        assertThat(initialValues).containsEntry(FormFieldId.Line1, "1234 Main St")
+        assertThat(initialValues).containsEntry(FormFieldId.Line2, null)
+        assertThat(initialValues).containsEntry(FormFieldId.City, "Berlin")
+        assertThat(initialValues).containsEntry(FormFieldId.State, "Capital")
+        assertThat(initialValues).containsEntry(FormFieldId.PostalCode, "10787")
+        assertThat(initialValues).containsEntry(FormFieldId.Country, "DE")
+        assertThat(initialValues).containsEntry(FormFieldId.Generic("type"), "card")
+        assertThat(initialValues).containsEntry(FormFieldId.CardNumber, "4242424242424242")
+        assertThat(initialValues).containsEntry(FormFieldId.CardExpMonth, "1")
+        assertThat(initialValues).containsEntry(FormFieldId.CardExpYear, "2024")
+        assertThat(initialValues).containsEntry(FormFieldId.CardCvc, "111")
     }
 
     @Test
@@ -90,15 +90,15 @@ class InitialValuesFactoryTest {
             )
         ).isEqualTo(
             mapOf(
-                IdentifierSpec.Name to "Jenny Smith",
-                IdentifierSpec.Email to "email.email.com",
-                IdentifierSpec.Phone to null,
-                IdentifierSpec.Line1 to "123 Main Street",
-                IdentifierSpec.Line2 to "APt 1",
-                IdentifierSpec.City to "Dublin",
-                IdentifierSpec.State to "Co. Dublin",
-                IdentifierSpec.PostalCode to "T37 F8HK",
-                IdentifierSpec.Country to "IE"
+                FormFieldId.Name to "Jenny Smith",
+                FormFieldId.Email to "email.email.com",
+                FormFieldId.Phone to null,
+                FormFieldId.Line1 to "123 Main Street",
+                FormFieldId.Line2 to "APt 1",
+                FormFieldId.City to "Dublin",
+                FormFieldId.State to "Co. Dublin",
+                FormFieldId.PostalCode to "T37 F8HK",
+                FormFieldId.Country to "IE"
             )
         )
     }
@@ -132,19 +132,19 @@ class InitialValuesFactoryTest {
             )
         ).isEqualTo(
             mapOf(
-                IdentifierSpec.Name to "Jenny Rosen",
-                IdentifierSpec.Email to "jenny.rosen@example.com",
-                IdentifierSpec.Phone to null,
-                IdentifierSpec.Line1 to "123 Main Street",
-                IdentifierSpec.Line2 to "APt 1",
-                IdentifierSpec.City to "Dublin",
-                IdentifierSpec.State to "Co. Dublin",
-                IdentifierSpec.PostalCode to "T37 F8HK",
-                IdentifierSpec.Country to "IE",
-                IdentifierSpec.Generic("type") to "bacs_debit",
-                IdentifierSpec.Generic("bacs_debit[account_number]") to "00012345",
-                IdentifierSpec.Generic("bacs_debit[sort_code]") to "10-88-00",
-                IdentifierSpec.BacsDebitConfirmed to "true"
+                FormFieldId.Name to "Jenny Rosen",
+                FormFieldId.Email to "jenny.rosen@example.com",
+                FormFieldId.Phone to null,
+                FormFieldId.Line1 to "123 Main Street",
+                FormFieldId.Line2 to "APt 1",
+                FormFieldId.City to "Dublin",
+                FormFieldId.State to "Co. Dublin",
+                FormFieldId.PostalCode to "T37 F8HK",
+                FormFieldId.Country to "IE",
+                FormFieldId.Generic("type") to "bacs_debit",
+                FormFieldId.Generic("bacs_debit[account_number]") to "00012345",
+                FormFieldId.Generic("bacs_debit[sort_code]") to "10-88-00",
+                FormFieldId.BacsDebitConfirmed to "true"
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -45,7 +45,7 @@ import com.stripe.android.ui.core.elements.MandateTextElement
 import com.stripe.android.uicore.IconStyle
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.EmailElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
@@ -428,7 +428,7 @@ internal class PaymentMethodMetadataTest {
 
         val identifiers = addressElement.fields.first().map { it.identifier }
         // Check that the address element contains country.
-        assertThat(identifiers).contains(IdentifierSpec.Country)
+        assertThat(identifiers).contains(FormFieldId.Country)
     }
 
     @Test
@@ -518,7 +518,7 @@ internal class PaymentMethodMetadataTest {
 
         val identifiers = addressElement.fields.first().map { it.identifier }
         // Check that the address element contains country.
-        assertThat(identifiers).contains(IdentifierSpec.Country)
+        assertThat(identifiers).contains(FormFieldId.Country)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/TestUiDefinitionFactoryArgumentsFactory.kt
@@ -16,7 +16,7 @@ import com.stripe.android.paymentsheet.LinkInlineHandler
 import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -31,7 +31,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
         paymentMethodCreateParams: PaymentMethodCreateParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
-        initialValues: Map<IdentifierSpec, String?>? = null,
+        initialValues: Map<FormFieldId, String?>? = null,
         linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
         linkInlineHandler: LinkInlineHandler? = null,
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
@@ -63,7 +63,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
         paymentMethodCreateParams: PaymentMethodCreateParams? = null,
         paymentMethodExtraParams: PaymentMethodExtraParams? = null,
         paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
-        initialValues: Map<IdentifierSpec, String?>? = null,
+        initialValues: Map<FormFieldId, String?>? = null,
         linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
         linkInlineHandler: LinkInlineHandler? = null,
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
@@ -110,7 +110,7 @@ internal object TestUiDefinitionFactoryArgumentsFactory {
      */
     private class InitialValuesOverridingFactory(
         private val delegate: UiDefinitionFactory.Arguments.Factory,
-        private val initialValues: Map<IdentifierSpec, String?>,
+        private val initialValues: Map<FormFieldId, String?>,
     ) : UiDefinitionFactory.Arguments.Factory {
         override fun create(
             metadata: PaymentMethodMetadata,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/UiDefinitionTestHelper.kt
@@ -11,7 +11,7 @@ import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotio
 import com.stripe.android.ui.core.elements.AutomaticallyLaunchedCardScanFormDataHelper
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import kotlinx.coroutines.CoroutineScope
 
 internal fun PaymentMethodDefinition.formElements(
@@ -19,7 +19,7 @@ internal fun PaymentMethodDefinition.formElements(
     paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
-    initialValues: Map<IdentifierSpec, String?>? = null,
+    initialValues: Map<FormFieldId, String?>? = null,
     initialLinkUserInput: UserInput? = null,
     linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
     setAsDefaultMatchesSaveForFutureUse: Boolean = false,
@@ -53,7 +53,7 @@ internal fun PaymentMethodDefinition.formElements(
     paymentMethodCreateParams: PaymentMethodCreateParams? = null,
     paymentMethodOptionsParams: PaymentMethodOptionsParams? = null,
     paymentMethodExtraParams: PaymentMethodExtraParams? = null,
-    initialValues: Map<IdentifierSpec, String?>? = null,
+    initialValues: Map<FormFieldId, String?>? = null,
     initialLinkUserInput: UserInput? = null,
     linkConfigurationCoordinator: LinkConfigurationCoordinator? = null,
     setAsDefaultMatchesSaveForFutureUse: Boolean = false,
@@ -87,7 +87,7 @@ private fun PaymentMethodDefinition.formElementsInternal(
     paymentMethodCreateParams: PaymentMethodCreateParams?,
     paymentMethodOptionsParams: PaymentMethodOptionsParams?,
     paymentMethodExtraParams: PaymentMethodExtraParams?,
-    initialValues: Map<IdentifierSpec, String?>?,
+    initialValues: Map<FormFieldId, String?>?,
     initialLinkUserInput: UserInput?,
     linkConfigurationCoordinator: LinkConfigurationCoordinator?,
     setAsDefaultMatchesSaveForFutureUse: Boolean,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AffirmLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val affirmRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val affirmNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AfterpayClearpayLpmBillingAddressTestCases.kt
@@ -5,16 +5,16 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val afterpayClearpayRawValues = mapOf(
-    IdentifierSpec.Email to "jenny.rosen@example.com",
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Email to "jenny.rosen@example.com",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val afterpayClearpayNoBillingDetailsExpectedParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlipayLpmBillingAddressTestCases.kt
@@ -5,13 +5,13 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val alipayRawValues = mapOf(
-    IdentifierSpec.Line1 to "10 Collyer Quay",
-    IdentifierSpec.Line2 to "#10-01",
-    IdentifierSpec.PostalCode to "049315",
-    IdentifierSpec.Country to "SG",
+    FormFieldId.Line1 to "10 Collyer Quay",
+    FormFieldId.Line2 to "#10-01",
+    FormFieldId.PostalCode to "049315",
+    FormFieldId.Country to "SG",
 )
 
 private val alipayNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AlmaLpmBillingAddressTestCases.kt
@@ -5,14 +5,14 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val almaRawValues = mapOf(
-    IdentifierSpec.Line1 to "12 Rue de la Paix",
-    IdentifierSpec.Line2 to "Appartement 4",
-    IdentifierSpec.City to "Paris",
-    IdentifierSpec.PostalCode to "75002",
-    IdentifierSpec.Country to "FR",
+    FormFieldId.Line1 to "12 Rue de la Paix",
+    FormFieldId.Line2 to "Appartement 4",
+    FormFieldId.City to "Paris",
+    FormFieldId.PostalCode to "75002",
+    FormFieldId.Country to "FR",
 )
 
 private val almaNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AmazonPayLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val amazonPayRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val amazonPayTypeOnlyExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/AuBecsDebitLpmBillingAddressTestCases.kt
@@ -5,19 +5,19 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val auBecsDebitFullRawValues = mapOf(
-    IdentifierSpec.Generic("au_becs_debit[bsb_number]") to "000000",
-    IdentifierSpec.Generic("au_becs_debit[account_number]") to "000123456",
-    IdentifierSpec.Name to "Jenny Rosen",
-    IdentifierSpec.Email to "jenny.rosen@example.com",
-    IdentifierSpec.Line1 to "123 Collins Street",
-    IdentifierSpec.Line2 to "Level 4",
-    IdentifierSpec.City to "Melbourne",
-    IdentifierSpec.State to "VIC",
-    IdentifierSpec.PostalCode to "3000",
-    IdentifierSpec.Country to "AU",
+    FormFieldId.Generic("au_becs_debit[bsb_number]") to "000000",
+    FormFieldId.Generic("au_becs_debit[account_number]") to "000123456",
+    FormFieldId.Name to "Jenny Rosen",
+    FormFieldId.Email to "jenny.rosen@example.com",
+    FormFieldId.Line1 to "123 Collins Street",
+    FormFieldId.Line2 to "Level 4",
+    FormFieldId.City to "Melbourne",
+    FormFieldId.State to "VIC",
+    FormFieldId.PostalCode to "3000",
+    FormFieldId.Country to "AU",
 )
 
 private val auBecsDebitBankDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BacsDebitLpmBillingAddressTestCases.kt
@@ -6,19 +6,19 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val bacsDebitFullRawValues = mapOf(
-    IdentifierSpec.Generic("bacs_debit[sort_code]") to "108800",
-    IdentifierSpec.Generic("bacs_debit[account_number]") to "00012345",
-    IdentifierSpec.BacsDebitConfirmed to "true",
-    IdentifierSpec.Name to "Jenny Rosen",
-    IdentifierSpec.Email to "jenny.rosen@example.com",
-    IdentifierSpec.Line1 to "10 Downing Street",
-    IdentifierSpec.Line2 to "Westminster",
-    IdentifierSpec.City to "London",
-    IdentifierSpec.PostalCode to "SW1A 2AA",
-    IdentifierSpec.Country to "GB",
+    FormFieldId.Generic("bacs_debit[sort_code]") to "108800",
+    FormFieldId.Generic("bacs_debit[account_number]") to "00012345",
+    FormFieldId.BacsDebitConfirmed to "true",
+    FormFieldId.Name to "Jenny Rosen",
+    FormFieldId.Email to "jenny.rosen@example.com",
+    FormFieldId.Line1 to "10 Downing Street",
+    FormFieldId.Line2 to "Westminster",
+    FormFieldId.City to "London",
+    FormFieldId.PostalCode to "SW1A 2AA",
+    FormFieldId.Country to "GB",
 )
 
 private val bacsDebitBankDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BancontactLpmBillingAddressTestCases.kt
@@ -5,19 +5,19 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val bancontactRawValues = mapOf(
-    IdentifierSpec.Name to "Marie Dubois",
-    IdentifierSpec.Line1 to "Rue de la Loi 16",
-    IdentifierSpec.Line2 to "Boîte 2",
-    IdentifierSpec.City to "Bruxelles",
-    IdentifierSpec.PostalCode to "1000",
-    IdentifierSpec.Country to "BE",
+    FormFieldId.Name to "Marie Dubois",
+    FormFieldId.Line1 to "Rue de la Loi 16",
+    FormFieldId.Line2 to "Boîte 2",
+    FormFieldId.City to "Bruxelles",
+    FormFieldId.PostalCode to "1000",
+    FormFieldId.Country to "BE",
 )
 
 private val bancontactSetupRawValues = bancontactRawValues + (
-    IdentifierSpec.Email to "marie.dubois@example.com"
+    FormFieldId.Email to "marie.dubois@example.com"
 )
 
 private val bancontactNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BillieLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BillieLpmBillingAddressTestCases.kt
@@ -5,14 +5,14 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val billieRawValues = mapOf(
-    IdentifierSpec.Line1 to "Unter den Linden 1",
-    IdentifierSpec.Line2 to "Etage 2",
-    IdentifierSpec.City to "Berlin",
-    IdentifierSpec.PostalCode to "10117",
-    IdentifierSpec.Country to "DE",
+    FormFieldId.Line1 to "Unter den Linden 1",
+    FormFieldId.Line2 to "Etage 2",
+    FormFieldId.City to "Berlin",
+    FormFieldId.PostalCode to "10117",
+    FormFieldId.Country to "DE",
 )
 
 private val billieNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikDefinitionTest.kt
@@ -6,7 +6,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.formElements
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.ui.core.elements.BlikElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import org.junit.Test
 
@@ -30,7 +30,7 @@ class BlikDefinitionTest {
     fun `createFormElements seeds the blik code from initialValues`() {
         val formElements = BlikDefinition.formElements(
             metadata = blikMetadata,
-            initialValues = mapOf(IdentifierSpec.BlikCode to "123456"),
+            initialValues = mapOf(FormFieldId.BlikCode to "123456"),
         )
 
         val blikElement = (formElements[0] as SectionElement).fields[0] as BlikElement

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BlikLpmBillingAddressTestCases.kt
@@ -6,15 +6,15 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val blikFullRawValues = mapOf(
-    IdentifierSpec.BlikCode to "123456",
-    IdentifierSpec.Line1 to "Marszalkowska 1",
-    IdentifierSpec.Line2 to "Apartment 2",
-    IdentifierSpec.City to "Warsaw",
-    IdentifierSpec.PostalCode to "00-001",
-    IdentifierSpec.Country to "PL",
+    FormFieldId.BlikCode to "123456",
+    FormFieldId.Line1 to "Marszalkowska 1",
+    FormFieldId.Line2 to "Apartment 2",
+    FormFieldId.City to "Warsaw",
+    FormFieldId.PostalCode to "00-001",
+    FormFieldId.Country to "PL",
 )
 
 private val blikExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/BoletoLpmBillingAddressTestCases.kt
@@ -5,21 +5,21 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val boletoNoBillingAddressRawValues = mapOf(
-    IdentifierSpec.Generic("boleto[tax_id]") to "123.456.789-09",
+    FormFieldId.Generic("boleto[tax_id]") to "123.456.789-09",
 )
 
 private val boletoWithBillingAddressRawValues = boletoNoBillingAddressRawValues + mapOf(
-    IdentifierSpec.Name to "Jane Doe",
-    IdentifierSpec.Email to "jane@example.com",
-    IdentifierSpec.Line1 to "Avenida Paulista 123",
-    IdentifierSpec.Line2 to "Apto 45",
-    IdentifierSpec.City to "Sao Paulo",
-    IdentifierSpec.State to "SP",
-    IdentifierSpec.Country to "BR",
-    IdentifierSpec.PostalCode to "01311000",
+    FormFieldId.Name to "Jane Doe",
+    FormFieldId.Email to "jane@example.com",
+    FormFieldId.Line1 to "Avenida Paulista 123",
+    FormFieldId.Line2 to "Apto 45",
+    FormFieldId.City to "Sao Paulo",
+    FormFieldId.State to "SP",
+    FormFieldId.Country to "BR",
+    FormFieldId.PostalCode to "01311000",
 )
 
 private val boletoNoBillingAddressExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CardUiDefinitionFactoryTest.kt
@@ -23,7 +23,7 @@ import com.stripe.android.ui.core.elements.CardDetailsSectionElement
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.ScannedCardDetails
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.utils.screenshots.PaymentSheetAppearance.DefaultAppearance
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -228,7 +228,7 @@ class CardUiDefinitionFactoryTest {
         )
 
         val saveForFutureUseElement = formElements.first {
-            it.identifier == IdentifierSpec.SaveForFutureUse
+            it.identifier == FormFieldId.SaveForFutureUse
         } as SaveForFutureUseElement
 
         saveForFutureUseElement.controller.onValueChange(true)
@@ -388,7 +388,7 @@ class CardUiDefinitionFactoryTest {
                             "exp_year" to "2050",
                             "cvc" to "123",
                         ),
-                        "billing_details" to emptyMap<IdentifierSpec, String?>(),
+                        "billing_details" to emptyMap<FormFieldId, String?>(),
                     ),
                     productUsage = emptySet(),
                     clientAttributionMetadata = CLIENT_ATTRIBUTION_METADATA,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CashAppPayLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val cashAppPayRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val cashAppPayTypeOnlyExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CryptoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/CryptoLpmBillingAddressTestCases.kt
@@ -5,14 +5,14 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val cryptoRawValues = mapOf(
-    IdentifierSpec.Line1 to "221B Baker Street",
-    IdentifierSpec.Line2 to "Flat B",
-    IdentifierSpec.City to "London",
-    IdentifierSpec.PostalCode to "NW16XE",
-    IdentifierSpec.Country to "GB",
+    FormFieldId.Line1 to "221B Baker Street",
+    FormFieldId.Line2 to "Flat B",
+    FormFieldId.City to "London",
+    FormFieldId.PostalCode to "NW16XE",
+    FormFieldId.Country to "GB",
 )
 
 private val cryptoNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/EpsLpmBillingAddressTestCases.kt
@@ -5,16 +5,16 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val epsFullRawValues = mapOf(
-    IdentifierSpec.Generic("eps[bank]") to "bank_austria",
-    IdentifierSpec.Name to "Anna Gruber",
-    IdentifierSpec.Line1 to "Kärntner Straße 1",
-    IdentifierSpec.Line2 to "Top 2",
-    IdentifierSpec.City to "Vienna",
-    IdentifierSpec.PostalCode to "1010",
-    IdentifierSpec.Country to "AT",
+    FormFieldId.Generic("eps[bank]") to "bank_austria",
+    FormFieldId.Name to "Anna Gruber",
+    FormFieldId.Line1 to "Kärntner Straße 1",
+    FormFieldId.Line2 to "Top 2",
+    FormFieldId.City to "Vienna",
+    FormFieldId.PostalCode to "1010",
+    FormFieldId.Country to "AT",
 )
 
 private val epsNoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/FpxLpmBillingAddressTestCases.kt
@@ -5,16 +5,16 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val fpxRawValues = mapOf(
-    IdentifierSpec.Generic("fpx[bank]") to "affin_bank",
-    IdentifierSpec.Line1 to "12 Jalan Ampang",
-    IdentifierSpec.Line2 to "Level 3",
-    IdentifierSpec.City to "Kuala Lumpur",
-    IdentifierSpec.State to "Kuala Lumpur",
-    IdentifierSpec.PostalCode to "50450",
-    IdentifierSpec.Country to "MY",
+    FormFieldId.Generic("fpx[bank]") to "affin_bank",
+    FormFieldId.Line1 to "12 Jalan Ampang",
+    FormFieldId.Line2 to "Level 3",
+    FormFieldId.City to "Kuala Lumpur",
+    FormFieldId.State to "Kuala Lumpur",
+    FormFieldId.PostalCode to "50450",
+    FormFieldId.Country to "MY",
 )
 
 private val fpxBankExpectedParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/GrabPayLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val grabPayRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 private val grabPayNeverExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/IdealLpmBillingAddressTestCases.kt
@@ -5,19 +5,19 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val idealRawValues = mapOf(
-    IdentifierSpec.Name to "Sanne de Vries",
-    IdentifierSpec.Line1 to "Herengracht 1",
-    IdentifierSpec.Line2 to "Appartement 2",
-    IdentifierSpec.City to "Amsterdam",
-    IdentifierSpec.PostalCode to "1015 BA",
-    IdentifierSpec.Country to "NL",
+    FormFieldId.Name to "Sanne de Vries",
+    FormFieldId.Line1 to "Herengracht 1",
+    FormFieldId.Line2 to "Appartement 2",
+    FormFieldId.City to "Amsterdam",
+    FormFieldId.PostalCode to "1015 BA",
+    FormFieldId.Country to "NL",
 )
 
 private val idealSetupRawValues = idealRawValues + (
-    IdentifierSpec.Email to "sanne.devries@example.com"
+    FormFieldId.Email to "sanne.devries@example.com"
 )
 
 private val idealNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaDefinitionTest.kt
@@ -18,7 +18,7 @@ import com.stripe.android.ui.core.elements.PaymentMethodMessageHeaderElement
 import com.stripe.android.ui.core.elements.StaticTextElement
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import org.junit.Test
@@ -73,10 +73,10 @@ class KlarnaDefinitionTest {
 
         val countrySection = formElements[2] as SectionElement
         assertThat(countrySection.identifier).isEqualTo(
-            IdentifierSpec.Generic("billing_details[address][country]_section"),
+            FormFieldId.Generic("billing_details[address][country]_section"),
         )
         val countryElement = countrySection.fields.single() as CountryElement
-        assertThat(countryElement.identifier).isEqualTo(IdentifierSpec.Country)
+        assertThat(countryElement.identifier).isEqualTo(FormFieldId.Country)
         assertThat(countryElement.controller.displayItems).containsExactly(
             "🇫🇷 France",
             "🇩🇪 Germany",
@@ -87,7 +87,7 @@ class KlarnaDefinitionTest {
                 .flatMap { it.fields }
                 .filterIsInstance<CountryElement>(),
         ).hasSize(1)
-        assertThat(countrySection.fields.map { it.identifier }).containsExactly(IdentifierSpec.Country)
+        assertThat(countrySection.fields.map { it.identifier }).containsExactly(FormFieldId.Country)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KlarnaLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val klarnaRawValues = mapOf(
-    IdentifierSpec.Country to "DE",
-    IdentifierSpec.Email to "jane@example.com",
-    IdentifierSpec.Line1 to "Unter den Linden 1",
-    IdentifierSpec.Line2 to "Wohnung 2",
-    IdentifierSpec.City to "Berlin",
-    IdentifierSpec.PostalCode to "10117",
+    FormFieldId.Country to "DE",
+    FormFieldId.Email to "jane@example.com",
+    FormFieldId.Line1 to "Unter den Linden 1",
+    FormFieldId.Line2 to "Wohnung 2",
+    FormFieldId.City to "Berlin",
+    FormFieldId.PostalCode to "10117",
 )
 
 private val klarnaNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KonbiniLpmBillingAddressTestCases.kt
@@ -6,17 +6,17 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val konbiniFullRawValues = mapOf(
-    IdentifierSpec.Name to "Haruto Tanaka",
-    IdentifierSpec.Email to "haruto.tanaka@example.com",
-    IdentifierSpec.KonbiniConfirmationNumber to "09012345678",
-    IdentifierSpec.Line1 to "1-1 Marunouchi",
-    IdentifierSpec.Line2 to "Chiyoda Building 2F",
-    IdentifierSpec.State to "Tokyo",
-    IdentifierSpec.PostalCode to "100-0005",
-    IdentifierSpec.Country to "JP",
+    FormFieldId.Name to "Haruto Tanaka",
+    FormFieldId.Email to "haruto.tanaka@example.com",
+    FormFieldId.KonbiniConfirmationNumber to "09012345678",
+    FormFieldId.Line1 to "1-1 Marunouchi",
+    FormFieldId.Line2 to "Chiyoda Building 2F",
+    FormFieldId.State to "Tokyo",
+    FormFieldId.PostalCode to "100-0005",
+    FormFieldId.Country to "JP",
 )
 
 private val konbiniNoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KrCardLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/KrCardLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val krCardFullRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val krCardNoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/LpmBillingAddressFormValuesToParamsTest.kt
@@ -17,7 +17,7 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.ui.transformToPaymentSelection
 import com.stripe.android.paymentsheet.utils.ViewModelStoreTestRule
 import com.stripe.android.testing.CleanupTestRule
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.cancel
@@ -93,7 +93,7 @@ internal class LpmBillingAddressFormValuesToParamsTest {
 
     private suspend fun createFormParamsFromFormValues(
         config: LpmBillingAddressTestConfiguration,
-        rawValues: Map<IdentifierSpec, String?>,
+        rawValues: Map<FormFieldId, String?>,
     ): LpmBillingAddressFormParams {
         val metadata = config.metadata()
         val formViewModel = createFormViewModel(
@@ -111,7 +111,7 @@ internal class LpmBillingAddressFormValuesToParamsTest {
     private fun createFormViewModel(
         paymentMethodType: PaymentMethod.Type,
         metadata: PaymentMethodMetadata,
-        initialValues: Map<IdentifierSpec, String?>,
+        initialValues: Map<FormFieldId, String?>,
     ): FormViewModel {
         val formElements = requireNotNull(
             metadata.formElementsForCode(
@@ -168,7 +168,7 @@ private val specializedFlowDefinitions: Set<PaymentMethodDefinition> = setOf(
 internal data class LpmBillingAddressFormValuesToParamsTestCase(
     val name: String,
     val config: LpmBillingAddressTestConfiguration,
-    val rawValues: Map<IdentifierSpec, String?>,
+    val rawValues: Map<FormFieldId, String?>,
     val expectedParams: LpmBillingAddressFormParams,
 ) {
     override fun toString(): String = name

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MobilePayLpmBillingAddressTestCases.kt
@@ -5,14 +5,14 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val mobilePayFullRawValues = mapOf(
-    IdentifierSpec.Line1 to "Kongens Nytorv 1",
-    IdentifierSpec.Line2 to "2. sal",
-    IdentifierSpec.City to "København",
-    IdentifierSpec.PostalCode to "1050",
-    IdentifierSpec.Country to "DK",
+    FormFieldId.Line1 to "Kongens Nytorv 1",
+    FormFieldId.Line2 to "2. sal",
+    FormFieldId.City to "København",
+    FormFieldId.PostalCode to "1050",
+    FormFieldId.Country to "DK",
 )
 
 private val mobilePayNoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/MultibancoLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val multibancoRawValues = mapOf(
-    IdentifierSpec.Email to "ines.silva@example.com",
-    IdentifierSpec.Line1 to "Rua do Ouro 1",
-    IdentifierSpec.Line2 to "2.º Esq.",
-    IdentifierSpec.City to "Lisboa",
-    IdentifierSpec.PostalCode to "1100-063",
-    IdentifierSpec.Country to "PT",
+    FormFieldId.Email to "ines.silva@example.com",
+    FormFieldId.Line1 to "Rua do Ouro 1",
+    FormFieldId.Line2 to "2.º Esq.",
+    FormFieldId.City to "Lisboa",
+    FormFieldId.PostalCode to "1100-063",
+    FormFieldId.Country to "PT",
 )
 
 private val multibancoNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/NaverPayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/NaverPayLpmBillingAddressTestCases.kt
@@ -5,16 +5,16 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val naverPayRawValues = mapOf(
-    IdentifierSpec.Generic("naver_pay[funding]") to "card",
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Generic("naver_pay[funding]") to "card",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val naverPayExpectedParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/OxxoLpmBillingAddressTestCases.kt
@@ -5,17 +5,17 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val oxxoFullRawValues = mapOf(
-    IdentifierSpec.Name to "Ana Garcia",
-    IdentifierSpec.Email to "ana.garcia@example.com",
-    IdentifierSpec.Line1 to "Paseo de la Reforma 222",
-    IdentifierSpec.Line2 to "Piso 3",
-    IdentifierSpec.City to "Ciudad de Mexico",
-    IdentifierSpec.State to "CDMX",
-    IdentifierSpec.PostalCode to "06600",
-    IdentifierSpec.Country to "MX",
+    FormFieldId.Name to "Ana Garcia",
+    FormFieldId.Email to "ana.garcia@example.com",
+    FormFieldId.Line1 to "Paseo de la Reforma 222",
+    FormFieldId.Line2 to "Piso 3",
+    FormFieldId.City to "Ciudad de Mexico",
+    FormFieldId.State to "CDMX",
+    FormFieldId.PostalCode to "06600",
+    FormFieldId.Country to "MX",
 )
 
 private val oxxoNoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24LpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/P24LpmBillingAddressTestCases.kt
@@ -5,17 +5,17 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val p24FullRawValues = mapOf(
-    IdentifierSpec.Generic("p24[bank]") to "santander_przelew24",
-    IdentifierSpec.Name to "Anna Kowalska",
-    IdentifierSpec.Email to "anna.kowalska@example.com",
-    IdentifierSpec.Line1 to "Marszalkowska 1",
-    IdentifierSpec.Line2 to "Apartment 2",
-    IdentifierSpec.City to "Warsaw",
-    IdentifierSpec.PostalCode to "00-001",
-    IdentifierSpec.Country to "PL",
+    FormFieldId.Generic("p24[bank]") to "santander_przelew24",
+    FormFieldId.Name to "Anna Kowalska",
+    FormFieldId.Email to "anna.kowalska@example.com",
+    FormFieldId.Line1 to "Marszalkowska 1",
+    FormFieldId.Line2 to "Apartment 2",
+    FormFieldId.City to "Warsaw",
+    FormFieldId.PostalCode to "00-001",
+    FormFieldId.Country to "PL",
 )
 
 private val p24NoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayByBankLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayByBankLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val payByBankRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 private val payByBankNeverExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayNowLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayNowLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val payNowRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 private val payNowNeverExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPalLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val payPalRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val payPalTypeOnlyExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PayPayLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val payPayRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 private val payPayNeverExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PaycoLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PaycoLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val paycoFullRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val paycoNoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PromptPayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/PromptPayLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val promptPayRawValues = mapOf(
-    IdentifierSpec.Email to "pimchanok.sukjai@example.com",
-    IdentifierSpec.Line1 to "1 ถนนสุขุมวิท",
-    IdentifierSpec.Line2 to "ชั้น 2",
-    IdentifierSpec.City to "กรุงเทพมหานคร",
-    IdentifierSpec.PostalCode to "10110",
-    IdentifierSpec.Country to "TH",
+    FormFieldId.Email to "pimchanok.sukjai@example.com",
+    FormFieldId.Line1 to "1 ถนนสุขุมวิท",
+    FormFieldId.Line2 to "ชั้น 2",
+    FormFieldId.City to "กรุงเทพมหานคร",
+    FormFieldId.PostalCode to "10110",
+    FormFieldId.Country to "TH",
 )
 
 private val promptPayNeverExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/RevolutPayLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val revolutPayRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val revolutPayTypeOnlyExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SatispayLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val satispayRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 
 private val satispayTypeOnlyExpectedParams = LpmBillingAddressFormParams(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SepaDebitLpmBillingAddressTestCases.kt
@@ -7,20 +7,20 @@ import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodExtraParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val sepaDebitNoBillingAddressRawValues = mapOf(
-    IdentifierSpec.Generic("sepa_debit[iban]") to "DE89370400440532013000",
+    FormFieldId.Generic("sepa_debit[iban]") to "DE89370400440532013000",
 )
 
 private val sepaDebitWithBillingAddressRawValues = sepaDebitNoBillingAddressRawValues + mapOf(
-    IdentifierSpec.Name to "Jane Doe",
-    IdentifierSpec.Email to "jane@example.com",
-    IdentifierSpec.Line1 to "Unter den Linden 1",
-    IdentifierSpec.Line2 to "Wohnung 2",
-    IdentifierSpec.City to "Berlin",
-    IdentifierSpec.Country to "DE",
-    IdentifierSpec.PostalCode to "10117",
+    FormFieldId.Name to "Jane Doe",
+    FormFieldId.Email to "jane@example.com",
+    FormFieldId.Line1 to "Unter den Linden 1",
+    FormFieldId.Line2 to "Wohnung 2",
+    FormFieldId.City to "Berlin",
+    FormFieldId.Country to "DE",
+    FormFieldId.PostalCode to "10117",
 )
 
 private val sepaDebitNoBillingAddressExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SequraLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SequraLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val sequraFullRawValues = mapOf(
-    IdentifierSpec.Line1 to "Gran Vía 1",
-    IdentifierSpec.Line2 to "Piso 2",
-    IdentifierSpec.City to "Madrid",
-    IdentifierSpec.State to "Madrid",
-    IdentifierSpec.PostalCode to "28013",
-    IdentifierSpec.Country to "ES",
+    FormFieldId.Line1 to "Gran Vía 1",
+    FormFieldId.Line2 to "Piso 2",
+    FormFieldId.City to "Madrid",
+    FormFieldId.State to "Madrid",
+    FormFieldId.PostalCode to "28013",
+    FormFieldId.Country to "ES",
 )
 
 private val sequraNoBillingDetailsExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SunbitLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SunbitLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val sunbitRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 private val sunbitNeverExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/SwishLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val swishRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 private val swishNeverExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/TwintLpmBillingAddressTestCases.kt
@@ -5,14 +5,14 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val twintRawValues = mapOf(
-    IdentifierSpec.Line1 to "Bahnhofstrasse 1",
-    IdentifierSpec.Line2 to "2. Stock",
-    IdentifierSpec.City to "Zürich",
-    IdentifierSpec.PostalCode to "8001",
-    IdentifierSpec.Country to "CH",
+    FormFieldId.Line1 to "Bahnhofstrasse 1",
+    FormFieldId.Line2 to "2. Stock",
+    FormFieldId.City to "Zürich",
+    FormFieldId.PostalCode to "8001",
+    FormFieldId.Country to "CH",
 )
 private val twintTypeOnlyExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeChatPayLpmBillingAddressTestCases.kt
@@ -6,15 +6,15 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.model.PaymentMethodOptionsParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val weChatPayRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 private val weChatPayNeverExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroDefinitionTest.kt
@@ -9,7 +9,7 @@ import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -25,7 +25,7 @@ class WeroDefinitionTest {
                     paymentMethodTypes = listOf("wero")
                 )
             ),
-            initialValues = mapOf(IdentifierSpec.Country to "BE"),
+            initialValues = mapOf(FormFieldId.Country to "BE"),
         )
 
         assertThat(formElements).hasSize(1)
@@ -72,7 +72,7 @@ class WeroDefinitionTest {
                     address = PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full,
                 ),
             ),
-            initialValues = mapOf(IdentifierSpec.Country to "DE"),
+            initialValues = mapOf(FormFieldId.Country to "DE"),
         )
 
         assertThat(formElements).hasSize(4)

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/WeroLpmBillingAddressTestCases.kt
@@ -5,17 +5,17 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val weroCountryOnlyRawValues = mapOf(
-    IdentifierSpec.Country to "DE",
+    FormFieldId.Country to "DE",
 )
 
 private val weroWithBillingAddressRawValues = weroCountryOnlyRawValues + mapOf(
-    IdentifierSpec.Line1 to "Unter den Linden 1",
-    IdentifierSpec.Line2 to "Wohnung 2",
-    IdentifierSpec.City to "Berlin",
-    IdentifierSpec.PostalCode to "10117",
+    FormFieldId.Line1 to "Unter den Linden 1",
+    FormFieldId.Line2 to "Wohnung 2",
+    FormFieldId.City to "Berlin",
+    FormFieldId.PostalCode to "10117",
 )
 
 private val weroCountryOnlyExpectedPaymentMethodParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipLpmBillingAddressTestCases.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/definitions/ZipLpmBillingAddressTestCases.kt
@@ -5,15 +5,15 @@ import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodCreateParams
 import com.stripe.android.paymentsheet.PaymentSheet
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 
 private val zipRawValues = mapOf(
-    IdentifierSpec.Line1 to "510 Townsend St",
-    IdentifierSpec.Line2 to "Floor 2",
-    IdentifierSpec.City to "San Francisco",
-    IdentifierSpec.State to "CA",
-    IdentifierSpec.PostalCode to "94103",
-    IdentifierSpec.Country to "US",
+    FormFieldId.Line1 to "510 Townsend St",
+    FormFieldId.Line2 to "Floor 2",
+    FormFieldId.City to "San Francisco",
+    FormFieldId.State to "CA",
+    FormFieldId.PostalCode to "94103",
+    FormFieldId.Country to "US",
 )
 private val zipNeverExpectedParams = LpmBillingAddressFormParams(
     createParams = PaymentMethodCreateParams.createWithOverride(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/FormHelperTest.kt
@@ -39,7 +39,7 @@ import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.ui.core.Amount
 import com.stripe.android.ui.core.R
 import com.stripe.android.ui.core.elements.PaymentMethodMessageHeaderElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
@@ -202,8 +202,8 @@ internal class FormHelperTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
-                IdentifierSpec.Name to FormFieldEntry(name, true),
+                FormFieldId.CardBrand to FormFieldEntry(cardBrand, true),
+                FormFieldId.Name to FormFieldEntry(name, true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -263,8 +263,8 @@ internal class FormHelperTest {
 
             val formFieldValues = FormFieldValues(
                 fieldValuePairs = mapOf(
-                    IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
-                    IdentifierSpec.Name to FormFieldEntry(name, true),
+                    FormFieldId.CardBrand to FormFieldEntry(cardBrand, true),
+                    FormFieldId.Name to FormFieldEntry(name, true),
                 ),
                 userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
             )
@@ -287,8 +287,8 @@ internal class FormHelperTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Country to FormFieldEntry("US", true),
-                IdentifierSpec.Email to FormFieldEntry("Joe@stripe.com", true),
+                FormFieldId.Country to FormFieldEntry("US", true),
+                FormFieldId.Email to FormFieldEntry("Joe@stripe.com", true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -331,8 +331,8 @@ internal class FormHelperTest {
 
         val firstFormFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Country to FormFieldEntry("US", true),
-                IdentifierSpec.Email to FormFieldEntry("Joe@stripe.com", true),
+                FormFieldId.Country to FormFieldEntry("US", true),
+                FormFieldId.Email to FormFieldEntry("Joe@stripe.com", true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -342,8 +342,8 @@ internal class FormHelperTest {
 
         val secondFormFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Country to FormFieldEntry("UK", true),
-                IdentifierSpec.Email to FormFieldEntry("Joey@stripe.com", true),
+                FormFieldId.Country to FormFieldEntry("UK", true),
+                FormFieldId.Email to FormFieldEntry("Joey@stripe.com", true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -371,8 +371,8 @@ internal class FormHelperTest {
 
         val klarnaFormFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Country to FormFieldEntry("US", true),
-                IdentifierSpec.Email to FormFieldEntry("Joe@stripe.com", true),
+                FormFieldId.Country to FormFieldEntry("US", true),
+                FormFieldId.Email to FormFieldEntry("Joe@stripe.com", true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -382,8 +382,8 @@ internal class FormHelperTest {
 
         val cardFormFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                IdentifierSpec.Name to FormFieldEntry("joe", true),
+                FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                FormFieldId.Name to FormFieldEntry("joe", true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -397,8 +397,8 @@ internal class FormHelperTest {
     fun `onFormFieldValuesChanged & onLinkStateChanged calls create Link Inline selection when card`() = runTest {
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                IdentifierSpec.Name to FormFieldEntry("Joe", true),
+                FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                FormFieldId.Name to FormFieldEntry("Joe", true),
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
         )
@@ -449,8 +449,8 @@ internal class FormHelperTest {
     fun `Skips Link if not being used`() = runTest {
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                IdentifierSpec.Name to FormFieldEntry("Joe", true),
+                FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                FormFieldId.Name to FormFieldEntry("Joe", true),
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
         )
@@ -499,7 +499,7 @@ internal class FormHelperTest {
     fun `onFormFieldValuesChanged & onLinkStateChanged calls create generic selection when not card`() = runTest {
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Name to FormFieldEntry("Joe", true),
+                FormFieldId.Name to FormFieldEntry("Joe", true),
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
         )
@@ -554,8 +554,8 @@ internal class FormHelperTest {
     fun `Creates null selection if Link input is null when expanded`() = runTest {
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
-                IdentifierSpec.Name to FormFieldEntry("Joe", true),
+                FormFieldId.CardBrand to FormFieldEntry("visa", true),
+                FormFieldId.Name to FormFieldEntry("Joe", true),
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
         )
@@ -627,8 +627,8 @@ internal class FormHelperTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
-                IdentifierSpec.Name to FormFieldEntry(name, true),
+                FormFieldId.CardBrand to FormFieldEntry(cardBrand, true),
+                FormFieldId.Name to FormFieldEntry(name, true),
             ),
             userRequestedReuse = customerRequestedSave,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentOptionsViewModelTest.kt
@@ -72,7 +72,7 @@ import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.PaymentMethodFactory
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
@@ -1389,7 +1389,7 @@ internal class PaymentOptionsViewModelTest {
             formHelper.onFormFieldValuesChanged(
                 formValues = FormFieldValues(
                     fieldValuePairs = mapOf(
-                        IdentifierSpec.CardBrand to FormFieldEntry(CardBrand.Visa.code, true),
+                        FormFieldId.CardBrand to FormFieldEntry(CardBrand.Visa.code, true),
                     ),
                     userRequestedReuse = expectedCustomerRequestedSave,
                 ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/PaymentSheetViewModelTest.kt
@@ -126,7 +126,7 @@ import com.stripe.android.testing.PaymentIntentFactory
 import com.stripe.android.testing.ResetMockRule
 import com.stripe.android.testing.SessionTestRule
 import com.stripe.android.ui.core.Amount
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.utils.BankFormScreenStateFactory
 import com.stripe.android.utils.FakeIsNfcScanningAvailable
@@ -824,7 +824,7 @@ internal class PaymentSheetViewModelTest {
             formHelper.onFormFieldValuesChanged(
                 formValues = FormFieldValues(
                     fieldValuePairs = mapOf(
-                        IdentifierSpec.CardBrand to FormFieldEntry(CardBrand.Visa.code, true),
+                        FormFieldId.CardBrand to FormFieldEntry(CardBrand.Visa.code, true),
                     ),
                     userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
                 ),
@@ -2804,7 +2804,7 @@ internal class PaymentSheetViewModelTest {
                 formHelper.onFormFieldValuesChanged(
                     formValues = FormFieldValues(
                         fieldValuePairs = mapOf(
-                            IdentifierSpec.CardBrand to FormFieldEntry(CardBrand.Visa.code, true),
+                            FormFieldId.CardBrand to FormFieldEntry(CardBrand.Visa.code, true),
                         ),
                         userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
                     ),
@@ -2836,7 +2836,7 @@ internal class PaymentSheetViewModelTest {
                 formHelper.onFormFieldValuesChanged(
                     formValues = FormFieldValues(
                         fieldValuePairs = mapOf(
-                            IdentifierSpec.Country to FormFieldEntry("CA", true),
+                            FormFieldId.Country to FormFieldEntry("CA", true),
                         ),
                         userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
                     ),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressFormControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressFormControllerTest.kt
@@ -8,7 +8,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.uicore.elements.AddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionElement
@@ -39,39 +39,39 @@ class AddressFormControllerTest {
 
         assertThat(
             fields.any { field ->
-                field.identifier == IdentifierSpec.Name
+                field.identifier == FormFieldId.Name
             }
         ).isTrue()
 
         assertThat(
             fields.any { field ->
-                field.identifier == IdentifierSpec.Line1
+                field.identifier == FormFieldId.Line1
             }
         ).isTrue()
 
         assertThat(
             fields.any { field ->
-                field.identifier == IdentifierSpec.Line2
+                field.identifier == FormFieldId.Line2
             }
         ).isTrue()
 
         assertThat(
             fields.any { field ->
                 field is RowElement &&
-                    field.fields.any { it.identifier == IdentifierSpec.City } &&
-                    field.fields.any { it.identifier == IdentifierSpec.PostalCode }
+                    field.fields.any { it.identifier == FormFieldId.City } &&
+                    field.fields.any { it.identifier == FormFieldId.PostalCode }
             }
         ).isTrue()
 
         assertThat(
             fields.any { field ->
-                field.identifier == IdentifierSpec.State
+                field.identifier == FormFieldId.State
             }
         ).isTrue()
 
         assertThat(
             fields.any { field ->
-                field.identifier == IdentifierSpec.Country
+                field.identifier == FormFieldId.Country
             }
         ).isTrue()
     }
@@ -113,29 +113,29 @@ class AddressFormControllerTest {
             registerCall.onEvent(
                 AutocompleteAddressInteractor.Event.OnValues(
                     values = mapOf(
-                        IdentifierSpec.Name to "John Doe",
-                        IdentifierSpec.Line1 to "123 Apple Street",
-                        IdentifierSpec.City to "San Francisco",
-                        IdentifierSpec.State to "CA",
-                        IdentifierSpec.Country to "US",
-                        IdentifierSpec.PostalCode to "94111",
+                        FormFieldId.Name to "John Doe",
+                        FormFieldId.Line1 to "123 Apple Street",
+                        FormFieldId.City to "San Francisco",
+                        FormFieldId.State to "CA",
+                        FormFieldId.Country to "US",
+                        FormFieldId.PostalCode to "94111",
                     ),
                 )
             )
 
             val completeFormValues = awaitItem()
 
-            assertThat(completeFormValues?.get(IdentifierSpec.Line1))
+            assertThat(completeFormValues?.get(FormFieldId.Line1))
                 .isEqualTo(FormFieldEntry(value = "123 Apple Street", isComplete = true))
-            assertThat(completeFormValues?.get(IdentifierSpec.Line2))
+            assertThat(completeFormValues?.get(FormFieldId.Line2))
                 .isEqualTo(FormFieldEntry(value = "", isComplete = true))
-            assertThat(completeFormValues?.get(IdentifierSpec.City))
+            assertThat(completeFormValues?.get(FormFieldId.City))
                 .isEqualTo(FormFieldEntry(value = "San Francisco", isComplete = true))
-            assertThat(completeFormValues?.get(IdentifierSpec.State))
+            assertThat(completeFormValues?.get(FormFieldId.State))
                 .isEqualTo(FormFieldEntry(value = "CA", isComplete = true))
-            assertThat(completeFormValues?.get(IdentifierSpec.Country))
+            assertThat(completeFormValues?.get(FormFieldId.Country))
                 .isEqualTo(FormFieldEntry(value = "US", isComplete = true))
-            assertThat(completeFormValues?.get(IdentifierSpec.PostalCode))
+            assertThat(completeFormValues?.get(FormFieldId.PostalCode))
                 .isEqualTo(FormFieldEntry(value = "94111", isComplete = true))
         }
     }
@@ -154,11 +154,11 @@ class AddressFormControllerTest {
         registerCall.onEvent(
             AutocompleteAddressInteractor.Event.OnValues(
                 values = mapOf(
-                    IdentifierSpec.Name to "John Doe",
-                    IdentifierSpec.Line1 to "123 Apple Street",
-                    IdentifierSpec.State to "CA",
-                    IdentifierSpec.Country to "US",
-                    IdentifierSpec.PostalCode to "94111",
+                    FormFieldId.Name to "John Doe",
+                    FormFieldId.Line1 to "123 Apple Street",
+                    FormFieldId.State to "CA",
+                    FormFieldId.Country to "US",
+                    FormFieldId.PostalCode to "94111",
                 ),
             )
         )
@@ -188,20 +188,20 @@ class AddressFormControllerTest {
         )
 
         addressFormController.lastTextFieldIdentifier.test {
-            assertThat(awaitItem()).isEqualTo(IdentifierSpec.PostalCode)
+            assertThat(awaitItem()).isEqualTo(FormFieldId.PostalCode)
         }
     }
 
     @Test
     fun `Initial provided values are pushed to address element`() = addressElementTest(
         initialValues = mapOf(
-            IdentifierSpec.Name to "John Doe",
-            IdentifierSpec.Line1 to "123 Apple Street",
-            IdentifierSpec.City to "San Francisco",
-            IdentifierSpec.State to "CA",
-            IdentifierSpec.Country to "US",
-            IdentifierSpec.PostalCode to "94111",
-            IdentifierSpec.Phone to "+17893424625"
+            FormFieldId.Name to "John Doe",
+            FormFieldId.Line1 to "123 Apple Street",
+            FormFieldId.City to "San Francisco",
+            FormFieldId.State to "CA",
+            FormFieldId.Country to "US",
+            FormFieldId.PostalCode to "94111",
+            FormFieldId.Phone to "+17893424625"
         ),
         autocompleteConfig = AutocompleteAddressInteractor.Config(
             autocompleteCountries = setOf("US"),
@@ -213,15 +213,15 @@ class AddressFormControllerTest {
         element.getFormFieldValueFlow().test {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
-                    IdentifierSpec.Phone to FormFieldEntry(value = "+17893424625", isComplete = true),
-                    IdentifierSpec.PhoneNumberCountry to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
+                    FormFieldId.Phone to FormFieldEntry(value = "+17893424625", isComplete = true),
+                    FormFieldId.PhoneNumberCountry to FormFieldEntry(value = "US", isComplete = true),
                 )
             )
         }
@@ -247,7 +247,7 @@ class AddressFormControllerTest {
     }
 
     private fun fieldsTest(
-        initialValues: Map<IdentifierSpec, String?> = emptyMap(),
+        initialValues: Map<FormFieldId, String?> = emptyMap(),
         autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
             autocompleteCountries = setOf("US"),
             googlePlacesApiKey = null,
@@ -267,7 +267,7 @@ class AddressFormControllerTest {
     }
 
     private fun addressElementTest(
-        initialValues: Map<IdentifierSpec, String?> = emptyMap(),
+        initialValues: Map<FormFieldId, String?> = emptyMap(),
         autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
             autocompleteCountries = setOf("US"),
             googlePlacesApiKey = null,
@@ -315,7 +315,7 @@ class AddressFormControllerTest {
     }
 
     private fun TestAutocompleteAddressInteractor.Scenario.createAddressFormController(
-        initialValues: Map<IdentifierSpec, String?> = emptyMap(),
+        initialValues: Map<FormFieldId, String?> = emptyMap(),
         launcherConfig: AddressLauncher.Configuration = AddressLauncher.Configuration(
             additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
                 phone = AddressLauncher.AdditionalFieldsConfiguration.FieldConfiguration.HIDDEN,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteControllerTest.kt
@@ -9,7 +9,7 @@ import com.stripe.android.ui.core.elements.autocomplete.model.AutocompletePredic
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor.InlinePredictionsState
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,7 +97,7 @@ class InlineAutocompleteControllerTest {
         val event = eventCalls.awaitItem()
         assertThat(event).isEqualTo(
             AutocompleteAddressInteractor.Event.OnValues(
-                mapOf(IdentifierSpec.Country to "CA")
+                mapOf(FormFieldId.Country to "CA")
             )
         )
     }
@@ -272,11 +272,11 @@ class InlineAutocompleteControllerTest {
             .isInstanceOf<AutocompleteAddressInteractor.Event.OnExpandForm>()
         val values =
             (event as AutocompleteAddressInteractor.Event.OnExpandForm).values
-        assertThat(values?.get(IdentifierSpec.Line1)).isEqualTo("123 Main Street")
-        assertThat(values?.get(IdentifierSpec.City)).isEqualTo("San Francisco")
-        assertThat(values?.get(IdentifierSpec.State)).isEqualTo("CA")
-        assertThat(values?.get(IdentifierSpec.Country)).isEqualTo("US")
-        assertThat(values?.get(IdentifierSpec.PostalCode)).isEqualTo("94105")
+        assertThat(values?.get(FormFieldId.Line1)).isEqualTo("123 Main Street")
+        assertThat(values?.get(FormFieldId.City)).isEqualTo("San Francisco")
+        assertThat(values?.get(FormFieldId.State)).isEqualTo("CA")
+        assertThat(values?.get(FormFieldId.Country)).isEqualTo("US")
+        assertThat(values?.get(FormFieldId.PostalCode)).isEqualTo("94105")
     }
 
     @Test
@@ -554,7 +554,7 @@ class InlineAutocompleteControllerTest {
         countryFlow.value = "CA"
         advanceTimeBy(500)
         assertThat(eventCalls.awaitItem()).isEqualTo(
-            AutocompleteAddressInteractor.Event.OnValues(mapOf(IdentifierSpec.Country to "CA"))
+            AutocompleteAddressInteractor.Event.OnValues(mapOf(FormFieldId.Country to "CA"))
         )
 
         // Expanding removes the inline field from composition, so focus is lost. The country
@@ -565,7 +565,7 @@ class InlineAutocompleteControllerTest {
         countryFlow.value = "US"
         advanceTimeBy(500)
         assertThat(eventCalls.awaitItem()).isEqualTo(
-            AutocompleteAddressInteractor.Event.OnValues(mapOf(IdentifierSpec.Country to "US"))
+            AutocompleteAddressInteractor.Event.OnValues(mapOf(FormFieldId.Country to "US"))
         )
     }
 
@@ -728,8 +728,8 @@ class InlineAutocompleteControllerTest {
         assertThat(eventCalls.awaitItem()).isEqualTo(
             AutocompleteAddressInteractor.Event.OnExpandForm(
                 values = mapOf(
-                    IdentifierSpec.Line1 to "123 Main",
-                    IdentifierSpec.Country to "US",
+                    FormFieldId.Line1 to "123 Main",
+                    FormFieldId.Country to "US",
                 )
             )
         )
@@ -762,8 +762,8 @@ class InlineAutocompleteControllerTest {
         assertThat(eventCalls.awaitItem()).isEqualTo(
             AutocompleteAddressInteractor.Event.OnExpandForm(
                 values = mapOf(
-                    IdentifierSpec.Line1 to "456 Oak Ave",
-                    IdentifierSpec.Country to "US",
+                    FormFieldId.Line1 to "456 Oak Ave",
+                    FormFieldId.Country to "US",
                 )
             )
         )
@@ -904,8 +904,8 @@ class InlineAutocompleteControllerTest {
         assertThat(eventCalls.awaitItem()).isEqualTo(
             AutocompleteAddressInteractor.Event.OnExpandForm(
                 values = mapOf(
-                    IdentifierSpec.Line1 to "123 Main St",
-                    IdentifierSpec.Country to "US",
+                    FormFieldId.Line1 to "123 Main St",
+                    FormFieldId.Country to "US",
                 )
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteCountrySwitchIntegrationTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InlineAutocompleteCountrySwitchIntegrationTest.kt
@@ -11,7 +11,7 @@ import com.stripe.android.uicore.elements.AutocompleteAddressController
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
@@ -48,8 +48,8 @@ class InlineAutocompleteCountrySwitchIntegrationTest {
             )
             val countryController = DropdownFieldController(CountryConfig(setOf("US", "JP")), "US")
             val controller = AutocompleteAddressController(
-                identifier = IdentifierSpec.Generic("address"),
-                initialValues = mapOf(IdentifierSpec.Country to "US"),
+                identifier = FormFieldId.Generic("address"),
+                initialValues = mapOf(FormFieldId.Country to "US"),
                 countryDropdownFieldController = countryController,
                 phoneNumberConfig = AddressFieldConfiguration.HIDDEN,
                 nameConfig = AddressFieldConfiguration.HIDDEN,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -13,7 +13,7 @@ import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -377,13 +377,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = true))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
                 )
             )
 
@@ -393,20 +393,20 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = false))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.Generic("address") to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Name to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.Generic("address") to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
             viewModel.onEnterManuallyFromInline()
-            assertThat(formValuesTurbine.awaitItem().keys).contains(IdentifierSpec.Line1)
+            assertThat(formValuesTurbine.awaitItem().keys).contains(FormFieldId.Line1)
 
             viewModel.setRawValues(
                 mapOf(
-                    IdentifierSpec.Name to "Jane Doe",
-                    IdentifierSpec.Line1 to "123 Pear Street",
-                    IdentifierSpec.PostalCode to "88888",
+                    FormFieldId.Name to "Jane Doe",
+                    FormFieldId.Line1 to "123 Pear Street",
+                    FormFieldId.PostalCode to "88888",
                 )
             )
 
@@ -414,13 +414,13 @@ class InputAddressViewModelTest {
             shippingSameAsBillingStateTurbine.expectNoEvents()
             assertThat(formValuesTurbine.expectMostRecentItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Pear Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "88888", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Pear Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "88888", isComplete = true)
                 )
             )
 
@@ -430,13 +430,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = true))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
                 )
             )
 
@@ -446,13 +446,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = false))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Pear Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "88888", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Pear Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "88888", isComplete = true)
                 )
             )
 
@@ -462,21 +462,21 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = true))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
                 )
             )
 
             viewModel.setRawValues(
                 mapOf(
-                    IdentifierSpec.Name to "Jane Doe",
-                    IdentifierSpec.Line1 to "123 Coffee Street",
-                    IdentifierSpec.PostalCode to "77777",
+                    FormFieldId.Name to "Jane Doe",
+                    FormFieldId.Line1 to "123 Coffee Street",
+                    FormFieldId.PostalCode to "77777",
                 )
             )
 
@@ -484,13 +484,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = false))
             assertThat(formValuesTurbine.expectMostRecentItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Coffee Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "77777", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Coffee Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "77777", isComplete = true)
                 )
             )
 
@@ -545,13 +545,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = false))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Coffee Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Jose", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "77777", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Coffee Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Jose", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "77777", isComplete = true)
                 )
             )
 
@@ -561,13 +561,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = true))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
                 )
             )
 
@@ -577,13 +577,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = false))
             assertThat(formValuesTurbine.expectMostRecentItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Coffee Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Jose", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "77777", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "Jane Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Coffee Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Jose", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "77777", isComplete = true)
                 )
             )
 
@@ -638,13 +638,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = true))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
                 )
             )
 
@@ -654,9 +654,9 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = false))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.Generic("address") to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Name to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.Generic("address") to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
@@ -713,13 +713,13 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = true))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Apple Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "99999", isComplete = true)
                 )
             )
 
@@ -729,9 +729,9 @@ class InputAddressViewModelTest {
             assertThat(shippingSameAsBillingStateTurbine.awaitItem()).isEqualTo(createShowState(isChecked = false))
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.Generic("address") to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Name to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.Generic("address") to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
@@ -893,9 +893,9 @@ class InputAddressViewModelTest {
                 .isEqualTo(InputAddressViewModel.ShippingSameAsBillingState.Hide)
             assertThat(formValuesTurbine.awaitItem()).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Generic("address") to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Name to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Generic("address") to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
@@ -925,7 +925,7 @@ class InputAddressViewModelTest {
     }
 
     private fun InputAddressViewModel.setRawValues(
-        values: Map<IdentifierSpec, String?>
+        values: Map<FormFieldId, String?>
     ) {
         val elements = addressFormController.elements
 
@@ -1016,7 +1016,7 @@ class InputAddressViewModelTest {
         assertThat(emittedEvent)
             .isEqualTo(
                 AutocompleteAddressInteractor.Event.OnExpandForm(
-                    values = mapOf(IdentifierSpec.Country to "US")
+                    values = mapOf(FormFieldId.Country to "US")
                 )
             )
     }
@@ -1037,8 +1037,8 @@ class InputAddressViewModelTest {
         assertThat(emittedEvent).isEqualTo(
             AutocompleteAddressInteractor.Event.OnExpandForm(
                 values = mapOf(
-                    IdentifierSpec.Line1 to "123 Main St",
-                    IdentifierSpec.Country to "US",
+                    FormFieldId.Line1 to "123 Main St",
+                    FormFieldId.Country to "US",
                 )
             )
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/PaymentElementAutocompleteAddressInteractorTest.kt
@@ -6,7 +6,7 @@ import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.analytics.FakeAddressLauncherEventReporter
 import com.stripe.android.ui.core.elements.autocomplete.model.FindAutocompletePredictionsResponse
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestScope
@@ -76,12 +76,12 @@ class PaymentElementAutocompleteAddressInteractorTest {
         assertThat(expandFormEvent.values).isNotNull()
         assertThat(expandFormEvent.values).containsExactlyEntriesIn(
             mapOf(
-                IdentifierSpec.Line1 to "123 Main Street",
-                IdentifierSpec.Line2 to "Apt 4B",
-                IdentifierSpec.City to "San Francisco",
-                IdentifierSpec.State to "CA",
-                IdentifierSpec.PostalCode to "94105",
-                IdentifierSpec.Country to "US",
+                FormFieldId.Line1 to "123 Main Street",
+                FormFieldId.Line2 to "Apt 4B",
+                FormFieldId.City to "San Francisco",
+                FormFieldId.State to "CA",
+                FormFieldId.PostalCode to "94105",
+                FormFieldId.Country to "US",
             )
         )
     }
@@ -112,12 +112,12 @@ class PaymentElementAutocompleteAddressInteractorTest {
 
         assertThat(valuesEvent.values).containsExactlyEntriesIn(
             mapOf(
-                IdentifierSpec.Line1 to "123 Main Street",
-                IdentifierSpec.Line2 to "Apt 4B",
-                IdentifierSpec.City to "San Francisco",
-                IdentifierSpec.State to "CA",
-                IdentifierSpec.PostalCode to "94105",
-                IdentifierSpec.Country to "US",
+                FormFieldId.Line1 to "123 Main Street",
+                FormFieldId.Line2 to "Apt 4B",
+                FormFieldId.City to "San Francisco",
+                FormFieldId.State to "CA",
+                FormFieldId.PostalCode to "94105",
+                FormFieldId.Country to "US",
             )
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/CompleteFormFieldValueFilterTest.kt
@@ -5,7 +5,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.uicore.elements.EmailConfig
 import com.stripe.android.uicore.elements.EmailElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionController
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
@@ -21,12 +21,12 @@ class CompleteFormFieldValueFilterTest {
     private val emailController = SimpleTextFieldController(EmailConfig())
     private var emailSection: SectionElement
 
-    private val hiddenIdentifersFlow = MutableStateFlow<Set<IdentifierSpec>>(emptySet())
+    private val hiddenIdentifersFlow = MutableStateFlow<Set<FormFieldId>>(emptySet())
 
     private val fieldFlow = MutableStateFlow(
         mapOf(
-            IdentifierSpec.Country to FormFieldEntry("US", true),
-            IdentifierSpec.Email to FormFieldEntry("email@email.com", false)
+            FormFieldId.Country to FormFieldEntry("US", true),
+            FormFieldId.Email to FormFieldEntry("email@email.com", false)
         )
     )
 
@@ -40,9 +40,9 @@ class CompleteFormFieldValueFilterTest {
     init {
         runBlocking {
             emailSection = SectionElement(
-                identifier = IdentifierSpec.Generic("email_section"),
+                identifier = FormFieldId.Generic("email_section"),
                 EmailElement(
-                    IdentifierSpec.Email,
+                    FormFieldId.Email,
                     controller = emailController
                 ),
                 SectionController(
@@ -65,33 +65,33 @@ class CompleteFormFieldValueFilterTest {
         runTest {
             fieldFlow.value =
                 mapOf(
-                    IdentifierSpec.Country to FormFieldEntry("US", true),
-                    IdentifierSpec.Email to FormFieldEntry("email@email.com", true)
+                    FormFieldId.Country to FormFieldEntry("US", true),
+                    FormFieldId.Email to FormFieldEntry("email@email.com", true)
                 )
 
             val formFieldValue = transformElementToFormFieldValueFlow.filterFlow().first()
 
             assertThat(formFieldValue).isNotNull()
             assertThat(formFieldValue?.fieldValuePairs)
-                .containsKey(IdentifierSpec.Email)
+                .containsKey(FormFieldId.Email)
             assertThat(formFieldValue?.fieldValuePairs)
-                .containsKey(IdentifierSpec.Country)
+                .containsKey(FormFieldId.Country)
         }
     }
 
     @Test
     fun `If an hidden field is incomplete field pairs have the non-hidden values`() {
         runTest {
-            hiddenIdentifersFlow.value = setOf(IdentifierSpec.Email)
+            hiddenIdentifersFlow.value = setOf(FormFieldId.Email)
 
             val formFieldValues = transformElementToFormFieldValueFlow.filterFlow()
 
             val formFieldValue = formFieldValues.first()
             assertThat(formFieldValue).isNotNull()
             assertThat(formFieldValue?.fieldValuePairs)
-                .doesNotContainKey(IdentifierSpec.Email)
+                .doesNotContainKey(FormFieldId.Email)
             assertThat(formFieldValue?.fieldValuePairs)
-                .containsKey(IdentifierSpec.Country)
+                .containsKey(FormFieldId.Country)
         }
     }
 
@@ -100,8 +100,8 @@ class CompleteFormFieldValueFilterTest {
         runTest {
             fieldFlow.value =
                 mapOf(
-                    IdentifierSpec.Country to FormFieldEntry("US", true),
-                    IdentifierSpec.Email to FormFieldEntry("email@email.com", true)
+                    FormFieldId.Country to FormFieldEntry("US", true),
+                    FormFieldId.Email to FormFieldEntry("email@email.com", true)
                 )
 
             hiddenIdentifersFlow.value = setOf(emailSection.fields[0].identifier)
@@ -110,9 +110,9 @@ class CompleteFormFieldValueFilterTest {
 
             assertThat(formFieldValue).isNotNull()
             assertThat(formFieldValue?.fieldValuePairs)
-                .doesNotContainKey(IdentifierSpec.Email)
+                .doesNotContainKey(FormFieldId.Email)
             assertThat(formFieldValue?.fieldValuePairs)
-                .containsKey(IdentifierSpec.Country)
+                .containsKey(FormFieldId.Country)
         }
     }
 
@@ -123,21 +123,21 @@ class CompleteFormFieldValueFilterTest {
             hiddenIdentifersFlow,
             userRequestedReuse = MutableStateFlow(PaymentSelection.CustomerRequestedSave.NoRequest),
             defaultValues = mapOf(
-                IdentifierSpec.Name to "Jane Doe",
-                IdentifierSpec.Email to "foo@bar.com",
+                FormFieldId.Name to "Jane Doe",
+                FormFieldId.Email to "foo@bar.com",
             ),
         )
 
         fieldFlow.value = mapOf(
-            IdentifierSpec.Country to FormFieldEntry("US", true),
+            FormFieldId.Country to FormFieldEntry("US", true),
         )
 
         formFieldValueFilter.filterFlow().test {
             assertThat(awaitItem()?.fieldValuePairs).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry("Jane Doe", true),
-                    IdentifierSpec.Email to FormFieldEntry("foo@bar.com", true),
-                    IdentifierSpec.Country to FormFieldEntry("US", true),
+                    FormFieldId.Name to FormFieldEntry("Jane Doe", true),
+                    FormFieldId.Email to FormFieldEntry("foo@bar.com", true),
+                    FormFieldId.Country to FormFieldEntry("US", true),
                 )
             )
         }
@@ -150,23 +150,23 @@ class CompleteFormFieldValueFilterTest {
             hiddenIdentifersFlow,
             userRequestedReuse = MutableStateFlow(PaymentSelection.CustomerRequestedSave.NoRequest),
             defaultValues = mapOf(
-                IdentifierSpec.Name to "Jane Doe",
-                IdentifierSpec.Email to "foo@bar.com",
+                FormFieldId.Name to "Jane Doe",
+                FormFieldId.Email to "foo@bar.com",
             ),
         )
 
         fieldFlow.value = mapOf(
-            IdentifierSpec.Country to FormFieldEntry("US", true),
-            IdentifierSpec.Name to FormFieldEntry("Jenny Rosen", true),
-            IdentifierSpec.Email to FormFieldEntry("mail@mail.com", true),
+            FormFieldId.Country to FormFieldEntry("US", true),
+            FormFieldId.Name to FormFieldEntry("Jenny Rosen", true),
+            FormFieldId.Email to FormFieldEntry("mail@mail.com", true),
         )
 
         formFieldValueFilter.filterFlow().test {
             assertThat(awaitItem()?.fieldValuePairs).containsExactlyEntriesIn(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry("Jenny Rosen", true),
-                    IdentifierSpec.Email to FormFieldEntry("mail@mail.com", true),
-                    IdentifierSpec.Country to FormFieldEntry("US", true),
+                    FormFieldId.Name to FormFieldEntry("Jenny Rosen", true),
+                    FormFieldId.Email to FormFieldEntry("mail@mail.com", true),
+                    FormFieldId.Country to FormFieldEntry("US", true),
                 )
             )
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/forms/FormViewModelTest.kt
@@ -28,7 +28,7 @@ import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PhoneNumberElement
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionElement
@@ -54,7 +54,7 @@ import com.stripe.android.uicore.R as UiCoreR
 @Suppress("LargeClass")
 @RunWith(RobolectricTestRunner::class)
 internal class FormViewModelTest {
-    private val emailIdentifier = IdentifierSpec.Email
+    private val emailIdentifier = FormFieldId.Email
 
     private val viewModelStoreRule = ViewModelStoreTestRule()
 
@@ -117,11 +117,11 @@ internal class FormViewModelTest {
                 )
             )
 
-            formViewModel.addHiddenIdentifiers(setOf(IdentifierSpec.Email))
+            formViewModel.addHiddenIdentifiers(setOf(FormFieldId.Email))
 
             // Verify formFieldValues does not contain email
             assertThat(formViewModel.lastTextFieldIdentifier.first()?.v1).isEqualTo(
-                IdentifierSpec.Name.v1
+                FormFieldId.Name.v1
             )
         }
 
@@ -149,13 +149,13 @@ internal class FormViewModelTest {
         // Verify formFieldValues contains email
         assertThat(
             formViewModel.completeFormValues.first()?.fieldValuePairs
-        ).containsKey(IdentifierSpec.Email)
+        ).containsKey(FormFieldId.Email)
 
-        formViewModel.addHiddenIdentifiers(setOf(IdentifierSpec.Email))
+        formViewModel.addHiddenIdentifiers(setOf(FormFieldId.Email))
 
         // Verify formFieldValues does not contain email
         assertThat(formViewModel.completeFormValues.first()?.fieldValuePairs)
-            .doesNotContainKey(IdentifierSpec.Email)
+            .doesNotContainKey(FormFieldId.Email)
     }
 
     @Test
@@ -184,7 +184,7 @@ internal class FormViewModelTest {
             // Verify formFieldValues is null because the email is required and invalid
             assertThat(formViewModel.completeFormValues.first()).isNull()
 
-            formViewModel.addHiddenIdentifiers(setOf(IdentifierSpec.Email))
+            formViewModel.addHiddenIdentifiers(setOf(FormFieldId.Email))
 
             // Verify formFieldValues is not null even though the card number is invalid
             // (because it is not required)
@@ -193,7 +193,7 @@ internal class FormViewModelTest {
                 completeFormFieldValues
             ).isNotNull()
             assertThat(formViewModel.completeFormValues.first()?.fieldValuePairs).doesNotContainKey(
-                IdentifierSpec.Email
+                FormFieldId.Email
             )
         }
 
@@ -233,23 +233,23 @@ internal class FormViewModelTest {
 
         nameElement?.onValueChange("joe")
         assertThat(
-            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(IdentifierSpec.Name)
+            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(FormFieldId.Name)
         ).isNull()
 
         emailElement?.onValueChange("joe@example.com")
         assertThat(
-            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(IdentifierSpec.Email)
+            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(FormFieldId.Email)
                 ?.value
         ).isEqualTo("joe@example.com")
         assertThat(
-            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(IdentifierSpec.Name)
+            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(FormFieldId.Name)
                 ?.value
         ).isEqualTo("joe")
 
         emailElement?.onValueChange("invalid.email@IncompleteDomain")
 
         assertThat(
-            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(IdentifierSpec.Name)
+            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(FormFieldId.Name)
         ).isNull()
     }
 
@@ -260,7 +260,7 @@ internal class FormViewModelTest {
             billingDetails = null
         )
         val addressElements = createAddressElements(
-            identifier = IdentifierSpec.Generic("address"),
+            identifier = FormFieldId.Generic("address"),
             allowedCountryCodes = setOf("US", "JP"),
             hideCountry = false,
         )
@@ -282,7 +282,7 @@ internal class FormViewModelTest {
             CoreR.string.stripe_address_label_full_name
         )?.onValueChange("joe")
         assertThat(
-            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(IdentifierSpec.Name)
+            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(FormFieldId.Name)
                 ?.value
         ).isNull()
 
@@ -291,7 +291,7 @@ internal class FormViewModelTest {
             UiCoreR.string.stripe_email
         )?.onValueChange("joe@example.com")
         assertThat(
-            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(IdentifierSpec.Email)
+            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(FormFieldId.Email)
                 ?.value
         ).isNull()
 
@@ -300,7 +300,7 @@ internal class FormViewModelTest {
             R.string.stripe_iban
         )?.onValueChange("DE89370400440532013000")
         assertThat(
-            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(IdentifierSpec.Generic("iban"))
+            formViewModel.completeFormValues.first()?.fieldValuePairs?.get(FormFieldId.Generic("iban"))
                 ?.value
         ).isNull()
 
@@ -353,7 +353,7 @@ internal class FormViewModelTest {
             billingDetails = null
         )
         val addressElements = createAddressElements(
-            identifier = IdentifierSpec.Generic("address"),
+            identifier = FormFieldId.Generic("address"),
             allowedCountryCodes = setOf("US", "JP"),
             hideCountry = false,
         )
@@ -469,15 +469,15 @@ internal class FormViewModelTest {
         viewModel.completeFormValues.test {
             assertThat(awaitItem()?.fieldValuePairs).isEqualTo(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry("Jenny Rosen", isComplete = true),
-                    IdentifierSpec.Email to FormFieldEntry("mail@mail.com", isComplete = true),
-                    IdentifierSpec.Phone to FormFieldEntry("+13105551234", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry("123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry("456", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry("San Francisco", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry("CA", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry("US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry("94111", isComplete = true),
+                    FormFieldId.Name to FormFieldEntry("Jenny Rosen", isComplete = true),
+                    FormFieldId.Email to FormFieldEntry("mail@mail.com", isComplete = true),
+                    FormFieldId.Phone to FormFieldEntry("+13105551234", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry("123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry("456", isComplete = true),
+                    FormFieldId.City to FormFieldEntry("San Francisco", isComplete = true),
+                    FormFieldId.State to FormFieldEntry("CA", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry("US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry("94111", isComplete = true),
                 )
             )
         }
@@ -508,10 +508,10 @@ internal class FormViewModelTest {
         viewModel.completeFormValues.test {
             assertThat(awaitItem()?.fieldValuePairs).isEqualTo(
                 mapOf(
-                    IdentifierSpec.Name to FormFieldEntry("Jenny Rosen", isComplete = true),
-                    IdentifierSpec.Email to FormFieldEntry("mail@mail.com", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry("US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry("94111", isComplete = true),
+                    FormFieldId.Name to FormFieldEntry("Jenny Rosen", isComplete = true),
+                    FormFieldId.Email to FormFieldEntry("mail@mail.com", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry("US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry("94111", isComplete = true),
                 )
             )
         }
@@ -620,7 +620,7 @@ internal class FormViewModelTest {
                 billingDetails = PaymentSheet.BillingDetails(),
             )
             val addressElements = createAddressElements(
-                identifier = IdentifierSpec.BillingAddress,
+                identifier = FormFieldId.BillingAddress,
                 allowedCountryCodes = CountryUtils.supportedBillingCountries,
                 hideCountry = true,
             )
@@ -827,7 +827,7 @@ internal class FormViewModelTest {
         )
         val originalElements = listOf(
             AffirmHeaderElement(
-                identifier = IdentifierSpec.Generic("affirm_promotion")
+                identifier = FormFieldId.Generic("affirm_promotion")
             ),
         )
         val formViewModel = createViewModel(args, originalElements)
@@ -836,7 +836,7 @@ internal class FormViewModelTest {
 
         val newElements = listOf(
             StaticTextElement(
-                identifier = IdentifierSpec.Generic("affirm_promotion"),
+                identifier = FormFieldId.Generic("affirm_promotion"),
                 text = resolvableString("Static text"),
             ),
         )
@@ -870,7 +870,7 @@ internal class FormViewModelTest {
     ): FormElement {
         return SectionElement.wrap(
             CountryElement(
-                identifier = IdentifierSpec.Country,
+                identifier = FormFieldId.Country,
                 controller = DropdownFieldController(
                     config = CountryConfig(allowedCountryCodes),
                     initialValue = null,
@@ -892,7 +892,7 @@ internal class FormViewModelTest {
     }
 
     private fun createAddressElements(
-        identifier: IdentifierSpec,
+        identifier: FormFieldId,
         allowedCountryCodes: Set<String>,
         hideCountry: Boolean,
     ): List<FormElement> {
@@ -911,7 +911,7 @@ internal class FormViewModelTest {
     }
 
     private fun createIbanElement(): FormElement {
-        val identifier = IdentifierSpec.Generic("sepa_debit[iban]")
+        val identifier = FormFieldId.Generic("sepa_debit[iban]")
         return SectionElement.wrap(
             SimpleTextElement(
                 identifier = identifier,
@@ -925,7 +925,7 @@ internal class FormViewModelTest {
 
     private fun createMandateElement(): FormElement {
         return MandateTextElement(
-            identifier = IdentifierSpec.Generic("mandate"),
+            identifier = FormFieldId.Generic("mandate"),
             stringResId = R.string.stripe_sepa_mandate,
             args = listOf(""),
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AccountPreviewScreenshotTest.kt
@@ -14,7 +14,7 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
 import com.stripe.android.uicore.elements.EmailConfig
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.NameConfig
 import com.stripe.android.uicore.elements.PhoneNumberController
 import com.stripe.android.uicore.elements.SameAsShippingController
@@ -180,7 +180,7 @@ internal class AccountPreviewScreenshotTest {
     )
 
     private val sameAsShippingElement = SameAsShippingElement(
-        identifier = IdentifierSpec.SameAsShipping,
+        identifier = FormFieldId.SameAsShipping,
         controller = SameAsShippingController(false),
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AddressControllerUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/AddressControllerUtils.kt
@@ -9,7 +9,7 @@ import com.stripe.android.uicore.elements.AddressController
 import com.stripe.android.uicore.elements.CountryConfig
 import com.stripe.android.uicore.elements.CountryElement
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionFieldElement
 import com.stripe.android.uicore.utils.stateFlowOf
@@ -60,7 +60,7 @@ internal fun createAddressController(
         stateFlowOf(
             listOf(
                 CountryElement(
-                    identifier = IdentifierSpec.BillingAddress,
+                    identifier = FormFieldId.BillingAddress,
                     controller = DropdownFieldController(
                         config = CountryConfig(setOf("US", "CA")),
                         initialValue = "US"
@@ -77,13 +77,13 @@ private fun setAddressValueForElement(element: SectionFieldElement) {
     element.setRawValue(mapOf(identifier to identifier.toTestAddressValue()))
 }
 
-private fun IdentifierSpec.toTestAddressValue(): String {
+private fun FormFieldId.toTestAddressValue(): String {
     return when (this) {
-        FieldType.AddressLine1.identifierSpec -> "354 Oyster Point Blvd"
-        FieldType.AddressLine2.identifierSpec -> "Levels 1-5"
-        FieldType.Locality.identifierSpec -> "South San Francisco"
-        FieldType.AdministrativeArea.identifierSpec -> "CA"
-        FieldType.PostalCode.identifierSpec -> "94080"
+        FieldType.AddressLine1.formFieldId -> "354 Oyster Point Blvd"
+        FieldType.AddressLine2.formFieldId -> "Levels 1-5"
+        FieldType.Locality.formFieldId -> "South San Francisco"
+        FieldType.AdministrativeArea.formFieldId -> "CA"
+        FieldType.PostalCode.formFieldId -> "94080"
         else -> ""
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -44,7 +44,7 @@ import com.stripe.android.ui.core.elements.SaveForFutureUseElement
 import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
 import com.stripe.android.uicore.elements.AutocompleteAddressElement
 import com.stripe.android.uicore.elements.AutocompleteAddressInteractor
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.utils.BankFormScreenStateFactory
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -757,7 +757,7 @@ class USBankAccountFormViewModelTest {
         )
 
         viewModel.lastTextFieldIdentifier.test {
-            assertThat(awaitItem()).isEqualTo(IdentifierSpec.Email)
+            assertThat(awaitItem()).isEqualTo(FormFieldId.Email)
         }
     }
 
@@ -780,7 +780,7 @@ class USBankAccountFormViewModelTest {
         )
 
         viewModel.lastTextFieldIdentifier.test {
-            assertThat(awaitItem()).isEqualTo(IdentifierSpec.Phone)
+            assertThat(awaitItem()).isEqualTo(FormFieldId.Phone)
         }
     }
 
@@ -808,7 +808,7 @@ class USBankAccountFormViewModelTest {
         )
 
         viewModel.lastTextFieldIdentifier.test {
-            assertThat(awaitItem()).isEqualTo(IdentifierSpec.PostalCode)
+            assertThat(awaitItem()).isEqualTo(FormFieldId.PostalCode)
         }
     }
 
@@ -836,7 +836,7 @@ class USBankAccountFormViewModelTest {
         )
 
         viewModel.lastTextFieldIdentifier.test {
-            assertThat(awaitItem()).isEqualTo(IdentifierSpec.PostalCode)
+            assertThat(awaitItem()).isEqualTo(FormFieldId.PostalCode)
         }
     }
 
@@ -1910,7 +1910,7 @@ class USBankAccountFormViewModelTest {
         )
 
         viewModel.lastTextFieldIdentifier.test {
-            assertThat(expectMostRecentItem()).isEqualTo(IdentifierSpec.OneLineAddress)
+            assertThat(expectMostRecentItem()).isEqualTo(FormFieldId.OneLineAddress)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/AddPaymentMethodTest.kt
@@ -33,7 +33,7 @@ import com.stripe.android.testing.createComposeCleanupRule
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.CheckboxFieldElement
 import com.stripe.android.uicore.elements.DEFAULT_CHECKBOX_TEST_TAG
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
@@ -69,8 +69,8 @@ internal class AddPaymentMethodTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
-                IdentifierSpec.Name to FormFieldEntry(name, true),
+                FormFieldId.CardBrand to FormFieldEntry(cardBrand, true),
+                FormFieldId.Name to FormFieldEntry(name, true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -90,7 +90,7 @@ internal class AddPaymentMethodTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
+                FormFieldId.CardBrand to FormFieldEntry(cardBrand, true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -116,7 +116,7 @@ internal class AddPaymentMethodTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
+                FormFieldId.CardBrand to FormFieldEntry(cardBrand, true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -142,7 +142,7 @@ internal class AddPaymentMethodTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry(cardBrand, true),
+                FormFieldId.CardBrand to FormFieldEntry(cardBrand, true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -217,8 +217,8 @@ internal class AddPaymentMethodTest {
         val addressLine1 = "123 Main Street"
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Name to FormFieldEntry(name, true),
-                IdentifierSpec.Line1 to FormFieldEntry(addressLine1, true)
+                FormFieldId.Name to FormFieldEntry(name, true),
+                FormFieldId.Line1 to FormFieldEntry(addressLine1, true)
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -246,8 +246,8 @@ internal class AddPaymentMethodTest {
 
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Name to FormFieldEntry(name, true),
-                IdentifierSpec.Line1 to FormFieldEntry(addressLine1, true)
+                FormFieldId.Name to FormFieldEntry(name, true),
+                FormFieldId.Line1 to FormFieldEntry(addressLine1, true)
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -280,7 +280,7 @@ internal class AddPaymentMethodTest {
         val name = "Joe"
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Name to FormFieldEntry(name, true),
+                FormFieldId.Name to FormFieldEntry(name, true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -338,7 +338,7 @@ internal class AddPaymentMethodTest {
                 AddPaymentMethodInteractor.ViewAction.OnFormFieldValuesChanged(
                     formValues = FormFieldValues(
                         fieldValuePairs = mapOf(
-                            IdentifierSpec.SameAsShipping to FormFieldEntry(
+                            FormFieldId.SameAsShipping to FormFieldEntry(
                                 value = "true",
                                 isComplete = true
                             )
@@ -359,7 +359,7 @@ internal class AddPaymentMethodTest {
         )
 
         val formValues = FormFieldValues(
-            fieldValuePairs = mapOf(IdentifierSpec.Name to FormFieldEntry("test", true)),
+            fieldValuePairs = mapOf(FormFieldId.Name to FormFieldEntry("test", true)),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
         )
 
@@ -380,7 +380,7 @@ internal class AddPaymentMethodTest {
         )
 
         val formValues = FormFieldValues(
-            fieldValuePairs = mapOf(IdentifierSpec.Name to FormFieldEntry("test", true)),
+            fieldValuePairs = mapOf(FormFieldId.Name to FormFieldEntry("test", true)),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
 
@@ -401,7 +401,7 @@ internal class AddPaymentMethodTest {
         )
 
         val formValues = FormFieldValues(
-            fieldValuePairs = mapOf(IdentifierSpec.Name to FormFieldEntry("test", true)),
+            fieldValuePairs = mapOf(FormFieldId.Name to FormFieldEntry("test", true)),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
         )
 
@@ -424,7 +424,7 @@ internal class AddPaymentMethodTest {
         )
 
         val formValues = FormFieldValues(
-            fieldValuePairs = mapOf(IdentifierSpec.Name to FormFieldEntry("test", true)),
+            fieldValuePairs = mapOf(FormFieldId.Name to FormFieldEntry("test", true)),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.NoRequest,
         )
 
@@ -447,7 +447,7 @@ internal class AddPaymentMethodTest {
         )
 
         val formValues = FormFieldValues(
-            fieldValuePairs = mapOf(IdentifierSpec.Name to FormFieldEntry("test", true)),
+            fieldValuePairs = mapOf(FormFieldId.Name to FormFieldEntry("test", true)),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
 
@@ -464,7 +464,7 @@ internal class AddPaymentMethodTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestReuse
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
+                FormFieldId.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -494,7 +494,7 @@ internal class AddPaymentMethodTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.RequestNoReuse
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("sepa_debit[iban]") to
+                FormFieldId.Generic("sepa_debit[iban]") to
                     FormFieldEntry("DE89370400440532013000", true),
             ),
             userRequestedReuse = customerRequestedSave,
@@ -525,7 +525,7 @@ internal class AddPaymentMethodTest {
         val customerRequestedSave = PaymentSelection.CustomerRequestedSave.NoRequest
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
+                FormFieldId.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
             ),
             userRequestedReuse = customerRequestedSave,
         )
@@ -562,7 +562,7 @@ internal class AddPaymentMethodTest {
 
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
+                FormFieldId.CardBrand to FormFieldEntry("visa", true),
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
         )
@@ -594,7 +594,7 @@ internal class AddPaymentMethodTest {
     fun `transformToPaymentSelection returns null if Link required but no input`() {
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.CardBrand to FormFieldEntry("visa", true),
+                FormFieldId.CardBrand to FormFieldEntry("visa", true),
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestNoReuse,
         )
@@ -622,8 +622,8 @@ internal class AddPaymentMethodTest {
     fun `transformToExtraParams returns correct params for SepaDebit with setAsDefault`() {
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
-                IdentifierSpec.SetAsDefaultPaymentMethod to FormFieldEntry("true", true),
+                FormFieldId.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
+                FormFieldId.SetAsDefaultPaymentMethod to FormFieldEntry("true", true),
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
@@ -642,7 +642,7 @@ internal class AddPaymentMethodTest {
     fun `transformToExtraParams returns correct params for SepaDebit without setAsDefault`() {
         val formFieldValues = FormFieldValues(
             fieldValuePairs = mapOf(
-                IdentifierSpec.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
+                FormFieldId.Generic("sepa_debit[iban]") to FormFieldEntry("DE89370400440532013000", true),
             ),
             userRequestedReuse = PaymentSelection.CustomerRequestedSave.RequestReuse,
         )
@@ -678,7 +678,7 @@ internal class AddPaymentMethodTest {
             ),
             formElements = listOf(
                 CheckboxFieldElement(
-                    identifier = IdentifierSpec.SameAsShipping,
+                    identifier = FormFieldId.SameAsShipping,
                 )
             ),
             paymentSelection = null,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultAddPaymentMethodInteractorTest.kt
@@ -30,7 +30,7 @@ import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
 import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.FieldValidationMessage
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
@@ -269,7 +269,7 @@ class DefaultAddPaymentMethodInteractorTest {
                     SectionElement.wrap(
                         listOf(
                             SimpleTextElement(
-                                IdentifierSpec.Name,
+                                FormFieldId.Name,
                                 SimpleTextFieldController(
                                     textFieldConfig = SimpleTextFieldConfig(
                                         label = resolvableString("")
@@ -287,8 +287,8 @@ class DefaultAddPaymentMethodInteractorTest {
 
                 val sectionElement = state.formUiElements[0] as SectionElement
 
-                sectionElement.fields.errorTest(identifierSpec = IdentifierSpec.Name, error = null)
-                sectionElement.fields.errorTest(identifierSpec = IdentifierSpec.Email, error = null)
+                sectionElement.fields.errorTest(formFieldId = FormFieldId.Name, error = null)
+                sectionElement.fields.errorTest(formFieldId = FormFieldId.Email, error = null)
 
                 validationRequestedSource.emit(Unit)
 
@@ -297,11 +297,11 @@ class DefaultAddPaymentMethodInteractorTest {
                 val nextSectionElement = nextState.formUiElements[0] as SectionElement
 
                 nextSectionElement.fields.errorTest(
-                    identifierSpec = IdentifierSpec.Name,
+                    formFieldId = FormFieldId.Name,
                     error = FieldValidationMessage.Error(UiCoreR.string.stripe_blank_and_required),
                 )
                 nextSectionElement.fields.errorTest(
-                    identifierSpec = IdentifierSpec.Email,
+                    formFieldId = FormFieldId.Email,
                     error = FieldValidationMessage.Error(UiCoreR.string.stripe_blank_and_required),
                 )
             }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/SectionFieldElementTestUtils.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/utils/SectionFieldElementTestUtils.kt
@@ -3,14 +3,14 @@ package com.stripe.android.paymentsheet.utils
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.uicore.elements.FieldValidationMessage
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionFieldElement
 
 internal suspend fun List<SectionFieldElement>.errorTest(
-    identifierSpec: IdentifierSpec,
+    formFieldId: FormFieldId,
     error: FieldValidationMessage?,
 ) {
-    val element = find { it.identifier == identifierSpec }
+    val element = find { it.identifier == formFieldId }
 
     assertThat(element).isNotNull()
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultPaymentMethodVerticalLayoutInteractorTest.kt
@@ -38,7 +38,7 @@ import com.stripe.android.paymentsheet.verticalmode.PaymentMethodVerticalLayoutI
 import com.stripe.android.testing.CleanupTestRule
 import com.stripe.android.testing.PaymentMethodFactory
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.forms.FormFieldEntry
 import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
@@ -1002,15 +1002,15 @@ class DefaultPaymentMethodVerticalLayoutInteractorTest {
                     first.run {
                         assertThat(fieldValuePairs).isEqualTo(
                             mapOf(
-                                IdentifierSpec.Name to FormFieldEntry("Jenny Rosen", isComplete = true),
-                                IdentifierSpec.Email to FormFieldEntry("mail@mail.com", isComplete = true),
-                                IdentifierSpec.Phone to FormFieldEntry("+13105551234", isComplete = true),
-                                IdentifierSpec.Line1 to FormFieldEntry("123 Main Street", isComplete = true),
-                                IdentifierSpec.Line2 to FormFieldEntry("456", isComplete = true),
-                                IdentifierSpec.City to FormFieldEntry("San Francisco", isComplete = true),
-                                IdentifierSpec.State to FormFieldEntry("CA", isComplete = true),
-                                IdentifierSpec.Country to FormFieldEntry("US", isComplete = true),
-                                IdentifierSpec.PostalCode to FormFieldEntry("94111", isComplete = true),
+                                FormFieldId.Name to FormFieldEntry("Jenny Rosen", isComplete = true),
+                                FormFieldId.Email to FormFieldEntry("mail@mail.com", isComplete = true),
+                                FormFieldId.Phone to FormFieldEntry("+13105551234", isComplete = true),
+                                FormFieldId.Line1 to FormFieldEntry("123 Main Street", isComplete = true),
+                                FormFieldId.Line2 to FormFieldEntry("456", isComplete = true),
+                                FormFieldId.City to FormFieldEntry("San Francisco", isComplete = true),
+                                FormFieldId.State to FormFieldEntry("CA", isComplete = true),
+                                FormFieldId.Country to FormFieldEntry("US", isComplete = true),
+                                FormFieldId.PostalCode to FormFieldEntry("94111", isComplete = true),
                             )
                         )
                         assertThat(userRequestedReuse).isEqualTo(PaymentSelection.CustomerRequestedSave.NoRequest)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/DefaultVerticalModeFormInteractorTest.kt
@@ -44,7 +44,7 @@ import com.stripe.android.ui.core.elements.SetAsDefaultPaymentMethodElement
 import com.stripe.android.uicore.elements.EmailElement
 import com.stripe.android.uicore.elements.FieldValidationMessage
 import com.stripe.android.uicore.elements.FormElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
@@ -184,7 +184,7 @@ internal class DefaultVerticalModeFormInteractorTest {
                 SectionElement.wrap(
                     listOf(
                         SimpleTextElement(
-                            IdentifierSpec.Name,
+                            FormFieldId.Name,
                             SimpleTextFieldController(
                                 textFieldConfig = SimpleTextFieldConfig(
                                     label = resolvableString("")
@@ -201,8 +201,8 @@ internal class DefaultVerticalModeFormInteractorTest {
 
                 val sectionElement = state.formUiElements[0] as SectionElement
 
-                sectionElement.fields.errorTest(identifierSpec = IdentifierSpec.Name, error = null)
-                sectionElement.fields.errorTest(identifierSpec = IdentifierSpec.Email, error = null)
+                sectionElement.fields.errorTest(formFieldId = FormFieldId.Name, error = null)
+                sectionElement.fields.errorTest(formFieldId = FormFieldId.Email, error = null)
 
                 validationRequestedSource.emit(Unit)
 
@@ -211,11 +211,11 @@ internal class DefaultVerticalModeFormInteractorTest {
                 val nextSectionElement = nextState.formUiElements[0] as SectionElement
 
                 nextSectionElement.fields.errorTest(
-                    identifierSpec = IdentifierSpec.Name,
+                    formFieldId = FormFieldId.Name,
                     error = FieldValidationMessage.Error(UiCoreR.string.stripe_blank_and_required),
                 )
                 nextSectionElement.fields.errorTest(
-                    identifierSpec = IdentifierSpec.Email,
+                    formFieldId = FormFieldId.Email,
                     error = FieldValidationMessage.Error(UiCoreR.string.stripe_blank_and_required),
                 )
             }
@@ -317,10 +317,10 @@ internal class DefaultVerticalModeFormInteractorTest {
         val formElements = interactor.state.value.formUiElements
 
         val saveForFutureUseElement = formElements.firstOrNull {
-            it.identifier == IdentifierSpec.SaveForFutureUse
+            it.identifier == FormFieldId.SaveForFutureUse
         } as? SaveForFutureUseElement
         val setAsDefaultElement = formElements.firstOrNull {
-            it.identifier == IdentifierSpec.SetAsDefaultPaymentMethod
+            it.identifier == FormFieldId.SetAsDefaultPaymentMethod
         } as? SetAsDefaultPaymentMethodElement
 
         block(saveForFutureUseElement, setAsDefaultElement)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/verticalmode/FakeSavedPaymentMethodConfirmInteractor.kt
@@ -7,7 +7,7 @@ import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.paymentsheet.DisplayableSavedPaymentMethod
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.SectionElement
 import com.stripe.android.uicore.elements.SimpleTextElement
 import com.stripe.android.uicore.elements.SimpleTextFieldConfig
@@ -43,7 +43,7 @@ internal class FakeSavedPaymentMethodConfirmInteractor(
                     SectionElement.wrap(
                         sectionFieldElements = listOf(
                             SimpleTextElement(
-                                identifier = IdentifierSpec.Generic("Name"),
+                                identifier = FormFieldId.Generic("Name"),
                                 controller = SimpleTextFieldController(
                                     initialValue = "John Doe",
                                     textFieldConfig = SimpleTextFieldConfig(

--- a/stripe-ui-core/api/stripe-ui-core.api
+++ b/stripe-ui-core/api/stripe-ui-core.api
@@ -94,14 +94,14 @@ public final class com/stripe/android/uicore/elements/ComposableSingletons$TextF
 	public final fun getLambda$549433638$stripe_ui_core_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final synthetic class com/stripe/android/uicore/elements/IdentifierSpec$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+public final synthetic class com/stripe/android/uicore/elements/FormFieldId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field $stable I
-	public static final field INSTANCE Lcom/stripe/android/uicore/elements/IdentifierSpec$$serializer;
+	public static final field INSTANCE Lcom/stripe/android/uicore/elements/FormFieldId$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
-	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/uicore/elements/IdentifierSpec;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/stripe/android/uicore/elements/FormFieldId;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
-	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/uicore/elements/IdentifierSpec;)V
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/stripe/android/uicore/elements/FormFieldId;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }

--- a/stripe-ui-core/detekt-baseline.xml
+++ b/stripe-ui-core/detekt-baseline.xml
@@ -2,15 +2,15 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
-    <ID>ConstructorParameterNaming:AddressElement.kt:AddressElement$_identifier: IdentifierSpec</ID>
-    <ID>ConstructorParameterNaming:RowElement.kt:RowElement$_identifier: IdentifierSpec</ID>
+    <ID>ConstructorParameterNaming:AddressElement.kt:AddressElement$_identifier: FormFieldId</ID>
+    <ID>ConstructorParameterNaming:RowElement.kt:RowElement$_identifier: FormFieldId</ID>
     <ID>CyclomaticComplexMethod:ContentTypeUtils.kt:internal fun ContentType.toReadableString: String</ID>
     <ID>CyclomaticComplexMethod:Html.kt:@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource: AnnotatedString</ID>
-    <ID>CyclomaticComplexMethod:IdentifierSpec.kt:IdentifierSpec.Companion$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) fun get</ID>
+    <ID>CyclomaticComplexMethod:FormFieldId.kt:FormFieldId.Companion$@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX) fun get</ID>
     <ID>CyclomaticComplexMethod:StripeTheme.kt:@Composable @ReadOnlyComposable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun StripeTypography.toComposeTypography: Typography</ID>
     <ID>EmptyFunctionBlock:DrawablePainter.kt:EmptyPainter${}</ID>
     <ID>ForEachOnRange:OTPController.kt:OTPController$0 until inputLength</ID>
-    <ID>FunctionParameterNaming:IdentifierSpec.kt:IdentifierSpec.Companion$_value: String</ID>
+    <ID>FunctionParameterNaming:FormFieldId.kt:FormFieldId.Companion$_value: String</ID>
     <ID>LargeClass:AutocompleteAddressControllerTest.kt:AutocompleteAddressControllerTest</ID>
     <ID>LongMethod:Html.kt:@Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun annotatedStringResource: AnnotatedString</ID>
     <ID>LongMethod:OTPElementUI.kt:@OptIn(ExperimentalComposeUiApi::class) @Composable @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP) fun OTPElementUI</ID>

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/address/TransformAddressToElement.kt
@@ -12,7 +12,7 @@ import com.stripe.android.uicore.elements.AddressTextFieldConfig
 import com.stripe.android.uicore.elements.AdministrativeAreaConfig
 import com.stripe.android.uicore.elements.AdministrativeAreaElement
 import com.stripe.android.uicore.elements.DropdownFieldController
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.PostalCodeConfig
 import com.stripe.android.uicore.elements.RowController
 import com.stripe.android.uicore.elements.RowElement
@@ -35,41 +35,41 @@ import com.stripe.android.core.R as CoreR
 @Serializable
 enum class FieldType(
     val serializedValue: String,
-    val identifierSpec: IdentifierSpec,
+    val formFieldId: FormFieldId,
     @StringRes val defaultLabel: Int
 ) {
     @SerialName("addressLine1")
     AddressLine1(
         "addressLine1",
-        IdentifierSpec.Line1,
+        FormFieldId.Line1,
         CoreR.string.stripe_address_label_address_line1
     ),
 
     @SerialName("addressLine2")
     AddressLine2(
         "addressLine2",
-        IdentifierSpec.Line2,
+        FormFieldId.Line2,
         R.string.stripe_address_label_address_line2
     ),
 
     @SerialName("locality")
     Locality(
         "locality",
-        IdentifierSpec.City,
+        FormFieldId.City,
         CoreR.string.stripe_address_label_city
     ),
 
     @SerialName("dependentLocality")
     DependentLocality(
         "dependentLocality",
-        IdentifierSpec.DependentLocality,
+        FormFieldId.DependentLocality,
         CoreR.string.stripe_address_label_city
     ),
 
     @SerialName("postalCode")
     PostalCode(
         "postalCode",
-        IdentifierSpec.PostalCode,
+        FormFieldId.PostalCode,
         CoreR.string.stripe_address_label_postal_code
     ) {
         override fun capitalization() = KeyboardCapitalization.None
@@ -78,7 +78,7 @@ enum class FieldType(
     @SerialName("sortingCode")
     SortingCode(
         "sortingCode",
-        IdentifierSpec.SortingCode,
+        FormFieldId.SortingCode,
         CoreR.string.stripe_address_label_postal_code
     ) {
         override fun capitalization() = KeyboardCapitalization.None
@@ -87,14 +87,14 @@ enum class FieldType(
     @SerialName("administrativeArea")
     AdministrativeArea(
         "administrativeArea",
-        IdentifierSpec.State,
+        FormFieldId.State,
         NameType.State.stringResId
     ),
 
     @SerialName("name")
     Name(
         "name",
-        IdentifierSpec.Name,
+        FormFieldId.Name,
         CoreR.string.stripe_address_label_full_name
     );
 
@@ -238,7 +238,7 @@ fun List<CountryAddressSchema>.transformToElementList(
         }
         .mapNotNull { addressField ->
             addressField.type?.toElement(
-                identifierSpec = addressField.type.identifierSpec,
+                formFieldId = addressField.type.formFieldId,
                 label = addressField.schema?.nameType?.stringResId
                     ?: addressField.type.defaultLabel,
                 capitalization = addressField.type.capitalization(),
@@ -258,7 +258,7 @@ private fun getJsonStringFromInputStream(inputStream: InputStream?) =
     inputStream?.bufferedReader().use { it?.readText() }
 
 private fun FieldType.toElement(
-    identifierSpec: IdentifierSpec,
+    formFieldId: FormFieldId,
     label: Int,
     capitalization: KeyboardCapitalization,
     keyboardType: KeyboardType,
@@ -266,7 +266,7 @@ private fun FieldType.toElement(
     showOptionalLabel: Boolean
 ): SectionSingleFieldElement {
     val simpleTextElement = SimpleTextElement(
-        identifierSpec,
+        formFieldId,
         SimpleTextFieldController(
             textFieldConfig = toConfig(
                 label = label,
@@ -293,7 +293,7 @@ private fun FieldType.toElement(
                     else -> throw IllegalArgumentException()
                 }
                 AdministrativeAreaElement(
-                    identifierSpec,
+                    formFieldId,
                     DropdownFieldController(
                         AdministrativeAreaConfig(country),
                     )
@@ -369,7 +369,7 @@ private fun combineCityAndPostal(countryAddressElements: List<SectionSingleField
             val rowFields = listOf(countryAddressElements[index], countryAddressElements[index + 1])
             acc.plus(
                 RowElement(
-                    IdentifierSpec.Generic("row_" + UUID.randomUUID().leastSignificantBits),
+                    FormFieldId.Generic("row_" + UUID.randomUUID().leastSignificantBits),
                     rowFields,
                     RowController(rowFields)
                 )
@@ -387,9 +387,9 @@ private fun isPostalNextToCity(
     element2: SectionSingleFieldElement
 ) = isCityOrPostal(element1.identifier) && isCityOrPostal(element2.identifier)
 
-private fun isCityOrPostal(identifierSpec: IdentifierSpec) =
-    identifierSpec == IdentifierSpec.PostalCode ||
-        identifierSpec == IdentifierSpec.City
+private fun isCityOrPostal(formFieldId: FormFieldId) =
+    formFieldId == FormFieldId.PostalCode ||
+        formFieldId == FormFieldId.City
 
 private fun getKeyboard(fieldSchema: FieldSchema?) = if (fieldSchema?.isNumeric == true) {
     KeyboardType.NumberPassword

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressController.kt
@@ -33,8 +33,8 @@ class AddressController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?,
     ) {
         AddressElementUI(
             enabled,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElement.kt
@@ -17,19 +17,19 @@ import com.stripe.android.core.R as CoreR
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressElement(
-    _identifier: IdentifierSpec,
-    private var rawValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
+    _identifier: FormFieldId,
+    private var rawValuesMap: Map<FormFieldId, String?> = emptyMap(),
     val addressInputMode: AddressInputMode = AddressInputMode.NoAutocomplete(),
     countryCodes: Set<String> = emptySet(),
     override val countryElement: CountryElement = CountryElement(
-        IdentifierSpec.Country,
+        FormFieldId.Country,
         DropdownFieldController(
             CountryConfig(countryCodes),
-            rawValuesMap[IdentifierSpec.Country]
+            rawValuesMap[FormFieldId.Country]
         )
     ),
     sameAsShippingElement: SameAsShippingElement?,
-    shippingValuesMap: Map<IdentifierSpec, String?>?,
+    shippingValuesMap: Map<FormFieldId, String?>?,
     private val isPlacesAvailable: Boolean = DefaultIsPlacesAvailable().invoke(),
     private val hideCountry: Boolean = false,
     private val inlineAutocompleteHandler: InlineAutocompleteHandler? = null,
@@ -40,23 +40,23 @@ class AddressElement(
 
     private val isValidating = MutableStateFlow(false)
     private val emailElement = EmailElement(
-        initialValue = rawValuesMap[IdentifierSpec.Email]
+        initialValue = rawValuesMap[FormFieldId.Email]
     )
 
     private val nameElement = SimpleTextElement(
-        IdentifierSpec.Name,
+        FormFieldId.Name,
         SimpleTextFieldController(
             textFieldConfig = SimpleTextFieldConfig(
                 label = resolvableString(CoreR.string.stripe_address_label_full_name),
                 optional = addressInputMode.nameConfig == AddressFieldConfiguration.OPTIONAL,
                 allowsEmojis = false,
             ),
-            initialValue = rawValuesMap[IdentifierSpec.Name]
+            initialValue = rawValuesMap[FormFieldId.Name]
         )
     )
 
     private val addressAutoCompleteElement = AddressTextFieldElement(
-        identifier = IdentifierSpec.OneLineAddress,
+        identifier = FormFieldId.OneLineAddress,
         label = resolvableString(R.string.stripe_address_label_address),
         addressInputMode = addressInputMode,
         inlineAutocompleteHandler = inlineAutocompleteHandler,
@@ -68,12 +68,12 @@ class AddressElement(
     private val expandedAutoCompleteElement: AddressTextFieldElement? =
         if (inlineAutocompleteHandler != null && addressInputMode is AddressInputMode.NoAutocomplete) {
             AddressTextFieldElement(
-                identifier = IdentifierSpec.Line1,
+                identifier = FormFieldId.Line1,
                 label = resolvableString(R.string.stripe_address_label_address),
                 addressInputMode = addressInputMode,
                 inlineAutocompleteHandler = inlineAutocompleteHandler,
                 reportsFormValue = true,
-                initialQuery = rawValuesMap[IdentifierSpec.Line1] ?: "",
+                initialQuery = rawValuesMap[FormFieldId.Line1] ?: "",
                 showEnterManually = false,
             )
         } else {
@@ -85,15 +85,15 @@ class AddressElement(
 
     @VisibleForTesting
     val phoneNumberElement = PhoneNumberElement(
-        IdentifierSpec.Phone,
+        FormFieldId.Phone,
         PhoneNumberController.createPhoneNumberController(
-            initialValue = rawValuesMap[IdentifierSpec.Phone] ?: "",
+            initialValue = rawValuesMap[FormFieldId.Phone] ?: "",
             showOptionalLabel = addressInputMode.phoneNumberConfig == AddressFieldConfiguration.OPTIONAL,
             acceptAnyInput = addressInputMode.phoneNumberConfig != AddressFieldConfiguration.REQUIRED,
         )
     )
 
-    private val currentValuesMap = mutableMapOf<IdentifierSpec, String?>()
+    private val currentValuesMap = mutableMapOf<FormFieldId, String?>()
 
     private val elementsRegistry = AddressElementUiRegistry(AddressSchemaRegistry)
 
@@ -140,7 +140,7 @@ class AddressElement(
                 shippingValuesMap ?: emptyMap()
             } else {
                 currentValuesMap.mapValues {
-                    if (it.key == IdentifierSpec.Country) {
+                    if (it.key == FormFieldId.Country) {
                         it.value
                     } else {
                         rawValuesMap[it.key] ?: ""
@@ -170,7 +170,7 @@ class AddressElement(
             expandedAutoCompleteElement?.inlineQuery ?: stateFlowOf(""),
         ) { country, values, expandedLine1 ->
             country?.let {
-                currentValuesMap[IdentifierSpec.Country] = it
+                currentValuesMap[FormFieldId.Country] = it
             }
             currentValuesMap.putAll(
                 values.associate {
@@ -178,7 +178,7 @@ class AddressElement(
                 }
             )
             if (expandedAutoCompleteElement != null) {
-                currentValuesMap[IdentifierSpec.Line1] = expandedLine1
+                currentValuesMap[FormFieldId.Line1] = expandedLine1
             }
             val same = currentValuesMap.all {
                 (shippingValuesMap?.get(it.key) ?: "") == it.value
@@ -220,7 +220,7 @@ class AddressElement(
             }
             else -> {
                 val bodyFields = otherFields.map { field ->
-                    expandedAutoCompleteElement?.takeIf { field.identifier == IdentifierSpec.Line1 } ?: field
+                    expandedAutoCompleteElement?.takeIf { field.identifier == FormFieldId.Line1 } ?: field
                 }
                 headerElements.plus(bodyFields)
             }
@@ -254,7 +254,7 @@ class AddressElement(
         }
     }
 
-    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> = fields.flatMapLatestAsStateFlow {
+    override fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> = fields.flatMapLatestAsStateFlow {
         combineAsStateFlow(
             it
                 .map {
@@ -265,13 +265,13 @@ class AddressElement(
         }
     }
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         this.rawValuesMap = rawValuesMap
         syncExpandedLine1(rawValuesMap)
     }
 
-    private fun syncExpandedLine1(values: Map<IdentifierSpec, String?>) {
-        expandedAutoCompleteElement?.controller?.onRawValueChange(values[IdentifierSpec.Line1] ?: "")
+    private fun syncExpandedLine1(values: Map<FormFieldId, String?>) {
+        expandedAutoCompleteElement?.controller?.onRawValueChange(values[FormFieldId.Line1] ?: "")
     }
 
     override fun onValidationStateChanged(isValidating: Boolean) {
@@ -318,7 +318,7 @@ internal fun updateLine1WithAutocompleteAffordance(
     addressInputMode: AddressInputMode,
     isPlacesAvailable: Boolean,
 ) {
-    if (field.identifier == IdentifierSpec.Line1) {
+    if (field.identifier == FormFieldId.Line1) {
         val fieldController = (field as? SimpleTextElement)?.controller
         val config = (fieldController as? SimpleTextFieldController?)?.textFieldConfig
         val textConfig = config as? SimpleTextFieldConfig?

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressElementUI.kt
@@ -17,8 +17,8 @@ import com.stripe.android.uicore.utils.collectAsState
 fun AddressElementUI(
     enabled: Boolean,
     controller: AddressController,
-    hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    hiddenIdentifiers: Set<FormFieldId>,
+    lastTextFieldIdentifier: FormFieldId?,
     modifier: Modifier = Modifier,
 ) {
     val fields by controller.fieldsFlowable.collectAsState()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldController.kt
@@ -94,8 +94,8 @@ class AddressTextFieldController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         if (inlineAutocompleteHandler != null) {
             val predictionsState by inlineAutocompleteHandler.predictionsState.collectAsState()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AddressTextFieldElement.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AddressTextFieldElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     label: ResolvableString,
     addressInputMode: AddressInputMode,
     inlineAutocompleteHandler: InlineAutocompleteHandler?,
@@ -30,7 +30,7 @@ class AddressTextFieldElement(
 
     val inlineQuery: StateFlow<String> get() = controller.inlineQuery
 
-    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> {
+    override fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> {
         return MutableStateFlow(listOf(identifier))
     }
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AdministrativeAreaElement.kt
@@ -5,7 +5,7 @@ import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class AdministrativeAreaElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: DropdownFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressController.kt
@@ -13,19 +13,19 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AutocompleteAddressController(
-    val identifier: IdentifierSpec,
-    val initialValues: Map<IdentifierSpec, String?>,
+    val identifier: FormFieldId,
+    val initialValues: Map<FormFieldId, String?>,
     interactorFactory: AutocompleteAddressInteractor.Factory,
     countryCodes: Set<String> = emptySet(),
     private val countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),
-        initialValues[IdentifierSpec.Country]
+        initialValues[FormFieldId.Country]
     ),
     private val phoneNumberConfig: AddressFieldConfiguration,
     private val nameConfig: AddressFieldConfiguration,
     private val emailConfig: AddressFieldConfiguration,
     private val sameAsShippingElement: SameAsShippingElement?,
-    private val shippingValuesMap: Map<IdentifierSpec, String?>?,
+    private val shippingValuesMap: Map<FormFieldId, String?>?,
     private val hideCountry: Boolean = false,
 ) : SectionFieldValidationController, SectionFieldComposable {
     private val interactor = interactorFactory.create()
@@ -80,7 +80,7 @@ class AutocompleteAddressController(
     private val isValidating = MutableStateFlow(false)
 
     val countryElement = CountryElement(
-        IdentifierSpec.Country,
+        FormFieldId.Country,
         countryDropdownFieldController,
     )
 
@@ -139,7 +139,7 @@ class AutocompleteAddressController(
             val newAddressInputMode = toAddressInputMode(expandForm, newValues)
 
             if (currentValues != newValues || newAddressInputMode != addressElementFlow.value.addressInputMode) {
-                newValues[IdentifierSpec.Country]?.let {
+                newValues[FormFieldId.Country]?.let {
                     countryDropdownFieldController.onRawValueChange(it)
                 }
 
@@ -149,15 +149,15 @@ class AutocompleteAddressController(
         }
     }
 
-    fun setRawValue(values: Map<IdentifierSpec, String?>) {
+    fun setRawValue(values: Map<FormFieldId, String?>) {
         _addressElementFlow.value = createAddressElement(values, toAddressInputMode(expandForm, values))
     }
 
     private fun createAddressElement(
-        values: Map<IdentifierSpec, String?>,
+        values: Map<FormFieldId, String?>,
         addressInputMode: AddressInputMode,
     ): AddressElement {
-        val handler = if (isCountrySupported(values[IdentifierSpec.Country])) {
+        val handler = if (isCountrySupported(values[FormFieldId.Country])) {
             inlineAutocompleteHandler
         } else {
             null
@@ -183,13 +183,13 @@ class AutocompleteAddressController(
 
     private fun toAddressInputMode(
         expandForm: Boolean,
-        values: Map<IdentifierSpec, String?>
+        values: Map<FormFieldId, String?>
     ): AddressInputMode {
         val googlePlacesApiKey = config.googlePlacesApiKey
-        val countrySupported = isCountrySupported(values[IdentifierSpec.Country])
+        val countrySupported = isCountrySupported(values[FormFieldId.Country])
 
         val showInline = inlineAutocompleteActive && !expandForm &&
-            countrySupported && values[IdentifierSpec.Line1].isNullOrEmpty()
+            countrySupported && values[FormFieldId.Line1].isNullOrEmpty()
         return if (showInline) {
             AddressInputMode.AutocompleteInline(
                 googleApiKey = googlePlacesApiKey,
@@ -204,7 +204,7 @@ class AutocompleteAddressController(
                 nameConfig = nameConfig,
                 emailConfig = emailConfig,
             )
-        } else if (expandForm || values[IdentifierSpec.Line1] != null) {
+        } else if (expandForm || values[FormFieldId.Line1] != null) {
             AddressInputMode.AutocompleteExpanded(
                 googleApiKey = googlePlacesApiKey,
                 autocompleteCountries = config.autocompleteCountries,
@@ -246,8 +246,8 @@ class AutocompleteAddressController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         val controller by addressController.collectAsState()
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressElement.kt
@@ -6,18 +6,18 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class AutocompleteAddressElement(
-    override val identifier: IdentifierSpec,
-    initialValues: Map<IdentifierSpec, String?>,
+    override val identifier: FormFieldId,
+    initialValues: Map<FormFieldId, String?>,
     countryCodes: Set<String> = emptySet(),
     countryDropdownFieldController: DropdownFieldController = DropdownFieldController(
         CountryConfig(countryCodes),
-        initialValues[IdentifierSpec.Country]
+        initialValues[FormFieldId.Country]
     ),
     phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
     nameConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
     emailConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
     sameAsShippingElement: SameAsShippingElement?,
-    shippingValuesMap: Map<IdentifierSpec, String?>?,
+    shippingValuesMap: Map<FormFieldId, String?>?,
     interactorFactory: AutocompleteAddressInteractor.Factory,
     hideCountry: Boolean = false,
 ) : AddressFieldsElement {
@@ -47,7 +47,7 @@ class AutocompleteAddressElement(
 
     override fun sectionFieldErrorController() = controller
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         controller.setRawValue(rawValuesMap)
     }
 

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/AutocompleteAddressInteractor.kt
@@ -65,13 +65,13 @@ interface AutocompleteAddressInteractor {
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     sealed interface Event {
-        val values: Map<IdentifierSpec, String?>?
+        val values: Map<FormFieldId, String?>?
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class OnExpandForm(override val values: Map<IdentifierSpec, String?>?) : Event
+        data class OnExpandForm(override val values: Map<FormFieldId, String?>?) : Event
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        data class OnValues(override val values: Map<IdentifierSpec, String?>) : Event
+        data class OnValues(override val values: Map<FormFieldId, String?>) : Event
     }
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldController.kt
@@ -48,8 +48,8 @@ class CheckboxFieldController constructor(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         CheckboxFieldUI(modifier = modifier, controller = this, enabled = enabled)
     }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CheckboxFieldElement.kt
@@ -7,7 +7,7 @@ import com.stripe.android.uicore.utils.mapAsStateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class CheckboxFieldElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: CheckboxFieldController = CheckboxFieldController()
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CountryElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/CountryElement.kt
@@ -5,7 +5,7 @@ import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class CountryElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: DropdownFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/DropdownFieldController.kt
@@ -107,8 +107,8 @@ class DropdownFieldController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         DropDown(
             this,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/EmailElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/EmailElement.kt
@@ -5,7 +5,7 @@ import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 data class EmailElement(
-    override val identifier: IdentifierSpec = IdentifierSpec.Email,
+    override val identifier: FormFieldId = FormFieldId.Email,
     val initialValue: String? = "",
     override val controller: TextFieldController = SimpleTextFieldController(
         EmailConfig(),

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FieldUtils.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FieldUtils.kt
@@ -4,13 +4,13 @@ import androidx.annotation.RestrictTo
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 fun List<SectionFieldElement>.filterOutHiddenIdentifiers(
-    hiddenIdentifiers: Set<IdentifierSpec>,
+    hiddenIdentifiers: Set<FormFieldId>,
 ) = filterNot { field ->
     field.isHidden(hiddenIdentifiers)
 }
 
 private fun SectionFieldElement.isHidden(
-    hiddenIdentifiers: Set<IdentifierSpec>,
+    hiddenIdentifiers: Set<FormFieldId>,
 ): Boolean {
     return when (this) {
         is RowElement -> fields.all { field ->

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FormElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FormElement.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface FormElement {
-    val identifier: IdentifierSpec
+    val identifier: FormFieldId
     val controller: Controller?
 
     /**
@@ -29,8 +29,8 @@ interface FormElement {
      */
     val mandateText: ResolvableString?
 
-    fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>>
-    fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
+    fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>>
+    fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> =
         stateFlowOf(emptyList())
     fun onValidationStateChanged(isValidating: Boolean) {}
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FormFieldId.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/FormFieldId.kt
@@ -22,15 +22,15 @@ sealed interface ParameterDestination : Parcelable {
 }
 
 /**
- * This uniquely identifies a element in the form.  The vals here are for identifier
- * specs that need to be found when pre-populating fields, or when extracting data.
+ * Uniquely identifies an element in a form. The predefined IDs are used when pre-populating
+ * fields and extracting their values.
  * @param ignoreField set this to true to ensure that the field does not get put in the params list
  * when making a Stripe request. Used in [FieldValuesToParamsMapConverter.kt]
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 @Serializable
 @Parcelize
-data class IdentifierSpec(
+data class FormFieldId(
     val v1: String,
     val ignoreField: Boolean = false,
     val destination: ParameterDestination = ParameterDestination.Api.Params,
@@ -39,83 +39,83 @@ data class IdentifierSpec(
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
     companion object {
-        fun Generic(_value: String) = IdentifierSpec(_value)
+        fun Generic(_value: String) = FormFieldId(_value)
 
         // Needed to pre-populate forms
-        val Name = IdentifierSpec("billing_details[name]")
+        val Name = FormFieldId("billing_details[name]")
 
-        val CardBrand = IdentifierSpec("card[brand]")
+        val CardBrand = FormFieldId("card[brand]")
 
-        val PreferredCardBrand = IdentifierSpec("card[networks][preferred]")
+        val PreferredCardBrand = FormFieldId("card[networks][preferred]")
 
-        val CardNumber = IdentifierSpec("card[number]")
+        val CardNumber = FormFieldId("card[number]")
 
-        val CardCvc = IdentifierSpec("card[cvc]")
+        val CardCvc = FormFieldId("card[cvc]")
 
-        val CardExpMonth = IdentifierSpec("card[exp_month]")
+        val CardExpMonth = FormFieldId("card[exp_month]")
 
-        val CardExpYear = IdentifierSpec("card[exp_year]")
+        val CardExpYear = FormFieldId("card[exp_year]")
 
-        val BillingAddress = IdentifierSpec("billing_details[address]")
+        val BillingAddress = FormFieldId("billing_details[address]")
 
-        val Email = IdentifierSpec("billing_details[email]")
+        val Email = FormFieldId("billing_details[email]")
 
-        val Phone = IdentifierSpec("billing_details[phone]")
+        val Phone = FormFieldId("billing_details[phone]")
 
-        val Line1 = IdentifierSpec("billing_details[address][line1]")
+        val Line1 = FormFieldId("billing_details[address][line1]")
 
-        val Line2 = IdentifierSpec("billing_details[address][line2]")
+        val Line2 = FormFieldId("billing_details[address][line2]")
 
-        val City = IdentifierSpec("billing_details[address][city]")
+        val City = FormFieldId("billing_details[address][city]")
 
         // FieldValuesToParamsMapConverter will ignore this in the parameter list
-        val DependentLocality = IdentifierSpec("")
+        val DependentLocality = FormFieldId("")
 
-        val PostalCode = IdentifierSpec("billing_details[address][postal_code]")
+        val PostalCode = FormFieldId("billing_details[address][postal_code]")
 
-        val SortingCode = IdentifierSpec("")
+        val SortingCode = FormFieldId("")
 
-        val State = IdentifierSpec("billing_details[address][state]")
+        val State = FormFieldId("billing_details[address][state]")
 
-        val Country = IdentifierSpec("billing_details[address][country]")
+        val Country = FormFieldId("billing_details[address][country]")
 
         // Unique extracting functionality
-        val SaveForFutureUse = IdentifierSpec("save_for_future_use")
-        val OneLineAddress = IdentifierSpec("address")
-        val SameAsShipping = IdentifierSpec("same_as_shipping", ignoreField = true)
+        val SaveForFutureUse = FormFieldId("save_for_future_use")
+        val OneLineAddress = FormFieldId("address")
+        val SameAsShipping = FormFieldId("same_as_shipping", ignoreField = true)
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val SetAsDefaultPaymentMethod = IdentifierSpec(
+        val SetAsDefaultPaymentMethod = FormFieldId(
             v1 = "set_as_default_payment_method",
             destination = ParameterDestination.Local.Extras
         )
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val Blik = IdentifierSpec("blik", destination = ParameterDestination.Api.Options)
+        val Blik = FormFieldId("blik", destination = ParameterDestination.Api.Options)
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val BlikCode = IdentifierSpec("blik[code]", destination = ParameterDestination.Api.Options)
+        val BlikCode = FormFieldId("blik[code]", destination = ParameterDestination.Api.Options)
 
         @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val KonbiniConfirmationNumber = IdentifierSpec(
+        val KonbiniConfirmationNumber = FormFieldId(
             v1 = "konbini[confirmation_number]",
             destination = ParameterDestination.Api.Options
         )
 
         @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val BacsDebitConfirmed = IdentifierSpec(
+        val BacsDebitConfirmed = FormFieldId(
             "bacs_debit[confirmed]",
             destination = ParameterDestination.Local.Extras
         )
 
         @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val PhoneNumberCountry = IdentifierSpec(
+        val PhoneNumberCountry = FormFieldId(
             v1 = "phone_number_country",
             destination = ParameterDestination.Local.Extras
         )
 
         @get:RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
-        val CardValidatedScan = IdentifierSpec(
+        val CardValidatedScan = FormFieldId(
             "card[validated_scan]",
             destination = ParameterDestination.Local.Extras
         )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElement.kt
@@ -10,13 +10,13 @@ import kotlinx.coroutines.flow.mapNotNull
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class OTPElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: OTPController
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
         return controller.fieldValue.mapAsStateFlow {
             listOf(identifier to FormFieldEntry(it, it.length == controller.otpLength))
         }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementFactory.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementFactory.kt
@@ -6,7 +6,7 @@ import androidx.annotation.RestrictTo
 object OTPElementFactory {
     fun create(): OTPElement {
         return OTPElement(
-            identifier = IdentifierSpec.Generic("otp"),
+            identifier = FormFieldId.Generic("otp"),
             controller = OTPController(),
         )
     }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/OTPElementUI.kt
@@ -65,7 +65,7 @@ internal fun OTPElementUIPreview() {
         OTPElementUI(
             enabled = true,
             element = OTPElement(
-                identifier = IdentifierSpec.Generic("otp"),
+                identifier = FormFieldId.Generic("otp"),
                 controller = OTPController()
             )
         )
@@ -79,7 +79,7 @@ internal fun OTPElementUIDisabledPreview() {
         OTPElementUI(
             enabled = false,
             element = OTPElement(
-                identifier = IdentifierSpec.Generic("otp"),
+                identifier = FormFieldId.Generic("otp"),
                 controller = OTPController()
             )
         )

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberController.kt
@@ -195,8 +195,8 @@ class PhoneNumberController private constructor(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         PhoneNumberElementUI(
             enabled,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/PhoneNumberElement.kt
@@ -8,17 +8,17 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 data class PhoneNumberElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: PhoneNumberController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
         return combineAsStateFlow(controller.formFieldValue, controller.phoneNumberFormatter) { phoneEntry, formatter ->
             listOf(
                 identifier to phoneEntry,
-                IdentifierSpec.PhoneNumberCountry to FormFieldEntry(
+                FormFieldId.PhoneNumberCountry to FormFieldEntry(
                     value = controller.getCountryCode(),
                     isComplete = true,
                 ),

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowController.kt
@@ -21,8 +21,8 @@ class RowController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     ) {
         RowElementUI(
             enabled,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElement.kt
@@ -8,27 +8,27 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class RowElement(
-    _identifier: IdentifierSpec,
+    _identifier: FormFieldId,
     val fields: List<SectionSingleFieldElement>,
     val controller: RowController
 ) : SectionMultiFieldElement(_identifier) {
     override val allowsUserInteraction: Boolean = fields.any { it.allowsUserInteraction }
     override val mandateText: ResolvableString? = null
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         combineAsStateFlow(fields.map { it.getFormFieldValueFlow() }) {
             it.toList().flatten()
         }
 
     override fun sectionFieldErrorController() = controller
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         fields.forEach {
             it.setRawValue(rawValuesMap)
         }
     }
 
-    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
+    override fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> =
         fields.map { it.getTextFieldIdentifiers() }.last()
 
     override fun onValidationStateChanged(isValidating: Boolean) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/RowElementUI.kt
@@ -23,8 +23,8 @@ import com.stripe.android.uicore.stripeShapes
 fun RowElementUI(
     enabled: Boolean,
     controller: RowController,
-    hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    hiddenIdentifiers: Set<FormFieldId>,
+    lastTextFieldIdentifier: FormFieldId?,
     modifier: Modifier = Modifier,
 ) {
     val visibleFields = controller.fields.filter { !hiddenIdentifiers.contains(it.identifier) }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SameAsShippingElement.kt
@@ -8,19 +8,19 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SameAsShippingElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: SameAsShippingController
 ) : FormElement {
     override val allowsUserInteraction: Boolean = true
     override val mandateText: ResolvableString? = null
 
-    fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         rawValuesMap[identifier]?.let {
             controller.onRawValueChange(it)
         }
     }
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
         return controller.formFieldValue.mapAsStateFlow { formFieldEntry ->
             listOf(identifier to formFieldEntry)
         }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElement.kt
@@ -8,12 +8,12 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 data class SectionElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     val fields: List<SectionFieldElement>,
     override val controller: SectionController
 ) : FormElement {
     constructor(
-        identifier: IdentifierSpec,
+        identifier: FormFieldId,
         field: SectionFieldElement,
         controller: SectionController
     ) : this(identifier, listOf(field), controller)
@@ -22,12 +22,12 @@ data class SectionElement(
 
     override val mandateText: ResolvableString? = fields.firstNotNullOfOrNull { it.mandateText }
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> =
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> =
         combineAsStateFlow(fields.map { it.getFormFieldValueFlow() }) {
             it.toList().flatten()
         }
 
-    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
+    override fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> =
         combineAsStateFlow(
             fields
                 .map {
@@ -64,7 +64,7 @@ data class SectionElement(
                 it.sectionFieldErrorController()
             }
             return SectionElement(
-                IdentifierSpec.Generic("${sectionFieldElements.first().identifier.v1}_section"),
+                FormFieldId.Generic("${sectionFieldElements.first().identifier.v1}_section"),
                 sectionFieldElements,
                 SectionController(
                     label,

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionElementUI.kt
@@ -18,8 +18,8 @@ import com.stripe.android.uicore.utils.collectAsState
 fun SectionElementUI(
     enabled: Boolean,
     element: SectionElement,
-    hiddenIdentifiers: Set<IdentifierSpec>,
-    lastTextFieldIdentifier: IdentifierSpec?,
+    hiddenIdentifiers: Set<FormFieldId>,
+    lastTextFieldIdentifier: FormFieldId?,
     modifier: Modifier = Modifier,
 ) {
     if (!hiddenIdentifiers.contains(element.identifier)) {

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldComposable.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldComposable.kt
@@ -14,7 +14,7 @@ fun interface SectionFieldComposable {
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?
     )
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElement.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.StateFlow
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 interface SectionFieldElement {
-    val identifier: IdentifierSpec
+    val identifier: FormFieldId
 
     /**
      * Whether the field element allows user interaction.
@@ -23,9 +23,9 @@ interface SectionFieldElement {
      */
     val mandateText: ResolvableString?
 
-    fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>>
+    fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>>
     fun sectionFieldErrorController(): SectionFieldValidationController
-    fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>)
-    fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>>
+    fun setRawValue(rawValuesMap: Map<FormFieldId, String?>)
+    fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>>
     fun onValidationStateChanged(isValidating: Boolean) {}
 }

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElementUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionFieldElementUI.kt
@@ -10,8 +10,8 @@ fun SectionFieldElementUI(
     enabled: Boolean,
     field: SectionFieldElement,
     modifier: Modifier = Modifier,
-    hiddenIdentifiers: Set<IdentifierSpec> = emptySet(),
-    lastTextFieldIdentifier: IdentifierSpec?,
+    hiddenIdentifiers: Set<FormFieldId> = emptySet(),
+    lastTextFieldIdentifier: FormFieldId?,
 ) {
     if (!hiddenIdentifiers.contains(field.identifier)) {
         (field.sectionFieldErrorController() as? SectionFieldComposable)?.ComposeUI(

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionMultiFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionMultiFieldElement.kt
@@ -4,5 +4,5 @@ import androidx.annotation.RestrictTo
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 abstract class SectionMultiFieldElement(
-    override val identifier: IdentifierSpec
+    override val identifier: FormFieldId
 ) : SectionFieldElement

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionSingleFieldElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SectionSingleFieldElement.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
  */
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 abstract class SectionSingleFieldElement(
-    override val identifier: IdentifierSpec
+    override val identifier: FormFieldId
 ) : SectionFieldElement {
     /**
      * Some fields in the section will have a single input controller.
@@ -23,17 +23,17 @@ abstract class SectionSingleFieldElement(
      */
     override fun sectionFieldErrorController(): SectionFieldValidationController = controller
 
-    override fun getFormFieldValueFlow(): StateFlow<List<Pair<IdentifierSpec, FormFieldEntry>>> {
+    override fun getFormFieldValueFlow(): StateFlow<List<Pair<FormFieldId, FormFieldEntry>>> {
         return controller.formFieldValue.mapAsStateFlow { formFieldEntry ->
             listOf(identifier to formFieldEntry)
         }
     }
 
-    override fun setRawValue(rawValuesMap: Map<IdentifierSpec, String?>) {
+    override fun setRawValue(rawValuesMap: Map<FormFieldId, String?>) {
         rawValuesMap[identifier]?.let { controller.onRawValueChange(it) }
     }
 
-    override fun getTextFieldIdentifiers(): StateFlow<List<IdentifierSpec>> =
+    override fun getTextFieldIdentifiers(): StateFlow<List<FormFieldId>> =
         MutableStateFlow(
             listOf(identifier).takeIf { controller is TextFieldController }
                 ?: emptyList()

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextElement.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/SimpleTextElement.kt
@@ -5,7 +5,7 @@ import com.stripe.android.core.strings.ResolvableString
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
 data class SimpleTextElement(
-    override val identifier: IdentifierSpec,
+    override val identifier: FormFieldId,
     override val controller: TextFieldController
 ) : SectionSingleFieldElement(identifier) {
     override val allowsUserInteraction: Boolean = true

--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/TextFieldController.kt
@@ -58,8 +58,8 @@ interface TextFieldController : InputController, SectionFieldComposable, Section
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?,
     ) {
         TextField(
             textFieldController = this,
@@ -251,8 +251,8 @@ class SimpleTextFieldController(
         enabled: Boolean,
         field: SectionFieldElement,
         modifier: Modifier,
-        hiddenIdentifiers: Set<IdentifierSpec>,
-        lastTextFieldIdentifier: IdentifierSpec?,
+        hiddenIdentifiers: Set<FormFieldId>,
+        lastTextFieldIdentifier: FormFieldId?,
     ) {
         TextField(
             textFieldController = this,

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/address/TransformAddressToElementTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/address/TransformAddressToElementTest.kt
@@ -7,7 +7,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.uicore.R
 import com.stripe.android.uicore.elements.AdministrativeAreaConfig
 import com.stripe.android.uicore.elements.AdministrativeAreaElement
-import com.stripe.android.uicore.elements.IdentifierSpec
+import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.uicore.elements.RowElement
 import com.stripe.android.uicore.elements.SectionSingleFieldElement
 import com.stripe.android.uicore.elements.SimpleTextFieldController
@@ -19,7 +19,7 @@ import com.stripe.android.core.R as CoreR
 
 class TransformAddressToElementTest {
     private data class TestTextSpec(
-        val apiPath: IdentifierSpec,
+        val apiPath: FormFieldId,
         val label: Int,
         val keyboardCapitalization: KeyboardCapitalization,
         val keyboardType: KeyboardType,
@@ -31,7 +31,7 @@ class TransformAddressToElementTest {
         val simpleTextList = AddressSchemaRegistry.get("US")!!.transformToElementList("US")
 
         val addressLine1 = TestTextSpec(
-            IdentifierSpec.Line1,
+            FormFieldId.Line1,
             CoreR.string.stripe_address_label_address_line1,
             KeyboardCapitalization.Words,
             KeyboardType.Text,
@@ -39,7 +39,7 @@ class TransformAddressToElementTest {
         )
 
         val addressLine2 = TestTextSpec(
-            IdentifierSpec.Line2,
+            FormFieldId.Line2,
             R.string.stripe_address_label_address_line2,
             KeyboardCapitalization.Words,
             KeyboardType.Text,
@@ -47,7 +47,7 @@ class TransformAddressToElementTest {
         )
 
         val city = TestTextSpec(
-            IdentifierSpec.City,
+            FormFieldId.City,
             CoreR.string.stripe_address_label_city,
             KeyboardCapitalization.Words,
             KeyboardType.Text,
@@ -55,7 +55,7 @@ class TransformAddressToElementTest {
         )
 
         val zip = TestTextSpec(
-            IdentifierSpec.PostalCode,
+            FormFieldId.PostalCode,
             CoreR.string.stripe_address_label_zip_code,
             KeyboardCapitalization.None,
             KeyboardType.NumberPassword,

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressElementUiTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressElementUiTest.kt
@@ -24,22 +24,22 @@ class AddressElementUiTest {
     @Test
     fun `On input updated, input is not reset in 'AddressElement' when observed`() {
         val element = AddressElement(
-            _identifier = IdentifierSpec.BillingAddress,
+            _identifier = FormFieldId.BillingAddress,
             rawValuesMap = mapOf(
-                IdentifierSpec.Line1 to "123 Main Street",
-                IdentifierSpec.Line2 to "456",
-                IdentifierSpec.City to "San Francisco",
-                IdentifierSpec.State to "CA",
-                IdentifierSpec.Country to "US",
-                IdentifierSpec.PostalCode to "94111",
+                FormFieldId.Line1 to "123 Main Street",
+                FormFieldId.Line2 to "456",
+                FormFieldId.City to "San Francisco",
+                FormFieldId.State to "CA",
+                FormFieldId.Country to "US",
+                FormFieldId.PostalCode to "94111",
             ),
             countryCodes = setOf("US"),
             sameAsShippingElement = SameAsShippingElement(
-                IdentifierSpec.SameAsShipping,
+                FormFieldId.SameAsShipping,
                 SameAsShippingController(false)
             ),
             shippingValuesMap = mapOf(
-                IdentifierSpec.Country to "US"
+                FormFieldId.Country to "US"
             ),
         )
 

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldElementTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AddressTextFieldElementTest.kt
@@ -10,7 +10,7 @@ class AddressTextFieldElementTest {
     @Test
     fun `Element should have a text field identifier`() = runTest {
         val element = AddressTextFieldElement(
-            identifier = IdentifierSpec.OneLineAddress,
+            identifier = FormFieldId.OneLineAddress,
             label = "Address".resolvableString,
             addressInputMode = AddressInputMode.NoAutocomplete(),
             inlineAutocompleteHandler = null,
@@ -21,7 +21,7 @@ class AddressTextFieldElementTest {
 
         element.getTextFieldIdentifiers().test {
             assertThat(awaitItem()).containsExactly(
-                IdentifierSpec.OneLineAddress
+                FormFieldId.OneLineAddress
             )
         }
     }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/AutocompleteAddressControllerTest.kt
@@ -41,7 +41,7 @@ class AutocompleteAddressControllerTest {
         nameConfig = AddressFieldConfiguration.HIDDEN
     ) { elements ->
         assertThat(
-            elements.any { it.identifier == IdentifierSpec.Name }
+            elements.any { it.identifier == FormFieldId.Name }
         ).isFalse()
     }
 
@@ -50,7 +50,7 @@ class AutocompleteAddressControllerTest {
         nameConfig = AddressFieldConfiguration.OPTIONAL
     ) { elements ->
         assertThat(
-            elements.any { it.identifier == IdentifierSpec.Name }
+            elements.any { it.identifier == FormFieldId.Name }
         ).isTrue()
     }
 
@@ -59,7 +59,7 @@ class AutocompleteAddressControllerTest {
         nameConfig = AddressFieldConfiguration.REQUIRED
     ) { elements ->
         assertThat(
-            elements.any { it.identifier == IdentifierSpec.Name }
+            elements.any { it.identifier == FormFieldId.Name }
         ).isTrue()
     }
 
@@ -101,12 +101,12 @@ class AutocompleteAddressControllerTest {
     @Test
     fun `Same as shipping element & shipping values are respected when provided`() {
         val shippingValuesMap = mapOf(
-            IdentifierSpec.Line1 to "123 Main Street",
-            IdentifierSpec.Line2 to "456",
-            IdentifierSpec.City to "San Francisco",
-            IdentifierSpec.State to "CA",
-            IdentifierSpec.Country to "US",
-            IdentifierSpec.PostalCode to "94111",
+            FormFieldId.Line1 to "123 Main Street",
+            FormFieldId.Line2 to "456",
+            FormFieldId.City to "San Francisco",
+            FormFieldId.State to "CA",
+            FormFieldId.Country to "US",
+            FormFieldId.PostalCode to "94111",
         )
         val element = createSameAsShippingElement()
 
@@ -116,12 +116,12 @@ class AutocompleteAddressControllerTest {
         ) {
             assertThat(awaitItem()).containsExactlyElementsIn(
                 listOf(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
@@ -129,23 +129,23 @@ class AutocompleteAddressControllerTest {
 
             assertThat(awaitItem()).containsAtLeastElementsIn(
                 listOf(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "456", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "456", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "", isComplete = false),
                 )
             )
 
             assertThat(awaitItem()).containsAtLeastElementsIn(
                 listOf(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "456", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "456", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
                 )
             )
 
@@ -193,7 +193,7 @@ class AutocompleteAddressControllerTest {
             ),
         ) { elements ->
             assertThat(elements.filterIsInstance<AddressTextFieldElement>()).hasSize(1)
-            assertThat(elements.any { it.identifier == IdentifierSpec.Line1 }).isFalse()
+            assertThat(elements.any { it.identifier == FormFieldId.Line1 }).isFalse()
         }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -223,12 +223,12 @@ class AutocompleteAddressControllerTest {
                         firstFields.any { it is AddressTextFieldElement }
                     ).isTrue()
                     assertThat(
-                        firstFields.any { it.identifier == IdentifierSpec.Line1 }
+                        firstFields.any { it.identifier == FormFieldId.Line1 }
                     ).isFalse()
 
                     registerCall.onEvent(
                         AutocompleteAddressInteractor.Event.OnValues(
-                            values = mapOf(IdentifierSpec.Country to "JP")
+                            values = mapOf(FormFieldId.Country to "JP")
                         )
                     )
 
@@ -239,7 +239,7 @@ class AutocompleteAddressControllerTest {
                         secondFields.any { it is AddressTextFieldElement }
                     ).isFalse()
                     assertThat(
-                        secondFields.any { it.identifier == IdentifierSpec.Line1 }
+                        secondFields.any { it.identifier == FormFieldId.Line1 }
                     ).isTrue()
                 }
             }
@@ -269,18 +269,18 @@ class AutocompleteAddressControllerTest {
 
                     registerCall.onEvent(
                         AutocompleteAddressInteractor.Event.OnValues(
-                            values = mapOf(IdentifierSpec.Country to "JP")
+                            values = mapOf(FormFieldId.Country to "JP")
                         )
                     )
 
                     val expandedElement = awaitItem()
                     assertThat(
-                        expandedElement.fields.value.any { it.identifier == IdentifierSpec.Line1 }
+                        expandedElement.fields.value.any { it.identifier == FormFieldId.Line1 }
                     ).isTrue()
 
                     registerCall.onEvent(
                         AutocompleteAddressInteractor.Event.OnValues(
-                            values = mapOf(IdentifierSpec.Country to "US")
+                            values = mapOf(FormFieldId.Country to "US")
                         )
                     )
 
@@ -289,7 +289,7 @@ class AutocompleteAddressControllerTest {
                         inlineElement.fields.value.any { it is AddressTextFieldElement }
                     ).isTrue()
                     assertThat(
-                        inlineElement.fields.value.any { it.identifier == IdentifierSpec.Line1 }
+                        inlineElement.fields.value.any { it.identifier == FormFieldId.Line1 }
                     ).isFalse()
                 }
             }
@@ -336,13 +336,13 @@ class AutocompleteAddressControllerTest {
 
                 assertThat(
                     firstElements.any { field ->
-                        field.identifier == IdentifierSpec.Line1
+                        field.identifier == FormFieldId.Line1
                     }
                 ).isFalse()
 
                 assertThat(
                     firstElements.any { field ->
-                        field.identifier == IdentifierSpec.Line2
+                        field.identifier == FormFieldId.Line2
                     }
                 ).isFalse()
 
@@ -362,13 +362,13 @@ class AutocompleteAddressControllerTest {
 
                 assertThat(
                     secondElements.any { field ->
-                        field.identifier == IdentifierSpec.Line1
+                        field.identifier == FormFieldId.Line1
                     }
                 ).isTrue()
 
                 assertThat(
                     secondElements.any { field ->
-                        field.identifier == IdentifierSpec.Line2
+                        field.identifier == FormFieldId.Line2
                     }
                 ).isTrue()
 
@@ -393,7 +393,7 @@ class AutocompleteAddressControllerTest {
             val controller = createAutocompleteAddressController(
                 interactor = interactor,
                 values = mapOf(
-                    IdentifierSpec.Line1 to "123",
+                    FormFieldId.Line1 to "123",
                 )
             )
 
@@ -401,34 +401,34 @@ class AutocompleteAddressControllerTest {
 
             controller.formFieldValues.test {
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "", isComplete = false),
                 )
 
                 registerCall.onEvent(
                     AutocompleteAddressInteractor.Event.OnValues(
                         values = mapOf(
-                            IdentifierSpec.Line1 to "123 Main Street",
-                            IdentifierSpec.Line2 to "456",
-                            IdentifierSpec.City to "San Francisco",
-                            IdentifierSpec.State to "CA",
-                            IdentifierSpec.Country to "US",
-                            IdentifierSpec.PostalCode to "94111",
+                            FormFieldId.Line1 to "123 Main Street",
+                            FormFieldId.Line2 to "456",
+                            FormFieldId.City to "San Francisco",
+                            FormFieldId.State to "CA",
+                            FormFieldId.Country to "US",
+                            FormFieldId.PostalCode to "94111",
                         )
                     )
                 )
 
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "456", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "456", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
                 )
             }
         }
@@ -446,7 +446,7 @@ class AutocompleteAddressControllerTest {
             val controller = createAutocompleteAddressController(
                 interactor = interactor,
                 values = mapOf(
-                    IdentifierSpec.Line1 to "123",
+                    FormFieldId.Line1 to "123",
                 )
             )
 
@@ -454,29 +454,29 @@ class AutocompleteAddressControllerTest {
 
             controller.formFieldValues.test {
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "", isComplete = false),
                 )
 
                 registerCall.onEvent(
                     AutocompleteAddressInteractor.Event.OnValues(
                         values = mapOf(
-                            IdentifierSpec.Line1 to "123 Main Street",
+                            FormFieldId.Line1 to "123 Main Street",
                         )
                     )
                 )
 
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "", isComplete = false),
                 )
             }
         }
@@ -492,10 +492,10 @@ class AutocompleteAddressControllerTest {
                 phoneNumberConfig = AddressFieldConfiguration.REQUIRED,
                 emailConfig = AddressFieldConfiguration.REQUIRED,
                 values = mapOf(
-                    IdentifierSpec.Name to "John Doe",
-                    IdentifierSpec.Email to "email@email.com",
-                    IdentifierSpec.Phone to "+11234567890",
-                    IdentifierSpec.Line1 to "123",
+                    FormFieldId.Name to "John Doe",
+                    FormFieldId.Email to "email@email.com",
+                    FormFieldId.Phone to "+11234567890",
+                    FormFieldId.Line1 to "123",
                 )
             )
 
@@ -503,42 +503,42 @@ class AutocompleteAddressControllerTest {
 
             controller.formFieldValues.test {
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Email to FormFieldEntry(value = "email@email.com", isComplete = true),
-                    IdentifierSpec.PhoneNumberCountry to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.Phone to FormFieldEntry(value = "+11234567890", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Email to FormFieldEntry(value = "email@email.com", isComplete = true),
+                    FormFieldId.PhoneNumberCountry to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.Phone to FormFieldEntry(value = "+11234567890", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "", isComplete = false),
                 )
 
                 registerCall.onEvent(
                     AutocompleteAddressInteractor.Event.OnValues(
                         values = mapOf(
-                            IdentifierSpec.Line1 to "123 Main Street",
-                            IdentifierSpec.Line2 to "456",
-                            IdentifierSpec.City to "San Francisco",
-                            IdentifierSpec.State to "CA",
-                            IdentifierSpec.Country to "US",
-                            IdentifierSpec.PostalCode to "94111",
+                            FormFieldId.Line1 to "123 Main Street",
+                            FormFieldId.Line2 to "456",
+                            FormFieldId.City to "San Francisco",
+                            FormFieldId.State to "CA",
+                            FormFieldId.Country to "US",
+                            FormFieldId.PostalCode to "94111",
                         )
                     )
                 )
 
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Name to FormFieldEntry(value = "John Doe", isComplete = true),
-                    IdentifierSpec.Email to FormFieldEntry(value = "email@email.com", isComplete = true),
-                    IdentifierSpec.PhoneNumberCountry to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.Phone to FormFieldEntry(value = "+11234567890", isComplete = true),
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "456", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
+                    FormFieldId.Name to FormFieldEntry(value = "John Doe", isComplete = true),
+                    FormFieldId.Email to FormFieldEntry(value = "email@email.com", isComplete = true),
+                    FormFieldId.PhoneNumberCountry to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.Phone to FormFieldEntry(value = "+11234567890", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "456", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
                 )
             }
         }
@@ -551,12 +551,12 @@ class AutocompleteAddressControllerTest {
             val controller = createAutocompleteAddressController(
                 interactor = interactor,
                 values = mapOf(
-                    IdentifierSpec.Line1 to "123 Main Street",
-                    IdentifierSpec.Line2 to "456",
-                    IdentifierSpec.City to "San Francisco",
-                    IdentifierSpec.State to "CA",
-                    IdentifierSpec.Country to "US",
-                    IdentifierSpec.PostalCode to "94111",
+                    FormFieldId.Line1 to "123 Main Street",
+                    FormFieldId.Line2 to "456",
+                    FormFieldId.City to "San Francisco",
+                    FormFieldId.State to "CA",
+                    FormFieldId.Country to "US",
+                    FormFieldId.PostalCode to "94111",
                 )
             )
 
@@ -564,34 +564,34 @@ class AutocompleteAddressControllerTest {
 
             controller.formFieldValues.test {
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "456", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "San Francisco", isComplete = true),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "456", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "San Francisco", isComplete = true),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
                 )
 
                 registerCall.onEvent(
                     AutocompleteAddressInteractor.Event.OnValues(
                         values = mapOf(
-                            IdentifierSpec.Line1 to "123 Main Street",
-                            IdentifierSpec.Line2 to null,
-                            IdentifierSpec.City to null,
-                            IdentifierSpec.State to "CA",
-                            IdentifierSpec.Country to "US",
-                            IdentifierSpec.PostalCode to "94111",
+                            FormFieldId.Line1 to "123 Main Street",
+                            FormFieldId.Line2 to null,
+                            FormFieldId.City to null,
+                            FormFieldId.State to "CA",
+                            FormFieldId.Country to "US",
+                            FormFieldId.PostalCode to "94111",
                         )
                     )
                 )
 
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "94111", isComplete = true),
                 )
             }
         }
@@ -609,7 +609,7 @@ class AutocompleteAddressControllerTest {
             val controller = createAutocompleteAddressController(
                 interactor = interactor,
                 values = mapOf(
-                    IdentifierSpec.Line1 to "123",
+                    FormFieldId.Line1 to "123",
                 )
             )
 
@@ -617,30 +617,30 @@ class AutocompleteAddressControllerTest {
 
             controller.formFieldValues.test {
                 assertThat(awaitItem()).containsExactly(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "US", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "", isComplete = false),
                 )
 
                 registerCall.onEvent(
                     AutocompleteAddressInteractor.Event.OnValues(
                         values = mapOf(
-                            IdentifierSpec.Line1 to "123 Main Street",
-                            IdentifierSpec.Country to "CA"
+                            FormFieldId.Line1 to "123 Main Street",
+                            FormFieldId.Country to "CA"
                         )
                     )
                 )
 
                 assertThat(expectMostRecentItem()).containsExactly(
-                    IdentifierSpec.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
-                    IdentifierSpec.Line2 to FormFieldEntry(value = "", isComplete = true),
-                    IdentifierSpec.City to FormFieldEntry(value = "", isComplete = false),
-                    IdentifierSpec.State to FormFieldEntry(value = null, isComplete = false),
-                    IdentifierSpec.Country to FormFieldEntry(value = "CA", isComplete = true),
-                    IdentifierSpec.PostalCode to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.Line1 to FormFieldEntry(value = "123 Main Street", isComplete = true),
+                    FormFieldId.Line2 to FormFieldEntry(value = "", isComplete = true),
+                    FormFieldId.City to FormFieldEntry(value = "", isComplete = false),
+                    FormFieldId.State to FormFieldEntry(value = null, isComplete = false),
+                    FormFieldId.Country to FormFieldEntry(value = "CA", isComplete = true),
+                    FormFieldId.PostalCode to FormFieldEntry(value = "", isComplete = false),
                 )
             }
         }
@@ -649,7 +649,7 @@ class AutocompleteAddressControllerTest {
     @Test
     fun `On values has line 1, should be expanded form`() = elementsTest(
         values = mapOf(
-            IdentifierSpec.Line1 to "123 Apple Street"
+            FormFieldId.Line1 to "123 Apple Street"
         ),
         autocompleteConfig = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "123",
@@ -658,11 +658,11 @@ class AutocompleteAddressControllerTest {
         ),
     ) { elements ->
         val containsLineOne = elements.any { element ->
-            element.identifier == IdentifierSpec.Line1
+            element.identifier == FormFieldId.Line1
         }
 
         val containsLineTwo = elements.any { element ->
-            element.identifier == IdentifierSpec.Line2
+            element.identifier == FormFieldId.Line2
         }
 
         assertThat(containsLineOne).isTrue()
@@ -692,7 +692,7 @@ class AutocompleteAddressControllerTest {
     @Test
     fun `Element contains expanded elements & navigates on autocomplete click`() = elementsTest(
         values = mapOf(
-            IdentifierSpec.Line1 to "123 Apple Street"
+            FormFieldId.Line1 to "123 Apple Street"
         ),
         autocompleteConfig = AutocompleteAddressInteractor.Config(
             googlePlacesApiKey = "123",
@@ -701,7 +701,7 @@ class AutocompleteAddressControllerTest {
         ),
     ) { elements ->
         val element = elements.firstOrNull { element ->
-            element.identifier == IdentifierSpec.Line1
+            element.identifier == FormFieldId.Line1
         }
 
         assertThat(element).isNotNull()
@@ -757,9 +757,9 @@ class AutocompleteAddressControllerTest {
                 )
             ),
             values = mapOf(
-                IdentifierSpec.Country to "US",
-                IdentifierSpec.PostalCode to "999",
-                IdentifierSpec.Phone to "+1222"
+                FormFieldId.Country to "US",
+                FormFieldId.PostalCode to "999",
+                FormFieldId.Phone to "+1222"
             )
         )
 
@@ -779,12 +779,12 @@ class AutocompleteAddressControllerTest {
                     assertThat(rowElements).hasSize(1)
 
                     val zipCodeElement = rowElements[0].fields.find { element ->
-                        element.identifier == IdentifierSpec.PostalCode
+                        element.identifier == FormFieldId.PostalCode
                     }
 
                     assertThat(zipCodeElement).isNotNull()
 
-                    requireNotNull(zipCodeElement).setRawValue(mapOf(IdentifierSpec.PostalCode to "99999"))
+                    requireNotNull(zipCodeElement).setRawValue(mapOf(FormFieldId.PostalCode to "99999"))
                 }
             }
 
@@ -813,12 +813,12 @@ class AutocompleteAddressControllerTest {
                 registerCall.onEvent(
                     AutocompleteAddressInteractor.Event.OnValues(
                         values = mapOf(
-                            IdentifierSpec.Line1 to "123 Main Street",
-                            IdentifierSpec.Line2 to "456",
-                            IdentifierSpec.City to "San Francisco",
-                            IdentifierSpec.State to "CA",
-                            IdentifierSpec.Country to "US",
-                            IdentifierSpec.PostalCode to "94111",
+                            FormFieldId.Line1 to "123 Main Street",
+                            FormFieldId.Line2 to "456",
+                            FormFieldId.City to "San Francisco",
+                            FormFieldId.State to "CA",
+                            FormFieldId.Country to "US",
+                            FormFieldId.PostalCode to "94111",
                         )
                     )
                 )
@@ -835,24 +835,24 @@ class AutocompleteAddressControllerTest {
         fieldsTest { controller ->
             val fields = awaitItem()
 
-            fields.element(IdentifierSpec.Country).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.Line1).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.Line2).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.State).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.PostalCode).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.City).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.Country).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.Line1).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.Line2).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.State).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.PostalCode).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.City).errorTest(fieldValidationMessage = null)
 
             controller.onValidationStateChanged(true)
 
-            fields.element(IdentifierSpec.Country).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.Line1)
+            fields.element(FormFieldId.Country).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.Line1)
                 .errorTest(fieldValidationMessage = FieldValidationMessage.Error(R.string.stripe_blank_and_required))
-            fields.element(IdentifierSpec.Line2).errorTest(fieldValidationMessage = null)
-            fields.element(IdentifierSpec.State)
+            fields.element(FormFieldId.Line2).errorTest(fieldValidationMessage = null)
+            fields.element(FormFieldId.State)
                 .errorTest(fieldValidationMessage = FieldValidationMessage.Error(R.string.stripe_blank_and_required))
-            fields.element(IdentifierSpec.PostalCode)
+            fields.element(FormFieldId.PostalCode)
                 .errorTest(fieldValidationMessage = FieldValidationMessage.Error(R.string.stripe_blank_and_required))
-            fields.element(IdentifierSpec.City)
+            fields.element(FormFieldId.City)
                 .errorTest(fieldValidationMessage = FieldValidationMessage.Error(R.string.stripe_blank_and_required))
         }
 
@@ -864,7 +864,7 @@ class AutocompleteAddressControllerTest {
         assertThat(fields.filterIsInstance<AutocompleteAddressElement>()).isEmpty()
 
         val field = fields.firstOrNull { field ->
-            field.identifier == IdentifierSpec.Line1
+            field.identifier == FormFieldId.Line1
         }
 
         assertThat(field).isNotNull()
@@ -880,12 +880,12 @@ class AutocompleteAddressControllerTest {
     }
 
     private fun elementsTest(
-        values: Map<IdentifierSpec, String?> = emptyMap(),
+        values: Map<FormFieldId, String?> = emptyMap(),
         nameConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         emailConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         sameAsShippingElement: SameAsShippingElement? = null,
-        shippingValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
+        shippingValuesMap: Map<FormFieldId, String?> = emptyMap(),
         autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
             autocompleteCountries = setOf("AT", "BE", "DE", "ES", "IT", "NL"),
             googlePlacesApiKey = null,
@@ -927,8 +927,8 @@ class AutocompleteAddressControllerTest {
     private fun formFieldsTest(
         phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         sameAsShippingElement: SameAsShippingElement? = null,
-        shippingValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
-        test: suspend TurbineTestContext<List<Pair<IdentifierSpec, FormFieldEntry>>>.() -> Unit
+        shippingValuesMap: Map<FormFieldId, String?> = emptyMap(),
+        test: suspend TurbineTestContext<List<Pair<FormFieldId, FormFieldEntry>>>.() -> Unit
     ) = runTest {
         val controller = createAutocompleteAddressController(
             phoneNumberConfig = phoneNumberConfig,
@@ -946,12 +946,12 @@ class AutocompleteAddressControllerTest {
     }
 
     private fun createAutocompleteAddressController(
-        values: Map<IdentifierSpec, String?> = emptyMap(),
+        values: Map<FormFieldId, String?> = emptyMap(),
         phoneNumberConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         nameConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         emailConfig: AddressFieldConfiguration = AddressFieldConfiguration.HIDDEN,
         sameAsShippingElement: SameAsShippingElement? = null,
-        shippingValuesMap: Map<IdentifierSpec, String?> = emptyMap(),
+        shippingValuesMap: Map<FormFieldId, String?> = emptyMap(),
         autocompleteConfig: AutocompleteAddressInteractor.Config = AutocompleteAddressInteractor.Config(
             autocompleteCountries = setOf("AT", "BE", "DE", "ES", "IT", "NL"),
             googlePlacesApiKey = null,
@@ -963,7 +963,7 @@ class AutocompleteAddressControllerTest {
             ),
     ): AutocompleteAddressController {
         return AutocompleteAddressController(
-            identifier = IdentifierSpec.Generic("address"),
+            identifier = FormFieldId.Generic("address"),
             initialValues = values,
             sameAsShippingElement = sameAsShippingElement,
             shippingValuesMap = shippingValuesMap,
@@ -977,26 +977,26 @@ class AutocompleteAddressControllerTest {
 
     private fun createSameAsShippingElement(): SameAsShippingElement {
         return SameAsShippingElement(
-            identifier = IdentifierSpec.SameAsShipping,
+            identifier = FormFieldId.SameAsShipping,
             controller = SameAsShippingController(initialValue = false)
         )
     }
 
-    private fun List<SectionFieldElement>.element(identifierSpec: IdentifierSpec): SectionFieldElement {
-        val element = nullableElement(identifierSpec)
+    private fun List<SectionFieldElement>.element(formFieldId: FormFieldId): SectionFieldElement {
+        val element = nullableElement(formFieldId)
 
         assertThat(element).isNotNull()
 
         return requireNotNull(element)
     }
 
-    private fun List<SectionFieldElement>.nullableElement(identifierSpec: IdentifierSpec): SectionFieldElement? {
+    private fun List<SectionFieldElement>.nullableElement(formFieldId: FormFieldId): SectionFieldElement? {
         for (element in this) {
             if (element is RowElement) {
-                element.fields.nullableElement(identifierSpec)?.let {
+                element.fields.nullableElement(formFieldId)?.let {
                     return it
                 }
-            } else if (element.identifier == identifierSpec) {
+            } else if (element.identifier == formFieldId) {
                 return element
             }
         }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CheckboxFieldElementTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/CheckboxFieldElementTest.kt
@@ -12,7 +12,7 @@ class CheckboxFieldElementTest {
     fun `when controller checked state is false, form value should indicate incomplete`() = runTest {
         val controller = CheckboxFieldController()
         val element = CheckboxFieldElement(
-            identifier = IdentifierSpec.Generic("test_checkbox"),
+            identifier = FormFieldId.Generic("test_checkbox"),
             controller = controller
         )
 
@@ -27,7 +27,7 @@ class CheckboxFieldElementTest {
     fun `when controller checked state is true, form value should indicate complete`() = runTest {
         val controller = CheckboxFieldController(initialValue = true)
         val element = CheckboxFieldElement(
-            identifier = IdentifierSpec.Generic("test_checkbox"),
+            identifier = FormFieldId.Generic("test_checkbox"),
             controller = controller
         )
 

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUITest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUITest.kt
@@ -92,7 +92,7 @@ class OTPElementUITest {
 
     private fun testElement(): OTPElement {
         return OTPElement(
-            identifier = IdentifierSpec.Generic("otp"),
+            identifier = FormFieldId.Generic("otp"),
             controller = OTPController(),
         )
     }

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUiScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/OTPElementUiScreenshotTest.kt
@@ -24,7 +24,7 @@ class OTPElementUiScreenshotTest {
             OTPElementUI(
                 enabled = true,
                 element = OTPElement(
-                    identifier = IdentifierSpec.Generic("otp"),
+                    identifier = FormFieldId.Generic("otp"),
                     controller = OTPController()
                 )
             )
@@ -37,7 +37,7 @@ class OTPElementUiScreenshotTest {
             OTPElementUI(
                 enabled = false,
                 element = OTPElement(
-                    identifier = IdentifierSpec.Generic("otp"),
+                    identifier = FormFieldId.Generic("otp"),
                     controller = OTPController()
                 )
             )

--- a/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SectionUIScreenshotTest.kt
+++ b/stripe-ui-core/src/test/java/com/stripe/android/uicore/elements/SectionUIScreenshotTest.kt
@@ -40,7 +40,7 @@ class SectionUIScreenshotTest {
 
             val sectionElement = SectionElement.wrap(
                 sectionFieldElement = SimpleTextElement(
-                    identifier = IdentifierSpec.Generic("zip"),
+                    identifier = FormFieldId.Generic("zip"),
                     controller = textFieldController
                 ),
                 label = "Billing Address".resolvableString
@@ -67,7 +67,7 @@ class SectionUIScreenshotTest {
 
             val sectionElement = SectionElement.wrap(
                 sectionFieldElement = SimpleTextElement(
-                    identifier = IdentifierSpec.Generic("zip"),
+                    identifier = FormFieldId.Generic("zip"),
                     controller = textFieldController
                 ),
                 label = "Billing Address".resolvableString
@@ -92,7 +92,7 @@ class SectionUIScreenshotTest {
 
             val sectionElement = SectionElement.wrap(
                 sectionFieldElement = SimpleTextElement(
-                    identifier = IdentifierSpec.Generic("zip"),
+                    identifier = FormFieldId.Generic("zip"),
                     controller = textFieldController
                 ),
                 label = "Billing Address".resolvableString


### PR DESCRIPTION
# Summary

Rename `IdentifierSpec` to `FormFieldId` across form UI code, tests, API snapshots, and Detekt baselines. Rename related `identifierSpec` properties and locals to `formFieldId`.

# Motivation

`IdentifierSpec` now represents the stable ID of a form field rather than a specification. `FormFieldId` describes its role more directly and makes form-value maps easier to understand.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Validated with:

- `./gradlew detekt`
- Affected-module Kotlin compilation, including both library and identity example sources
- `./gradlew :stripe-ui-core:apiCheck`

No tests were newly ignored.

# Screenshots

Not applicable. This is an internal naming refactor with no UI changes.

# Changelog

Not applicable. This library-group-restricted rename does not change user-facing behavior.

Committed and created by Codex.
