### PR TITLE
Add Checkout playground scenarios

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleActivity.kt
@@ -26,6 +26,8 @@ import androidx.lifecycle.lifecycleScope
 import com.stripe.android.paymentsheet.example.playground.PlaygroundTheme
 import com.stripe.android.paymentsheet.example.playground.SearchSettingsField
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundScenarios
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundScenariosUi
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettingsUi
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.configurations
 import kotlinx.coroutines.launch
@@ -63,14 +65,23 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
             var navigationPath by rememberSaveable {
                 mutableStateOf<List<String>>(emptyList())
             }
+            var scenarioNavigationPath by rememberSaveable {
+                mutableStateOf<List<String>>(emptyList())
+            }
             var settingsSearchQuery by rememberSaveable { mutableStateOf("") }
             val isSearching = settingsSearchQuery.isNotBlank()
+            val isBrowsingScenarios = scenarioNavigationPath.isNotEmpty()
             val currentConfiguration = CheckoutPlaygroundDefinitions.root.configurations()
                 .firstOrNull { it.key == navigationPath.lastOrNull() }
                 ?: CheckoutPlaygroundDefinitions.root
+            val currentScenarioGroup = CheckoutPlaygroundScenarios.groups
+                .firstOrNull { it.key == scenarioNavigationPath.lastOrNull() }
+                ?: CheckoutPlaygroundScenarios.root
             val navigateBack = {
                 if (status is CheckoutControllerExampleViewModel.Status.Settings) {
-                    if (isSearching) {
+                    if (isBrowsingScenarios) {
+                        scenarioNavigationPath = scenarioNavigationPath.dropLast(1)
+                    } else if (isSearching) {
                         settingsSearchQuery = ""
                     } else {
                         navigationPath = navigationPath.dropLast(1)
@@ -82,7 +93,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
 
             BackHandler(
                 enabled = status !is CheckoutControllerExampleViewModel.Status.Settings ||
-                    navigationPath.isNotEmpty() || isSearching
+                    navigationPath.isNotEmpty() || isSearching || isBrowsingScenarios
             ) { navigateBack() }
 
             PlaygroundTheme(
@@ -94,6 +105,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                                 Text(
                                     when {
                                         status !is CheckoutControllerExampleViewModel.Status.Settings -> "Checkout"
+                                        isBrowsingScenarios -> currentScenarioGroup.displayName
                                         isSearching -> "Search settings"
                                         else -> currentConfiguration.displayName
                                     }
@@ -101,7 +113,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                             },
                             navigationIcon = if (
                                 status !is CheckoutControllerExampleViewModel.Status.Settings ||
-                                navigationPath.isNotEmpty() || isSearching
+                                navigationPath.isNotEmpty() || isSearching || isBrowsingScenarios
                             ) {
                                 {
                                     IconButton(onClick = navigateBack) {
@@ -114,9 +126,13 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                             actions = {
                                 if (
                                     status is CheckoutControllerExampleViewModel.Status.Settings &&
-                                    navigationPath.isEmpty()
+                                    navigationPath.isEmpty() && !isBrowsingScenarios
                                 ) {
                                     SettingsOverflowMenu(
+                                        onRunScenario = {
+                                            settingsSearchQuery = ""
+                                            scenarioNavigationPath = listOf(CheckoutPlaygroundScenarios.root.key)
+                                        },
                                         onImport = settingsImportExport::importSettings,
                                         onExport = settingsImportExport::exportSettings,
                                         onReset = viewModel.settings::reset,
@@ -124,7 +140,10 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                                 }
                             },
                         )
-                        if (status is CheckoutControllerExampleViewModel.Status.Settings) {
+                        if (
+                            status is CheckoutControllerExampleViewModel.Status.Settings &&
+                            !isBrowsingScenarios
+                        ) {
                             SearchSettingsField(
                                 query = settingsSearchQuery,
                                 onQueryChanged = { settingsSearchQuery = it },
@@ -136,16 +155,28 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                 content = {
                     when (val currentStatus = status) {
                         CheckoutControllerExampleViewModel.Status.Settings -> {
-                            CheckoutPlaygroundSettingsUi(
-                                configuration = currentConfiguration,
-                                searchQuery = settingsSearchQuery,
-                                settings = viewModel.settings,
-                                onOpenConfiguration = { navigationPath += it.key },
-                                onOpenConfigurationPath = { configurationPath ->
-                                    navigationPath = configurationPath.map { it.key }
-                                    settingsSearchQuery = ""
-                                },
-                            )
+                            if (isBrowsingScenarios) {
+                                CheckoutPlaygroundScenariosUi(
+                                    group = currentScenarioGroup,
+                                    onOpenGroup = { scenarioNavigationPath += it.key },
+                                    onSelect = { scenario ->
+                                        scenarioNavigationPath = emptyList()
+                                        viewModel.settings.applyPreset(scenario.preset)
+                                        viewModel.start()
+                                    },
+                                )
+                            } else {
+                                CheckoutPlaygroundSettingsUi(
+                                    configuration = currentConfiguration,
+                                    searchQuery = settingsSearchQuery,
+                                    settings = viewModel.settings,
+                                    onOpenConfiguration = { navigationPath += it.key },
+                                    onOpenConfigurationPath = { configurationPath ->
+                                        navigationPath = configurationPath.map { it.key }
+                                        settingsSearchQuery = ""
+                                    },
+                                )
+                            }
                         }
                         CheckoutControllerExampleViewModel.Status.Loading -> LoadingContent()
                         is CheckoutControllerExampleViewModel.Status.Error -> ErrorContent(
@@ -173,7 +204,7 @@ internal class CheckoutControllerExampleActivity : AppCompatActivity() {
                 bottomBarContent = {
                     when (status) {
                         CheckoutControllerExampleViewModel.Status.Settings -> {
-                            if (navigationPath.isEmpty()) {
+                            if (navigationPath.isEmpty() && !isBrowsingScenarios) {
                                 SettingsActions(
                                     canStart = settingValues.isNotEmpty() &&
                                         viewModel.settings.validationErrors().isEmpty(),

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.stripe.android.checkout.CheckoutController
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutCustomer
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettings
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.checkoutControllerConfiguration
@@ -132,7 +133,7 @@ internal class CheckoutControllerExampleViewModel(
 
                     configurationResult.fold(
                         onSuccess = {
-                            if (snapshot[CheckoutPlaygroundDefinitions.session.customer] == NEW_CUSTOMER) {
+                            if (snapshot[CheckoutPlaygroundDefinitions.session.customer] == CheckoutCustomer.New) {
                                 response.customerId?.let(settings::saveReturningCustomer)
                             }
                             savedStateHandle[RUN_ACTIVE_KEY] = true
@@ -197,7 +198,6 @@ internal class CheckoutControllerExampleViewModel(
     companion object {
         private const val TAG = "CheckoutControllerExample"
         private const val RUN_ACTIVE_KEY = "checkout_controller_run_active"
-        private const val NEW_CUSTOMER = "new"
 
         val factory = viewModelFactory {
             initializer {

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SettingsActions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/SettingsActions.kt
@@ -32,6 +32,7 @@ internal fun SettingsActions(
 
 @Composable
 internal fun SettingsOverflowMenu(
+    onRunScenario: () -> Unit,
     onImport: () -> Unit,
     onExport: () -> Unit,
     onReset: () -> Unit,
@@ -48,6 +49,11 @@ internal fun SettingsOverflowMenu(
         expanded = expanded,
         onDismissRequest = { expanded = false },
     ) {
+        SettingsDropdownMenuItem(
+            text = "Run scenario",
+            onClick = onRunScenario,
+            onDismiss = { expanded = false },
+        )
         SettingsDropdownMenuItem(
             text = "Import settings from JSON",
             onClick = onImport,

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutElementScenarios.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutElementScenarios.kt
@@ -1,0 +1,110 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.elements.ExpressCheckoutElement
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
+
+internal object CheckoutElementScenarios {
+    private val session = CheckoutPlaygroundDefinitions.session
+    private val controller = CheckoutPlaygroundDefinitions.Controller
+
+    val group = group(
+        "elements",
+        "Elements",
+        leaf("payment_element", "Payment Element — card only") {
+            regional(Merchant.US, Currency.USD, PaymentMethod.Type.Card)
+            set(controller.payment.shouldSetConfiguration, true)
+        },
+        group(
+            "ece",
+            "ECE",
+            eceLeaf("link_google_pay", "Link and Google Pay"),
+            eceLeaf("link_only", "Link only", googlePay = false),
+            eceLeaf("google_pay_only", "Google Pay only", link = false),
+            eceLeaf("shipping_required", "Shipping required", shipping = true),
+        ),
+        group(
+            "sae",
+            "SAE",
+            leaf("collect_new_shipping", "Collect a new shipping address") {
+                set(session.shippingAddressCollection, true)
+            },
+            leaf("prefilled_us_shipping", "Prefilled US shipping address") {
+                set(controller.defaults.shipping.enabled, true)
+                set(controller.defaults.shipping.name, "Jenny Rosen")
+                set(controller.defaults.shipping.address.enabled, true)
+                set(controller.defaults.shipping.address.country, "US")
+                set(controller.defaults.shipping.address.city, "San Francisco")
+                set(controller.defaults.shipping.address.line1, "510 Townsend St")
+                set(controller.defaults.shipping.address.postalCode, "94103")
+                set(controller.defaults.shipping.address.state, "CA")
+            },
+        ),
+        group(
+            "currency_selector",
+            "Currency Selector",
+            currencySelectorLeaf("france", "France", AdaptivePricingCountry.France),
+            currencySelectorLeaf("japan", "Japan", AdaptivePricingCountry.Japan),
+        ),
+        leaf("all_elements", "All elements") {
+            set(controller.payment.shouldSetConfiguration, true)
+            set(controller.express.shouldSetConfiguration, true)
+            showWalletsInExpressOnly()
+            set(controller.currencySelector.shouldSetConfiguration, true)
+            set(session.shippingAddressCollection, true)
+            set(session.adaptivePricingCountry, AdaptivePricingCountry.France)
+        },
+    )
+
+    private fun eceLeaf(
+        key: String,
+        name: String,
+        link: Boolean = true,
+        googlePay: Boolean = true,
+        shipping: Boolean = false,
+    ) = leaf(key, name) {
+        set(controller.express.shouldSetConfiguration, true)
+        showWalletsInExpressOnly()
+        set(
+            controller.express.link.display,
+            if (link) {
+                ExpressCheckoutElement.Configuration.LinkConfiguration.Display.Automatic
+            } else {
+                ExpressCheckoutElement.Configuration.LinkConfiguration.Display.Never
+            },
+        )
+        set(
+            controller.express.googlePay.display,
+            if (googlePay) {
+                ExpressCheckoutElement.Configuration.GooglePayConfiguration.Display.Automatic
+            } else {
+                ExpressCheckoutElement.Configuration.GooglePayConfiguration.Display.Never
+            },
+        )
+        set(controller.express.shippingRequired, shipping)
+    }
+
+    private fun CheckoutPlaygroundPresetBuilder.showWalletsInExpressOnly() {
+        set(
+            controller.payment.link.display,
+            PaymentElement.Configuration.LinkConfiguration.Display.Never,
+        )
+        set(
+            controller.payment.googlePay.display,
+            PaymentElement.Configuration.GooglePayConfiguration.Display.Never,
+        )
+    }
+
+    private fun currencySelectorLeaf(
+        key: String,
+        name: String,
+        country: AdaptivePricingCountry,
+    ) = leaf(key, name) {
+        set(controller.currencySelector.shouldSetConfiguration, true)
+        set(session.adaptivePricingCountry, country)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutLpmScenarios.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutLpmScenarios.kt
@@ -1,0 +1,135 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
+
+internal object CheckoutLpmScenarios {
+    val group = group(
+        "lpms",
+        "LPMs",
+        group(
+            "north_america",
+            "North America",
+            regionalLeaf(
+                "us_common", "US common", Merchant.US, Currency.USD,
+                PaymentMethod.Type.Card, PaymentMethod.Type.USBankAccount, PaymentMethod.Type.Link,
+                PaymentMethod.Type.CashAppPay, PaymentMethod.Type.Klarna,
+            ),
+            regionalLeaf(
+                "us_alternatives", "US alternatives", Merchant.US, Currency.USD,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Affirm, PaymentMethod.Type.AfterpayClearpay,
+                PaymentMethod.Type.AmazonPay, PaymentMethod.Type.Crypto, PaymentMethod.Type.Sunbit,
+            ),
+            regionalLeaf(
+                "mexico", "Mexico", Merchant.MX, Currency.MXN,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Oxxo,
+            ),
+        ),
+        group(
+            "europe",
+            "Europe",
+            regionalLeaf(
+                "euro_bank_methods", "Euro bank methods", Merchant.FR, Currency.EUR,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Ideal, PaymentMethod.Type.Bancontact,
+                PaymentMethod.Type.SepaDebit, PaymentMethod.Type.Eps,
+            ),
+            regionalLeaf(
+                "france_alternatives", "France / EU alternatives", Merchant.FR, Currency.EUR,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Alma, PaymentMethod.Type.MobilePay,
+            ),
+            regionalLeaf(
+                "germany", "Germany", Merchant.DE, Currency.EUR,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Billie, PaymentMethod.Type.Wero,
+            ),
+            regionalLeaf(
+                "italy", "Italy", Merchant.IT, Currency.EUR,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Satispay,
+            ),
+            regionalLeaf(
+                "spain", "Spain", Merchant.ES, Currency.EUR,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Sequra,
+            ),
+            regionalLeaf(
+                "poland", "Poland", Merchant.FR, Currency.PLN,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Blik, PaymentMethod.Type.P24,
+            ),
+            regionalLeaf(
+                "sweden", "Sweden", Merchant.FR, Currency.SEK,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Swish,
+            ),
+            regionalLeaf(
+                "uk_bank_debit", "UK bank debit", Merchant.GB, Currency.GBP,
+                PaymentMethod.Type.Card, PaymentMethod.Type.BacsDebit,
+            ),
+            regionalLeaf(
+                "gbp_wallets", "GBP wallets", Merchant.GB, Currency.GBP,
+                PaymentMethod.Type.Card, PaymentMethod.Type.PayPal, PaymentMethod.Type.RevolutPay,
+            ),
+            regionalLeaf(
+                "switzerland", "Switzerland", Merchant.GB, Currency.CHF,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Twint,
+            ),
+            regionalLeaf(
+                "portugal", "Portugal", Merchant.FR, Currency.EUR,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Multibanco,
+            ),
+        ),
+        group(
+            "asia_pacific",
+            "Asia-Pacific",
+            regionalLeaf(
+                "australia", "Australia", Merchant.AU, Currency.AUD,
+                PaymentMethod.Type.Card, PaymentMethod.Type.AuBecsDebit,
+            ),
+            regionalLeaf(
+                "singapore", "Singapore", Merchant.SG, Currency.SGD,
+                PaymentMethod.Type.Card, PaymentMethod.Type.GrabPay, PaymentMethod.Type.PayNow,
+            ),
+            regionalLeaf(
+                "malaysia", "Malaysia", Merchant.MY, Currency.MYR,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Fpx,
+            ),
+            regionalLeaf(
+                "thailand", "Thailand", Merchant.TH, Currency.THB,
+                PaymentMethod.Type.Card, PaymentMethod.Type.PromptPay,
+            ),
+            regionalLeaf(
+                "japan", "Japan", Merchant.JP, Currency.JPY,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Konbini, PaymentMethod.Type.PayPay,
+            ),
+            regionalLeaf(
+                "korea", "Korea", Merchant.US, Currency.KRW,
+                PaymentMethod.Type.Card, PaymentMethod.Type.KrCard,
+                PaymentMethod.Type.NaverPay, PaymentMethod.Type.Payco,
+            ),
+            regionalLeaf(
+                "china", "China", Merchant.CN, Currency.EUR,
+                PaymentMethod.Type.Card, PaymentMethod.Type.WeChatPay,
+            ),
+            regionalLeaf(
+                "alipay", "Alipay", Merchant.US, Currency.USD,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Klarna,
+                PaymentMethod.Type.Affirm, PaymentMethod.Type.Alipay,
+            ),
+        ),
+        group(
+            "latin_america",
+            "Latin America",
+            regionalLeaf(
+                "brazil", "Brazil", Merchant.BR, Currency.BRL,
+                PaymentMethod.Type.Card, PaymentMethod.Type.Boleto,
+            ),
+        ),
+    )
+
+    private fun regionalLeaf(
+        key: String,
+        name: String,
+        merchant: Merchant,
+        currency: Currency,
+        vararg paymentMethods: PaymentMethod.Type,
+    ) = leaf(key, name) {
+        regional(merchant, currency, *paymentMethods)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundScenarios.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundScenarios.kt
@@ -1,0 +1,97 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
+
+internal class CheckoutPlaygroundPreset internal constructor(
+    internal val serializedValues: Map<CheckoutPlaygroundSettingDefinition.Value<*>, String>,
+)
+
+internal class CheckoutPlaygroundPresetBuilder {
+    private val values = linkedMapOf<CheckoutPlaygroundSettingDefinition.Value<*>, String>()
+
+    fun <T> set(definition: CheckoutPlaygroundSettingDefinition.Value<T>, value: T) {
+        values[definition] = definition.serialize(value)
+    }
+
+    fun regional(
+        merchant: Merchant,
+        currency: Currency,
+        vararg paymentMethods: PaymentMethod.Type,
+    ) {
+        set(CheckoutPlaygroundDefinitions.session.merchant, merchant)
+        set(CheckoutPlaygroundDefinitions.session.currency, currency)
+        set(CheckoutPlaygroundDefinitions.session.automaticPaymentMethods, false)
+        set(CheckoutPlaygroundDefinitions.session.paymentMethodTypes, paymentMethods.map(PaymentMethod.Type::code))
+    }
+
+    internal fun build(): CheckoutPlaygroundPreset = CheckoutPlaygroundPreset(values.toMap())
+}
+
+internal fun checkoutPlaygroundPreset(
+    block: CheckoutPlaygroundPresetBuilder.() -> Unit,
+): CheckoutPlaygroundPreset = CheckoutPlaygroundPresetBuilder().apply(block).build()
+
+internal sealed interface CheckoutPlaygroundScenario {
+    val key: String
+    val displayName: String
+
+    data class Group(
+        override val key: String,
+        override val displayName: String,
+        val children: List<CheckoutPlaygroundScenario>,
+    ) : CheckoutPlaygroundScenario
+
+    data class Leaf(
+        override val key: String,
+        override val displayName: String,
+        val preset: CheckoutPlaygroundPreset,
+    ) : CheckoutPlaygroundScenario
+}
+
+internal object CheckoutPlaygroundScenarios {
+    val root: CheckoutPlaygroundScenario.Group by lazy {
+        group(
+            "scenarios",
+            "Run scenario",
+            CheckoutLpmScenarios.group,
+            CheckoutTaxScenarios.group,
+            CheckoutSavedPaymentMethodScenarios.group,
+            CheckoutElementScenarios.group,
+        )
+    }
+
+    val groups: List<CheckoutPlaygroundScenario.Group> by lazy {
+        fun CheckoutPlaygroundScenario.Group.flatten(): List<CheckoutPlaygroundScenario.Group> {
+            return listOf(this) + children.filterIsInstance<CheckoutPlaygroundScenario.Group>().flatMap { it.flatten() }
+        }
+        root.flatten()
+    }
+
+    val leaves: List<CheckoutPlaygroundScenario.Leaf> by lazy {
+        fun CheckoutPlaygroundScenario.Group.flatten(): List<CheckoutPlaygroundScenario.Leaf> {
+            return children.flatMap { child ->
+                when (child) {
+                    is CheckoutPlaygroundScenario.Group -> child.flatten()
+                    is CheckoutPlaygroundScenario.Leaf -> listOf(child)
+                }
+            }
+        }
+        root.flatten()
+    }
+}
+
+internal fun group(
+    key: String,
+    name: String,
+    vararg children: CheckoutPlaygroundScenario,
+) = CheckoutPlaygroundScenario.Group(key, name, children.toList())
+
+internal fun leaf(
+    key: String,
+    name: String,
+    block: CheckoutPlaygroundPresetBuilder.() -> Unit,
+) = CheckoutPlaygroundScenario.Leaf(key, name, checkoutPlaygroundPreset(block))

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundScenariosUi.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundScenariosUi.kt
@@ -1,0 +1,63 @@
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+internal const val CheckoutScenariosScreenTestTag = "checkout_scenarios_screen"
+private const val CheckoutScenarioTestTagPrefix = "checkout_scenario:"
+
+@Composable
+internal fun CheckoutPlaygroundScenariosUi(
+    group: CheckoutPlaygroundScenario.Group,
+    onOpenGroup: (CheckoutPlaygroundScenario.Group) -> Unit,
+    onSelect: (CheckoutPlaygroundScenario.Leaf) -> Unit,
+) {
+    androidx.compose.foundation.layout.Column(
+        modifier = Modifier.testTag(CheckoutScenariosScreenTestTag),
+    ) {
+        group.children.forEach { scenario ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag(checkoutScenarioTestTag(scenario))
+                    .clickable {
+                        when (scenario) {
+                            is CheckoutPlaygroundScenario.Group -> onOpenGroup(scenario)
+                            is CheckoutPlaygroundScenario.Leaf -> onSelect(scenario)
+                        }
+                    }
+                    .padding(vertical = 16.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = scenario.displayName,
+                    style = MaterialTheme.typography.subtitle1,
+                    fontWeight = if (scenario is CheckoutPlaygroundScenario.Group) {
+                        FontWeight.Bold
+                    } else {
+                        FontWeight.Normal
+                    },
+                )
+                if (scenario is CheckoutPlaygroundScenario.Group) {
+                    Text(text = "›", style = MaterialTheme.typography.h5)
+                }
+            }
+        }
+    }
+}
+
+internal fun checkoutScenarioTestTag(scenario: CheckoutPlaygroundScenario): String {
+    return CheckoutScenarioTestTagPrefix + scenario.key
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettings.kt
@@ -57,12 +57,18 @@ internal class CheckoutPlaygroundSettings private constructor(
         persist(_values.value.serialized())
     }
 
+    fun applyPreset(preset: CheckoutPlaygroundPreset) {
+        _values.value = currentDefaults() + preset.serializedValues
+        persist(_values.value.serialized())
+    }
+
     fun saveReturningCustomer(customerId: String) {
         returningCustomerId = customerId
         persistReturningCustomerId(customerId)
         _values.value += mapOf(
             CheckoutPlaygroundDefinitions.session.customerId to customerId,
-            CheckoutPlaygroundDefinitions.session.customer to RETURNING_CUSTOMER,
+            CheckoutPlaygroundDefinitions.session.customer to
+                CheckoutPlaygroundDefinitions.session.customer.serialize(CheckoutCustomer.Returning),
         )
         persist(_values.value.serialized())
     }
@@ -132,7 +138,6 @@ internal class CheckoutPlaygroundSettings private constructor(
         private const val PREFERENCES_NAME = "CheckoutControllerPlaygroundSettings"
         private const val PREFERENCES_KEY = "settings_v1"
         private const val RETURNING_CUSTOMER_ID_KEY = "returning_customer_id"
-        private const val RETURNING_CUSTOMER = "returning"
         private const val TAG = "CheckoutSettings"
 
         fun create(context: Context): CheckoutPlaygroundSettings {
@@ -171,6 +176,7 @@ internal class CheckoutPlaygroundSettings private constructor(
 
         fun createInMemory(
             json: String? = null,
+            persist: (Map<String, String>) -> Unit = {},
         ): CheckoutPlaygroundSettings {
             return CheckoutPlaygroundSettings(
                 root = CheckoutPlaygroundDefinitions.root,
@@ -178,7 +184,7 @@ internal class CheckoutPlaygroundSettings private constructor(
                 initialValues = json?.let(::decodeValues).orEmpty(),
                 initialReturningCustomerId = null,
                 logWarning = {},
-                persist = {},
+                persist = persist,
                 persistReturningCustomerId = {},
             )
         }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSavedPaymentMethodScenarios.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSavedPaymentMethodScenarios.kt
@@ -1,0 +1,43 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+internal object CheckoutSavedPaymentMethodScenarios {
+    private val session = CheckoutPlaygroundDefinitions.session
+
+    val group = group(
+        "saved_payment_methods",
+        "Saved payment methods",
+        leaf("guest", "Guest") {
+            set(session.customer, CheckoutCustomer.Guest)
+        },
+        leaf("new_save_enabled", "New customer — saving enabled") {
+            set(session.customer, CheckoutCustomer.New)
+            set(session.paymentMethodSave, true)
+        },
+        leaf("new_save_disabled", "New customer — saving disabled") {
+            set(session.customer, CheckoutCustomer.New)
+            set(session.paymentMethodSave, false)
+        },
+        group(
+            "returning_customer",
+            "Returning customer",
+            returningCustomerLeaf("save_remove", "Save and remove"),
+            returningCustomerLeaf("save_only", "Save only", remove = false),
+            returningCustomerLeaf("remove_only", "Remove only", save = false),
+            returningCustomerLeaf("view_only", "View only", save = false, remove = false),
+        ),
+    )
+
+    private fun returningCustomerLeaf(
+        key: String,
+        name: String,
+        save: Boolean = true,
+        remove: Boolean = true,
+    ) = leaf(key, name) {
+        set(session.customer, CheckoutCustomer.Returning)
+        set(session.customerId, null)
+        set(session.paymentMethodSave, save)
+        set(session.paymentMethodRemove, remove)
+    }
+}

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.example.playground.checkout.settings
 
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.put
@@ -21,14 +22,10 @@ internal object CheckoutSessionDefinitions {
     val customer = choice(
         key = "session.customer",
         displayName = "Customer",
-        defaultValue = "guest",
-        options = listOf(
-            "Guest" to "guest",
-            "New" to "new",
-            "Returning" to "returning",
-        ),
-        serialize = { it },
-        updateRequest = { customer -> put("customer", customer) },
+        defaultValue = CheckoutCustomer.Guest,
+        options = CheckoutCustomer.entries.map { it.displayName to it },
+        serialize = CheckoutCustomer::serializedValue,
+        updateRequest = { customer -> put("customer", customer.serializedValue) },
     )
     val customerId = optionalText(
         key = "session.customer_id",
@@ -37,7 +34,7 @@ internal object CheckoutSessionDefinitions {
             customerId?.let { put("customer", it) }
         },
         validate = { null },
-        isApplicable = { settings -> settings[customer] == RETURNING_CUSTOMER },
+        isApplicable = { settings -> settings[customer] == CheckoutCustomer.Returning },
     )
     val paymentMethodSave = boolean(
         key = "session.payment_method_save",
@@ -46,7 +43,16 @@ internal object CheckoutSessionDefinitions {
         updateRequest = { enabled ->
             put("checkout_session_payment_method_save", if (enabled) "enabled" else "disabled")
         },
-        isApplicable = { settings -> settings[customer] != GUEST_CUSTOMER },
+        isApplicable = { settings -> settings[customer] != CheckoutCustomer.Guest },
+    )
+    val paymentMethodRemove = boolean(
+        key = "session.payment_method_remove",
+        displayName = "Remove saved payment methods",
+        defaultValue = true,
+        updateRequest = { enabled ->
+            put("checkout_session_payment_method_remove", if (enabled) "enabled" else "disabled")
+        },
+        isApplicable = { settings -> settings[customer] == CheckoutCustomer.Returning },
     )
     val customerEmail = text(
         key = "session.customer_email",
@@ -64,6 +70,14 @@ internal object CheckoutSessionDefinitions {
         },
         serialize = PlaygroundCurrency::value,
         updateRequest = { currency -> put("currency", currency.value) },
+    )
+    val merchant = choice(
+        key = "session.merchant",
+        displayName = "Merchant",
+        defaultValue = Merchant.US,
+        options = Merchant.entries.filter { it != Merchant.Custom }.map { it.name to it },
+        serialize = Merchant::value,
+        updateRequest = { merchant -> put("merchant_country_code", merchant.value) },
     )
     val automaticPaymentMethods = boolean(
         key = "session.automatic_payment_methods",
@@ -95,8 +109,18 @@ internal object CheckoutSessionDefinitions {
         defaultValue = false,
         updateRequest = { enabled ->
             put("automatic_tax", enabled)
-            if (enabled) {
-                put("merchant_country_code", "us_tax")
+        },
+    )
+    val adaptivePricingCountry = choice(
+        key = "session.adaptive_pricing_country",
+        displayName = "Adaptive pricing country",
+        defaultValue = AdaptivePricingCountry.None,
+        options = AdaptivePricingCountry.entries.map { it.displayName to it },
+        serialize = AdaptivePricingCountry::serializedValue,
+        updateRequest = { country ->
+            country.countryCode?.let { countryCode ->
+                put("adaptive_pricing", true)
+                put("customer_email", "test+location_$countryCode@example.com")
             }
         },
     )
@@ -120,16 +144,35 @@ internal object CheckoutSessionDefinitions {
             customer,
             customerId,
             paymentMethodSave,
+            paymentMethodRemove,
             customerEmail,
             currency,
+            merchant,
             automaticPaymentMethods,
             paymentMethodTypes,
             automaticTax,
+            adaptivePricingCountry,
             shippingAddressCollection,
             billingAddressCollection,
         ),
     )
+}
 
-    private const val GUEST_CUSTOMER = "guest"
-    private const val RETURNING_CUSTOMER = "returning"
+internal enum class CheckoutCustomer(
+    val displayName: String,
+    val serializedValue: String,
+) {
+    Guest("Guest", "guest"),
+    New("New", "new"),
+    Returning("Returning", "returning"),
+}
+
+internal enum class AdaptivePricingCountry(
+    val displayName: String,
+    val serializedValue: String,
+    val countryCode: String?,
+) {
+    None("Off", "", null),
+    France("France", "FR", "FR"),
+    Japan("Japan", "JP", "JP"),
 }

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutTaxScenarios.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutTaxScenarios.kt
@@ -1,0 +1,32 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
+
+internal object CheckoutTaxScenarios {
+    private val session = CheckoutPlaygroundDefinitions.session
+
+    val group = group(
+        "tax",
+        "Tax",
+        leaf("no_tax", "No tax") {
+            set(session.automaticTax, false)
+        },
+        leaf("automatic_tax_automatic_billing", "Automatic tax — automatic billing") {
+            set(session.merchant, Merchant.US_TAX)
+            set(session.automaticTax, true)
+            set(session.billingAddressCollection, false)
+        },
+        leaf("automatic_tax_required_billing", "Automatic tax — required billing") {
+            set(session.merchant, Merchant.US_TAX)
+            set(session.automaticTax, true)
+            set(session.billingAddressCollection, true)
+        },
+        leaf("automatic_tax_shipping", "Automatic tax — shipping") {
+            set(session.merchant, Merchant.US_TAX)
+            set(session.automaticTax, true)
+            set(session.shippingAddressCollection, true)
+        },
+    )
+}

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/CheckoutControllerExampleRequestFactoryTest.kt
@@ -1,10 +1,13 @@
 package com.stripe.android.paymentsheet.example.playground.checkout
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.AdaptivePricingCountry
+import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutCustomer
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions.Controller
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundDefinitions.session
 import com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettings
 import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -22,22 +25,23 @@ class CheckoutControllerExampleRequestFactoryTest {
                 put("customer", "guest")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
+                put("merchant_country_code", "US")
                 put("automatic_payment_methods", true)
                 put("automatic_tax", false)
                 put("shipping_address_collection", false)
                 put("billing_address_collection", false)
             }
         )
-        assertThat(request.body).doesNotContainKey("merchant_country_code")
     }
 
     @Test
     fun `new customer enables payment method saving`() = runScenario {
         settings.update(session.customerId, "cus_ignored")
-        settings.update(session.customer, "new")
+        settings.update(session.customer, CheckoutCustomer.New)
         settings.update(session.customerEmail, "another@example.com")
         settings.update(session.currency, Currency.EUR)
         settings.update(session.automaticTax, true)
+        settings.update(session.merchant, Merchant.US_TAX)
         settings.update(session.shippingAddressCollection, true)
         settings.update(session.billingAddressCollection, true)
 
@@ -60,7 +64,7 @@ class CheckoutControllerExampleRequestFactoryTest {
 
     @Test
     fun `new customer can disable payment method saving`() = runScenario {
-        settings.update(session.customer, "new")
+        settings.update(session.customer, CheckoutCustomer.New)
         settings.update(session.paymentMethodSave, false)
 
         val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
@@ -71,6 +75,7 @@ class CheckoutControllerExampleRequestFactoryTest {
                 put("checkout_session_payment_method_save", "disabled")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
+                put("merchant_country_code", "US")
                 put("automatic_payment_methods", true)
                 put("automatic_tax", false)
                 put("shipping_address_collection", false)
@@ -81,7 +86,7 @@ class CheckoutControllerExampleRequestFactoryTest {
 
     @Test
     fun `returning customer with arbitrary ID enables payment method saving`() = runScenario {
-        settings.update(session.customer, "returning")
+        settings.update(session.customer, CheckoutCustomer.Returning)
         settings.update(session.customerId, "cus_custom")
 
         val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
@@ -90,8 +95,10 @@ class CheckoutControllerExampleRequestFactoryTest {
             buildJsonObject {
                 put("customer", "cus_custom")
                 put("checkout_session_payment_method_save", "enabled")
+                put("checkout_session_payment_method_remove", "enabled")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
+                put("merchant_country_code", "US")
                 put("automatic_payment_methods", true)
                 put("automatic_tax", false)
                 put("shipping_address_collection", false)
@@ -102,7 +109,7 @@ class CheckoutControllerExampleRequestFactoryTest {
 
     @Test
     fun `returning customer without saved ID uses fixture and enables payment method saving`() = runScenario {
-        settings.update(session.customer, "returning")
+        settings.update(session.customer, CheckoutCustomer.Returning)
 
         val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
 
@@ -110,8 +117,10 @@ class CheckoutControllerExampleRequestFactoryTest {
             buildJsonObject {
                 put("customer", "returning")
                 put("checkout_session_payment_method_save", "enabled")
+                put("checkout_session_payment_method_remove", "enabled")
                 put("customer_email", "email@example.com")
                 put("currency", "usd")
+                put("merchant_country_code", "US")
                 put("automatic_payment_methods", true)
                 put("automatic_tax", false)
                 put("shipping_address_collection", false)
@@ -132,6 +141,16 @@ class CheckoutControllerExampleRequestFactoryTest {
             JsonArray(listOf(JsonPrimitive("card"), JsonPrimitive("klarna"))),
         )
         assertThat(request.body).containsEntry("automatic_payment_methods", JsonPrimitive(false))
+    }
+
+    @Test
+    fun `adaptive pricing country generates location test email`() = runScenario {
+        settings.update(session.adaptivePricingCountry, AdaptivePricingCountry.Japan)
+
+        val request = CheckoutControllerExampleRequestFactory.create(settings = settings.snapshot())
+
+        assertThat(request.body).containsEntry("adaptive_pricing", JsonPrimitive(true))
+        assertThat(request.body).containsEntry("customer_email", JsonPrimitive("test+location_JP@example.com"))
     }
 
     @Test

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundScenariosTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundScenariosTest.kt
@@ -1,0 +1,128 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.elements.PaymentElement
+import com.stripe.android.model.PaymentMethod
+import com.stripe.android.paymentsheet.example.playground.checkout.CheckoutControllerExampleRequestFactory
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.Test
+
+class CheckoutPlaygroundScenariosTest {
+    @Test
+    fun `every catalog leaf produces a valid snapshot`() {
+        CheckoutPlaygroundScenarios.leaves.forEach { leaf ->
+            val settings = CheckoutPlaygroundSettings.createInMemory()
+
+            settings.applyPreset(leaf.preset)
+
+            assertThat(settings.validationErrors()).isEmpty()
+            settings.snapshot()
+        }
+    }
+
+    @Test
+    fun `catalog paths are unique`() {
+        val paths = CheckoutPlaygroundScenarios.root.leafPaths()
+
+        assertThat(paths).containsNoDuplicates()
+        assertThat(paths).hasSize(CheckoutPlaygroundScenarios.leaves.size)
+    }
+
+    @Test
+    fun `US common contains expected typed regional values`() {
+        val snapshot = snapshotFor("us_common")
+
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.session.merchant]).isEqualTo(Merchant.US)
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.session.currency]).isEqualTo(Currency.USD)
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.session.automaticPaymentMethods]).isFalse()
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.session.paymentMethodTypes]).containsExactly(
+            PaymentMethod.Type.Card.code,
+            PaymentMethod.Type.USBankAccount.code,
+            PaymentMethod.Type.Link.code,
+            PaymentMethod.Type.CashAppPay.code,
+            PaymentMethod.Type.Klarna.code,
+        ).inOrder()
+    }
+
+    @Test
+    fun `Japan contains expected typed regional values`() {
+        val snapshot = snapshotFor("japan", parentKey = "asia_pacific")
+
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.session.merchant]).isEqualTo(Merchant.JP)
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.session.currency]).isEqualTo(Currency.JPY)
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.session.paymentMethodTypes]).containsExactly(
+            PaymentMethod.Type.Card.code,
+            PaymentMethod.Type.Konbini.code,
+            PaymentMethod.Type.PayPay.code,
+        ).inOrder()
+    }
+
+    @Test
+    fun `returning customer scenario does not reuse customer from another merchant`() {
+        val settings = CheckoutPlaygroundSettings.createInMemory().apply {
+            saveReturningCustomer("cus_from_another_merchant")
+        }
+        val returningCustomer = CheckoutPlaygroundScenarios.groups
+            .single { it.key == "returning_customer" }
+        val saveAndRemove = returningCustomer.children
+            .filterIsInstance<CheckoutPlaygroundScenario.Leaf>()
+            .single { it.key == "save_remove" }
+
+        settings.applyPreset(saveAndRemove.preset)
+        val request = CheckoutControllerExampleRequestFactory.create(settings.snapshot())
+
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customerId]).isNull()
+        assertThat(request.body).containsEntry("customer", JsonPrimitive("returning"))
+    }
+
+    @Test
+    fun `ECE scenarios hide Link and Google Pay in Payment Element`() {
+        val snapshot = snapshotFor("link_google_pay", parentKey = "ece")
+
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.Controller.payment.link.display])
+            .isEqualTo(PaymentElement.Configuration.LinkConfiguration.Display.Never)
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.Controller.payment.googlePay.display])
+            .isEqualTo(PaymentElement.Configuration.GooglePayConfiguration.Display.Never)
+    }
+
+    @Test
+    fun `all elements hides Link and Google Pay in Payment Element`() {
+        val snapshot = snapshotFor("all_elements", parentKey = "elements")
+
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.Controller.payment.link.display])
+            .isEqualTo(PaymentElement.Configuration.LinkConfiguration.Display.Never)
+        assertThat(snapshot[CheckoutPlaygroundDefinitions.Controller.payment.googlePay.display])
+            .isEqualTo(PaymentElement.Configuration.GooglePayConfiguration.Display.Never)
+    }
+
+    private fun snapshotFor(
+        key: String,
+        parentKey: String? = null,
+    ): CheckoutPlaygroundSettings.Snapshot {
+        val parent = parentKey?.let { requestedKey ->
+            CheckoutPlaygroundScenarios.groups.single { it.key == requestedKey }
+        }
+        val leaf = (parent?.children ?: CheckoutPlaygroundScenarios.leaves)
+            .filterIsInstance<CheckoutPlaygroundScenario.Leaf>()
+            .single { it.key == key }
+        return CheckoutPlaygroundSettings.createInMemory().apply {
+            applyPreset(leaf.preset)
+        }.snapshot()
+    }
+}
+
+private fun CheckoutPlaygroundScenario.Group.leafPaths(
+    parents: List<String> = emptyList(),
+): List<String> {
+    val path = parents + key
+    return children.flatMap { child ->
+        when (child) {
+            is CheckoutPlaygroundScenario.Group -> child.leafPaths(path)
+            is CheckoutPlaygroundScenario.Leaf -> listOf((path + child.key).joinToString("/"))
+        }
+    }
+}

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundScenariosUiTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundScenariosUiTest.kt
@@ -1,0 +1,77 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
+package com.stripe.android.paymentsheet.example.playground.checkout.settings
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CheckoutPlaygroundScenariosUiTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+
+    @Test
+    fun `group rows navigate through nested catalog`() = runScenario {
+        scenario("lpms").assertIsDisplayed().performClick()
+
+        scenario("north_america").assertIsDisplayed().performClick()
+
+        scenario("us_common").assertIsDisplayed()
+    }
+
+    @Test
+    fun `leaf selection returns selected preset`() = runScenario {
+        scenario("tax").performClick()
+        scenario("no_tax").performClick()
+
+        assertThat(selected?.key).isEqualTo("no_tax")
+    }
+
+    private fun runScenario(block: Scenario.() -> Unit) {
+        var currentGroup by mutableStateOf(CheckoutPlaygroundScenarios.root)
+        var selected: CheckoutPlaygroundScenario.Leaf? = null
+        composeRule.setContent {
+            CheckoutPlaygroundScenariosUi(
+                group = currentGroup,
+                onOpenGroup = { currentGroup = it },
+                onSelect = { selected = it },
+            )
+        }
+        block(
+            Scenario(
+                scenario = { key ->
+                    val node = currentGroup.children.single { it.key == key }
+                    composeRule.onNodeWithTag(checkoutScenarioTestTag(node))
+                },
+                selectedLeaf = { selected },
+            )
+        )
+    }
+
+    private data class Scenario(
+        val scenario: (String) -> androidx.compose.ui.test.SemanticsNodeInteraction,
+        private val selectedLeaf: () -> CheckoutPlaygroundScenario.Leaf?,
+    ) {
+        val selected: CheckoutPlaygroundScenario.Leaf?
+            get() = selectedLeaf()
+    }
+}

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.paymentsheet.example.playground.checkout.settings
 
 import androidx.compose.ui.graphics.Color
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.paymentsheet.example.playground.settings.Currency
+import com.stripe.android.paymentsheet.example.playground.settings.Merchant
 import org.junit.Test
 
 class CheckoutPlaygroundSettingsTest {
@@ -168,12 +170,12 @@ class CheckoutPlaygroundSettingsTest {
 
     @Test
     fun `new customer is saved as returning customer`() = runScenario {
-        settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, CheckoutCustomer.New)
 
         settings.saveReturningCustomer("cus_123")
 
         assertThat(settings.returningCustomerId).isEqualTo("cus_123")
-        assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo("returning")
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo(CheckoutCustomer.Returning)
         assertThat(settings[CheckoutPlaygroundDefinitions.session.customerId]).isEqualTo("cus_123")
     }
 
@@ -186,7 +188,66 @@ class CheckoutPlaygroundSettingsTest {
 
         assertThat(settings.returningCustomerId).isEqualTo("cus_123")
         assertThat(settings[CheckoutPlaygroundDefinitions.session.customerId]).isEqualTo("cus_123")
-        assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo("guest")
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo(CheckoutCustomer.Guest)
+    }
+
+    @Test
+    fun `preset atomically replaces settings and persists once`() {
+        val persisted = mutableListOf<Map<String, String>>()
+        val settings = CheckoutPlaygroundSettings.createInMemory(persist = persisted::add)
+        settings.update(CheckoutPlaygroundDefinitions.session.currency, Currency.GBP)
+        persisted.clear()
+        val preset = checkoutPlaygroundPreset {
+            set(CheckoutPlaygroundDefinitions.session.currency, Currency.EUR)
+            set(CheckoutPlaygroundDefinitions.session.merchant, Merchant.FR)
+        }
+
+        settings.applyPreset(preset)
+
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.currency]).isEqualTo(Currency.EUR)
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.merchant]).isEqualTo(Merchant.FR)
+        assertThat(persisted).hasSize(1)
+    }
+
+    @Test
+    fun `preset restores values not overridden to defaults`() = runScenario {
+        val save = CheckoutPlaygroundDefinitions.session.paymentMethodSave
+        settings.update(save, false)
+
+        settings.applyPreset(
+            checkoutPlaygroundPreset {
+                set(CheckoutPlaygroundDefinitions.session.currency, Currency.EUR)
+            }
+        )
+
+        assertThat(settings[save]).isTrue()
+    }
+
+    @Test
+    fun `returning customer preset preserves stored customer ID`() = runScenario {
+        settings.saveReturningCustomer("cus_123")
+
+        settings.applyPreset(
+            checkoutPlaygroundPreset {
+                set(CheckoutPlaygroundDefinitions.session.customer, CheckoutCustomer.Returning)
+            }
+        )
+
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customerId]).isEqualTo("cus_123")
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo(CheckoutCustomer.Returning)
+    }
+
+    @Test
+    fun `legacy JSON without new settings uses defaults`() {
+        val settings = CheckoutPlaygroundSettings.createInMemory(
+            json = """{"session.customer":"returning","session.currency":"eur"}""",
+        )
+
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.customer]).isEqualTo(CheckoutCustomer.Returning)
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.paymentMethodRemove]).isTrue()
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.merchant]).isEqualTo(Merchant.US)
+        assertThat(settings[CheckoutPlaygroundDefinitions.session.adaptivePricingCountry])
+            .isEqualTo(AdaptivePricingCountry.None)
     }
 
     private fun runScenario(

--- a/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
+++ b/paymentsheet-example/src/test/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingsUiTest.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
@@ -136,11 +139,13 @@ class CheckoutPlaygroundSettingsUiTest {
         page.value(definition).performScrollTo().assertIsDisplayed().assertIsNotEnabled()
         assertThat(settings[definition]).isTrue()
 
-        settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, CheckoutCustomer.New)
         composeRule.waitForIdle()
 
         page.value(definition).assertIsEnabled()
-        composeRule.onNodeWithText("Off").performClick()
+        composeRule.onNode(
+            hasText("Off").and(hasAnyAncestor(hasTestTag(checkoutSettingValueTestTag(definition))))
+        ).performClick()
         assertThat(settings[definition]).isFalse()
     }
 
@@ -180,7 +185,7 @@ class CheckoutPlaygroundSettingsUiTest {
         composeRule.onNodeWithText("Guest").assertIsDisplayed()
         composeRule.onNodeWithText("New").assertIsDisplayed().performClick()
 
-        assertThat(settings[definition]).isEqualTo("new")
+        assertThat(settings[definition]).isEqualTo(CheckoutCustomer.New)
     }
 
     @Test
@@ -198,7 +203,7 @@ class CheckoutPlaygroundSettingsUiTest {
     fun `returning customer without stored ID displays empty customer ID setting`() = runScenario(
         initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
         configureSettings = {
-            update(CheckoutPlaygroundDefinitions.session.customer, "returning")
+            update(CheckoutPlaygroundDefinitions.session.customer, CheckoutCustomer.Returning)
         },
     ) {
         page.value(CheckoutPlaygroundDefinitions.session.customerId)
@@ -210,7 +215,7 @@ class CheckoutPlaygroundSettingsUiTest {
     fun `returning customer can enter arbitrary customer ID`() = runScenario(
         initialConfiguration = CheckoutPlaygroundDefinitions.session.configuration,
         configureSettings = {
-            update(CheckoutPlaygroundDefinitions.session.customer, "returning")
+            update(CheckoutPlaygroundDefinitions.session.customer, CheckoutCustomer.Returning)
         },
     ) {
         page.value(CheckoutPlaygroundDefinitions.session.customerId)
@@ -225,7 +230,7 @@ class CheckoutPlaygroundSettingsUiTest {
     ) {
         page.value(CheckoutPlaygroundDefinitions.session.customerId).assertDoesNotExist()
 
-        settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, CheckoutCustomer.New)
         composeRule.waitForIdle()
 
         page.value(CheckoutPlaygroundDefinitions.session.customerId).assertDoesNotExist()
@@ -238,11 +243,11 @@ class CheckoutPlaygroundSettingsUiTest {
         val definition = CheckoutPlaygroundDefinitions.session.paymentMethodSave
         page.value(definition).assertDoesNotExist()
 
-        settings.update(CheckoutPlaygroundDefinitions.session.customer, "new")
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, CheckoutCustomer.New)
         composeRule.waitForIdle()
         page.value(definition).assertIsDisplayed()
 
-        settings.update(CheckoutPlaygroundDefinitions.session.customer, "returning")
+        settings.update(CheckoutPlaygroundDefinitions.session.customer, CheckoutCustomer.Returning)
         composeRule.waitForIdle()
         page.value(definition).assertIsDisplayed()
     }
@@ -256,7 +261,9 @@ class CheckoutPlaygroundSettingsUiTest {
         settings.update(CheckoutPlaygroundDefinitions.session.automaticPaymentMethods, false)
         composeRule.waitForIdle()
 
-        page.value(CheckoutPlaygroundDefinitions.session.paymentMethodTypes).assertIsDisplayed()
+        page.value(CheckoutPlaygroundDefinitions.session.paymentMethodTypes)
+            .performScrollTo()
+            .assertIsDisplayed()
     }
 
     private fun runScenario(


### PR DESCRIPTION
# Summary

Add runnable scenario presets to the Checkout playground for LPMs, tax, saved payment methods, and embedded elements. Add scenario navigation to the settings UI and extend Checkout Session settings for merchant, adaptive pricing, and saved-payment-method removal behavior.

# Motivation

Common Checkout configurations currently require manually updating several playground settings before each run. Scenario presets make these configurations repeatable and easier to exercise while keeping the underlying settings available for customization.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew detekt`
- `./gradlew :paymentsheet-example:testBaseDebugUnitTest`

# Screenshots

Not applicable: this changes internal example tooling, and the scenario navigation is covered by Compose UI tests.

# Changelog

Not applicable: this only affects the internal PaymentSheet example app.

Committed and created by Codex.
