### PR TITLE
Extract embedded payment options presenter

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -9,11 +9,13 @@ import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateA
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedLinkHelper
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedPaymentOptionsPresenter
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedWalletsHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedLinkHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentMethodVerticalLayoutInteractorFactory
+import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentOptionsPresenter
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.EmbeddedWalletsHelper
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -26,6 +28,11 @@ import kotlinx.coroutines.flow.StateFlow
 internal interface PaymentElementModule {
     @Binds
     fun bindsEmbeddedContentHelper(helper: DefaultEmbeddedContentHelper): EmbeddedContentHelper
+
+    @Binds
+    fun bindsEmbeddedPaymentOptionsPresenter(
+        presenter: DefaultEmbeddedPaymentOptionsPresenter,
+    ): EmbeddedPaymentOptionsPresenter
 
     @Binds
     fun bindsEmbeddedPaymentMethodVerticalLayoutInteractorFactory(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentHelper.kt
@@ -1,10 +1,7 @@
 package com.stripe.android.paymentelement.embedded.content
 
 import com.stripe.android.core.injection.ViewModelScope
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
-import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.paymentsheet.CustomerStateHolder
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,12 +20,9 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     @ViewModelScope private val coroutineScope: CoroutineScope,
     private val state: StateFlow<EmbeddedContentHelperStateHolder.State?>,
     private val verticalLayoutInteractorFactory: EmbeddedPaymentMethodVerticalLayoutInteractorFactory,
-    private val sheetStateHolder: SheetStateHolder,
     private val embeddedWalletsHelper: EmbeddedWalletsHelper,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
-    private val customerStateHolder: CustomerStateHolder,
-    private val selectionHolder: EmbeddedSelectionHolder,
-    private val errorReporter: ErrorReporter,
+    private val paymentOptionsPresenter: EmbeddedPaymentOptionsPresenter,
 ) : EmbeddedContentHelper {
 
     private val _embeddedContent = MutableStateFlow<EmbeddedContent?>(null)
@@ -59,25 +53,6 @@ internal class DefaultEmbeddedContentHelper @Inject constructor(
     }
 
     override fun presentPaymentOptions() {
-        val state = state.value
-        if (state == null) {
-            errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NOT_CONFIGURED
-            )
-            return
-        }
-        val launcher = sheetStateHolder.sheetLauncher
-        if (launcher == null) {
-            errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NO_LAUNCHER
-            )
-            return
-        }
-        launcher.launchPaymentOptions(
-            paymentMethodMetadata = state.paymentMethodMetadata,
-            customerState = customerStateHolder.customer.value,
-            selection = selectionHolder.selection.value,
-            configuration = state.configuration,
-        )
+        paymentOptionsPresenter.present()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -177,6 +177,11 @@ internal interface EmbeddedPaymentElementViewModelModule {
     fun bindsEmbeddedContentHelper(helper: DefaultEmbeddedContentHelper): EmbeddedContentHelper
 
     @Binds
+    fun bindsEmbeddedPaymentOptionsPresenter(
+        presenter: DefaultEmbeddedPaymentOptionsPresenter,
+    ): EmbeddedPaymentOptionsPresenter
+
+    @Binds
     fun bindsEmbeddedContentHelperStateHolder(
         stateHolder: DefaultEmbeddedContentHelperStateHolder
     ): EmbeddedContentHelperStateHolder

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentOptionsPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentOptionsPresenter.kt
@@ -1,0 +1,42 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Inject
+
+internal interface EmbeddedPaymentOptionsPresenter {
+    fun present()
+}
+
+internal class DefaultEmbeddedPaymentOptionsPresenter @Inject constructor(
+    private val state: StateFlow<EmbeddedContentHelperStateHolder.State?>,
+    private val sheetStateHolder: SheetStateHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val errorReporter: ErrorReporter,
+) : EmbeddedPaymentOptionsPresenter {
+    override fun present() {
+        val state = state.value
+        if (state == null) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NOT_CONFIGURED
+            )
+            return
+        }
+        val launcher = sheetStateHolder.sheetLauncher
+        if (launcher == null) {
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NO_LAUNCHER
+            )
+            return
+        }
+        launcher.launchPaymentOptions(
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            customerState = customerStateHolder.customer.value,
+            selection = selectionHolder.selection.value,
+            configuration = state.configuration,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedContentHelperTest.kt
@@ -1,25 +1,12 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
-import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
-import com.stripe.android.model.PaymentMethodFixtures
-import com.stripe.android.model.PaymentMethodMessagePromotion
-import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.ExperimentalAnalyticEventCallbackApi
-import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
-import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet.Appearance.Embedded
-import com.stripe.android.paymentsheet.createCustomerState
-import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.verticalmode.FakePaymentMethodVerticalLayoutInteractor
 import com.stripe.android.testing.CoroutineTestRule
-import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.utils.stateFlowOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -88,60 +75,15 @@ internal class DefaultEmbeddedContentHelperTest {
     }
 
     @Test
-    fun `presentPaymentOptions reports error when state is null`() = testScenario {
+    fun `presentPaymentOptions delegates to presenter`() = testScenario {
         embeddedContentHelper.presentPaymentOptions()
-        assertThat(errorReporter.getLoggedErrors()).containsExactly(
-            "unexpected_error.embedded.present_payment_options.not_configured"
-        )
-    }
-
-    @Test
-    fun `presentPaymentOptions reports error when launcher is null`() = testScenario(
-        initialState = EmbeddedContentHelperStateFactory.create()
-    ) {
-        embeddedContentHelper.presentPaymentOptions()
-        assertThat(errorReporter.getLoggedErrors()).containsExactly(
-            "unexpected_error.embedded.present_payment_options.no_launcher"
-        )
-    }
-
-    @Test
-    fun `presentPaymentOptions launches with the current state, customer, and selection`() {
-        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
-        val customerState = createCustomerState()
-        val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
-        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
-        testScenario(
-            initialState = EmbeddedContentHelperStateFactory.create(
-                paymentMethodMetadata = paymentMethodMetadata,
-                configuration = configuration,
-            ),
-            setup = {
-                set(CustomerStateHolder.SAVED_CUSTOMER, customerState)
-                set(DefaultEmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY, selection)
-            }
-        ) {
-            val fakeLauncher = RecordingEmbeddedSheetLauncher()
-            sheetStateHolder.sheetLauncher = fakeLauncher
-            embeddedContentHelper.presentPaymentOptions()
-
-            assertThat(fakeLauncher.launchPaymentOptionsCalls.single()).isEqualTo(
-                RecordingEmbeddedSheetLauncher.LaunchPaymentOptionsCall(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerState = customerState,
-                    selection = selection,
-                    configuration = configuration,
-                )
-            )
-            assertThat(errorReporter.getLoggedErrors()).isEmpty()
-        }
+        presenter.presentCalls.awaitItem()
     }
 
     private class Scenario(
         val embeddedContentHelper: DefaultEmbeddedContentHelper,
         val state: MutableStateFlow<EmbeddedContentHelperStateHolder.State?>,
-        val sheetStateHolder: SheetStateHolder,
-        val errorReporter: FakeErrorReporter,
+        val presenter: FakeEmbeddedPaymentOptionsPresenter,
         val verticalLayoutInteractors: List<FakePaymentMethodVerticalLayoutInteractor>,
     )
 
@@ -149,23 +91,10 @@ internal class DefaultEmbeddedContentHelperTest {
     @Suppress("LongMethod")
     private fun testScenario(
         initialState: EmbeddedContentHelperStateHolder.State? = null,
-        setup: SavedStateHandle.() -> Unit = {},
         block: suspend Scenario.() -> Unit,
     ) = runTest(UnconfinedTestDispatcher()) {
-        val savedStateHandle = SavedStateHandle().apply { setup() }
-        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
-        val errorReporter = FakeErrorReporter()
-        val customerStateHolder = DefaultCustomerStateHolder(
-            savedStateHandle = savedStateHandle,
-            selection = selectionHolder.selection,
-            customerMetadata = stateFlowOf(
-                PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA
-            ),
-            paymentMethodMetadataFlow = stateFlowOf(null),
-        )
-        val sheetStateHolder = SheetStateHolder(savedStateHandle)
-
         val state = MutableStateFlow(initialState)
+        val presenter = FakeEmbeddedPaymentOptionsPresenter()
         val verticalLayoutInteractors = mutableListOf<FakePaymentMethodVerticalLayoutInteractor>()
         val verticalLayoutInteractorFactory = EmbeddedPaymentMethodVerticalLayoutInteractorFactory {
             paymentMethodMetadata, _, _, _, _ ->
@@ -177,62 +106,25 @@ internal class DefaultEmbeddedContentHelperTest {
             coroutineScope = backgroundScope,
             state = state,
             verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
-            sheetStateHolder = sheetStateHolder,
             embeddedWalletsHelper = { stateFlowOf(null) },
             internalRowSelectionCallback = { null },
-            customerStateHolder = customerStateHolder,
-            selectionHolder = selectionHolder,
-            errorReporter = errorReporter,
+            paymentOptionsPresenter = presenter,
         )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,
             state = state,
-            sheetStateHolder = sheetStateHolder,
-            errorReporter = errorReporter,
+            presenter = presenter,
             verticalLayoutInteractors = verticalLayoutInteractors,
         ).block()
         verticalLayoutInteractors.forEach(FakePaymentMethodVerticalLayoutInteractor::validate)
+        presenter.presentCalls.ensureAllEventsConsumed()
     }
 
-    private class RecordingEmbeddedSheetLauncher : EmbeddedSheetLauncher {
-        val launchPaymentOptionsCalls = mutableListOf<LaunchPaymentOptionsCall>()
+    private class FakeEmbeddedPaymentOptionsPresenter : EmbeddedPaymentOptionsPresenter {
+        val presentCalls = Turbine<Unit>()
 
-        override fun launchForm(
-            code: String,
-            paymentMethodMetadata: PaymentMethodMetadata,
-            configuration: EmbeddedPaymentElement.Configuration?,
-            customerState: CustomerState?,
-            promotion: PaymentMethodMessagePromotion?,
-        ) = error("Not expected.")
-
-        override fun launchManage(
-            paymentMethodMetadata: PaymentMethodMetadata,
-            customerState: CustomerState,
-            selection: PaymentSelection?,
-            configuration: EmbeddedPaymentElement.Configuration?,
-        ) = error("Not expected.")
-
-        override fun launchPaymentOptions(
-            paymentMethodMetadata: PaymentMethodMetadata,
-            customerState: CustomerState?,
-            selection: PaymentSelection?,
-            configuration: EmbeddedPaymentElement.Configuration?,
-        ) {
-            launchPaymentOptionsCalls.add(
-                LaunchPaymentOptionsCall(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    customerState = customerState,
-                    selection = selection,
-                    configuration = configuration,
-                )
-            )
+        override fun present() {
+            presentCalls.add(Unit)
         }
-
-        data class LaunchPaymentOptionsCall(
-            val paymentMethodMetadata: PaymentMethodMetadata,
-            val customerState: CustomerState?,
-            val selection: PaymentSelection?,
-            val configuration: EmbeddedPaymentElement.Configuration?,
-        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedPaymentOptionsPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedPaymentOptionsPresenterTest.kt
@@ -1,0 +1,144 @@
+package com.stripe.android.paymentelement.embedded.content
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
+import com.stripe.android.paymentsheet.createCustomerState
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.testing.FakeErrorReporter
+import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class DefaultEmbeddedPaymentOptionsPresenterTest {
+    @Test
+    fun `present reports error when state is null`() = runScenario {
+        presenter.present()
+
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            "unexpected_error.embedded.present_payment_options.not_configured"
+        )
+    }
+
+    @Test
+    fun `present reports error when launcher is null`() = runScenario(
+        initialState = EmbeddedContentHelperStateFactory.create(),
+    ) {
+        presenter.present()
+
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            "unexpected_error.embedded.present_payment_options.no_launcher"
+        )
+    }
+
+    @Test
+    fun `present launches with current state customer and selection`() {
+        val metadata = PaymentMethodMetadataFactory.create()
+        val customer = createCustomerState()
+        val selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
+        runScenario(
+            initialState = EmbeddedContentHelperStateFactory.create(
+                paymentMethodMetadata = metadata,
+                configuration = configuration,
+            ),
+            customer = customer,
+            selection = selection,
+        ) {
+            val launcher = FakeEmbeddedSheetLauncher()
+            sheetStateHolder.sheetLauncher = launcher
+
+            presenter.present()
+
+            assertThat(launcher.paymentOptionsCalls.awaitItem()).isEqualTo(
+                FakeEmbeddedSheetLauncher.PaymentOptionsCall(metadata, customer, selection, configuration)
+            )
+            assertThat(errorReporter.getLoggedErrors()).isEmpty()
+            launcher.paymentOptionsCalls.ensureAllEventsConsumed()
+        }
+    }
+
+    private fun runScenario(
+        initialState: EmbeddedContentHelperStateHolder.State? = null,
+        customer: CustomerState? = null,
+        selection: PaymentSelection? = null,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val savedStateHandle = SavedStateHandle().apply {
+            set(CustomerStateHolder.SAVED_CUSTOMER, customer)
+            set(DefaultEmbeddedSelectionHolder.EMBEDDED_SELECTION_KEY, selection)
+        }
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
+        val customerStateHolder = DefaultCustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(PaymentMethodMetadataFixtures.DEFAULT_CUSTOMER_METADATA),
+            paymentMethodMetadataFlow = stateFlowOf(null),
+        )
+        val sheetStateHolder = SheetStateHolder(savedStateHandle)
+        val errorReporter = FakeErrorReporter()
+        val presenter = DefaultEmbeddedPaymentOptionsPresenter(
+            state = MutableStateFlow(initialState),
+            sheetStateHolder = sheetStateHolder,
+            customerStateHolder = customerStateHolder,
+            selectionHolder = selectionHolder,
+            errorReporter = errorReporter,
+        )
+
+        Scenario(presenter, sheetStateHolder, errorReporter).block()
+    }
+
+    private data class Scenario(
+        val presenter: DefaultEmbeddedPaymentOptionsPresenter,
+        val sheetStateHolder: SheetStateHolder,
+        val errorReporter: FakeErrorReporter,
+    )
+
+    private class FakeEmbeddedSheetLauncher : EmbeddedSheetLauncher {
+        val paymentOptionsCalls = Turbine<PaymentOptionsCall>()
+
+        override fun launchForm(
+            code: String,
+            paymentMethodMetadata: PaymentMethodMetadata,
+            configuration: EmbeddedPaymentElement.Configuration?,
+            customerState: CustomerState?,
+            promotion: PaymentMethodMessagePromotion?,
+        ) = error("Not expected")
+
+        override fun launchManage(
+            paymentMethodMetadata: PaymentMethodMetadata,
+            customerState: CustomerState,
+            selection: PaymentSelection?,
+            configuration: EmbeddedPaymentElement.Configuration?,
+        ) = error("Not expected")
+
+        override fun launchPaymentOptions(
+            paymentMethodMetadata: PaymentMethodMetadata,
+            customerState: CustomerState?,
+            selection: PaymentSelection?,
+            configuration: EmbeddedPaymentElement.Configuration?,
+        ) {
+            paymentOptionsCalls.add(
+                PaymentOptionsCall(paymentMethodMetadata, customerState, selection, configuration)
+            )
+        }
+
+        data class PaymentOptionsCall(
+            val paymentMethodMetadata: PaymentMethodMetadata,
+            val customerState: CustomerState?,
+            val selection: PaymentSelection?,
+            val configuration: EmbeddedPaymentElement.Configuration?,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/EmbeddedContentUiTest.kt
@@ -192,12 +192,15 @@ internal class EmbeddedContentUiTest {
                 coroutineScope = viewModelScope,
                 state = state,
                 verticalLayoutInteractorFactory = verticalLayoutInteractorFactory,
-                sheetStateHolder = sheetStateHolder,
                 embeddedWalletsHelper = { stateFlowOf(null) },
                 internalRowSelectionCallback = { internalRowSelectionCallback },
-                customerStateHolder = customerStateHolder,
-                selectionHolder = selectionHolder,
-                errorReporter = errorReporter,
+                paymentOptionsPresenter = DefaultEmbeddedPaymentOptionsPresenter(
+                    state = state,
+                    sheetStateHolder = sheetStateHolder,
+                    customerStateHolder = customerStateHolder,
+                    selectionHolder = selectionHolder,
+                    errorReporter = errorReporter,
+                ),
             )
         Scenario(
             embeddedContentHelper = embeddedContentHelper,


### PR DESCRIPTION
# Summary

Extracts `EmbeddedPaymentOptionsPresenter` from `DefaultEmbeddedContentHelper` and binds the behavior-preserving default implementation in both the legacy Embedded and Checkout graphs. This is layer 1 of 4 and targets `master`.

# Motivation

Checkout needs an integration-specific payment-options presentation seam. Moving the existing launcher availability checks and launch delegation behind a presenter makes that customization possible without changing `PaymentElement.present()` or legacy Embedded behavior.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran focused presenter/content-helper JVM tests, `./gradlew :paymentsheet:testDebugUnitTest`, and `./gradlew detekt`.

# Screenshots

Not applicable — this is an internal behavior-preserving extraction with no UI changes.

# Changelog

Not applicable — no public API or user-visible behavior changes.

Committed and created by Codex.
