### PR TITLE
Remove unused Checkout billing-address update

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -208,18 +208,6 @@ class CheckoutController @Inject internal constructor(
         }
     }
 
-    internal suspend fun updateBillingAddress(
-        name: String?,
-        address: Address,
-    ): kotlin.Result<Unit> = updateAddress(CheckoutSessionResponse.TaxAddressSource.BILLING, address) {
-        copy(
-            collectedDetails = collectedDetails.copy(
-                billingName = name,
-                billingAddress = it,
-            ),
-        )
-    }
-
     /**
      * Runs an async function that calls your server to update the Checkout Session,
      * then automatically refreshes [session] with the latest session data.
@@ -987,7 +975,7 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
-     * Builder for an address passed to [updateShippingAddress] and [updateBillingAddress].
+     * Builder for an address passed to [updateShippingAddress].
      */
     @CheckoutSessionPreview
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -733,70 +733,6 @@ internal class CheckoutControllerTest {
             )
         }
 
-    @Test
-    fun `updateBillingAddress sends tax_region and stores address when automatic tax targets billing`() =
-        runMutationScenario(initModifier = automaticTaxFor("billing")) {
-            networkRule.checkoutUpdate(
-                bodyPart("tax_region[country]", "US"),
-                bodyPart("tax_region[city]", "Denver"),
-                bodyPart("tax_region[postal_code]", "80202"),
-                bodyPart("elements_session_client[is_aggregation_expected]", "true"),
-                responseFactory = successResponseFactory(automaticTaxFor("billing")),
-            )
-
-            val result = controller.updateBillingAddress(
-                name = "Jane",
-                address = fullAddress,
-            )
-
-            result.getOrThrow()
-            val state = committedState()
-            assertThat(state.collectedDetails.billingName).isEqualTo("Jane")
-            assertThat(state.collectedDetails.billingAddress).isEqualTo(fullAddress.build())
-        }
-
-    @Test
-    fun `updateBillingAddress does not send tax_region when automatic tax targets shipping`() =
-        runMutationScenario(initModifier = automaticTaxFor("shipping")) {
-            // Automatic tax targets shipping, so a billing address update stays local: no request.
-            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
-
-            result.getOrThrow()
-            val state = committedState()
-            assertThat(state.collectedDetails.billingName).isEqualTo("Jane")
-            assertThat(state.collectedDetails.billingAddress).isEqualTo(fullAddress.build())
-        }
-
-    @Test
-    fun `updateBillingAddress stores address without a network call when automatic tax is disabled`() =
-        runMutationScenario {
-            // No checkoutUpdate is enqueued: with automatic tax off, the address is stored locally
-            // and the payment element is reloaded from the existing response, firing no request.
-            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
-
-            result.getOrThrow()
-            val state = committedState()
-            assertThat(state.collectedDetails.billingName).isEqualTo("Jane")
-            assertThat(state.collectedDetails.billingAddress).isEqualTo(fullAddress.build())
-        }
-
-    @Test
-    fun `updateBillingAddress does not store address on failure`() =
-        runMutationScenario(initModifier = automaticTaxFor("billing")) {
-            networkRule.checkoutUpdate { response ->
-                response.setResponseCode(400)
-                response.setBody("""{"error": {"message": "Invalid address"}}""")
-            }
-
-            val result = controller.updateBillingAddress(name = "Jane", address = fullAddress)
-
-            assertThat(result.isFailure).isTrue()
-            val state = committedState()
-            assertThat(state.collectedDetails.billingName).isNull()
-            assertThat(state.collectedDetails.billingAddress).isNull()
-        }
-
-    @Test
     fun `runServerUpdate refreshes the session after serverUpdate completes`() = runMutationScenario {
         networkRule.checkoutInit(
             responseFactory = successResponseFactory { json ->
@@ -1062,17 +998,6 @@ internal class CheckoutControllerTest {
                 "Country code 'US' is not in allowedShippingCountries"
             )
             assertThat(controller.session.value).isEqualTo(before)
-        }
-
-    @Test
-    fun `updateBillingAddress is not gated by allowedShippingCountries`() =
-        runMutationScenario(initModifier = allowedShippingCountries(listOf("US"))) {
-            val result = controller.updateBillingAddress(
-                name = null,
-                address = Address().country("DE"),
-            )
-
-            assertThat(result.isSuccess).isTrue()
         }
 
     @Test


### PR DESCRIPTION
# Summary

Removes unused internal `CheckoutController.updateBillingAddress(name, address)`.

Existing Automatic Tax updates for configured billing defaults and Payment Element confirmation continue through their direct Checkout tax-region paths. `updateShippingAddress` is unchanged.

# Motivation

Mobile Checkout does not provide merchants a separate custom billing-address flow. Billing details remain owned by Payment Element configuration and confirmation, so retaining a controller method that copies them into mutable Checkout state is unnecessary.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused Checkout controller coverage continues to verify shipping updates, configured billing defaults, and existing tax-region behavior.

# Screenshots

Not applicable. No visual changes.

# Changelog

No changelog entry. Checkout Session remains private preview.

Committed and created by Codex.
