### PR TITLE
Present eligible Link from Checkout payment element

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -311,6 +311,7 @@ class CheckoutController @Inject internal constructor(
                 registryOwner = activity,
             ),
             lifecycleOwner = activity,
+            activityResultRegistry = activity.activityResultRegistry,
             statusBarColor = StatusBarCompat.color(activity),
         )
         subcomponent.initializer.initialize()

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -25,6 +25,7 @@ internal data class CheckoutControllerState(
     val paymentSelection: PaymentSelection?,
     val temporarySelection: String?,
     val previousNewSelections: Bundle,
+    val linkEagerPresentationSuppressed: Boolean,
 ) : Parcelable {
     fun asCheckoutSession(
         paymentOptionFactory: CheckoutPaymentOptionDisplayDataFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
@@ -1,0 +1,115 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultRegistry
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.checkout.injection.CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER
+import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.LinkPaymentMethodSelectionLauncher
+import com.stripe.android.link.LinkPaymentMethodSelectionOutcome
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.handleLinkPaymentMethodSelectionResult
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedPaymentOptionsPresenter
+import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentOptionsPresenter
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import javax.inject.Inject
+import javax.inject.Named
+
+internal class CheckoutLinkPaymentOptionsPresenter @Inject constructor(
+    private val defaultPresenter: DefaultEmbeddedPaymentOptionsPresenter,
+    private val selectionLauncher: LinkPaymentMethodSelectionLauncher,
+    @Named(CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER)
+    private val linkPaymentLauncher: LinkPaymentLauncher,
+    private val activityResultRegistry: ActivityResultRegistry,
+    private val lifecycleOwner: LifecycleOwner,
+    private val stateHolder: CheckoutControllerStateHolder,
+    private val customerStateHolder: CustomerStateHolder,
+    private val linkAccountHolder: LinkAccountHolder,
+    private val sheetStateHolder: SheetStateHolder,
+) : EmbeddedPaymentOptionsPresenter {
+    init {
+        linkPaymentLauncher.register(
+            key = CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER,
+            activityResultRegistry = activityResultRegistry,
+            callback = ::onLinkResult,
+        )
+        lifecycleOwner.lifecycle.addObserver(
+            object : DefaultLifecycleObserver {
+                override fun onDestroy(owner: LifecycleOwner) {
+                    linkPaymentLauncher.unregister()
+                    sheetStateHolder.sheetIsOpen = false
+                }
+            }
+        )
+    }
+
+    override fun present() {
+        if (sheetStateHolder.sheetIsOpen) return
+        val state = stateHolder.state
+        if (state == null) {
+            defaultPresenter.present()
+            return
+        }
+
+        sheetStateHolder.sheetIsOpen = true
+        val didLaunch = selectionLauncher.launchIfEligible(
+            selection = state.paymentSelection,
+            configuration = state.paymentMethodMetadata.linkState?.configuration,
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            hasUserDeclinedVerification = state.linkEagerPresentationSuppressed,
+        )
+        if (!didLaunch) {
+            presentDefault()
+        }
+    }
+
+    private fun onLinkResult(result: LinkActivityResult) {
+        val state = stateHolder.state
+        if (state == null) {
+            sheetStateHolder.sheetIsOpen = false
+            return
+        }
+        handleLinkPaymentMethodSelectionResult(
+            result = result,
+            selection = state.paymentSelection,
+            customerState = customerStateHolder.customer.value,
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            currentLinkAccountInfo = linkAccountHolder.linkAccountInfo.value,
+        ).forEach(::applyOutcome)
+    }
+
+    private fun applyOutcome(outcome: LinkPaymentMethodSelectionOutcome) {
+        when (outcome) {
+            LinkPaymentMethodSelectionOutcome.Dismiss -> sheetStateHolder.sheetIsOpen = false
+            LinkPaymentMethodSelectionOutcome.ShowPaymentOptions -> presentDefault()
+            LinkPaymentMethodSelectionOutcome.SuppressFutureEagerPresentation -> {
+                stateHolder.state = stateHolder.state?.copy(linkEagerPresentationSuppressed = true)
+            }
+            is LinkPaymentMethodSelectionOutcome.UpdateSelection -> {
+                stateHolder.setSelection(outcome.selection)
+                if (outcome.showPaymentOptions) {
+                    presentDefault()
+                } else {
+                    sheetStateHolder.sheetIsOpen = false
+                }
+            }
+            is LinkPaymentMethodSelectionOutcome.UpdatedLinkMetadata -> updateLinkMetadata(outcome)
+        }
+    }
+
+    private fun updateLinkMetadata(outcome: LinkPaymentMethodSelectionOutcome.UpdatedLinkMetadata) {
+        linkAccountHolder.set(outcome.linkAccountInfo)
+        stateHolder.state = stateHolder.state?.copy(
+            paymentMethodMetadata = outcome.paymentMethodMetadata,
+        )
+    }
+
+    private fun presentDefault() {
+        sheetStateHolder.sheetIsOpen = false
+        defaultPresenter.present()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -116,6 +116,7 @@ internal class CheckoutStateLoader @Inject constructor(
             paymentSelection = selection,
             temporarySelection = carryForward.temporarySelection,
             previousNewSelections = carryForward.previousNewSelections,
+            linkEagerPresentationSuppressed = carryForward.linkEagerPresentationSuppressed,
         )
 
         customerStateHolder.setCustomerState(loadResults.customer)
@@ -181,6 +182,7 @@ internal class CheckoutStateLoader @Inject constructor(
         val previousSelection: PaymentSelection?,
         val temporarySelection: String?,
         val previousNewSelections: Bundle,
+        val linkEagerPresentationSuppressed: Boolean,
     ) {
         companion object {
             fun initial() = CarryForward(
@@ -188,6 +190,7 @@ internal class CheckoutStateLoader @Inject constructor(
                 previousSelection = null,
                 temporarySelection = null,
                 previousNewSelections = Bundle(),
+                linkEagerPresentationSuppressed = false,
             )
 
             fun from(state: CheckoutControllerState) = CarryForward(
@@ -195,6 +198,7 @@ internal class CheckoutStateLoader @Inject constructor(
                 previousSelection = state.paymentSelection,
                 temporarySelection = state.temporarySelection,
                 previousNewSelections = state.previousNewSelections,
+                linkEagerPresentationSuppressed = state.linkEagerPresentationSuppressed,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutPresenterSubcomponent.kt
@@ -3,6 +3,7 @@
 package com.stripe.android.checkout.injection
 
 import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.ActivityResultRegistry
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.checkout.CheckoutPresenter
 import com.stripe.android.checkout.CheckoutPresenterInitializer
@@ -27,6 +28,7 @@ internal interface CheckoutPresenterSubcomponent {
         fun create(
             @BindsInstance activityResultCaller: ActivityResultCaller,
             @BindsInstance lifecycleOwner: LifecycleOwner,
+            @BindsInstance activityResultRegistry: ActivityResultRegistry,
             @BindsInstance @Named(STATUS_BAR_COLOR) statusBarColor: Int?,
         ): CheckoutPresenterSubcomponent
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/PaymentElementModule.kt
@@ -1,15 +1,23 @@
 package com.stripe.android.checkout.injection
 
 import com.stripe.android.checkout.CheckoutControllerStateHolder
+import com.stripe.android.checkout.CheckoutLinkPaymentOptionsPresenter
 import com.stripe.android.checkout.CheckoutSheetLauncher
 import com.stripe.android.elements.PaymentElement
+import com.stripe.android.link.LinkActivityContract
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.LinkPaymentMethodSelectionLauncher
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.account.LinkStore
+import com.stripe.android.link.gate.LinkGate
+import com.stripe.android.link.injection.LinkAnalyticsComponent
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedLinkHelper
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedPaymentMethodVerticalLayoutInteractorFactory
-import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedPaymentOptionsPresenter
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedWalletsHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
@@ -18,11 +26,16 @@ import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentMethodV
 import com.stripe.android.paymentelement.embedded.content.EmbeddedPaymentOptionsPresenter
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.EmbeddedWalletsHelper
+import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.uicore.utils.mapAsStateFlow
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.flow.StateFlow
+import javax.inject.Named
+
+internal const val CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER =
+    "LinkPaymentLauncher_CheckoutPaymentMethodSelection"
 
 @Module
 internal interface PaymentElementModule {
@@ -31,7 +44,7 @@ internal interface PaymentElementModule {
 
     @Binds
     fun bindsEmbeddedPaymentOptionsPresenter(
-        presenter: DefaultEmbeddedPaymentOptionsPresenter,
+        presenter: CheckoutLinkPaymentOptionsPresenter,
     ): EmbeddedPaymentOptionsPresenter
 
     @Binds
@@ -75,6 +88,37 @@ internal interface PaymentElementModule {
                     )
                 }
             }
+        }
+
+        @Provides
+        @Named(CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER)
+        fun provideCheckoutLinkPaymentLauncher(
+            linkAnalyticsComponentFactory: LinkAnalyticsComponent.Factory,
+            linkActivityContract: LinkActivityContract,
+            @PaymentElementCallbackIdentifier identifier: String,
+            linkStore: LinkStore,
+        ): LinkPaymentLauncher {
+            return LinkPaymentLauncher(
+                linkAnalyticsComponentFactory = linkAnalyticsComponentFactory,
+                paymentElementCallbackIdentifier = identifier,
+                linkActivityContract = linkActivityContract,
+                linkStore = linkStore,
+            )
+        }
+
+        @Provides
+        fun provideLinkPaymentMethodSelectionLauncher(
+            @Named(CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER) launcher: LinkPaymentLauncher,
+            linkGateFactory: LinkGate.Factory,
+            linkAccountHolder: LinkAccountHolder,
+            @Named(STATUS_BAR_COLOR) statusBarColor: Int?,
+        ): LinkPaymentMethodSelectionLauncher {
+            return LinkPaymentMethodSelectionLauncher(
+                launcher = launcher,
+                linkGateFactory = linkGateFactory,
+                linkAccountHolder = linkAccountHolder,
+                statusBarColor = statusBarColor,
+            )
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -32,6 +32,7 @@ internal object CheckoutControllerStateFactory {
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
         previousNewSelections: Bundle = Bundle(),
+        linkEagerPresentationSuppressed: Boolean = false,
     ): CheckoutControllerState {
         return CheckoutControllerState(
             configuration = configuration,
@@ -44,6 +45,7 @@ internal object CheckoutControllerStateFactory {
             paymentSelection = paymentSelection,
             temporarySelection = temporarySelection,
             previousNewSelections = previousNewSelections,
+            linkEagerPresentationSuppressed = linkEagerPresentationSuppressed,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -215,6 +215,7 @@ internal class CheckoutControllerStateHolderTest {
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,
         previousNewSelections = previousNewSelections,
+        linkEagerPresentationSuppressed = false,
     )
 
     private fun testScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
@@ -1,0 +1,324 @@
+@file:OptIn(com.stripe.android.paymentelement.CheckoutSessionPreview::class)
+
+package com.stripe.android.checkout
+
+import androidx.activity.result.ActivityResultRegistry
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.injection.CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER
+import com.stripe.android.link.LinkAccountUpdate
+import com.stripe.android.link.LinkActivityResult
+import com.stripe.android.link.LinkConfiguration
+import com.stripe.android.link.LinkExpressMode
+import com.stripe.android.link.LinkLaunchMode
+import com.stripe.android.link.LinkPaymentLauncher
+import com.stripe.android.link.LinkPaymentMethod
+import com.stripe.android.link.LinkPaymentMethodSelectionLauncher
+import com.stripe.android.link.TestFactory
+import com.stripe.android.link.account.LinkAccountHolder
+import com.stripe.android.link.gate.FakeLinkGate
+import com.stripe.android.link.model.AccountStatus
+import com.stripe.android.link.model.LinkAccount
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.LinkBrand
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedPaymentOptionsPresenter
+import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.createCustomerState
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.state.CustomerState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.same
+import org.mockito.kotlin.verify
+
+internal class CheckoutLinkPaymentOptionsPresenterTest {
+    @Test
+    fun `registers direct Link with unique key and host registry`() = runScenario {
+        verify(linkPaymentLauncher).register(
+            key = eq(CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER),
+            activityResultRegistry = same(activityResultRegistry),
+            callback = any(),
+        )
+    }
+
+    @Test
+    fun `ordinary payment options delegate to default presenter`() = runScenario(
+        selection = PaymentSelection.GooglePay,
+    ) {
+        presenter.present()
+
+        verify(defaultPresenter).present()
+        verifyLinkWasNotPresented()
+    }
+
+    @Test
+    fun `eligible Link launches with exact arguments and keeps sheet open`() = runScenario {
+        presenter.present()
+
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+        verify(linkPaymentLauncher).present(
+            configuration = linkConfiguration,
+            paymentMethodMetadata = paymentMethodMetadata,
+            linkAccountInfo = linkAccountInfo,
+            launchMode = LinkLaunchMode.PaymentMethodSelection(selectedPayment.details),
+            linkExpressMode = LinkExpressMode.ENABLED,
+            statusBarColor = 123,
+        )
+        verify(defaultPresenter, never()).present()
+    }
+
+    @Test
+    fun `completion updates selection and closes`() = runScenario {
+        presenter.present()
+        val updatedPayment = selectedPayment.copy(collectedCvc = "123")
+
+        resultCallback(
+            LinkActivityResult.Completed(LinkAccountUpdate.None, selectedPayment = updatedPayment)
+        )
+
+        assertThat(stateHolder.state?.paymentSelection)
+            .isEqualTo(linkSelection.copy(selectedPayment = updatedPayment))
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+    }
+
+    @Test
+    fun `logout uses current customer fallback and opens payment options`() = runScenario {
+        presenter.present()
+        val fallback = PaymentMethodFixtures.CARD_PAYMENT_METHOD
+        customerState.value = createCustomerState(paymentMethods = listOf(fallback))
+
+        resultCallback(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.LoggedOut,
+                linkAccountUpdate = LinkAccountUpdate.None,
+            )
+        )
+
+        assertThat(stateHolder.state?.paymentSelection).isEqualTo(PaymentSelection.Saved(fallback))
+        verify(defaultPresenter).present()
+    }
+
+    @Test
+    fun `pay another way opens payment options`() = runScenario {
+        presenter.present()
+
+        resultCallback(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.PayAnotherWay,
+                linkAccountUpdate = LinkAccountUpdate.None,
+            )
+        )
+
+        verify(defaultPresenter).present()
+    }
+
+    @Test
+    fun `back opens payment options when Link has no usable payment`() = runScenario(
+        selection = linkSelection.copy(selectedPayment = null),
+    ) {
+        presenter.present()
+
+        resultCallback(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                linkAccountUpdate = LinkAccountUpdate.None,
+            )
+        )
+
+        verify(defaultPresenter).present()
+    }
+
+    @Test
+    fun `back closes when Link has a usable payment`() = runScenario {
+        presenter.present()
+
+        resultCallback(
+            LinkActivityResult.Canceled(
+                reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                linkAccountUpdate = LinkAccountUpdate.None,
+            )
+        )
+
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        verify(defaultPresenter, never()).present()
+    }
+
+    @Test
+    fun `failure closes and applies Link account update`() = runScenario {
+        presenter.present()
+
+        resultCallback(
+            LinkActivityResult.Failed(
+                error = Throwable("failure"),
+                linkAccountUpdate = LinkAccountUpdate.Value(null),
+            )
+        )
+
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(linkAccountHolder.linkAccountInfo.value.account).isNull()
+        assertThat(stateHolder.state?.paymentMethodMetadata?.linkState?.loginState)
+            .isEqualTo(com.stripe.android.paymentsheet.state.LinkState.LoginState.LoggedOut)
+    }
+
+    @Test
+    fun `verification dismissal persists suppression across recreation`() {
+        val savedStateHandle = SavedStateHandle()
+        runScenario(savedStateHandle = savedStateHandle) {
+            presenter.present()
+            val verifyingAccount = mock<LinkAccount> {
+                on { accountStatus } doReturn AccountStatus.VerificationStarted
+            }
+
+            resultCallback(
+                LinkActivityResult.Canceled(
+                    reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                    linkAccountUpdate = LinkAccountUpdate.Value(verifyingAccount),
+                )
+            )
+
+            assertThat(stateHolder.state?.linkEagerPresentationSuppressed).isTrue()
+        }
+
+        runScenario(savedStateHandle = savedStateHandle) {
+            sheetStateHolder.sheetIsOpen = false
+            presenter.present()
+
+            verify(defaultPresenter).present()
+            verifyLinkWasNotPresented()
+        }
+    }
+
+    @Test
+    fun `destroy unregisters direct Link and clears open state`() = runScenario {
+        presenter.present()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+        verify(linkPaymentLauncher).unregister()
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+    }
+
+    @Suppress("LongMethod")
+    private fun runScenario(
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        selection: PaymentSelection? = linkSelection,
+        block: Scenario.() -> Unit,
+    ) {
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            linkState = com.stripe.android.paymentsheet.state.LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = com.stripe.android.paymentsheet.state.LinkState.LoginState.LoggedIn,
+                signupMode = null,
+            )
+        )
+        val existingState = savedStateHandle.get<CheckoutControllerState>(CheckoutControllerStateHolder.STATE_KEY)
+        val state = existingState ?: CheckoutControllerStateFactory.create(
+            paymentSelection = selection,
+            paymentMethodMetadata = paymentMethodMetadata,
+        )
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle).apply {
+            this.state = state
+        }
+        val customerState = MutableStateFlow<CustomerState?>(null)
+        val customerStateHolder = mock<CustomerStateHolder> {
+            on { customer } doReturn customerState
+        }
+        val linkAccountInfo = LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT)
+        val linkAccountHolder = LinkAccountHolder(SavedStateHandle()).apply { set(linkAccountInfo) }
+        val sheetStateHolder = SheetStateHolder(savedStateHandle)
+        val defaultPresenter = mock<DefaultEmbeddedPaymentOptionsPresenter>()
+        val linkPaymentLauncher = mock<LinkPaymentLauncher>()
+        val activityResultRegistry = mock<ActivityResultRegistry>()
+        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = Dispatchers.Unconfined)
+        val presenter = CheckoutLinkPaymentOptionsPresenter(
+            defaultPresenter = defaultPresenter,
+            selectionLauncher = LinkPaymentMethodSelectionLauncher(
+                launcher = linkPaymentLauncher,
+                linkGateFactory = FakeLinkGate.Factory(),
+                linkAccountHolder = linkAccountHolder,
+                statusBarColor = 123,
+            ),
+            linkPaymentLauncher = linkPaymentLauncher,
+            activityResultRegistry = activityResultRegistry,
+            lifecycleOwner = lifecycleOwner,
+            stateHolder = stateHolder,
+            customerStateHolder = customerStateHolder,
+            linkAccountHolder = linkAccountHolder,
+            sheetStateHolder = sheetStateHolder,
+        )
+        val callbackCaptor = argumentCaptor<(LinkActivityResult) -> Unit>()
+        verify(linkPaymentLauncher).register(
+            key = eq(CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER),
+            activityResultRegistry = same(activityResultRegistry),
+            callback = callbackCaptor.capture(),
+        )
+
+        Scenario(
+            presenter = presenter,
+            defaultPresenter = defaultPresenter,
+            linkPaymentLauncher = linkPaymentLauncher,
+            activityResultRegistry = activityResultRegistry,
+            lifecycleOwner = lifecycleOwner,
+            stateHolder = stateHolder,
+            customerState = customerState,
+            sheetStateHolder = sheetStateHolder,
+            linkAccountHolder = linkAccountHolder,
+            linkAccountInfo = linkAccountInfo,
+            paymentMethodMetadata = paymentMethodMetadata,
+            resultCallback = callbackCaptor.firstValue,
+        ).block()
+    }
+
+    private data class Scenario(
+        val presenter: CheckoutLinkPaymentOptionsPresenter,
+        val defaultPresenter: DefaultEmbeddedPaymentOptionsPresenter,
+        val linkPaymentLauncher: LinkPaymentLauncher,
+        val activityResultRegistry: ActivityResultRegistry,
+        val lifecycleOwner: TestLifecycleOwner,
+        val stateHolder: CheckoutControllerStateHolder,
+        val customerState: MutableStateFlow<CustomerState?>,
+        val sheetStateHolder: SheetStateHolder,
+        val linkAccountHolder: LinkAccountHolder,
+        val linkAccountInfo: LinkAccountUpdate.Value,
+        val paymentMethodMetadata: com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata,
+        val resultCallback: (LinkActivityResult) -> Unit,
+    ) {
+        val linkConfiguration: LinkConfiguration
+            get() = requireNotNull(paymentMethodMetadata.linkState?.configuration)
+
+        fun verifyLinkWasNotPresented() {
+            verify(linkPaymentLauncher, never()).present(
+                configuration = any(),
+                paymentMethodMetadata = any(),
+                linkAccountInfo = any(),
+                launchMode = any(),
+                linkExpressMode = any(),
+                statusBarColor = anyOrNull(),
+            )
+        }
+    }
+
+    private companion object {
+        val selectedPayment = LinkPaymentMethod.ConsumerPaymentDetails(
+            details = TestFactory.CONSUMER_PAYMENT_DETAILS_CARD,
+            collectedCvc = null,
+            billingPhone = null,
+        )
+        val linkSelection = PaymentSelection.Link(
+            brand = LinkBrand.Link,
+            selectedPayment = selectedPayment,
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -322,6 +322,13 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
+    fun `reload preserves eager Link suppression`() = runScenario {
+        loader.reload(committedState(linkEagerPresentationSuppressed = true))
+
+        assertThat(stateHolder.state?.linkEagerPresentationSuppressed).isTrue()
+    }
+
+    @Test
     fun `loadInitial resets the temporary selection and previous new selections`() = runScenario {
         // A prior state carries a temporary selection and a stashed new payment method; a fresh
         // configuration load must start from a clean slate rather than carrying them forward.
@@ -336,6 +343,15 @@ internal class CheckoutStateLoaderTest {
 
         assertThat(stateHolder.state?.temporarySelection).isNull()
         assertThat(stateHolder.getPreviousNewSelection("cashapp")).isNull()
+    }
+
+    @Test
+    fun `loadInitial resets eager Link suppression for a newly configured session`() = runScenario {
+        stateHolder.state = committedState(linkEagerPresentationSuppressed = true)
+
+        loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
+
+        assertThat(stateHolder.state?.linkEagerPresentationSuppressed).isFalse()
     }
 
     private fun defaultConfiguration() = CheckoutController.Configuration().build()
@@ -356,6 +372,7 @@ internal class CheckoutStateLoaderTest {
         temporarySelection: String? = null,
         previousNewSelections: Bundle = Bundle(),
         checkoutSessionResponse: CheckoutSessionResponse = CheckoutSessionResponseFactory.create(),
+        linkEagerPresentationSuppressed: Boolean = false,
     ) = CheckoutControllerState(
         configuration = CheckoutController.Configuration().build(),
         checkoutSessionResponse = checkoutSessionResponse,
@@ -367,6 +384,7 @@ internal class CheckoutStateLoaderTest {
         paymentSelection = paymentSelection,
         temporarySelection = temporarySelection,
         previousNewSelections = previousNewSelections,
+        linkEagerPresentationSuppressed = linkEagerPresentationSuppressed,
     )
 
     // Adaptive pricing (usd → eur) drives flag image resolution during load.


### PR DESCRIPTION
# Summary

Adds Checkout's Link-aware payment-options presenter. Eligible Link selections open Link directly; ordinary and fallback paths continue through a fresh Embedded payment-options sheet. This is layer 4 of 4.

# Motivation

Checkout should eagerly present Link when the current selection, account, RUX policy, and verification state allow it. The presenter uses a separately qualified launcher and unique registry key, keeps presentation state accurate, applies all normalized outcomes, and persists verification-dismissal suppression across recreation while resetting it for a newly configured session.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran focused Checkout presenter and state-loader JVM tests, `./gradlew :paymentsheet:testDebugUnitTest`, and `./gradlew detekt`. Coverage includes default-sheet delegation, exact eligible Link arguments, unique registration, lifecycle cleanup, completion, logout, pay-another-way, back, failure/account updates, current-state fallback, recreation, suppression persistence, and suppression reset.

# Screenshots

Not applicable — presentation routing changes, but no visual UI implementation changes were made.

# Changelog

Not applicable — Checkout Session remains a preview API and this stack intentionally contains no changelog changes.

Committed and created by Codex.
