### PR TITLE
Extract Link payment method selection result handling

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethodSelectionOutcome.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkPaymentMethodSelectionOutcome.kt
@@ -1,0 +1,123 @@
+package com.stripe.android.link
+
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason
+import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.toLoginState
+import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.isLink
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.LinkDisabledState
+import com.stripe.android.paymentsheet.state.LinkState
+
+internal fun handleLinkPaymentMethodSelectionResult(
+    result: LinkActivityResult,
+    selection: PaymentSelection?,
+    customerState: CustomerState?,
+    paymentMethodMetadata: PaymentMethodMetadata,
+    currentLinkAccountInfo: LinkAccountUpdate.Value,
+): List<LinkPaymentMethodSelectionOutcome> = buildList {
+    val accountUpdate = result.linkAccountUpdate as? LinkAccountUpdate.Value
+    if (accountUpdate != null) {
+        add(
+            LinkPaymentMethodSelectionOutcome.UpdatedLinkMetadata(
+                linkAccountInfo = accountUpdate,
+                paymentMethodMetadata = paymentMethodMetadata.withLinkAccount(accountUpdate),
+            )
+        )
+    }
+    val effectiveAccountInfo = accountUpdate ?: currentLinkAccountInfo
+
+    when (result) {
+        is LinkActivityResult.PaymentMethodObtained,
+        is LinkActivityResult.Failed -> add(LinkPaymentMethodSelectionOutcome.Dismiss)
+        is LinkActivityResult.Completed -> add(completionOutcome(selection, result))
+        is LinkActivityResult.Canceled -> when (result.reason) {
+            Reason.BackPressed -> {
+                if (effectiveAccountInfo.account?.accountStatus == AccountStatus.VerificationStarted) {
+                    add(LinkPaymentMethodSelectionOutcome.SuppressFutureEagerPresentation)
+                }
+                add(
+                    if (selection.readyToPayWithLink()) {
+                        LinkPaymentMethodSelectionOutcome.Dismiss
+                    } else {
+                        LinkPaymentMethodSelectionOutcome.ShowPaymentOptions
+                    }
+                )
+            }
+            Reason.LoggedOut -> add(logoutOutcome(selection, customerState, paymentMethodMetadata))
+            Reason.PayAnotherWay -> add(LinkPaymentMethodSelectionOutcome.ShowPaymentOptions)
+        }
+    }
+}
+
+private fun completionOutcome(
+    selection: PaymentSelection?,
+    result: LinkActivityResult.Completed,
+): LinkPaymentMethodSelectionOutcome {
+    return if (selection is PaymentSelection.Link) {
+        LinkPaymentMethodSelectionOutcome.UpdateSelection(
+            selection = selection.copy(selectedPayment = result.selectedPayment),
+            isCanceled = false,
+            showPaymentOptions = false,
+        )
+    } else {
+        LinkPaymentMethodSelectionOutcome.Dismiss
+    }
+}
+
+private fun logoutOutcome(
+    selection: PaymentSelection?,
+    customerState: CustomerState?,
+    paymentMethodMetadata: PaymentMethodMetadata,
+): LinkPaymentMethodSelectionOutcome {
+    return if (selection is PaymentSelection.Link) {
+        LinkPaymentMethodSelectionOutcome.UpdateSelection(
+            selection = determineFallbackPaymentSelectionAfterLinkLogout(
+                customerState = customerState,
+                paymentMethodMetadata = paymentMethodMetadata,
+            ),
+            isCanceled = true,
+            showPaymentOptions = true,
+        )
+    } else {
+        LinkPaymentMethodSelectionOutcome.ShowPaymentOptions
+    }
+}
+
+private fun PaymentMethodMetadata.withLinkAccount(
+    accountUpdate: LinkAccountUpdate.Value,
+): PaymentMethodMetadata {
+    val accountStatus = accountUpdate.account?.accountStatus ?: AccountStatus.SignedOut
+    val updatedLinkState = when (val currentLinkState = linkStateResult) {
+        is LinkState -> currentLinkState.copy(loginState = accountStatus.toLoginState())
+        is LinkDisabledState, null -> currentLinkState
+    }
+    return copy(linkStateResult = updatedLinkState)
+}
+
+private fun PaymentSelection?.readyToPayWithLink(): Boolean {
+    return when (this) {
+        is PaymentSelection.Link -> selectedPayment != null
+        null -> false
+        else -> isLink
+    }
+}
+
+internal sealed interface LinkPaymentMethodSelectionOutcome {
+    data object Dismiss : LinkPaymentMethodSelectionOutcome
+    data object ShowPaymentOptions : LinkPaymentMethodSelectionOutcome
+    data object SuppressFutureEagerPresentation : LinkPaymentMethodSelectionOutcome
+
+    data class UpdateSelection(
+        val selection: PaymentSelection?,
+        val isCanceled: Boolean,
+        val showPaymentOptions: Boolean,
+    ) : LinkPaymentMethodSelectionOutcome
+
+    data class UpdatedLinkMetadata(
+        val linkAccountInfo: LinkAccountUpdate.Value,
+        val paymentMethodMetadata: PaymentMethodMetadata,
+    ) : LinkPaymentMethodSelectionOutcome
+}

--- a/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/utils/LinkPaymentSelectionUtils.kt
@@ -1,7 +1,8 @@
 package com.stripe.android.link.utils
 
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentsheet.model.PaymentSelection
-import com.stripe.android.paymentsheet.state.PaymentSheetState
+import com.stripe.android.paymentsheet.state.CustomerState
 
 /**
  * Determines the best fallback payment selection.
@@ -9,8 +10,11 @@ import com.stripe.android.paymentsheet.state.PaymentSheetState
  *
  * @return The best fallback payment selection, or null if no suitable fallback exists
  */
-internal fun PaymentSheetState.Full.determineFallbackPaymentSelectionAfterLinkLogout(): PaymentSelection? {
-    if (customer == null) return null
+internal fun determineFallbackPaymentSelectionAfterLinkLogout(
+    customerState: CustomerState?,
+    paymentMethodMetadata: PaymentMethodMetadata,
+): PaymentSelection? {
+    if (customerState == null) return null
 
     // Check if default payment method feature is enabled
     val isDefaultPaymentMethodEnabled = paymentMethodMetadata
@@ -18,11 +22,11 @@ internal fun PaymentSheetState.Full.determineFallbackPaymentSelectionAfterLinkLo
 
     return if (isDefaultPaymentMethodEnabled) {
         // Use default payment method if available
-        customer.paymentMethods.firstOrNull { paymentMethod ->
-            customer.defaultPaymentMethodId != null && paymentMethod.id == customer.defaultPaymentMethodId
+        customerState.paymentMethods.firstOrNull { paymentMethod ->
+            customerState.defaultPaymentMethodId != null && paymentMethod.id == customerState.defaultPaymentMethodId
         }
     } else {
         // Fall back to first customer payment method (most recently used appears first)
-        customer.paymentMethods.firstOrNull()
+        customerState.paymentMethods.firstOrNull()
     }?.let { PaymentSelection.Saved(it) }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -24,9 +24,11 @@ import com.stripe.android.link.LinkActivityResult.Canceled.Reason
 import com.stripe.android.link.LinkPaymentLauncher
 import com.stripe.android.link.LinkPaymentMethod
 import com.stripe.android.link.LinkPaymentMethodSelectionLauncher
+import com.stripe.android.link.LinkPaymentMethodSelectionOutcome
 import com.stripe.android.link.account.LinkAccountHolder
 import com.stripe.android.link.account.updateLinkAccount
 import com.stripe.android.link.effectiveLinkBrand
+import com.stripe.android.link.handleLinkPaymentMethodSelectionResult
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.model.toLoginState
 import com.stripe.android.link.utils.determineFallbackPaymentSelectionAfterLinkLogout
@@ -336,37 +338,53 @@ internal class DefaultFlowController @Inject internal constructor(
     }
 
     fun onLinkResultFromFlowController(result: LinkActivityResult) {
-        result.linkAccountUpdate?.updateLinkAccount()
-        when (result) {
-            is LinkActivityResult.PaymentMethodObtained,
-            is LinkActivityResult.Failed -> Unit
-            is LinkActivityResult.Canceled -> when (result.reason) {
-                Reason.BackPressed -> withCurrentState {
-                    val accountStatus = linkAccountHolder.linkAccountInfo.value.account?.accountStatus
-                    // The user dismissed the Link 2FA -> prevent from showing it again
-                    if (accountStatus == AccountStatus.VerificationStarted) {
-                        viewModel.updateState { it?.copy(declinedLink2FA = true) }
-                    }
-                    // just show the payment option list if
-                    // the user didn't have any preselected Link payment details
-                    // (preselected Link payment means the user is attempting to change their Link payment method)
-                    if (viewModel.paymentSelection?.readyToPayWithLink() == false) {
-                        showPaymentOptionList(it, viewModel.paymentSelection)
-                    }
-                }
-                Reason.LoggedOut -> {
-                    updateLinkPaymentSelection(linkPaymentMethod = null, canceled = true)
-                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
-                }
-                Reason.PayAnotherWay -> {
-                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
+        val state = viewModel.state ?: return
+        handleLinkPaymentMethodSelectionResult(
+            result = result,
+            selection = viewModel.paymentSelection,
+            customerState = state.paymentSheetState.customer,
+            paymentMethodMetadata = state.paymentSheetState.paymentMethodMetadata,
+            currentLinkAccountInfo = linkAccountHolder.linkAccountInfo.value,
+        ).forEach(::applyLinkPaymentMethodSelectionOutcome)
+    }
+
+    private fun applyLinkPaymentMethodSelectionOutcome(outcome: LinkPaymentMethodSelectionOutcome) {
+        when (outcome) {
+            LinkPaymentMethodSelectionOutcome.Dismiss -> Unit
+            LinkPaymentMethodSelectionOutcome.ShowPaymentOptions -> withCurrentState {
+                showPaymentOptionList(it, viewModel.paymentSelection)
+            }
+            LinkPaymentMethodSelectionOutcome.SuppressFutureEagerPresentation -> {
+                viewModel.updateState { it?.copy(declinedLink2FA = true) }
+            }
+            is LinkPaymentMethodSelectionOutcome.UpdatedLinkMetadata -> {
+                linkAccountHolder.set(outcome.linkAccountInfo)
+                viewModel.updateState {
+                    it?.copyPaymentSheetState(metadata = outcome.paymentMethodMetadata)
                 }
             }
-
-            is LinkActivityResult.Completed -> {
-                updateLinkPaymentSelection(linkPaymentMethod = result.selectedPayment, canceled = false)
+            is LinkPaymentMethodSelectionOutcome.UpdateSelection -> {
+                updatePaymentSelectionFromLinkResult(outcome.selection, outcome.isCanceled)
+                if (outcome.showPaymentOptions) {
+                    withCurrentState { showPaymentOptionList(it, viewModel.paymentSelection) }
+                }
             }
         }
+    }
+
+    private fun updatePaymentSelectionFromLinkResult(
+        selection: PaymentSelection?,
+        isCanceled: Boolean,
+    ) {
+        viewModel.paymentSelection = selection
+        val paymentOption = selection?.let {
+            val linkBrand = viewModel.state?.linkConfiguration
+                ?.effectiveLinkBrand(linkAccountHolder.linkAccountInfo.value.account)
+            createPaymentOption(it, linkBrand)
+        }
+        paymentOptionResultCallback.onPaymentOptionResult(
+            PaymentOptionResult(paymentOption = paymentOption, didCancel = isCanceled)
+        )
     }
 
     fun onLinkResultFromWalletsButton(result: LinkActivityResult) {
@@ -404,11 +422,6 @@ internal class DefaultFlowController @Inject internal constructor(
                 )
             }
         }
-    }
-
-    fun PaymentSelection.readyToPayWithLink(): Boolean = when (this) {
-        is Link -> selectedPayment != null
-        else -> isLink
     }
 
     /**
@@ -452,7 +465,12 @@ internal class DefaultFlowController @Inject internal constructor(
             } else {
                 // User logged out - determine best fallback payment method,
                 // or clear selection if there is no fallback
-                viewModel.state?.paymentSheetState?.determineFallbackPaymentSelectionAfterLinkLogout()
+                viewModel.state?.paymentSheetState?.let {
+                    determineFallbackPaymentSelectionAfterLinkLogout(
+                        customerState = it.customer,
+                        paymentMethodMetadata = it.paymentMethodMetadata,
+                    )
+                }
             }
             viewModel.paymentSelection = newSelection
             val paymentOption = newSelection?.let {

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodSelectionOutcomeTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkPaymentMethodSelectionOutcomeTest.kt
@@ -1,0 +1,175 @@
+package com.stripe.android.link
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.link.LinkActivityResult.Canceled.Reason
+import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentsheet.createCustomerState
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
+import com.stripe.android.paymentsheet.state.LinkState
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+internal class LinkPaymentMethodSelectionOutcomeTest {
+    private val selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+        details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+        collectedCvc = null,
+        billingPhone = null,
+    )
+    private val linkSelection = PaymentSelection.Link(
+        brand = LinkBrand.Link,
+        selectedPayment = selectedPayment,
+    )
+
+    @Test
+    fun `completion updates Link selection`() {
+        val updatedPayment = selectedPayment.copy(collectedCvc = "123")
+
+        val outcomes = handle(
+            LinkActivityResult.Completed(LinkAccountUpdate.None, selectedPayment = updatedPayment)
+        )
+
+        assertThat(outcomes).containsExactly(
+            LinkPaymentMethodSelectionOutcome.UpdateSelection(
+                selection = linkSelection.copy(selectedPayment = updatedPayment),
+                isCanceled = false,
+                showPaymentOptions = false,
+            )
+        )
+    }
+
+    @Test
+    fun `logout falls back to current customer payment method and shows payment options`() {
+        val paymentMethod = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+
+        val outcomes = handle(
+            result = LinkActivityResult.Canceled(Reason.LoggedOut, LinkAccountUpdate.None),
+            customerState = createCustomerState(paymentMethods = listOf(paymentMethod)),
+        )
+
+        assertThat(outcomes).containsExactly(
+            LinkPaymentMethodSelectionOutcome.UpdateSelection(
+                selection = PaymentSelection.Saved(paymentMethod),
+                isCanceled = true,
+                showPaymentOptions = true,
+            )
+        )
+    }
+
+    @Test
+    fun `logout uses default payment method when enabled`() {
+        val first = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        val default = first.copy(id = "pm_default")
+        val metadata = PaymentMethodMetadataFactory.create(
+            hasCustomerConfiguration = true,
+            isPaymentMethodSetAsDefaultEnabled = true,
+        )
+
+        val outcomes = handle(
+            result = LinkActivityResult.Canceled(Reason.LoggedOut, LinkAccountUpdate.None),
+            customerState = createCustomerState(
+                paymentMethods = listOf(first, default),
+                defaultPaymentMethodId = default.id,
+            ),
+            metadata = metadata,
+        )
+
+        assertThat((outcomes.single() as LinkPaymentMethodSelectionOutcome.UpdateSelection).selection)
+            .isEqualTo(PaymentSelection.Saved(default))
+    }
+
+    @Test
+    fun `back shows payment options when Link has no usable payment`() {
+        val outcomes = handle(
+            result = LinkActivityResult.Canceled(Reason.BackPressed, LinkAccountUpdate.None),
+            selection = linkSelection.copy(selectedPayment = null),
+        )
+
+        assertThat(outcomes).containsExactly(LinkPaymentMethodSelectionOutcome.ShowPaymentOptions)
+    }
+
+    @Test
+    fun `back dismisses when Link has a usable payment`() {
+        val outcomes = handle(
+            LinkActivityResult.Canceled(Reason.BackPressed, LinkAccountUpdate.None)
+        )
+
+        assertThat(outcomes).containsExactly(LinkPaymentMethodSelectionOutcome.Dismiss)
+    }
+
+    @Test
+    fun `pay another way shows payment options`() {
+        val outcomes = handle(
+            LinkActivityResult.Canceled(Reason.PayAnotherWay, LinkAccountUpdate.None)
+        )
+
+        assertThat(outcomes).containsExactly(LinkPaymentMethodSelectionOutcome.ShowPaymentOptions)
+    }
+
+    @Test
+    fun `failure dismisses`() {
+        val outcomes = handle(LinkActivityResult.Failed(Throwable("failure"), LinkAccountUpdate.None))
+
+        assertThat(outcomes).containsExactly(LinkPaymentMethodSelectionOutcome.Dismiss)
+    }
+
+    @Test
+    fun `account update produces updated Link metadata`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedOut,
+                signupMode = null,
+            )
+        )
+        val accountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+
+        val outcomes = handle(
+            result = LinkActivityResult.Failed(Throwable("failure"), accountInfo),
+            metadata = metadata,
+        )
+
+        val update = outcomes.first() as LinkPaymentMethodSelectionOutcome.UpdatedLinkMetadata
+        assertThat(update.linkAccountInfo).isEqualTo(accountInfo)
+        assertThat(update.paymentMethodMetadata.linkState?.loginState)
+            .isEqualTo(LinkState.LoginState.LoggedIn)
+        assertThat(outcomes.last()).isEqualTo(LinkPaymentMethodSelectionOutcome.Dismiss)
+    }
+
+    @Test
+    fun `back during verification suppresses future eager presentation`() {
+        val account = mock<LinkAccount> {
+            on { accountStatus } doReturn AccountStatus.VerificationStarted
+        }
+
+        val outcomes = handle(
+            result = LinkActivityResult.Canceled(
+                Reason.BackPressed,
+                LinkAccountUpdate.Value(account),
+            )
+        )
+
+        assertThat(outcomes).contains(LinkPaymentMethodSelectionOutcome.SuppressFutureEagerPresentation)
+    }
+
+    private fun handle(
+        result: LinkActivityResult,
+        selection: PaymentSelection? = linkSelection,
+        customerState: CustomerState? = null,
+        metadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+    ): List<LinkPaymentMethodSelectionOutcome> {
+        return handleLinkPaymentMethodSelectionResult(
+            result = result,
+            selection = selection,
+            customerState = customerState,
+            paymentMethodMetadata = metadata,
+            currentLinkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT),
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationDefinitionTest.kt
@@ -119,7 +119,7 @@ internal class LinkConfirmationDefinitionTest {
         val presentCall = launcherScenario.presentCalls.awaitItem()
 
         assertThat(presentCall.configuration).isEqualTo(LINK_CONFIRMATION_OPTION.configuration)
-        assertThat(presentCall.linkAccount).isNull()
+        assertThat(presentCall.linkAccountInfo.account).isNull()
     }
 
     @Test
@@ -173,7 +173,7 @@ internal class LinkConfirmationDefinitionTest {
         val presentCall = launcherScenario.presentCalls.awaitItem()
 
         assertThat(presentCall.configuration).isEqualTo(LINK_CONFIRMATION_OPTION.configuration)
-        assertThat(presentCall.linkAccount).isNull()
+        assertThat(presentCall.linkAccountInfo.account).isNull()
         assertThat(presentCall.linkExpressMode).isEqualTo(LinkExpressMode.DISABLED)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/RecordingLinkPaymentLauncher.kt
@@ -3,12 +3,12 @@ package com.stripe.android.utils
 import androidx.activity.result.ActivityResultCaller
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.link.LinkAccountUpdate
 import com.stripe.android.link.LinkActivityResult
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.LinkExpressMode
 import com.stripe.android.link.LinkLaunchMode
 import com.stripe.android.link.LinkPaymentLauncher
-import com.stripe.android.link.model.LinkAccount
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -58,7 +58,7 @@ internal object RecordingLinkPaymentLauncher {
                     PresentCall(
                         configuration = arguments[0] as LinkConfiguration,
                         paymentMethodMetadata = arguments[1] as PaymentMethodMetadata,
-                        linkAccount = arguments[2] as? LinkAccount,
+                        linkAccountInfo = arguments[2] as LinkAccountUpdate.Value,
                         launchMode = arguments[3] as LinkLaunchMode,
                         linkExpressMode = arguments[4] as LinkExpressMode,
                         statusBarColor = arguments[5] as? Int,
@@ -96,7 +96,7 @@ internal object RecordingLinkPaymentLauncher {
     data class PresentCall(
         val configuration: LinkConfiguration,
         val paymentMethodMetadata: PaymentMethodMetadata,
-        val linkAccount: LinkAccount?,
+        val linkAccountInfo: LinkAccountUpdate.Value,
         val launchMode: LinkLaunchMode,
         val linkExpressMode: LinkExpressMode,
         val statusBarColor: Int?,


### PR DESCRIPTION
# Summary

Extracts `LinkPaymentMethodSelectionResultHandler`, generalizes Link-logout fallback inputs, and migrates FlowController's direct Link-selection results to integration-neutral outcomes. It also fixes the recording Link launcher to retain `LinkAccountUpdate.Value`. This is layer 3 of 4.

# Motivation

Checkout needs the same completion, cancellation, logout, account-update, and verification-dismissal semantics as FlowController. A pure result normalizer makes those rules reusable while leaving integration-specific state writes and callbacks at each call site.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran focused result-handler, FlowController, and Link confirmation JVM tests, `./gradlew :paymentsheet:testDebugUnitTest`, and `./gradlew detekt`.

# Screenshots

Not applicable — this is an internal behavior-preserving extraction with no UI changes.

# Changelog

Not applicable — no public API or user-visible behavior changes.

Committed and created by Codex.
