### PR TITLE
Extract Link payment method selection launcher

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentLauncher.kt
@@ -20,7 +20,7 @@ internal class LinkPaymentLauncher @Inject internal constructor(
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val linkActivityContract: LinkActivityContract,
     private val linkStore: LinkStore
-) {
+) : LinkPaymentPresenter {
     private val analyticsHelper = linkAnalyticsComponentFactory.create().linkAnalyticsHelper
 
     private var linkActivityResultLauncher:
@@ -74,7 +74,7 @@ internal class LinkPaymentLauncher @Inject internal constructor(
      *
      * @param configuration The payment and customer settings
      */
-    fun present(
+    override fun present(
         configuration: LinkConfiguration,
         paymentMethodMetadata: PaymentMethodMetadata,
         linkAccountInfo: LinkAccountUpdate.Value,
@@ -93,4 +93,15 @@ internal class LinkPaymentLauncher @Inject internal constructor(
         linkActivityResultLauncher?.launch(args)
         analyticsHelper.onLinkLaunched()
     }
+}
+
+internal interface LinkPaymentPresenter {
+    fun present(
+        configuration: LinkConfiguration,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        linkAccountInfo: LinkAccountUpdate.Value,
+        launchMode: LinkLaunchMode,
+        linkExpressMode: LinkExpressMode,
+        statusBarColor: Int?,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethodSelectionLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethodSelectionLauncher.kt
@@ -1,0 +1,55 @@
+package com.stripe.android.link
+
+import androidx.annotation.ColorInt
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.PaymentSelection
+
+internal class LinkPaymentMethodSelectionLauncher(
+    private val launcher: LinkPaymentPresenter,
+    private val linkGateFactory: LinkGate.Factory,
+    private val linkAccountHolder: LinkAccountHolder,
+    @ColorInt private val statusBarColor: Int?,
+) {
+    fun launchIfEligible(
+        selection: PaymentSelection?,
+        configuration: LinkConfiguration?,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        hasUserDeclinedVerification: Boolean,
+    ): Boolean {
+        val linkAccountInfo = linkAccountHolder.linkAccountInfo.value
+        if (!isEligible(selection, configuration, linkAccountInfo, hasUserDeclinedVerification)) {
+            return false
+        }
+        val linkSelection = requireNotNull(selection as? PaymentSelection.Link)
+        val linkConfiguration = requireNotNull(configuration)
+
+        launcher.present(
+            configuration = linkConfiguration,
+            paymentMethodMetadata = paymentMethodMetadata,
+            linkAccountInfo = linkAccountInfo,
+            linkExpressMode = LinkExpressMode.ENABLED,
+            launchMode = LinkLaunchMode.PaymentMethodSelection(
+                selectedPayment = linkSelection.selectedPayment?.details,
+            ),
+            statusBarColor = statusBarColor,
+        )
+        return true
+    }
+
+    private fun isEligible(
+        selection: PaymentSelection?,
+        configuration: LinkConfiguration?,
+        linkAccountInfo: LinkAccountUpdate.Value,
+        hasUserDeclinedVerification: Boolean,
+    ): Boolean {
+        return when {
+            selection !is PaymentSelection.Link -> false
+            configuration == null -> false
+            linkAccountInfo.account == null -> false
+            hasUserDeclinedVerification -> false
+            else -> linkGateFactory.create(configuration).showRuxInFlowController
+        }
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -21,15 +21,12 @@ import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkActivityResult.Canceled.Reason
-import com.stripe.android.link.LinkConfiguration
-import com.stripe.android.link.LinkExpressMode
-import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.LinkPaymentMethodSelectionLauncher
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.effectiveLinkBrand
-import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.toLoginState
 import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
@@ -99,7 +96,7 @@ internal class DefaultFlowController @Inject internal constructor(
     private val eventReporter: EventReporter,
     private val viewModel: FlowControllerViewModel,
     private val confirmationHandler: FlowControllerConfirmationHandler,
-    private val linkGateFactory: LinkGate.Factory,
+    private val linkPaymentMethodSelectionLauncher: LinkPaymentMethodSelectionLauncher,
     private val linkHandler: LinkHandler,
     private val linkAccountHolder: LinkAccountHolder,
     @Named(FLOW_CONTROLLER_LINK_LAUNCHER) private val flowControllerLinkLauncher: LinkPaymentLauncher,
@@ -295,45 +292,18 @@ internal class DefaultFlowController @Inject internal constructor(
         withCurrentState { state ->
             val linkConfiguration = state.paymentSheetState.linkConfiguration
             val paymentSelection = viewModel.paymentSelection
-            val linkAccountInfo = linkAccountHolder.linkAccountInfo.value
 
-            val shouldPresentLink = linkConfiguration != null && shouldPresentLinkInsteadOfPaymentOptions(
-                paymentSelection = paymentSelection,
-                linkAccountInfo = linkAccountInfo,
-                linkConfiguration = linkConfiguration
+            val didPresentLink = linkPaymentMethodSelectionLauncher.launchIfEligible(
+                selection = paymentSelection,
+                configuration = linkConfiguration,
+                paymentMethodMetadata = state.paymentSheetState.paymentMethodMetadata,
+                hasUserDeclinedVerification = viewModel.state?.declinedLink2FA == true,
             )
 
-            if (shouldPresentLink) {
-                val paymentMethodMetadata = state.paymentSheetState.paymentMethodMetadata
-                flowControllerLinkLauncher.present(
-                    configuration = linkConfiguration,
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    linkAccountInfo = linkAccountInfo,
-                    linkExpressMode = LinkExpressMode.ENABLED,
-                    launchMode = LinkLaunchMode.PaymentMethodSelection(
-                        selectedPayment = (paymentSelection as? Link)?.selectedPayment?.details
-                    ),
-                    statusBarColor = viewModel.statusBarColor,
-                )
-            } else {
+            if (!didPresentLink) {
                 showPaymentOptionList(state, paymentSelection)
             }
         }
-    }
-
-    private fun shouldPresentLinkInsteadOfPaymentOptions(
-        paymentSelection: PaymentSelection?,
-        linkAccountInfo: LinkAccountUpdate.Value,
-        linkConfiguration: LinkConfiguration
-    ): Boolean {
-        // If the user has declined to use Link in the past, do not show it again.
-        return viewModel.state?.declinedLink2FA != true &&
-            // The current payment selection is Link
-            paymentSelection is Link &&
-            // The current user has a Link account (not necessarily logged in)
-            linkAccountInfo.account != null &&
-            // feature flag and other conditions are met
-            linkGateFactory.create(linkConfiguration).showRuxInFlowController
     }
 
     private fun showPaymentOptionList(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerModule.kt
@@ -7,7 +7,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.stripe.android.link.LinkActivityContract
 import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.LinkPaymentMethodSelectionLauncher
+import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.LinkStore
+import com.stripe.android.link.gate.LinkGate
 import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
@@ -75,6 +78,22 @@ internal object FlowControllerModule {
         linkActivityContract,
         linkStore,
     )
+
+    @Provides
+    @Singleton
+    fun provideLinkPaymentMethodSelectionLauncher(
+        @Named(FLOW_CONTROLLER_LINK_LAUNCHER) launcher: LinkPaymentLauncher,
+        linkGateFactory: LinkGate.Factory,
+        linkAccountHolder: LinkAccountHolder,
+        viewModel: FlowControllerViewModel,
+    ): LinkPaymentMethodSelectionLauncher {
+        return LinkPaymentMethodSelectionLauncher(
+            launcher = launcher,
+            linkGateFactory = linkGateFactory,
+            linkAccountHolder = linkAccountHolder,
+            statusBarColor = viewModel.statusBarColor,
+        )
+    }
 
     @Provides
     @Singleton

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodSelectionLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodSelectionLauncherTest.kt
@@ -1,0 +1,162 @@
+package com.stripe.android.link
+
+import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.gate.FakeLinkGate
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class LinkPaymentMethodSelectionLauncherTest {
+    private val linkGate = FakeLinkGate().apply { setShowRuxInFlowController(true) }
+    private val selection = PaymentSelection.Link(
+        brand = LinkBrand.Link,
+        selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+            collectedCvc = null,
+            billingPhone = null,
+        ),
+    )
+
+    @Test
+    fun `launchIfEligible launches with payment method selection arguments`() = runScenario {
+        val metadata = PaymentMethodMetadataFactory.create()
+        val accountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+
+        val launched = subject.launchIfEligible(
+            selection = selection,
+            configuration = TestFactory.LINK_CONFIGURATION,
+            paymentMethodMetadata = metadata,
+            hasUserDeclinedVerification = false,
+        )
+
+        assertThat(launched).isTrue()
+        assertThat(launcher.presentCalls.awaitItem()).isEqualTo(
+            FakeLinkPaymentPresenter.PresentCall(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                paymentMethodMetadata = metadata,
+                linkAccountInfo = accountInfo,
+                launchMode = LinkLaunchMode.PaymentMethodSelection(
+                    TestFactory.CONSUMER_PAYMENT_DETAILS_CARD
+                ),
+                linkExpressMode = LinkExpressMode.ENABLED,
+                statusBarColor = 123,
+            )
+        )
+    }
+
+    @Test
+    fun `launchIfEligible does not launch without Link selection`() = runScenario {
+        assertNotLaunched(selection = PaymentSelection.GooglePay)
+    }
+
+    @Test
+    fun `launchIfEligible does not launch without configuration`() = runScenario {
+        assertNotLaunched(configuration = null)
+    }
+
+    @Test
+    fun `launchIfEligible does not launch without Link account`() = runScenario(
+        linkAccountInfo = LinkAccountUpdate.Value(null),
+    ) {
+        assertNotLaunched()
+    }
+
+    @Test
+    fun `launchIfEligible does not launch after verification dismissal`() = runScenario {
+        assertNotLaunched(hasUserDeclinedVerification = true)
+    }
+
+    @Test
+    fun `launchIfEligible does not launch when RUX is disabled`() = runScenario {
+        linkGate.setShowRuxInFlowController(false)
+
+        assertNotLaunched()
+    }
+
+    private suspend fun Scenario.assertNotLaunched(
+        selection: PaymentSelection? = this@LinkPaymentMethodSelectionLauncherTest.selection,
+        configuration: LinkConfiguration? = TestFactory.LINK_CONFIGURATION,
+        hasUserDeclinedVerification: Boolean = false,
+    ) {
+        val launched = subject.launchIfEligible(
+            selection = selection,
+            configuration = configuration,
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            hasUserDeclinedVerification = hasUserDeclinedVerification,
+        )
+
+        assertThat(launched).isFalse()
+        launcher.presentCalls.expectNoEvents()
+    }
+
+    private fun runScenario(
+        linkAccountInfo: LinkAccountUpdate.Value = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val launcher = FakeLinkPaymentPresenter()
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle()).apply {
+            set(linkAccountInfo)
+        }
+        val scenario = Scenario(
+            subject = LinkPaymentMethodSelectionLauncher(
+                launcher = launcher,
+                linkGateFactory = FakeLinkGate.Factory(linkGate),
+                linkAccountHolder = linkAccountHolder,
+                statusBarColor = 123,
+            ),
+            launcher = launcher,
+        )
+
+        scenario.block()
+
+        launcher.ensureAllEventsConsumed()
+    }
+
+    private data class Scenario(
+        val subject: LinkPaymentMethodSelectionLauncher,
+        val launcher: FakeLinkPaymentPresenter,
+    )
+}
+
+internal class FakeLinkPaymentPresenter : LinkPaymentPresenter {
+    val presentCalls = Turbine<PresentCall>()
+
+    override fun present(
+        configuration: LinkConfiguration,
+        paymentMethodMetadata: PaymentMethodMetadata,
+        linkAccountInfo: LinkAccountUpdate.Value,
+        launchMode: LinkLaunchMode,
+        linkExpressMode: LinkExpressMode,
+        statusBarColor: Int?,
+    ) {
+        presentCalls.add(
+            PresentCall(
+                configuration = configuration,
+                paymentMethodMetadata = paymentMethodMetadata,
+                linkAccountInfo = linkAccountInfo,
+                launchMode = launchMode,
+                linkExpressMode = linkExpressMode,
+                statusBarColor = statusBarColor,
+            )
+        )
+    }
+
+    fun ensureAllEventsConsumed() {
+        presentCalls.ensureAllEventsConsumed()
+    }
+
+    data class PresentCall(
+        val configuration: LinkConfiguration,
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val linkAccountInfo: LinkAccountUpdate.Value,
+        val launchMode: LinkLaunchMode,
+        val linkExpressMode: LinkExpressMode,
+        val statusBarColor: Int?,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -26,6 +26,7 @@ import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.LinkPaymentMethodSelectionLauncher
 import com.stripe.android.link.TestFactory
 import com.stripe.android.link.TestFactory.CONSUMER_SESSION
 import com.stripe.android.link.TestFactory.VERIFICATION_STARTED_SESSION
@@ -2520,7 +2521,12 @@ internal class DefaultFlowControllerTest {
             flowControllerLinkLauncher = flowControllerLinkPaymentLauncher,
             walletsButtonLinkLauncher = walletsButtonLinkPaymentLauncher,
             activityResultRegistryOwner = mock(),
-            linkGateFactory = FakeLinkGate.Factory(linkGate),
+            linkPaymentMethodSelectionLauncher = LinkPaymentMethodSelectionLauncher(
+                launcher = flowControllerLinkPaymentLauncher,
+                linkGateFactory = FakeLinkGate.Factory(linkGate),
+                linkAccountHolder = linkAccountHolder,
+                statusBarColor = viewModel.statusBarColor,
+            ),
             confirmationHandler = confirmationHandler ?: FakeFlowControllerConfirmationHandler(),
             paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(
                 listOf(KLARNA_PROMOTION)


### PR DESCRIPTION
# Summary

Extracts `LinkPaymentMethodSelectionLauncher`, including FlowController's eligibility policy and exact Link launch arguments, and migrates `presentPaymentOptions()` to use it. This is layer 2 of 4 and depends on the embedded presenter extraction.

# Motivation

FlowController and Checkout need the same eager Link-selection launch policy. Centralizing selection/configuration/account/RUX/verification eligibility and the `ENABLED`/`PaymentMethodSelection` arguments avoids duplicating or drifting that behavior.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran focused launcher and FlowController JVM tests, `./gradlew :paymentsheet:testDebugUnitTest`, and `./gradlew detekt`.

# Screenshots

Not applicable — this is an internal behavior-preserving extraction with no UI changes.

# Changelog

Not applicable — no public API or user-visible behavior changes.

Committed and created by Codex.
