### PR TITLE
Extract Google Pay state loading

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -71,11 +71,13 @@ import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.CreateLinkState
 import com.stripe.android.paymentsheet.state.DefaultAnalyticsMetadataFactory
 import com.stripe.android.paymentsheet.state.DefaultCreateLinkState
+import com.stripe.android.paymentsheet.state.DefaultGetGooglePayState
 import com.stripe.android.paymentsheet.state.DefaultLinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.DefaultPaymentElementLoader
 import com.stripe.android.paymentsheet.state.DefaultPaymentMethodFilter
 import com.stripe.android.paymentsheet.state.DefaultRetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.DefaultTapToAddAvailabilityFactory
+import com.stripe.android.paymentsheet.state.GetGooglePayState
 import com.stripe.android.paymentsheet.state.LinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentMethodFilter
@@ -156,6 +158,9 @@ internal interface CheckoutControllerModule {
 
     @Binds
     fun bindsCreateLinkState(impl: DefaultCreateLinkState): CreateLinkState
+
+    @Binds
+    fun bindsGetGooglePayState(impl: DefaultGetGooglePayState): GetGooglePayState
 
     @Binds
     fun bindRetrieveCustomerEmail(impl: DefaultRetrieveCustomerEmail): RetrieveCustomerEmail

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -36,11 +36,13 @@ import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepositor
 import com.stripe.android.paymentsheet.state.CreateLinkState
 import com.stripe.android.paymentsheet.state.DefaultAnalyticsMetadataFactory
 import com.stripe.android.paymentsheet.state.DefaultCreateLinkState
+import com.stripe.android.paymentsheet.state.DefaultGetGooglePayState
 import com.stripe.android.paymentsheet.state.DefaultLinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.DefaultPaymentElementLoader
 import com.stripe.android.paymentsheet.state.DefaultPaymentMethodFilter
 import com.stripe.android.paymentsheet.state.DefaultRetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.DefaultTapToAddAvailabilityFactory
+import com.stripe.android.paymentsheet.state.GetGooglePayState
 import com.stripe.android.paymentsheet.state.LinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentMethodFilter
@@ -156,6 +158,11 @@ internal interface EmbeddedPaymentElementViewModelModule {
     fun bindsCreateLinkState(
         impl: DefaultCreateLinkState,
     ): CreateLinkState
+
+    @Binds
+    fun bindsGetGooglePayState(
+        impl: DefaultGetGooglePayState,
+    ): GetGooglePayState
 
     @Binds
     fun bindRetrieveCustomerEmail(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -59,11 +59,13 @@ import com.stripe.android.paymentsheet.repositories.SavedPaymentMethodRepository
 import com.stripe.android.paymentsheet.state.CreateLinkState
 import com.stripe.android.paymentsheet.state.DefaultAnalyticsMetadataFactory
 import com.stripe.android.paymentsheet.state.DefaultCreateLinkState
+import com.stripe.android.paymentsheet.state.DefaultGetGooglePayState
 import com.stripe.android.paymentsheet.state.DefaultLinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.DefaultPaymentElementLoader
 import com.stripe.android.paymentsheet.state.DefaultPaymentMethodFilter
 import com.stripe.android.paymentsheet.state.DefaultRetrieveCustomerEmail
 import com.stripe.android.paymentsheet.state.DefaultTapToAddAvailabilityFactory
+import com.stripe.android.paymentsheet.state.GetGooglePayState
 import com.stripe.android.paymentsheet.state.LinkAccountStatusProvider
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentMethodFilter
@@ -150,6 +152,11 @@ internal abstract class PaymentSheetCommonModule {
     abstract fun bindsCreateLinkState(
         impl: DefaultCreateLinkState,
     ): CreateLinkState
+
+    @Binds
+    abstract fun bindsGetGooglePayState(
+        impl: DefaultGetGooglePayState,
+    ): GetGooglePayState
 
     @Binds
     abstract fun bindsPaymentSheetUpdater(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/GetGooglePayState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/GetGooglePayState.kt
@@ -1,28 +1,20 @@
 package com.stripe.android.paymentsheet.state
 
-import com.stripe.android.DefaultCardBrandFilter
-import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.common.model.CommonConfiguration
-import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.UserFacingLogger
-import com.stripe.android.googlepaylauncher.GooglePayEnvironment
-import com.stripe.android.googlepaylauncher.injection.GooglePayRepositoryFactory
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.payments.core.analytics.ErrorReporter
-import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 internal fun interface GetGooglePayState {
     suspend operator fun invoke(
         configuration: CommonConfiguration,
+        elementsSession: ElementsSession,
         initializationMode: PaymentElementLoader.InitializationMode,
-        elementsSession: Deferred<ElementsSession>,
+        isGooglePaySupportedOnDevice: Deferred<Boolean>,
+        isGooglePaySupportedByConfiguration: Deferred<Boolean>,
     ): GooglePayState
 }
 
@@ -32,55 +24,17 @@ internal data class GooglePayState(
 )
 
 internal class DefaultGetGooglePayState @Inject constructor(
-    private val googlePayRepositoryFactory: GooglePayRepositoryFactory,
     private val userFacingLogger: UserFacingLogger,
     private val errorReporter: ErrorReporter,
-    private val durationProvider: DurationProvider,
 ) : GetGooglePayState {
 
     override suspend fun invoke(
         configuration: CommonConfiguration,
-        initializationMode: PaymentElementLoader.InitializationMode,
-        elementsSession: Deferred<ElementsSession>,
-    ): GooglePayState = coroutineScope {
-        val isGooglePaySupportedOnDevice = async(start = CoroutineStart.UNDISPATCHED) {
-            durationProvider.measureDuration(
-                DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported
-            ) {
-                isGooglePayReadyForEnvironment(GooglePayEnvironment.Production)
-            }
-        }
-        val isGooglePaySupportedByConfiguration = async {
-            durationProvider.measureDuration(
-                DurationProvider.Key.PaymentSheetLoadIsGooglePayReady
-            ) {
-                configuration.isGooglePayReady()
-            }
-        }
-
-        val isGooglePayReady = isGooglePayReady(
-            configuration = configuration,
-            elementsSession = elementsSession.await(),
-            initializationMode = initializationMode,
-            isGooglePaySupportedByConfiguration = isGooglePaySupportedByConfiguration,
-        )
-        val isGooglePaySupported = isGooglePaySupportedOnDevice.completeResultOrNull {
-            errorReporter.report(ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_SKIPPED_DURING_LOAD)
-        } ?: false
-        isGooglePaySupportedByConfiguration.cancel()
-
-        GooglePayState(
-            isGooglePayReady = isGooglePayReady,
-            isGooglePaySupported = isGooglePaySupported,
-        )
-    }
-
-    private suspend fun isGooglePayReady(
-        configuration: CommonConfiguration,
         elementsSession: ElementsSession,
         initializationMode: PaymentElementLoader.InitializationMode,
+        isGooglePaySupportedOnDevice: Deferred<Boolean>,
         isGooglePaySupportedByConfiguration: Deferred<Boolean>,
-    ): Boolean {
+    ): GooglePayState {
         val shouldDisableForAutomaticTaxBilling =
             (initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession)
             ?.checkoutSessionResponse
@@ -90,57 +44,46 @@ internal class DefaultGetGooglePayState @Inject constructor(
                     configuration.defaultBillingDetails == null
             } == true
 
-        if (!elementsSession.isGooglePayEnabled) {
-            userFacingLogger.logWarningWithoutPii(
-                "Google Pay is not enabled for this session."
-            )
-        } else if (configuration.googlePay == null) {
-            userFacingLogger.logWarningWithoutPii(
-                "GooglePayConfiguration is not set."
-            )
-        } else if (shouldDisableForAutomaticTaxBilling) {
-            userFacingLogger.logWarningWithoutPii(
-                "Google Pay is disabled because automatic tax is configured to use the billing address and no " +
-                    "default billing address was provided."
-            )
-            return false
-        } else if (!isGooglePaySupportedByConfiguration.await()) {
-            @Suppress("MaxLineLength")
-            userFacingLogger.logWarningWithoutPii(
-                """
-                    Google Pay API check failed.
-                    Possible reasons:
-                    - Google Play service is not available on this device.
-                    - Google account is not signed in on this device.
-                    See https://developers.google.com/android/reference/com/google/android/gms/wallet/PaymentsClient#public-taskboolean-isreadytopay-isreadytopayrequest-request for more details.
-                """.trimIndent()
-            )
+        val isGooglePayReady = when {
+            !elementsSession.isGooglePayEnabled -> {
+                userFacingLogger.logWarningWithoutPii("Google Pay is not enabled for this session.")
+                false
+            }
+            configuration.googlePay == null -> {
+                userFacingLogger.logWarningWithoutPii("GooglePayConfiguration is not set.")
+                false
+            }
+            shouldDisableForAutomaticTaxBilling -> {
+                userFacingLogger.logWarningWithoutPii(
+                    "Google Pay is disabled because automatic tax is configured to use the billing address and no " +
+                        "default billing address was provided."
+                )
+                false
+            }
+            !isGooglePaySupportedByConfiguration.await() -> {
+                @Suppress("MaxLineLength")
+                userFacingLogger.logWarningWithoutPii(
+                    """
+                        Google Pay API check failed.
+                        Possible reasons:
+                        - Google Play service is not available on this device.
+                        - Google account is not signed in on this device.
+                        See https://developers.google.com/android/reference/com/google/android/gms/wallet/PaymentsClient#public-taskboolean-isreadytopay-isreadytopayrequest-request for more details.
+                    """.trimIndent()
+                )
+                false
+            }
+            else -> true
         }
-        return elementsSession.isGooglePayEnabled && isGooglePaySupportedByConfiguration.await()
-    }
 
-    // Default filters are used here because this only determines the ready state,
-    // not what's presented to Google Pay. This check runs async before we fetch the
-    // elements session, so using merchant-defined filters would add latency.
-    private suspend fun isGooglePayReadyForEnvironment(environment: GooglePayEnvironment): Boolean {
-        return googlePayRepositoryFactory(
-            environment = environment,
-            cardFundingFilter = DefaultCardFundingFilter,
-            cardBrandFilter = DefaultCardBrandFilter
-        ).isReady().first()
-    }
-
-    private suspend fun CommonConfiguration.isGooglePayReady(): Boolean {
-        return googlePay?.environment?.let { environment ->
-            isGooglePayReadyForEnvironment(
-                when (environment) {
-                    PaymentSheet.GooglePayConfiguration.Environment.Production ->
-                        GooglePayEnvironment.Production
-                    PaymentSheet.GooglePayConfiguration.Environment.Test ->
-                        GooglePayEnvironment.Test
-                }
-            )
+        val isGooglePaySupported = isGooglePaySupportedOnDevice.completeResultOrNull {
+            errorReporter.report(ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_SKIPPED_DURING_LOAD)
         } ?: false
+
+        return GooglePayState(
+            isGooglePayReady = isGooglePayReady,
+            isGooglePaySupported = isGooglePaySupported,
+        )
     }
 }
 
@@ -150,6 +93,5 @@ private suspend fun <T> Deferred<T>.completeResultOrNull(
     await()
 } else {
     skippedCallback()
-    cancel()
     null
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/GetGooglePayState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/GetGooglePayState.kt
@@ -1,0 +1,155 @@
+package com.stripe.android.paymentsheet.state
+
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.DefaultCardFundingFilter
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.utils.DurationProvider
+import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.injection.GooglePayRepositoryFactory
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+internal fun interface GetGooglePayState {
+    suspend operator fun invoke(
+        configuration: CommonConfiguration,
+        initializationMode: PaymentElementLoader.InitializationMode,
+        elementsSession: Deferred<ElementsSession>,
+    ): GooglePayState
+}
+
+internal data class GooglePayState(
+    val isGooglePayReady: Boolean,
+    val isGooglePaySupported: Boolean,
+)
+
+internal class DefaultGetGooglePayState @Inject constructor(
+    private val googlePayRepositoryFactory: GooglePayRepositoryFactory,
+    private val userFacingLogger: UserFacingLogger,
+    private val errorReporter: ErrorReporter,
+    private val durationProvider: DurationProvider,
+) : GetGooglePayState {
+
+    override suspend fun invoke(
+        configuration: CommonConfiguration,
+        initializationMode: PaymentElementLoader.InitializationMode,
+        elementsSession: Deferred<ElementsSession>,
+    ): GooglePayState = coroutineScope {
+        val isGooglePaySupportedOnDevice = async(start = CoroutineStart.UNDISPATCHED) {
+            durationProvider.measureDuration(
+                DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported
+            ) {
+                isGooglePayReadyForEnvironment(GooglePayEnvironment.Production)
+            }
+        }
+        val isGooglePaySupportedByConfiguration = async {
+            durationProvider.measureDuration(
+                DurationProvider.Key.PaymentSheetLoadIsGooglePayReady
+            ) {
+                configuration.isGooglePayReady()
+            }
+        }
+
+        val isGooglePayReady = isGooglePayReady(
+            configuration = configuration,
+            elementsSession = elementsSession.await(),
+            initializationMode = initializationMode,
+            isGooglePaySupportedByConfiguration = isGooglePaySupportedByConfiguration,
+        )
+        val isGooglePaySupported = isGooglePaySupportedOnDevice.completeResultOrNull {
+            errorReporter.report(ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_SKIPPED_DURING_LOAD)
+        } ?: false
+        isGooglePaySupportedByConfiguration.cancel()
+
+        GooglePayState(
+            isGooglePayReady = isGooglePayReady,
+            isGooglePaySupported = isGooglePaySupported,
+        )
+    }
+
+    private suspend fun isGooglePayReady(
+        configuration: CommonConfiguration,
+        elementsSession: ElementsSession,
+        initializationMode: PaymentElementLoader.InitializationMode,
+        isGooglePaySupportedByConfiguration: Deferred<Boolean>,
+    ): Boolean {
+        val shouldDisableForAutomaticTaxBilling =
+            (initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession)
+            ?.checkoutSessionResponse
+            ?.let { checkoutSessionResponse ->
+                checkoutSessionResponse.automaticTaxEnabled &&
+                    checkoutSessionResponse.taxAddressSource == CheckoutSessionResponse.TaxAddressSource.BILLING &&
+                    configuration.defaultBillingDetails == null
+            } == true
+
+        if (!elementsSession.isGooglePayEnabled) {
+            userFacingLogger.logWarningWithoutPii(
+                "Google Pay is not enabled for this session."
+            )
+        } else if (configuration.googlePay == null) {
+            userFacingLogger.logWarningWithoutPii(
+                "GooglePayConfiguration is not set."
+            )
+        } else if (shouldDisableForAutomaticTaxBilling) {
+            userFacingLogger.logWarningWithoutPii(
+                "Google Pay is disabled because automatic tax is configured to use the billing address and no " +
+                    "default billing address was provided."
+            )
+            return false
+        } else if (!isGooglePaySupportedByConfiguration.await()) {
+            @Suppress("MaxLineLength")
+            userFacingLogger.logWarningWithoutPii(
+                """
+                    Google Pay API check failed.
+                    Possible reasons:
+                    - Google Play service is not available on this device.
+                    - Google account is not signed in on this device.
+                    See https://developers.google.com/android/reference/com/google/android/gms/wallet/PaymentsClient#public-taskboolean-isreadytopay-isreadytopayrequest-request for more details.
+                """.trimIndent()
+            )
+        }
+        return elementsSession.isGooglePayEnabled && isGooglePaySupportedByConfiguration.await()
+    }
+
+    // Default filters are used here because this only determines the ready state,
+    // not what's presented to Google Pay. This check runs async before we fetch the
+    // elements session, so using merchant-defined filters would add latency.
+    private suspend fun isGooglePayReadyForEnvironment(environment: GooglePayEnvironment): Boolean {
+        return googlePayRepositoryFactory(
+            environment = environment,
+            cardFundingFilter = DefaultCardFundingFilter,
+            cardBrandFilter = DefaultCardBrandFilter
+        ).isReady().first()
+    }
+
+    private suspend fun CommonConfiguration.isGooglePayReady(): Boolean {
+        return googlePay?.environment?.let { environment ->
+            isGooglePayReadyForEnvironment(
+                when (environment) {
+                    PaymentSheet.GooglePayConfiguration.Environment.Production ->
+                        GooglePayEnvironment.Production
+                    PaymentSheet.GooglePayConfiguration.Environment.Test ->
+                        GooglePayEnvironment.Test
+                }
+            )
+        } ?: false
+    }
+}
+
+private suspend fun <T> Deferred<T>.completeResultOrNull(
+    skippedCallback: () -> Unit,
+): T? = if (isCompleted) {
+    await()
+} else {
+    skippedCallback()
+    cancel()
+    null
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -1,9 +1,6 @@
 package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
-import androidx.annotation.VisibleForTesting
-import com.stripe.android.DefaultCardBrandFilter
-import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
@@ -18,8 +15,6 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.FeatureFlag
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
-import com.stripe.android.googlepaylauncher.GooglePayEnvironment
-import com.stripe.android.googlepaylauncher.injection.GooglePayRepositoryFactory
 import com.stripe.android.link.LinkController
 import com.stripe.android.lpmfoundations.paymentmethod.AnalyticsMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
@@ -56,7 +51,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -264,12 +258,12 @@ internal interface PaymentElementLoader {
 @SuppressWarnings("LargeClass")
 internal class DefaultPaymentElementLoader @Inject constructor(
     private val prefsRepositoryFactory: PrefsRepository.Factory,
-    private val googlePayRepositoryFactory: GooglePayRepositoryFactory,
     private val logger: Logger,
     private val eventReporter: LoadingEventReporter,
     private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
     private val createLinkState: CreateLinkState,
+    private val getGooglePayState: GetGooglePayState,
     private val logLinkHoldbackExperiment: LogLinkHoldbackExperiment,
     private val logFcLiteExperiment: LogFcLiteExperiment,
     private val externalPaymentMethodsRepository: ExternalPaymentMethodsRepository,
@@ -322,30 +316,25 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         eventReporter.onLoadStarted(metadata.initializedViaCompose)
         tapToAddConnectionStarter.start(configuration)
 
-        // Give immediately available results a chance to complete before later load work checks isCompleted.
-        val isGooglePaySupportedOnDevice = async(start = CoroutineStart.UNDISPATCHED) {
-            durationProvider.measureDuration(
-                DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported
-            ) {
-                isGooglePaySupportedOnDevice()
-            }
-        }
-        val isGooglePaySupportedByConfiguration = async {
-            durationProvider.measureDuration(
-                DurationProvider.Key.PaymentSheetLoadIsGooglePayReady
-            ) {
-                configuration.isGooglePayReady()
-            }
-        }
-
         val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration)
 
         val savedPaymentMethodSelection = retrieveSavedPaymentMethodSelection(configuration)
-        val elementsSession = loadSession(
-            initializationMode = initializationMode,
-            configuration = configuration,
-            savedPaymentMethodSelection = savedPaymentMethodSelection,
-        )
+        val elementsSessionResult = async {
+            loadSession(
+                initializationMode = initializationMode,
+                configuration = configuration,
+                savedPaymentMethodSelection = savedPaymentMethodSelection,
+            )
+        }
+        // Start Google Pay checks immediately so they continue in parallel with the session load.
+        val googlePayState = async(start = CoroutineStart.UNDISPATCHED) {
+            getGooglePayState(
+                configuration = configuration,
+                initializationMode = initializationMode,
+                elementsSession = elementsSessionResult,
+            )
+        }
+        val elementsSession = elementsSessionResult.await()
 
         // Preemptively prepare Integrity asynchronously if needed, as warm up can take
         // a few seconds.
@@ -355,17 +344,10 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
         fetchPaymentMethodMessaging(elementsSession)
 
-        val isGooglePayReady = isGooglePayReady(
-            configuration = configuration,
-            elementsSession = elementsSession,
-            initializationMode = initializationMode,
-            isGooglePaySupportedByConfiguration = isGooglePaySupportedByConfiguration,
-        )
-
         val savedSelection = async {
             retrieveSavedSelection(
                 configuration = configuration,
-                isGooglePayReady = isGooglePayReady,
+                isGooglePayReady = googlePayState.await().isGooglePayReady,
                 elementsSession = elementsSession
             )
         }
@@ -396,9 +378,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
         val paymentMethodMetadata = async {
             val linkStateResult = linkState.await()
-            val isGooglePaySupported = isGooglePaySupportedOnDevice.completeResultOrNull {
-                errorReporter.report(ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_SKIPPED_DURING_LOAD)
-            } ?: false
+            val googlePayState = googlePayState.await()
 
             durationProvider.measureDuration(DurationProvider.Key.PaymentSheetLoadComputePaymentMethodTypes) {
                 createPaymentMethodMetadata(
@@ -406,8 +386,8 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     elementsSession = elementsSession,
                     configuration = configuration,
                     linkStateResult = linkStateResult,
-                    isGooglePayReady = isGooglePayReady,
-                    isGooglePaySupported = isGooglePaySupported,
+                    isGooglePayReady = googlePayState.isGooglePayReady,
+                    isGooglePaySupported = googlePayState.isGooglePaySupported,
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
@@ -440,7 +420,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     savedSelection = savedSelection,
                     metadata = paymentMethodMetadata,
                     customer = customer,
-                    isGooglePayReady = isGooglePayReady,
+                    isGooglePayReady = googlePayState.await().isGooglePayReady,
                     isUsingWalletButtons = configuration.walletButtons?.willDisplayExternally ?: false
                 )
             }
@@ -638,79 +618,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     integrationConfiguration.configuration.paymentMethodLayout
                 }
         }
-    }
-
-    @VisibleForTesting
-    internal suspend fun isGooglePayReady(
-        configuration: CommonConfiguration,
-        elementsSession: ElementsSession,
-        initializationMode: PaymentElementLoader.InitializationMode,
-        isGooglePaySupportedByConfiguration: Deferred<Boolean>,
-    ): Boolean {
-        val shouldDisableForAutomaticTaxBilling =
-            (initializationMode as? PaymentElementLoader.InitializationMode.CheckoutSession)
-            ?.checkoutSessionResponse
-            ?.let { checkoutSessionResponse ->
-                checkoutSessionResponse.automaticTaxEnabled &&
-                    checkoutSessionResponse.taxAddressSource == CheckoutSessionResponse.TaxAddressSource.BILLING &&
-                    configuration.defaultBillingDetails == null
-            } == true
-
-        if (!elementsSession.isGooglePayEnabled) {
-            userFacingLogger.logWarningWithoutPii(
-                "Google Pay is not enabled for this session."
-            )
-        } else if (configuration.googlePay == null) {
-            userFacingLogger.logWarningWithoutPii(
-                "GooglePayConfiguration is not set."
-            )
-        } else if (shouldDisableForAutomaticTaxBilling) {
-            userFacingLogger.logWarningWithoutPii(
-                "Google Pay is disabled because automatic tax is configured to use the billing address and no " +
-                    "default billing address was provided."
-            )
-            return false
-        } else if (!isGooglePaySupportedByConfiguration.await()) {
-            @Suppress("MaxLineLength")
-            userFacingLogger.logWarningWithoutPii(
-                """
-                    Google Pay API check failed.
-                    Possible reasons:
-                    - Google Play service is not available on this device.
-                    - Google account is not signed in on this device.
-                    See https://developers.google.com/android/reference/com/google/android/gms/wallet/PaymentsClient#public-taskboolean-isreadytopay-isreadytopayrequest-request for more details.
-                """.trimIndent()
-            )
-        }
-        return elementsSession.isGooglePayEnabled && isGooglePaySupportedByConfiguration.await()
-    }
-
-    // Default filters are used here because this only determines the ready state,
-    // not what's presented to Google Pay. This check runs async before we fetch the
-    // elements session, so using merchant-defined filters would add latency.
-    private suspend fun isGooglePayReadyForEnvironment(environment: GooglePayEnvironment): Boolean {
-        return googlePayRepositoryFactory(
-            environment = environment,
-            cardFundingFilter = DefaultCardFundingFilter,
-            cardBrandFilter = DefaultCardBrandFilter
-        ).isReady().first()
-    }
-
-    private suspend fun CommonConfiguration.isGooglePayReady(): Boolean {
-        return googlePay?.environment?.let { environment ->
-            isGooglePayReadyForEnvironment(
-                when (environment) {
-                    PaymentSheet.GooglePayConfiguration.Environment.Production ->
-                        GooglePayEnvironment.Production
-                    PaymentSheet.GooglePayConfiguration.Environment.Test ->
-                        GooglePayEnvironment.Test
-                }
-            )
-        } ?: false
-    }
-
-    private suspend fun isGooglePaySupportedOnDevice(): Boolean {
-        return isGooglePayReadyForEnvironment(GooglePayEnvironment.Production)
     }
 
     @Suppress("CyclomaticComplexMethod")
@@ -921,13 +828,4 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
 private fun PaymentMethod.toPaymentSelection(): PaymentSelection.Saved {
     return PaymentSelection.Saved(this)
-}
-
-private suspend fun <T> Deferred<T>.completeResultOrNull(
-    skippedCallback: () -> Unit,
-): T? = if (isCompleted) {
-    await()
-} else {
-    skippedCallback()
-    null
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.paymentsheet.state
 
 import android.os.Parcelable
+import com.stripe.android.DefaultCardBrandFilter
+import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
@@ -15,6 +17,8 @@ import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.FeatureFlag
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.core.utils.UserFacingLogger
+import com.stripe.android.googlepaylauncher.GooglePayEnvironment
+import com.stripe.android.googlepaylauncher.injection.GooglePayRepositoryFactory
 import com.stripe.android.link.LinkController
 import com.stripe.android.lpmfoundations.paymentmethod.AnalyticsMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
@@ -51,6 +55,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
@@ -258,6 +263,7 @@ internal interface PaymentElementLoader {
 @SuppressWarnings("LargeClass")
 internal class DefaultPaymentElementLoader @Inject constructor(
     private val prefsRepositoryFactory: PrefsRepository.Factory,
+    private val googlePayRepositoryFactory: GooglePayRepositoryFactory,
     private val logger: Logger,
     private val eventReporter: LoadingEventReporter,
     private val errorReporter: ErrorReporter,
@@ -316,25 +322,29 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         eventReporter.onLoadStarted(metadata.initializedViaCompose)
         tapToAddConnectionStarter.start(configuration)
 
+        val isGooglePaySupportedOnDevice = async(start = CoroutineStart.UNDISPATCHED) {
+            durationProvider.measureDuration(
+                DurationProvider.Key.PaymentSheetLoadIsGooglePaySupported
+            ) {
+                isGooglePaySupportedOnDevice()
+            }
+        }
+        val isGooglePaySupportedByConfiguration = async {
+            durationProvider.measureDuration(
+                DurationProvider.Key.PaymentSheetLoadIsGooglePayReady
+            ) {
+                configuration.isGooglePayReady()
+            }
+        }
+
         val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration)
 
         val savedPaymentMethodSelection = retrieveSavedPaymentMethodSelection(configuration)
-        val elementsSessionResult = async {
-            loadSession(
-                initializationMode = initializationMode,
-                configuration = configuration,
-                savedPaymentMethodSelection = savedPaymentMethodSelection,
-            )
-        }
-        // Start Google Pay checks immediately so they continue in parallel with the session load.
-        val googlePayState = async(start = CoroutineStart.UNDISPATCHED) {
-            getGooglePayState(
-                configuration = configuration,
-                initializationMode = initializationMode,
-                elementsSession = elementsSessionResult,
-            )
-        }
-        val elementsSession = elementsSessionResult.await()
+        val elementsSession = loadSession(
+            initializationMode = initializationMode,
+            configuration = configuration,
+            savedPaymentMethodSelection = savedPaymentMethodSelection,
+        )
 
         // Preemptively prepare Integrity asynchronously if needed, as warm up can take
         // a few seconds.
@@ -343,14 +353,6 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         }
 
         fetchPaymentMethodMessaging(elementsSession)
-
-        val savedSelection = async {
-            retrieveSavedSelection(
-                configuration = configuration,
-                isGooglePayReady = googlePayState.await().isGooglePayReady,
-                elementsSession = elementsSession
-            )
-        }
 
         val clientAttributionMetadata = ClientAttributionMetadata.create(
             elementsSessionConfigId = elementsSession.elementsSessionConfigId,
@@ -374,6 +376,25 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     clientAttributionMetadata = clientAttributionMetadata,
                 )
             }
+        }
+
+        val googlePayState = async {
+            linkState.await()
+            getGooglePayState(
+                configuration = configuration,
+                elementsSession = elementsSession,
+                initializationMode = initializationMode,
+                isGooglePaySupportedOnDevice = isGooglePaySupportedOnDevice,
+                isGooglePaySupportedByConfiguration = isGooglePaySupportedByConfiguration,
+            )
+        }
+
+        val savedSelection = async {
+            retrieveSavedSelection(
+                configuration = configuration,
+                isGooglePayReady = googlePayState.await().isGooglePayReady,
+                elementsSession = elementsSession
+            )
         }
 
         val paymentMethodMetadata = async {
@@ -618,6 +639,34 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     integrationConfiguration.configuration.paymentMethodLayout
                 }
         }
+    }
+
+    // Default filters are used here because this only determines the ready state,
+    // not what's presented to Google Pay. This check runs async before we fetch the
+    // elements session, so using merchant-defined filters would add latency.
+    private suspend fun isGooglePayReadyForEnvironment(environment: GooglePayEnvironment): Boolean {
+        return googlePayRepositoryFactory(
+            environment = environment,
+            cardFundingFilter = DefaultCardFundingFilter,
+            cardBrandFilter = DefaultCardBrandFilter
+        ).isReady().first()
+    }
+
+    private suspend fun CommonConfiguration.isGooglePayReady(): Boolean {
+        return googlePay?.environment?.let { environment ->
+            isGooglePayReadyForEnvironment(
+                when (environment) {
+                    PaymentSheet.GooglePayConfiguration.Environment.Production ->
+                        GooglePayEnvironment.Production
+                    PaymentSheet.GooglePayConfiguration.Environment.Test ->
+                        GooglePayEnvironment.Test
+                }
+            )
+        } ?: false
+    }
+
+    private suspend fun isGooglePaySupportedOnDevice(): Boolean {
+        return isGooglePayReadyForEnvironment(GooglePayEnvironment.Production)
     }
 
     @Suppress("CyclomaticComplexMethod")

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultGetGooglePayStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultGetGooglePayStateTest.kt
@@ -1,0 +1,226 @@
+package com.stripe.android.paymentsheet.state
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.PaymentIntentFixtures
+import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.paymentsheet.utils.FakeUserFacingLogger
+import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+
+internal class DefaultGetGooglePayStateTest {
+
+    @Test
+    fun `returns ready and supported when all checks pass`() = runScenario {
+        val result = getGooglePayState(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.asCommonConfiguration(),
+            elementsSession = ELEMENTS_SESSION,
+            initializationMode = INITIALIZATION_MODE,
+            isGooglePaySupportedOnDevice = CompletableDeferred(true),
+            isGooglePaySupportedByConfiguration = CompletableDeferred(true),
+        )
+
+        assertThat(result).isEqualTo(
+            GooglePayState(
+                isGooglePayReady = true,
+                isGooglePaySupported = true,
+            )
+        )
+    }
+
+    @Test
+    fun `returns device support independently from readiness`() = runScenario {
+        val result = getGooglePayState(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.asCommonConfiguration(),
+            elementsSession = ELEMENTS_SESSION,
+            initializationMode = INITIALIZATION_MODE,
+            isGooglePaySupportedOnDevice = CompletableDeferred(false),
+            isGooglePaySupportedByConfiguration = CompletableDeferred(true),
+        )
+
+        assertThat(result.isGooglePayReady).isTrue()
+        assertThat(result.isGooglePaySupported).isFalse()
+    }
+
+    @Test
+    fun `returns not ready when Google Pay is disabled for the session`() = runScenario {
+        val result = getGooglePayState(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.asCommonConfiguration(),
+            elementsSession = ELEMENTS_SESSION.copy(isGooglePayEnabled = false),
+            initializationMode = INITIALIZATION_MODE,
+            isGooglePaySupportedOnDevice = CompletableDeferred(true),
+            isGooglePaySupportedByConfiguration = CompletableDeferred(true),
+        )
+
+        assertThat(result.isGooglePayReady).isFalse()
+        assertThat(userFacingLogger.getLoggedMessages())
+            .contains("Google Pay is not enabled for this session.")
+    }
+
+    @Test
+    fun `returns not ready when Google Pay is not configured`() = runScenario {
+        val result = getGooglePayState(
+            configuration = PaymentSheetFixtures.CONFIG_MINIMUM.asCommonConfiguration(),
+            elementsSession = ELEMENTS_SESSION,
+            initializationMode = INITIALIZATION_MODE,
+            isGooglePaySupportedOnDevice = CompletableDeferred(true),
+            isGooglePaySupportedByConfiguration = CompletableDeferred(false),
+        )
+
+        assertThat(result.isGooglePayReady).isFalse()
+        assertThat(userFacingLogger.getLoggedMessages())
+            .contains("GooglePayConfiguration is not set.")
+    }
+
+    @Test
+    fun `returns not ready when the configured Google Pay check fails`() = runScenario {
+        val result = getGooglePayState(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.asCommonConfiguration(),
+            elementsSession = ELEMENTS_SESSION,
+            initializationMode = INITIALIZATION_MODE,
+            isGooglePaySupportedOnDevice = CompletableDeferred(true),
+            isGooglePaySupportedByConfiguration = CompletableDeferred(false),
+        )
+
+        assertThat(result.isGooglePayReady).isFalse()
+        assertThat(
+            userFacingLogger.getLoggedMessages().any { it.startsWith("Google Pay API check failed.") }
+        ).isTrue()
+    }
+
+    @Test
+    fun `returns not ready for automatic tax billing without default billing details`() = runScenario {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
+
+        val result = getGooglePayState(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
+                .defaultBillingDetails(null)
+                .build()
+                .asCommonConfiguration(),
+            elementsSession = ELEMENTS_SESSION,
+            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+                instancesKey = "DefaultGetGooglePayStateTest",
+                checkoutSessionResponse = checkoutSessionResponse,
+            ),
+            isGooglePaySupportedOnDevice = CompletableDeferred(true),
+            isGooglePaySupportedByConfiguration = CompletableDeferred(true),
+        )
+
+        assertThat(result.isGooglePayReady).isFalse()
+        assertThat(userFacingLogger.getLoggedMessages()).contains(
+            "Google Pay is disabled because automatic tax is configured to use the billing address and no " +
+                "default billing address was provided."
+        )
+    }
+
+    @Test
+    fun `keeps Google Pay ready for automatic tax billing with default billing details`() = runScenario {
+        val checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+            automaticTaxEnabled = true,
+            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
+        )
+
+        val result = getGooglePayState(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
+                .defaultBillingDetails(PaymentSheet.BillingDetails(email = "customer@email.com"))
+                .build()
+                .asCommonConfiguration(),
+            elementsSession = ELEMENTS_SESSION,
+            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
+                instancesKey = "DefaultGetGooglePayStateTest",
+                checkoutSessionResponse = checkoutSessionResponse,
+            ),
+            isGooglePaySupportedOnDevice = CompletableDeferred(true),
+            isGooglePaySupportedByConfiguration = CompletableDeferred(true),
+        )
+
+        assertThat(result.isGooglePayReady).isTrue()
+    }
+
+    @Test
+    fun `reports when device support check has not completed`() = runScenario(expectError = true) {
+        val result = getGooglePayState(
+            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.asCommonConfiguration(),
+            elementsSession = ELEMENTS_SESSION,
+            initializationMode = INITIALIZATION_MODE,
+            isGooglePaySupportedOnDevice = CompletableDeferred(),
+            isGooglePaySupportedByConfiguration = CompletableDeferred(true),
+        )
+
+        assertThat(result.isGooglePaySupported).isFalse()
+        assertThat(errorReporter.awaitCall().errorEvent)
+            .isEqualTo(ErrorReporter.ExpectedErrorEvent.GOOGLE_PAY_SKIPPED_DURING_LOAD)
+    }
+
+    private fun runScenario(
+        block: suspend Scenario.() -> Unit,
+    ) = runScenario(
+        expectError = false,
+        block = block,
+    )
+
+    private fun runScenario(
+        expectError: Boolean,
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
+        val userFacingLogger = FakeUserFacingLogger()
+        val errorReporter = FakeErrorReporter()
+        val getGooglePayState = DefaultGetGooglePayState(
+            userFacingLogger = userFacingLogger,
+            errorReporter = errorReporter,
+        )
+
+        Scenario(
+            getGooglePayState = getGooglePayState,
+            userFacingLogger = userFacingLogger,
+            errorReporter = errorReporter,
+        ).block()
+
+        if (!expectError) {
+            assertThat(errorReporter.getLoggedErrors()).isEmpty()
+        }
+        errorReporter.ensureAllEventsConsumed()
+    }
+
+    private data class Scenario(
+        val getGooglePayState: DefaultGetGooglePayState,
+        val userFacingLogger: FakeUserFacingLogger,
+        val errorReporter: FakeErrorReporter,
+    )
+
+    private companion object {
+        val INITIALIZATION_MODE = PaymentElementLoader.InitializationMode.PaymentIntent(
+            clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+        )
+        val ELEMENTS_SESSION = ElementsSession(
+            linkSettings = null,
+            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
+            merchantCountry = null,
+            isGooglePayEnabled = true,
+            sessionsError = null,
+            externalPaymentMethodData = null,
+            customer = null,
+            cardBrandChoice = null,
+            customPaymentMethods = emptyList(),
+            elementsSessionId = "es_123",
+            flags = emptyMap(),
+            orderedPaymentMethodTypesAndWallets = listOf("card"),
+            experimentsData = null,
+            passiveCaptcha = null,
+            merchantLogoUrl = null,
+            elementsSessionConfigId = "config_123",
+            accountId = "acct_123",
+            merchantId = "acct_123",
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -100,7 +100,6 @@ import com.stripe.android.utils.FakeLinkStore
 import com.stripe.android.utils.FakePaymentMethodFilter
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import com.stripe.attestation.IntegrityRequestManager
-import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -356,124 +355,38 @@ internal class DefaultPaymentElementLoaderTest {
     }
 
     @Test
-    fun `load with checkout session automatic tax billing and default billing details keeps google pay`() = runScenario {
-        val userFacingLogger = FakeUserFacingLogger()
-        val loader = createPaymentElementLoader(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-            isGooglePayReady = true,
-            userFacingLogger = userFacingLogger,
-        )
-        val checkoutSessionResponse = createCheckoutSessionResponse(
-            canDetachPaymentMethod = true,
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-            automaticTaxEnabled = true,
-            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-        )
-
-        assertThat(
-            loader.load(
-                initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
-                    instancesKey = "DefaultPaymentElementLoaderTest",
-                    checkoutSessionResponse = checkoutSessionResponse,
-                ),
-                PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
-                    .defaultBillingDetails(PaymentSheet.BillingDetails(email = "customer@email.com"))
-                    .build(),
-                metadata = PaymentElementLoader.Metadata(
-                    initializedViaCompose = false,
-                ),
-            ).getOrThrow().paymentMethodMetadata.isGooglePayReady
-        ).isTrue()
-
-        assertThat(userFacingLogger.getLoggedMessages())
-            .doesNotContain(
-                "Google Pay is disabled because automatic tax is configured to use the billing address and" +
-                    " no default billing address was provided."
+    fun `load calls getGooglePayState with expected arguments`() = runScenario {
+        val getGooglePayState = FakeGetGooglePayState(
+            result = GooglePayState(
+                isGooglePayReady = true,
+                isGooglePaySupported = true,
             )
+        )
+        val configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY
+        val initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+            clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+        )
+        val loader = createPaymentElementLoader(
+            getGooglePayStateOverride = getGooglePayState,
+        )
+
+        val state = loader.load(
+            initializationMode = initializationMode,
+            paymentSheetConfiguration = configuration,
+            metadata = PaymentElementLoader.Metadata(initializedViaCompose = false),
+        ).getOrThrow()
+
+        val call = getGooglePayState.calls.awaitItem()
+        assertThat(call.configuration).isEqualTo(configuration.asCommonConfiguration())
+        assertThat(call.elementsSession.stripeIntent).isEqualTo(state.stripeIntent)
+        assertThat(call.initializationMode).isEqualTo(initializationMode)
+        assertThat(call.isGooglePaySupportedOnDevice.await()).isTrue()
+        assertThat(call.isGooglePaySupportedByConfiguration.await()).isTrue()
+        getGooglePayState.ensureAllEventsConsumed()
 
         consumeLoadingEvents()
-
-        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
-        assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
-    }
-
-    @Test
-    fun `google pay is disabled for automatic tax billing without default billing details`() = runScenario {
-        val userFacingLogger = FakeUserFacingLogger()
-        val getGooglePayState = createGetGooglePayState(
-            isGooglePayReady = true,
-            userFacingLogger = userFacingLogger,
-            errorReporter = FakeErrorReporter(),
-            durationProvider = FakeDurationProvider(),
-        )
-        val checkoutSessionResponse = createCheckoutSessionResponse(
-            canDetachPaymentMethod = true,
-            automaticTaxEnabled = true,
-            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-        )
-
-        val isGooglePayReady = getGooglePayState(
-            configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
-                .defaultBillingDetails(null)
-                .build()
-                .asCommonConfiguration(),
-            initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
-                instancesKey = "DefaultPaymentElementLoaderTest",
-                checkoutSessionResponse = checkoutSessionResponse,
-            ),
-            elementsSession = CompletableDeferred(requireNotNull(checkoutSessionResponse.elementsSession)),
-        ).isGooglePayReady
-
-        assertThat(isGooglePayReady).isFalse()
-        assertThat(userFacingLogger.getLoggedMessages())
-            .contains(
-                "Google Pay is disabled because automatic tax is configured to use the billing address and no " +
-                    "default billing address was provided."
-            )
-    }
-
-    @Test
-    fun `load with checkout session automatic tax billing and no google pay config logs missing config`() = runScenario {
-        val userFacingLogger = FakeUserFacingLogger()
-        val loader = createPaymentElementLoader(
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-            isGooglePayReady = true,
-            userFacingLogger = userFacingLogger,
-        )
-        val checkoutSessionResponse = createCheckoutSessionResponse(
-            canDetachPaymentMethod = true,
-            stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD_WITHOUT_LINK,
-            automaticTaxEnabled = true,
-            taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
-        )
-
-        assertThat(
-            loader.load(
-                initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
-                    instancesKey = "DefaultPaymentElementLoaderTest",
-                    checkoutSessionResponse = checkoutSessionResponse,
-                ),
-                PaymentSheetFixtures.CONFIG_MINIMUM.newBuilder()
-                    .defaultBillingDetails(PaymentSheet.BillingDetails(email = "customer@email.com"))
-                    .build(),
-                metadata = PaymentElementLoader.Metadata(
-                    initializedViaCompose = false,
-                ),
-            ).getOrThrow().paymentMethodMetadata.isGooglePayReady
-        ).isFalse()
-
-        assertThat(userFacingLogger.getLoggedMessages())
-            .contains("GooglePayConfiguration is not set.")
-        assertThat(userFacingLogger.getLoggedMessages())
-            .doesNotContain(
-                "Google Pay is disabled because automatic tax is configured to use the billing address and " +
-                    "no default billing address was provided."
-            )
-
-        consumeLoadingEvents()
-
-        assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
-        assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
+        eventReporter.loadStartedTurbine.awaitItem()
+        eventReporter.loadSucceededTurbine.awaitItem()
     }
 
     @Test
@@ -836,9 +749,7 @@ internal class DefaultPaymentElementLoaderTest {
         runScenario {
             prefsRepository.setSavedSelection(null)
 
-            val userFacingLogger = FakeUserFacingLogger()
             val loader = createPaymentElementLoader(
-                userFacingLogger = userFacingLogger,
                 stripeIntent = PaymentIntentFixtures.PI_REQUIRES_PAYMENT_METHOD,
                 isGooglePayReady = true,
                 customerRepo = FakeCustomerRepository(paymentMethods = emptyList()),
@@ -855,8 +766,6 @@ internal class DefaultPaymentElementLoaderTest {
             ).getOrThrow()
 
             assertThat(result.paymentSelection).isNull()
-            assertThat(userFacingLogger.getLoggedMessages())
-                .containsExactlyElementsIn(listOf("GooglePayConfiguration is not set."))
 
             assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
             assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()
@@ -5010,6 +4919,7 @@ internal class DefaultPaymentElementLoaderTest {
         durationProvider: FakeDurationProvider = FakeDurationProvider(),
         paymentMethodMessageExperimentHandler: PaymentMethodMessagePromotionsExperimentHandler =
             FakePaymentMethodMessagePromotionsExperimentHandler(),
+        getGooglePayStateOverride: GetGooglePayState? = null,
     ): DefaultPaymentElementLoader {
         val retrieveCustomerEmailImpl = DefaultRetrieveCustomerEmail(
             customerRepo,
@@ -5025,17 +4935,34 @@ internal class DefaultPaymentElementLoaderTest {
 
         return DefaultPaymentElementLoader(
             prefsRepositoryFactory = { prefsRepository },
+            googlePayRepositoryFactory = object : GooglePayRepositoryFactory {
+                override fun invoke(
+                    environment: GooglePayEnvironment,
+                    cardFundingFilter: CardFundingFilter,
+                    cardBrandFilter: CardBrandFilter
+                ): GooglePayRepository {
+                    return GooglePayRepository { flowOf(isGooglePayReady) }
+                }
+            },
             logger = Logger.noop(),
             eventReporter = eventReporter,
             errorReporter = errorReporter,
             workContext = testDispatcher,
             createLinkState = createLinkState,
-            getGooglePayState = createGetGooglePayState(
-                isGooglePayReady = isGooglePayReady,
-                userFacingLogger = userFacingLogger,
-                errorReporter = errorReporter,
-                durationProvider = durationProvider,
-            ),
+            getGooglePayState = getGooglePayStateOverride ?: GetGooglePayState {
+                    configuration,
+                    elementsSession,
+                    _,
+                    isGooglePaySupportedOnDevice,
+                    isGooglePaySupportedByConfiguration,
+                ->
+                GooglePayState(
+                    isGooglePayReady = elementsSession.isGooglePayEnabled &&
+                        configuration.googlePay != null &&
+                        isGooglePaySupportedByConfiguration.await(),
+                    isGooglePaySupported = isGooglePaySupportedOnDevice.await(),
+                )
+            },
             logLinkHoldbackExperiment = logLinkHoldbackExperiment,
             logFcLiteExperiment = logFcLiteExperiment,
             externalPaymentMethodsRepository = ExternalPaymentMethodsRepository(errorReporter = FakeErrorReporter()),
@@ -5059,28 +4986,6 @@ internal class DefaultPaymentElementLoaderTest {
             tapToAddAvailabilityFactory = tapToAddAvailabilityFactory,
             durationProvider = durationProvider,
             paymentMethodMessagePromotionsExperimentHandler = paymentMethodMessageExperimentHandler,
-        )
-    }
-
-    private fun createGetGooglePayState(
-        isGooglePayReady: Boolean,
-        userFacingLogger: FakeUserFacingLogger,
-        errorReporter: ErrorReporter,
-        durationProvider: DurationProvider,
-    ): DefaultGetGooglePayState {
-        return DefaultGetGooglePayState(
-            googlePayRepositoryFactory = object : GooglePayRepositoryFactory {
-                override fun invoke(
-                    environment: GooglePayEnvironment,
-                    cardFundingFilter: CardFundingFilter,
-                    cardBrandFilter: CardBrandFilter
-                ): GooglePayRepository {
-                    return GooglePayRepository { flowOf(isGooglePayReady) }
-                }
-            },
-            userFacingLogger = userFacingLogger,
-            errorReporter = errorReporter,
-            durationProvider = durationProvider,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -400,25 +400,29 @@ internal class DefaultPaymentElementLoaderTest {
     @Test
     fun `google pay is disabled for automatic tax billing without default billing details`() = runScenario {
         val userFacingLogger = FakeUserFacingLogger()
-        val loader = createPaymentElementLoader(userFacingLogger = userFacingLogger)
+        val getGooglePayState = createGetGooglePayState(
+            isGooglePayReady = true,
+            userFacingLogger = userFacingLogger,
+            errorReporter = FakeErrorReporter(),
+            durationProvider = FakeDurationProvider(),
+        )
         val checkoutSessionResponse = createCheckoutSessionResponse(
             canDetachPaymentMethod = true,
             automaticTaxEnabled = true,
             taxAddressSource = CheckoutSessionResponse.TaxAddressSource.BILLING,
         )
 
-        val isGooglePayReady = loader.isGooglePayReady(
+        val isGooglePayReady = getGooglePayState(
             configuration = PaymentSheetFixtures.CONFIG_GOOGLEPAY.newBuilder()
                 .defaultBillingDetails(null)
                 .build()
                 .asCommonConfiguration(),
-            elementsSession = requireNotNull(checkoutSessionResponse.elementsSession),
             initializationMode = PaymentElementLoader.InitializationMode.CheckoutSession(
                 instancesKey = "DefaultPaymentElementLoaderTest",
                 checkoutSessionResponse = checkoutSessionResponse,
             ),
-            isGooglePaySupportedByConfiguration = CompletableDeferred(true),
-        )
+            elementsSession = CompletableDeferred(requireNotNull(checkoutSessionResponse.elementsSession)),
+        ).isGooglePayReady
 
         assertThat(isGooglePayReady).isFalse()
         assertThat(userFacingLogger.getLoggedMessages())
@@ -5021,20 +5025,17 @@ internal class DefaultPaymentElementLoaderTest {
 
         return DefaultPaymentElementLoader(
             prefsRepositoryFactory = { prefsRepository },
-            googlePayRepositoryFactory = object : GooglePayRepositoryFactory {
-                override fun invoke(
-                    environment: GooglePayEnvironment,
-                    cardFundingFilter: CardFundingFilter,
-                    cardBrandFilter: CardBrandFilter
-                ): GooglePayRepository {
-                    return GooglePayRepository { flowOf(isGooglePayReady) }
-                }
-            },
             logger = Logger.noop(),
             eventReporter = eventReporter,
             errorReporter = errorReporter,
             workContext = testDispatcher,
             createLinkState = createLinkState,
+            getGooglePayState = createGetGooglePayState(
+                isGooglePayReady = isGooglePayReady,
+                userFacingLogger = userFacingLogger,
+                errorReporter = errorReporter,
+                durationProvider = durationProvider,
+            ),
             logLinkHoldbackExperiment = logLinkHoldbackExperiment,
             logFcLiteExperiment = logFcLiteExperiment,
             externalPaymentMethodsRepository = ExternalPaymentMethodsRepository(errorReporter = FakeErrorReporter()),
@@ -5058,6 +5059,28 @@ internal class DefaultPaymentElementLoaderTest {
             tapToAddAvailabilityFactory = tapToAddAvailabilityFactory,
             durationProvider = durationProvider,
             paymentMethodMessagePromotionsExperimentHandler = paymentMethodMessageExperimentHandler,
+        )
+    }
+
+    private fun createGetGooglePayState(
+        isGooglePayReady: Boolean,
+        userFacingLogger: FakeUserFacingLogger,
+        errorReporter: ErrorReporter,
+        durationProvider: DurationProvider,
+    ): DefaultGetGooglePayState {
+        return DefaultGetGooglePayState(
+            googlePayRepositoryFactory = object : GooglePayRepositoryFactory {
+                override fun invoke(
+                    environment: GooglePayEnvironment,
+                    cardFundingFilter: CardFundingFilter,
+                    cardBrandFilter: CardBrandFilter
+                ): GooglePayRepository {
+                    return GooglePayRepository { flowOf(isGooglePayReady) }
+                }
+            },
+            userFacingLogger = userFacingLogger,
+            errorReporter = errorReporter,
+            durationProvider = durationProvider,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeGetGooglePayState.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/FakeGetGooglePayState.kt
@@ -1,0 +1,43 @@
+package com.stripe.android.paymentsheet.state
+
+import app.cash.turbine.Turbine
+import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.model.ElementsSession
+import kotlinx.coroutines.Deferred
+
+internal class FakeGetGooglePayState(
+    private val result: GooglePayState,
+) : GetGooglePayState {
+    val calls = Turbine<Call>()
+
+    override suspend fun invoke(
+        configuration: CommonConfiguration,
+        elementsSession: ElementsSession,
+        initializationMode: PaymentElementLoader.InitializationMode,
+        isGooglePaySupportedOnDevice: Deferred<Boolean>,
+        isGooglePaySupportedByConfiguration: Deferred<Boolean>,
+    ): GooglePayState {
+        calls.add(
+            Call(
+                configuration = configuration,
+                elementsSession = elementsSession,
+                initializationMode = initializationMode,
+                isGooglePaySupportedOnDevice = isGooglePaySupportedOnDevice,
+                isGooglePaySupportedByConfiguration = isGooglePaySupportedByConfiguration,
+            )
+        )
+        return result
+    }
+
+    fun ensureAllEventsConsumed() {
+        calls.ensureAllEventsConsumed()
+    }
+
+    data class Call(
+        val configuration: CommonConfiguration,
+        val elementsSession: ElementsSession,
+        val initializationMode: PaymentElementLoader.InitializationMode,
+        val isGooglePaySupportedOnDevice: Deferred<Boolean>,
+        val isGooglePaySupportedByConfiguration: Deferred<Boolean>,
+    )
+}


### PR DESCRIPTION
# Summary
Extract Google Pay readiness and support loading into an injectable `GetGooglePayState` fun interface that returns both values in `GooglePayState`.

Preserve loading parallelism by starting the new function in an `async` block and awaiting its result only at pipeline stages that consume it.

Committed and created by Codex.

# Motivation
Keep Google Pay state loading independently injectable, matching the existing `CreateLinkState` pattern and making the payment element loading pipeline easier to compose and test.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:compileDebugUnitTestKotlin`
- `./gradlew :paymentsheet:testDebugUnitTest :paymentsheet:detekt :paymentsheet:apiCheck :paymentsheet:verifyPaparazziDebug`

# Screenshots
| Before  | After |
| ------------- | ------------- |
| N/A — no visual changes | N/A — no visual changes |

# Changelog
No user-facing change.
