### PR TITLE
Route Address Element results by launch mode.

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -63,8 +63,11 @@ class ShippingAddressElement internal constructor(
         errorReporter = errorReporter,
     )
 
-    private val activityLauncher: ActivityResultLauncher<AddressElementActivityContract.Args> =
-        activityResultCaller.registerForActivityResult(AddressElementActivityContract) { result ->
+    private val activityLauncher:
+        ActivityResultLauncher<AddressElementActivityContract.Args.CheckoutShipping> =
+        activityResultCaller.registerForActivityResult(
+            AddressElementActivityContract.CheckoutShipping
+        ) { result ->
             when (result) {
                 is AddressElementActivityContract.Result.CheckoutShippingSucceeded -> {
                     val address = result.address.address?.toCheckoutAddress()
@@ -83,8 +86,7 @@ class ShippingAddressElement internal constructor(
                         }
                     }
                 }
-                AddressElementActivityContract.Result.Canceled,
-                is AddressElementActivityContract.Result.StandaloneSucceeded -> {
+                AddressElementActivityContract.Result.Canceled -> {
                     shippingAddressElementStateHolder.isPresenting = false
                 }
             }
@@ -115,7 +117,7 @@ class ShippingAddressElement internal constructor(
 
         shippingAddressElementStateHolder.isPresenting = true
         activityLauncher.launch(
-            AddressElementActivityContract.Args(
+            AddressElementActivityContract.Args.CheckoutShipping(
                 publishableKey = paymentConfiguration.get().publishableKey,
                 config = AddressLauncher.Configuration(
                     additionalFields = AddressLauncher.AdditionalFieldsConfiguration(
@@ -124,7 +126,6 @@ class ShippingAddressElement internal constructor(
                     billingAddress = null,
                     useStripeHostedAutocomplete = true,
                 ),
-                launchMode = AddressElementActivityContract.LaunchMode.CheckoutShipping,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -16,7 +16,6 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
-import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
@@ -67,7 +66,7 @@ class ShippingAddressElement internal constructor(
     private val activityLauncher: ActivityResultLauncher<AddressElementActivityContract.Args> =
         activityResultCaller.registerForActivityResult(AddressElementActivityContract) { result ->
             when (result) {
-                is AddressLauncherResult.Succeeded -> {
+                is AddressElementActivityContract.Result.CheckoutShippingSucceeded -> {
                     val address = result.address.address?.toCheckoutAddress()
                     if (address == null) {
                         shippingAddressElementStateHolder.isPresenting = false
@@ -84,7 +83,8 @@ class ShippingAddressElement internal constructor(
                         }
                     }
                 }
-                is AddressLauncherResult.Canceled -> {
+                AddressElementActivityContract.Result.Canceled,
+                is AddressElementActivityContract.Result.StandaloneSucceeded -> {
                     shippingAddressElementStateHolder.isPresenting = false
                 }
             }
@@ -124,6 +124,7 @@ class ShippingAddressElement internal constructor(
                     billingAddress = null,
                     useStripeHostedAutocomplete = true,
                 ),
+                launchMode = AddressElementActivityContract.LaunchMode.CheckoutShipping,
             )
         )
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -75,7 +75,7 @@ internal class AddressElementActivity : ComponentActivity() {
 
             BackHandler {
                 if (!viewModel.navigator.onBack()) {
-                    viewModel.resultStateHolder.setResult(AddressLauncherResult.Canceled())
+                    viewModel.resultStateHolder.setResult(AddressElementActivityContract.Result.Canceled)
                 }
             }
 
@@ -92,7 +92,7 @@ internal class AddressElementActivity : ComponentActivity() {
             ElementsBottomSheetLayout(
                 state = bottomSheetState,
                 onDismissed = {
-                    viewModel.resultStateHolder.setResult(AddressLauncherResult.Canceled())
+                    viewModel.resultStateHolder.setResult(AddressElementActivityContract.Result.Canceled)
                 },
             ) {
                 Surface(modifier = Modifier.fillMaxSize()) {
@@ -128,11 +128,11 @@ internal class AddressElementActivity : ComponentActivity() {
         }
     }
 
-    private fun finishWithResult(result: AddressLauncherResult) {
+    private fun finishWithResult(result: AddressElementActivityContract.Result) {
         setResult(
             result.resultCode,
             Intent().putExtras(
-                AddressElementActivityContract.Result(result).toBundle()
+                result.toBundle()
             )
         )
         finish()

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
@@ -1,23 +1,25 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.os.bundleOf
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
 internal object AddressElementActivityContract :
-    ActivityResultContract<AddressElementActivityContract.Args, AddressLauncherResult>() {
+    ActivityResultContract<AddressElementActivityContract.Args, AddressElementActivityContract.Result>() {
 
     override fun createIntent(context: Context, input: Args): Intent {
         return Intent(context, AddressElementActivity::class.java).putExtra(EXTRA_ARGS, input)
     }
 
     @Suppress("DEPRECATION")
-    override fun parseResult(resultCode: Int, intent: Intent?): AddressLauncherResult =
-        intent?.getParcelableExtra<Result>(EXTRA_RESULT)?.addressOptionsResult
-            ?: AddressLauncherResult.Canceled()
+    override fun parseResult(resultCode: Int, intent: Intent?): Result =
+        intent?.getParcelableExtra<Result>(EXTRA_RESULT)
+            ?: Result.Canceled
 
     /**
      * Arguments for launching [AddressElementActivity] to collect an address.
@@ -29,6 +31,7 @@ internal object AddressElementActivityContract :
     data class Args internal constructor(
         internal val publishableKey: String,
         internal val config: AddressLauncher.Configuration?,
+        internal val launchMode: LaunchMode,
     ) : ActivityStarter.Args {
 
         internal companion object {
@@ -40,10 +43,41 @@ internal object AddressElementActivityContract :
     }
 
     @Parcelize
-    data class Result(
-        val addressOptionsResult: AddressLauncherResult
-    ) : ActivityStarter.Result {
+    sealed class LaunchMode : Parcelable {
+        @Parcelize
+        data object Standalone : LaunchMode()
+
+        @Parcelize
+        data object CheckoutShipping : LaunchMode()
+    }
+
+    @Parcelize
+    sealed class Result : ActivityStarter.Result, Parcelable {
+        abstract val resultCode: Int
+
         override fun toBundle() = bundleOf(EXTRA_RESULT to this)
+
+        @Parcelize
+        data object Canceled : Result() {
+            override val resultCode: Int
+                get() = Activity.RESULT_CANCELED
+        }
+
+        @Parcelize
+        data class StandaloneSucceeded(
+            val address: AddressDetails,
+        ) : Result() {
+            override val resultCode: Int
+                get() = Activity.RESULT_OK
+        }
+
+        @Parcelize
+        data class CheckoutShippingSucceeded(
+            val address: AddressDetails,
+        ) : Result() {
+            override val resultCode: Int
+                get() = Activity.RESULT_OK
+        }
     }
 
     const val EXTRA_ARGS =

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
@@ -5,21 +5,51 @@ import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
 
-internal object AddressElementActivityContract :
-    ActivityResultContract<AddressElementActivityContract.Args, AddressElementActivityContract.Result>() {
+internal object AddressElementActivityContract {
+    internal object Standalone : ActivityResultContract<Args.Standalone, AddressLauncherResult>() {
+        override fun createIntent(context: Context, input: Args.Standalone): Intent {
+            return createActivityIntent(context, input)
+        }
 
-    override fun createIntent(context: Context, input: Args): Intent {
+        override fun parseResult(resultCode: Int, intent: Intent?): AddressLauncherResult {
+            return when (val result = parseActivityResult(intent)) {
+                Result.Canceled,
+                is Result.CheckoutShippingSucceeded -> AddressLauncherResult.Canceled()
+                is Result.StandaloneSucceeded -> AddressLauncherResult.Succeeded(result.address)
+            }
+        }
+    }
+
+    internal object CheckoutShipping :
+        ActivityResultContract<Args.CheckoutShipping, CheckoutShippingResult>() {
+        override fun createIntent(context: Context, input: Args.CheckoutShipping): Intent {
+            return createActivityIntent(context, input)
+        }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): CheckoutShippingResult {
+            return when (val result = parseActivityResult(intent)) {
+                Result.Canceled -> Result.Canceled
+                is Result.CheckoutShippingSucceeded -> result
+                is Result.StandaloneSucceeded -> Result.Canceled
+            }
+        }
+    }
+
+    private fun createActivityIntent(context: Context, input: Args): Intent {
         return Intent(context, AddressElementActivity::class.java).putExtra(EXTRA_ARGS, input)
     }
 
-    @Suppress("DEPRECATION")
-    override fun parseResult(resultCode: Int, intent: Intent?): Result =
-        intent?.getParcelableExtra<Result>(EXTRA_RESULT)
-            ?: Result.Canceled
+    private fun parseActivityResult(intent: Intent?): Result {
+        val result = intent?.extras?.let { extras ->
+            BundleCompat.getParcelable(extras, EXTRA_RESULT, Result::class.java)
+        }
+        return result ?: Result.Canceled
+    }
 
     /**
      * Arguments for launching [AddressElementActivity] to collect an address.
@@ -27,38 +57,42 @@ internal object AddressElementActivityContract :
      * @param publishableKey the Stripe publishable key
      * @param config the paymentsheet configuration passed from the merchant
      */
-    @Parcelize
-    data class Args internal constructor(
-        internal val publishableKey: String,
-        internal val config: AddressLauncher.Configuration?,
-        internal val launchMode: LaunchMode,
-    ) : ActivityStarter.Args {
+    sealed class Args : ActivityStarter.Args {
+        internal abstract val publishableKey: String
+        internal abstract val config: AddressLauncher.Configuration?
+
+        @Parcelize
+        data class Standalone internal constructor(
+            override val publishableKey: String,
+            override val config: AddressLauncher.Configuration?,
+        ) : Args()
+
+        @Parcelize
+        data class CheckoutShipping internal constructor(
+            override val publishableKey: String,
+            override val config: AddressLauncher.Configuration?,
+        ) : Args()
 
         internal companion object {
             internal fun fromIntent(intent: Intent): Args? {
-                @Suppress("DEPRECATION")
-                return intent.getParcelableExtra(EXTRA_ARGS)
+                return intent.extras?.let { extras ->
+                    BundleCompat.getParcelable(extras, EXTRA_ARGS, Args::class.java)
+                }
             }
         }
     }
 
-    @Parcelize
-    sealed class LaunchMode : Parcelable {
-        @Parcelize
-        data object Standalone : LaunchMode()
+    internal sealed interface StandaloneResult : Result
 
-        @Parcelize
-        data object CheckoutShipping : LaunchMode()
-    }
+    internal sealed interface CheckoutShippingResult : Result
 
-    @Parcelize
-    sealed class Result : ActivityStarter.Result, Parcelable {
-        abstract val resultCode: Int
+    internal sealed interface Result : ActivityStarter.Result, Parcelable {
+        val resultCode: Int
 
         override fun toBundle() = bundleOf(EXTRA_RESULT to this)
 
         @Parcelize
-        data object Canceled : Result() {
+        data object Canceled : StandaloneResult, CheckoutShippingResult {
             override val resultCode: Int
                 get() = Activity.RESULT_CANCELED
         }
@@ -66,7 +100,7 @@ internal object AddressElementActivityContract :
         @Parcelize
         data class StandaloneSucceeded(
             val address: AddressDetails,
-        ) : Result() {
+        ) : StandaloneResult {
             override val resultCode: Int
                 get() = Activity.RESULT_OK
         }
@@ -74,7 +108,7 @@ internal object AddressElementActivityContract :
         @Parcelize
         data class CheckoutShippingSucceeded(
             val address: AddressDetails,
-        ) : Result() {
+        ) : CheckoutShippingResult {
             override val resultCode: Int
                 get() = Activity.RESULT_OK
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityContract.kt
@@ -17,9 +17,15 @@ internal object AddressElementActivityContract {
         }
 
         override fun parseResult(resultCode: Int, intent: Intent?): AddressLauncherResult {
-            return when (val result = parseActivityResult(intent)) {
-                Result.Canceled,
-                is Result.CheckoutShippingSucceeded -> AddressLauncherResult.Canceled()
+            val result = intent?.extras?.let {
+                BundleCompat.getParcelable(
+                    it,
+                    EXTRA_RESULT,
+                    StandaloneResult::class.java,
+                )
+            } ?: Result.Canceled
+            return when (result) {
+                Result.Canceled -> AddressLauncherResult.Canceled()
                 is Result.StandaloneSucceeded -> AddressLauncherResult.Succeeded(result.address)
             }
         }
@@ -32,23 +38,18 @@ internal object AddressElementActivityContract {
         }
 
         override fun parseResult(resultCode: Int, intent: Intent?): CheckoutShippingResult {
-            return when (val result = parseActivityResult(intent)) {
-                Result.Canceled -> Result.Canceled
-                is Result.CheckoutShippingSucceeded -> result
-                is Result.StandaloneSucceeded -> Result.Canceled
-            }
+            return intent?.extras?.let {
+                BundleCompat.getParcelable(
+                    it,
+                    EXTRA_RESULT,
+                    CheckoutShippingResult::class.java,
+                )
+            } ?: Result.Canceled
         }
     }
 
     private fun createActivityIntent(context: Context, input: Args): Intent {
         return Intent(context, AddressElementActivity::class.java).putExtra(EXTRA_ARGS, input)
-    }
-
-    private fun parseActivityResult(intent: Intent?): Result {
-        val result = intent?.extras?.let { extras ->
-            BundleCompat.getParcelable(extras, EXTRA_RESULT, Result::class.java)
-        }
-        return result ?: Result.Canceled
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementResultStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementResultStateHolder.kt
@@ -8,11 +8,11 @@ import javax.inject.Singleton
 
 @Singleton
 internal class AddressElementResultStateHolder @Inject constructor() {
-    private val _result = MutableStateFlow<AddressLauncherResult?>(null)
+    private val _result = MutableStateFlow<AddressElementActivityContract.Result?>(null)
 
-    val result: StateFlow<AddressLauncherResult?> = _result.asStateFlow()
+    val result: StateFlow<AddressElementActivityContract.Result?> = _result.asStateFlow()
 
-    fun setResult(result: AddressLauncherResult) {
+    fun setResult(result: AddressElementActivityContract.Result) {
         _result.compareAndSet(expect = null, update = result)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -41,7 +41,7 @@ class AddressLauncher internal constructor(
         activityResultLauncher = activity.registerForActivityResult(
             AddressElementActivityContract
         ) {
-            callback.onAddressLauncherResult(it)
+            callback.onAddressElementActivityResult(it)
         },
     )
 
@@ -58,7 +58,7 @@ class AddressLauncher internal constructor(
             signal,
             AddressElementActivityContract
         ) {
-            callback.onAddressLauncherResult(it)
+            callback.onAddressElementActivityResult(it)
         },
     )
 
@@ -76,7 +76,7 @@ class AddressLauncher internal constructor(
         activityResultLauncher = fragment.registerForActivityResult(
             AddressElementActivityContract
         ) {
-            callback.onAddressLauncherResult(it)
+            callback.onAddressElementActivityResult(it)
         },
     )
 
@@ -88,6 +88,7 @@ class AddressLauncher internal constructor(
         val args = AddressElementActivityContract.Args(
             publishableKey = publishableKey,
             config = configuration,
+            launchMode = AddressElementActivityContract.LaunchMode.Standalone,
         )
 
         val options = ActivityOptionsCompat.makeCustomAnimation(
@@ -320,7 +321,7 @@ fun rememberAddressLauncher(
 ): AddressLauncher {
     val activityResultLauncher = rememberLauncherForActivityResult(
         contract = AddressElementActivityContract,
-        onResult = callback::onAddressLauncherResult
+        onResult = callback::onAddressElementActivityResult
     )
 
     val context = LocalContext.current
@@ -331,4 +332,20 @@ fun rememberAddressLauncher(
             activityResultLauncher = activityResultLauncher,
         )
     }
+}
+
+internal fun AddressLauncherResultCallback.onAddressElementActivityResult(
+    result: AddressElementActivityContract.Result,
+) {
+    onAddressLauncherResult(
+        when (result) {
+            AddressElementActivityContract.Result.Canceled -> AddressLauncherResult.Canceled()
+            is AddressElementActivityContract.Result.StandaloneSucceeded -> {
+                AddressLauncherResult.Succeeded(result.address)
+            }
+            is AddressElementActivityContract.Result.CheckoutShippingSucceeded -> {
+                AddressLauncherResult.Succeeded(result.address)
+            }
+        }
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressLauncher.kt
@@ -25,7 +25,8 @@ import kotlinx.parcelize.Parcelize
  */
 class AddressLauncher internal constructor(
     private val application: Application,
-    private val activityResultLauncher: ActivityResultLauncher<AddressElementActivityContract.Args>
+    private val activityResultLauncher:
+        ActivityResultLauncher<AddressElementActivityContract.Args.Standalone>
 ) {
     /**
      * Constructor to be used when launching the address element from an Activity.
@@ -39,10 +40,9 @@ class AddressLauncher internal constructor(
     ) : this(
         application = activity.application,
         activityResultLauncher = activity.registerForActivityResult(
-            AddressElementActivityContract
-        ) {
-            callback.onAddressElementActivityResult(it)
-        },
+            AddressElementActivityContract.Standalone,
+            callback::onAddressLauncherResult,
+        ),
     )
 
     @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
@@ -56,10 +56,9 @@ class AddressLauncher internal constructor(
         activityResultLauncher = registerForReactNativeActivityResult(
             activity,
             signal,
-            AddressElementActivityContract
-        ) {
-            callback.onAddressElementActivityResult(it)
-        },
+            AddressElementActivityContract.Standalone,
+            callback::onAddressLauncherResult,
+        ),
     )
 
     /**
@@ -74,10 +73,9 @@ class AddressLauncher internal constructor(
     ) : this(
         application = fragment.requireActivity().application,
         activityResultLauncher = fragment.registerForActivityResult(
-            AddressElementActivityContract
-        ) {
-            callback.onAddressElementActivityResult(it)
-        },
+            AddressElementActivityContract.Standalone,
+            callback::onAddressLauncherResult,
+        ),
     )
 
     @JvmOverloads
@@ -85,10 +83,9 @@ class AddressLauncher internal constructor(
         publishableKey: String,
         configuration: Configuration = Configuration()
     ) {
-        val args = AddressElementActivityContract.Args(
+        val args = AddressElementActivityContract.Args.Standalone(
             publishableKey = publishableKey,
             config = configuration,
-            launchMode = AddressElementActivityContract.LaunchMode.Standalone,
         )
 
         val options = ActivityOptionsCompat.makeCustomAnimation(
@@ -320,8 +317,8 @@ fun rememberAddressLauncher(
     callback: AddressLauncherResultCallback
 ): AddressLauncher {
     val activityResultLauncher = rememberLauncherForActivityResult(
-        contract = AddressElementActivityContract,
-        onResult = callback::onAddressElementActivityResult
+        contract = AddressElementActivityContract.Standalone,
+        onResult = callback::onAddressLauncherResult,
     )
 
     val context = LocalContext.current
@@ -332,20 +329,4 @@ fun rememberAddressLauncher(
             activityResultLauncher = activityResultLauncher,
         )
     }
-}
-
-internal fun AddressLauncherResultCallback.onAddressElementActivityResult(
-    result: AddressElementActivityContract.Result,
-) {
-    onAddressLauncherResult(
-        when (result) {
-            AddressElementActivityContract.Result.Canceled -> AddressLauncherResult.Canceled()
-            is AddressElementActivityContract.Result.StandaloneSucceeded -> {
-                AddressLauncherResult.Succeeded(result.address)
-            }
-            is AddressElementActivityContract.Result.CheckoutShippingSucceeded -> {
-                AddressLauncherResult.Succeeded(result.address)
-            }
-        }
-    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -137,7 +137,7 @@ internal fun InputAddressScreen(
             )
         },
         onCloseClick = {
-            viewModel.resultStateHolder.setResult(AddressLauncherResult.Canceled())
+            viewModel.resultStateHolder.setResult(AddressElementActivityContract.Result.Canceled)
         },
         topContent = {
             val currentState = billingSameAsShippingState

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -212,24 +212,36 @@ internal class InputAddressViewModel @Inject constructor(
             return
         }
         _formEnabled.value = false
+        val addressDetails = AddressDetails(
+            name = completedFormValues[FormFieldId.Name]?.value,
+            address = PaymentSheet.Address(
+                city = completedFormValues[FormFieldId.City]?.value,
+                country = completedFormValues[FormFieldId.Country]?.value,
+                line1 = completedFormValues[FormFieldId.Line1]?.value,
+                line2 = completedFormValues[FormFieldId.Line2]?.value,
+                postalCode = completedFormValues[FormFieldId.PostalCode]?.value,
+                state = completedFormValues[FormFieldId.State]?.value
+            ),
+            phoneNumber = completedFormValues[FormFieldId.Phone]?.value,
+            isCheckboxSelected = checkboxChecked
+        )
         completeWithAddress(
-            AddressDetails(
-                name = completedFormValues[FormFieldId.Name]?.value,
-                address = PaymentSheet.Address(
-                    city = completedFormValues[FormFieldId.City]?.value,
-                    country = completedFormValues[FormFieldId.Country]?.value,
-                    line1 = completedFormValues[FormFieldId.Line1]?.value,
-                    line2 = completedFormValues[FormFieldId.Line2]?.value,
-                    postalCode = completedFormValues[FormFieldId.PostalCode]?.value,
-                    state = completedFormValues[FormFieldId.State]?.value
-                ),
-                phoneNumber = completedFormValues[FormFieldId.Phone]?.value,
-                isCheckboxSelected = checkboxChecked
-            )
+            addressDetails = addressDetails,
+            result = when (args.launchMode) {
+                AddressElementActivityContract.LaunchMode.Standalone -> {
+                    AddressElementActivityContract.Result.StandaloneSucceeded(addressDetails)
+                }
+                AddressElementActivityContract.LaunchMode.CheckoutShipping -> {
+                    AddressElementActivityContract.Result.CheckoutShippingSucceeded(addressDetails)
+                }
+            },
         )
     }
 
-    private fun completeWithAddress(addressDetails: AddressDetails) {
+    private fun completeWithAddress(
+        addressDetails: AddressDetails,
+        result: AddressElementActivityContract.Result,
+    ) {
         addressDetails.address?.country?.let { country ->
             eventReporter.onCompleted(
                 country = country,
@@ -237,7 +249,7 @@ internal class InputAddressViewModel @Inject constructor(
                 editDistance = addressDetails.editDistance(collectedAddress.value)
             )
         }
-        resultStateHolder.setResult(AddressLauncherResult.Succeeded(addressDetails))
+        resultStateHolder.setResult(result)
     }
 
     fun clickBillingSameAsShipping(newValue: Boolean) {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -227,11 +227,11 @@ internal class InputAddressViewModel @Inject constructor(
         )
         completeWithAddress(
             addressDetails = addressDetails,
-            result = when (args.launchMode) {
-                AddressElementActivityContract.LaunchMode.Standalone -> {
+            result = when (args) {
+                is AddressElementActivityContract.Args.Standalone -> {
                     AddressElementActivityContract.Result.StandaloneSucceeded(addressDetails)
                 }
-                AddressElementActivityContract.LaunchMode.CheckoutShipping -> {
+                is AddressElementActivityContract.Args.CheckoutShipping -> {
                     AddressElementActivityContract.Result.CheckoutShippingSucceeded(addressDetails)
                 }
             },

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -25,7 +25,6 @@ import com.stripe.android.paymentsheet.addresselement.AUTOCOMPLETE_DEFAULT_COUNT
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.addresselement.AddressElementActivityContract
 import com.stripe.android.paymentsheet.addresselement.AddressLauncher
-import com.stripe.android.paymentsheet.addresselement.AddressLauncherResult
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.CompletableDeferred
@@ -77,6 +76,8 @@ internal class ShippingAddressElementTest {
         assertThat(config.autocompleteCountries).isEqualTo(AUTOCOMPLETE_DEFAULT_COUNTRIES)
         assertThat(config.billingAddress).isNull()
         assertThat(config.useStripeHostedAutocomplete).isTrue()
+        assertThat(launch.input.launchMode)
+            .isEqualTo(AddressElementActivityContract.LaunchMode.CheckoutShipping)
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
     }
 
@@ -112,7 +113,7 @@ internal class ShippingAddressElementTest {
         assertThat(firstLaunch.input.publishableKey).isEqualTo(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY)
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
 
-        registration.dispatch(AddressLauncherResult.Canceled())
+        registration.dispatch(AddressElementActivityContract.Result.Canceled)
         paymentConfiguration.value = PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY)
 
         shippingAddressElement.present()
@@ -139,9 +140,7 @@ internal class ShippingAddressElementTest {
             ),
         )
         registration.dispatch(
-            AddressLauncherResult.Succeeded(
-                addressDetails,
-            )
+            AddressElementActivityContract.Result.CheckoutShippingSucceeded(addressDetails)
         )
 
         assertThat(commitShippingAddress.calls.awaitItem()).isEqualTo(
@@ -178,7 +177,7 @@ internal class ShippingAddressElementTest {
             assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
 
             registration.dispatch(
-                AddressLauncherResult.Succeeded(
+                AddressElementActivityContract.Result.CheckoutShippingSucceeded(
                     AddressDetails(
                         name = "Jenny Rosen",
                         address = PaymentSheet.Address(
@@ -188,7 +187,7 @@ internal class ShippingAddressElementTest {
                             postalCode = "94103",
                             state = "CA",
                         ),
-                    )
+                    ),
                 )
             )
             commitShippingAddress.calls.awaitItem()
@@ -212,7 +211,7 @@ internal class ShippingAddressElementTest {
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
 
-        registration.dispatch(AddressLauncherResult.Canceled())
+        registration.dispatch(AddressElementActivityContract.Result.Canceled)
 
         assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
         commitShippingAddress.calls.expectNoEvents()
@@ -225,14 +224,14 @@ internal class ShippingAddressElementTest {
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
 
         registration.dispatch(
-            AddressLauncherResult.Succeeded(
+            AddressElementActivityContract.Result.CheckoutShippingSucceeded(
                 AddressDetails(
                     name = "Missing country",
                     address = PaymentSheet.Address(
                         line1 = "510 Townsend St",
                         country = " ",
                     ),
-                )
+                ),
             )
         )
 
@@ -254,7 +253,7 @@ internal class ShippingAddressElementTest {
         recreated.shippingAddressElement.present()
         recreated.activityLauncher.launchCalls.expectNoEvents()
 
-        recreated.registration.dispatch(AddressLauncherResult.Canceled())
+        recreated.registration.dispatch(AddressElementActivityContract.Result.Canceled)
         assertThat(shippingAddressElementStateHolder.isPresenting).isFalse()
 
         recreated.shippingAddressElement.present()
@@ -401,8 +400,9 @@ internal class ShippingAddressElementTest {
         val callback: ActivityResultCallback<*>,
     ) {
         @Suppress("UNCHECKED_CAST")
-        fun dispatch(result: AddressLauncherResult) {
-            (callback as ActivityResultCallback<AddressLauncherResult>).onActivityResult(result)
+        fun dispatch(result: AddressElementActivityContract.Result) {
+            (callback as ActivityResultCallback<AddressElementActivityContract.Result>)
+                .onActivityResult(result)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -76,8 +76,6 @@ internal class ShippingAddressElementTest {
         assertThat(config.autocompleteCountries).isEqualTo(AUTOCOMPLETE_DEFAULT_COUNTRIES)
         assertThat(config.billingAddress).isNull()
         assertThat(config.useStripeHostedAutocomplete).isTrue()
-        assertThat(launch.input.launchMode)
-            .isEqualTo(AddressElementActivityContract.LaunchMode.CheckoutShipping)
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
     }
 
@@ -313,7 +311,7 @@ internal class ShippingAddressElementTest {
                 errorReporter = errorReporter,
             )
             val registration = activityResultCaller.registerCalls.awaitItem()
-            assertThat(registration.contract).isSameInstanceAs(AddressElementActivityContract)
+            assertThat(registration.contract).isSameInstanceAs(AddressElementActivityContract.CheckoutShipping)
             return ElementScenario(
                 shippingAddressElement = shippingAddressElement,
                 activityResultCaller = activityResultCaller,
@@ -365,12 +363,12 @@ internal class ShippingAddressElementTest {
     }
 
     private class RecordingActivityResultLauncher :
-        ActivityResultLauncher<AddressElementActivityContract.Args>() {
+        ActivityResultLauncher<AddressElementActivityContract.Args.CheckoutShipping>() {
         val launchCalls = Turbine<LaunchCall>()
         val unregisterCalls = Turbine<Unit>()
 
         override fun launch(
-            input: AddressElementActivityContract.Args,
+            input: AddressElementActivityContract.Args.CheckoutShipping,
             options: ActivityOptionsCompat?,
         ) {
             launchCalls.add(LaunchCall(input))
@@ -380,8 +378,9 @@ internal class ShippingAddressElementTest {
             unregisterCalls.add(Unit)
         }
 
-        override val contract: ActivityResultContract<AddressElementActivityContract.Args, *>
-            get() = AddressElementActivityContract
+        override val contract:
+            ActivityResultContract<AddressElementActivityContract.Args.CheckoutShipping, *>
+            get() = AddressElementActivityContract.CheckoutShipping
     }
 
     private class RecordingProvider<T>(
@@ -400,14 +399,14 @@ internal class ShippingAddressElementTest {
         val callback: ActivityResultCallback<*>,
     ) {
         @Suppress("UNCHECKED_CAST")
-        fun dispatch(result: AddressElementActivityContract.Result) {
-            (callback as ActivityResultCallback<AddressElementActivityContract.Result>)
+        fun dispatch(result: AddressElementActivityContract.CheckoutShippingResult) {
+            (callback as ActivityResultCallback<AddressElementActivityContract.CheckoutShippingResult>)
                 .onActivityResult(result)
         }
     }
 
     private data class LaunchCall(
-        val input: AddressElementActivityContract.Args,
+        val input: AddressElementActivityContract.Args.CheckoutShipping,
     )
 
     private data class ElementScenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
@@ -18,7 +19,31 @@ internal class AddressElementActivityTest {
         ).use { activityScenario ->
             assertThat(activityScenario.state).isEqualTo(Lifecycle.State.DESTROYED)
             val result = AddressElementActivityContract.parseResult(0, activityScenario.result.resultData)
-            assertThat(result).isEqualTo(AddressLauncherResult.Canceled())
+            assertThat(result).isEqualTo(AddressElementActivityContract.Result.Canceled)
         }
+    }
+
+    @Test
+    fun `contract preserves standalone success`() {
+        val result = AddressElementActivityContract.Result.StandaloneSucceeded(AddressDetails())
+
+        val parsed = AddressElementActivityContract.parseResult(
+            resultCode = result.resultCode,
+            intent = Intent().putExtras(result.toBundle()),
+        )
+
+        assertThat(parsed).isEqualTo(result)
+    }
+
+    @Test
+    fun `contract preserves checkout shipping success`() {
+        val result = AddressElementActivityContract.Result.CheckoutShippingSucceeded(AddressDetails())
+
+        val parsed = AddressElementActivityContract.parseResult(
+            resultCode = result.resultCode,
+            intent = Intent().putExtras(result.toBundle()),
+        )
+
+        assertThat(parsed).isEqualTo(result)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivityTest.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.paymentsheet.addresselement
 
+import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,16 +20,97 @@ internal class AddressElementActivityTest {
             Bundle.EMPTY
         ).use { activityScenario ->
             assertThat(activityScenario.state).isEqualTo(Lifecycle.State.DESTROYED)
-            val result = AddressElementActivityContract.parseResult(0, activityScenario.result.resultData)
-            assertThat(result).isEqualTo(AddressElementActivityContract.Result.Canceled)
+            val result = AddressElementActivityContract.Standalone.parseResult(
+                activityScenario.result.resultCode,
+                activityScenario.result.resultData,
+            )
+            assertThat(result).isEqualTo(AddressLauncherResult.Canceled())
         }
     }
 
     @Test
-    fun `contract preserves standalone success`() {
+    fun `standalone contract creates intent with standalone args`() {
+        val args = AddressElementActivityContract.Args.Standalone(
+            publishableKey = "pk_test_123",
+            config = null,
+        )
+
+        val intent = AddressElementActivityContract.Standalone.createIntent(
+            ApplicationProvider.getApplicationContext(),
+            args,
+        )
+
+        assertThat(intent.component?.className).isEqualTo(AddressElementActivity::class.java.name)
+        assertThat(AddressElementActivityContract.Args.fromIntent(intent)).isEqualTo(args)
+    }
+
+    @Test
+    fun `checkout shipping contract creates intent with checkout shipping args`() {
+        val args = AddressElementActivityContract.Args.CheckoutShipping(
+            publishableKey = "pk_test_123",
+            config = null,
+        )
+
+        val intent = AddressElementActivityContract.CheckoutShipping.createIntent(
+            ApplicationProvider.getApplicationContext(),
+            args,
+        )
+
+        assertThat(intent.component?.className).isEqualTo(AddressElementActivity::class.java.name)
+        assertThat(AddressElementActivityContract.Args.fromIntent(intent)).isEqualTo(args)
+    }
+
+    @Test
+    fun `standalone contract maps standalone success to public success`() {
         val result = AddressElementActivityContract.Result.StandaloneSucceeded(AddressDetails())
 
-        val parsed = AddressElementActivityContract.parseResult(
+        val parsed = AddressElementActivityContract.Standalone.parseResult(
+            resultCode = result.resultCode,
+            intent = Intent().putExtras(result.toBundle()),
+        )
+
+        assertThat(parsed).isEqualTo(AddressLauncherResult.Succeeded(result.address))
+    }
+
+    @Test
+    fun `standalone contract maps missing result to canceled`() {
+        val parsed = AddressElementActivityContract.Standalone.parseResult(
+            resultCode = Activity.RESULT_CANCELED,
+            intent = Intent(),
+        )
+
+        assertThat(parsed).isEqualTo(AddressLauncherResult.Canceled())
+    }
+
+    @Test
+    fun `standalone contract maps canceled result to public canceled`() {
+        val result = AddressElementActivityContract.Result.Canceled
+
+        val parsed = AddressElementActivityContract.Standalone.parseResult(
+            resultCode = result.resultCode,
+            intent = Intent().putExtras(result.toBundle()),
+        )
+
+        assertThat(parsed).isEqualTo(AddressLauncherResult.Canceled())
+    }
+
+    @Test
+    fun `standalone contract maps checkout shipping success to canceled`() {
+        val result = AddressElementActivityContract.Result.CheckoutShippingSucceeded(AddressDetails())
+
+        val parsed = AddressElementActivityContract.Standalone.parseResult(
+            resultCode = result.resultCode,
+            intent = Intent().putExtras(result.toBundle()),
+        )
+
+        assertThat(parsed).isEqualTo(AddressLauncherResult.Canceled())
+    }
+
+    @Test
+    fun `checkout shipping contract preserves checkout shipping success`() {
+        val result = AddressElementActivityContract.Result.CheckoutShippingSucceeded(AddressDetails())
+
+        val parsed = AddressElementActivityContract.CheckoutShipping.parseResult(
             resultCode = result.resultCode,
             intent = Intent().putExtras(result.toBundle()),
         )
@@ -36,14 +119,36 @@ internal class AddressElementActivityTest {
     }
 
     @Test
-    fun `contract preserves checkout shipping success`() {
-        val result = AddressElementActivityContract.Result.CheckoutShippingSucceeded(AddressDetails())
+    fun `checkout shipping contract maps missing result to canceled`() {
+        val parsed = AddressElementActivityContract.CheckoutShipping.parseResult(
+            resultCode = Activity.RESULT_CANCELED,
+            intent = Intent(),
+        )
 
-        val parsed = AddressElementActivityContract.parseResult(
+        assertThat(parsed).isEqualTo(AddressElementActivityContract.Result.Canceled)
+    }
+
+    @Test
+    fun `checkout shipping contract preserves canceled result`() {
+        val result = AddressElementActivityContract.Result.Canceled
+
+        val parsed = AddressElementActivityContract.CheckoutShipping.parseResult(
             resultCode = result.resultCode,
             intent = Intent().putExtras(result.toBundle()),
         )
 
         assertThat(parsed).isEqualTo(result)
+    }
+
+    @Test
+    fun `checkout shipping contract maps standalone success to canceled`() {
+        val result = AddressElementActivityContract.Result.StandaloneSucceeded(AddressDetails())
+
+        val parsed = AddressElementActivityContract.CheckoutShipping.parseResult(
+            resultCode = result.resultCode,
+            intent = Intent().putExtras(result.toBundle()),
+        )
+
+        assertThat(parsed).isEqualTo(AddressElementActivityContract.Result.Canceled)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementResultStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementResultStateHolderTest.kt
@@ -6,11 +6,11 @@ import org.junit.Test
 internal class AddressElementResultStateHolderTest {
     @Test
     fun `first terminal result is retained`() {
-        val expectedResult = AddressLauncherResult.Succeeded(AddressDetails())
+        val expectedResult = AddressElementActivityContract.Result.StandaloneSucceeded(AddressDetails())
         val resultStateHolder = AddressElementResultStateHolder()
 
         resultStateHolder.setResult(expectedResult)
-        resultStateHolder.setResult(AddressLauncherResult.Canceled())
+        resultStateHolder.setResult(AddressElementActivityContract.Result.Canceled)
 
         assertThat(resultStateHolder.result.value).isEqualTo(expectedResult)
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressLauncherTest.kt
@@ -26,30 +26,15 @@ internal class AddressLauncherTest {
 
         val args = activityLauncher.launchCalls.awaitItem()
         assertThat(args.publishableKey).isEqualTo("pk_test_123")
-        assertThat(args.launchMode).isEqualTo(AddressElementActivityContract.LaunchMode.Standalone)
         activityLauncher.launchCalls.ensureAllEventsConsumed()
     }
 
-    @Test
-    fun `public callback receives standalone success as address launcher result`() = runTest {
-        val callbackResults = Turbine<AddressLauncherResult>()
-        val callback = AddressLauncherResultCallback(callbackResults::add)
-        val address = AddressDetails()
-
-        callback.onAddressElementActivityResult(
-            AddressElementActivityContract.Result.StandaloneSucceeded(address)
-        )
-
-        assertThat(callbackResults.awaitItem()).isEqualTo(AddressLauncherResult.Succeeded(address))
-        callbackResults.ensureAllEventsConsumed()
-    }
-
     private class RecordingActivityResultLauncher :
-        ActivityResultLauncher<AddressElementActivityContract.Args>() {
-        val launchCalls = Turbine<AddressElementActivityContract.Args>()
+        ActivityResultLauncher<AddressElementActivityContract.Args.Standalone>() {
+        val launchCalls = Turbine<AddressElementActivityContract.Args.Standalone>()
 
         override fun launch(
-            input: AddressElementActivityContract.Args,
+            input: AddressElementActivityContract.Args.Standalone,
             options: ActivityOptionsCompat?,
         ) {
             launchCalls.add(input)
@@ -57,7 +42,7 @@ internal class AddressLauncherTest {
 
         override fun unregister() = Unit
 
-        override val contract: ActivityResultContract<AddressElementActivityContract.Args, *>
-            get() = AddressElementActivityContract
+        override val contract: ActivityResultContract<AddressElementActivityContract.Args.Standalone, *>
+            get() = AddressElementActivityContract.Standalone
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressLauncherTest.kt
@@ -1,0 +1,63 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import android.app.Application
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.app.ActivityOptionsCompat
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class AddressLauncherTest {
+    @Test
+    fun `present launches standalone mode`() = runTest {
+        val activityLauncher = RecordingActivityResultLauncher()
+        val launcher = AddressLauncher(
+            application = ApplicationProvider.getApplicationContext<Application>(),
+            activityResultLauncher = activityLauncher,
+        )
+
+        launcher.present(publishableKey = "pk_test_123")
+
+        val args = activityLauncher.launchCalls.awaitItem()
+        assertThat(args.publishableKey).isEqualTo("pk_test_123")
+        assertThat(args.launchMode).isEqualTo(AddressElementActivityContract.LaunchMode.Standalone)
+        activityLauncher.launchCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `public callback receives standalone success as address launcher result`() = runTest {
+        val callbackResults = Turbine<AddressLauncherResult>()
+        val callback = AddressLauncherResultCallback(callbackResults::add)
+        val address = AddressDetails()
+
+        callback.onAddressElementActivityResult(
+            AddressElementActivityContract.Result.StandaloneSucceeded(address)
+        )
+
+        assertThat(callbackResults.awaitItem()).isEqualTo(AddressLauncherResult.Succeeded(address))
+        callbackResults.ensureAllEventsConsumed()
+    }
+
+    private class RecordingActivityResultLauncher :
+        ActivityResultLauncher<AddressElementActivityContract.Args>() {
+        val launchCalls = Turbine<AddressElementActivityContract.Args>()
+
+        override fun launch(
+            input: AddressElementActivityContract.Args,
+            options: ActivityOptionsCompat?,
+        ) {
+            launchCalls.add(input)
+        }
+
+        override fun unregister() = Unit
+
+        override val contract: ActivityResultContract<AddressElementActivityContract.Args, *>
+            get() = AddressElementActivityContract
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -39,12 +39,15 @@ class InputAddressViewModelTest {
         address: AddressDetails? = null,
         config: AddressLauncher.Configuration = AddressLauncher.Configuration.Builder()
             .address(address)
-            .build()
+            .build(),
+        launchMode: AddressElementActivityContract.LaunchMode =
+            AddressElementActivityContract.LaunchMode.Standalone,
     ): InputAddressViewModel {
         return InputAddressViewModel(
             AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
                 config = config,
+                launchMode = launchMode,
             ),
             navigator,
             resultStateHolder,
@@ -194,7 +197,7 @@ class InputAddressViewModelTest {
         )
 
         assertThat(resultStateHolder.result.value)
-            .isEqualTo(AddressLauncherResult.Succeeded(expectedAddress))
+            .isEqualTo(AddressElementActivityContract.Result.StandaloneSucceeded(expectedAddress))
         assertThat(viewModel.formEnabled.value).isFalse()
         verify(eventReporter).onCompleted(
             country = eq("US"),
@@ -987,6 +990,30 @@ class InputAddressViewModelTest {
     }
 
     @Test
+    fun `standalone save emits standalone success`() {
+        val viewModel = createViewModel()
+
+        viewModel.clickPrimaryButton(COMPLETED_FORM_VALUES, checkboxChecked = true)
+
+        assertThat(resultStateHolder.result.value).isEqualTo(
+            AddressElementActivityContract.Result.StandaloneSucceeded(EXPECTED_ADDRESS)
+        )
+    }
+
+    @Test
+    fun `checkout shipping save emits checkout success without performing additional work`() {
+        val viewModel = createViewModel(
+            launchMode = AddressElementActivityContract.LaunchMode.CheckoutShipping,
+        )
+
+        viewModel.clickPrimaryButton(COMPLETED_FORM_VALUES, checkboxChecked = true)
+
+        assertThat(resultStateHolder.result.value).isEqualTo(
+            AddressElementActivityContract.Result.CheckoutShippingSucceeded(EXPECTED_ADDRESS)
+        )
+    }
+
+    @Test
     fun `isInlineAutocompleteEnabled is always true`() {
         val viewModel = createViewModel()
         assertThat(viewModel.autocompleteConfig.isInlineAutocompleteEnabled).isTrue()
@@ -1008,6 +1035,7 @@ class InputAddressViewModelTest {
                     .googlePlacesApiKey(googlePlacesApiKey)
                     .autocompleteCountries(autocompleteCountries)
                     .build(),
+                launchMode = AddressElementActivityContract.LaunchMode.Standalone,
             ),
             navigator,
             resultStateHolder,
@@ -1060,4 +1088,30 @@ class InputAddressViewModelTest {
 
     private fun createShowState(isChecked: Boolean) =
         InputAddressViewModel.ShippingSameAsBillingState.Show(isChecked)
+
+    private companion object {
+        val EXPECTED_ADDRESS = AddressDetails(
+            name = "Jenny Rosen",
+            address = PaymentSheet.Address(
+                city = "San Francisco",
+                country = "US",
+                line1 = "510 Townsend St",
+                line2 = "Floor 2",
+                postalCode = "94103",
+                state = "CA",
+            ),
+            phoneNumber = "+14155551212",
+            isCheckboxSelected = true,
+        )
+        val COMPLETED_FORM_VALUES = mapOf(
+            FormFieldId.Name to FormFieldEntry("Jenny Rosen", true),
+            FormFieldId.City to FormFieldEntry("San Francisco", true),
+            FormFieldId.Country to FormFieldEntry("US", true),
+            FormFieldId.Line1 to FormFieldEntry("510 Townsend St", true),
+            FormFieldId.Line2 to FormFieldEntry("Floor 2", true),
+            FormFieldId.Phone to FormFieldEntry("+14155551212", true),
+            FormFieldId.PostalCode to FormFieldEntry("94103", true),
+            FormFieldId.State to FormFieldEntry("CA", true),
+        )
+    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -40,15 +40,16 @@ class InputAddressViewModelTest {
         config: AddressLauncher.Configuration = AddressLauncher.Configuration.Builder()
             .address(address)
             .build(),
-        launchMode: AddressElementActivityContract.LaunchMode =
-            AddressElementActivityContract.LaunchMode.Standalone,
+        argsFactory:
+            (AddressLauncher.Configuration) -> AddressElementActivityContract.Args = { currentConfig ->
+                AddressElementActivityContract.Args.Standalone(
+                    publishableKey = "pk_123",
+                    config = currentConfig,
+                )
+            },
     ): InputAddressViewModel {
         return InputAddressViewModel(
-            AddressElementActivityContract.Args(
-                publishableKey = "pk_123",
-                config = config,
-                launchMode = launchMode,
-            ),
+            argsFactory(config),
             navigator,
             resultStateHolder,
             eventReporter,
@@ -1003,7 +1004,12 @@ class InputAddressViewModelTest {
     @Test
     fun `checkout shipping save emits checkout success without performing additional work`() {
         val viewModel = createViewModel(
-            launchMode = AddressElementActivityContract.LaunchMode.CheckoutShipping,
+            argsFactory = { config ->
+                AddressElementActivityContract.Args.CheckoutShipping(
+                    publishableKey = "pk_123",
+                    config = config,
+                )
+            },
         )
 
         viewModel.clickPrimaryButton(COMPLETED_FORM_VALUES, checkboxChecked = true)
@@ -1029,13 +1035,12 @@ class InputAddressViewModelTest {
         autocompleteCountries: Set<String> = emptySet(),
     ): InputAddressViewModel {
         return InputAddressViewModel(
-            AddressElementActivityContract.Args(
+            AddressElementActivityContract.Args.Standalone(
                 publishableKey = "pk_123",
                 config = AddressLauncher.Configuration.Builder()
                     .googlePlacesApiKey(googlePlacesApiKey)
                     .autocompleteCountries(autocompleteCountries)
                     .build(),
-                launchMode = AddressElementActivityContract.LaunchMode.Standalone,
             ),
             navigator,
             resultStateHolder,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
@@ -18,10 +18,9 @@ class AddressElementViewModelModuleTest {
     fun `provideInlinePlacesClient returns hosted client by default when google client is available`() {
         val googlePlacesClient = mock<PlacesClientProxy>()
         val placesClient = module.provideInlinePlacesClient(
-            args = AddressElementActivityContract.Args(
+            args = AddressElementActivityContract.Args.Standalone(
                 publishableKey = "pk_123",
                 config = AddressLauncher.Configuration(),
-                launchMode = AddressElementActivityContract.LaunchMode.Standalone,
             ),
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             googlePlacesClient = googlePlacesClient,
@@ -36,10 +35,9 @@ class AddressElementViewModelModuleTest {
     fun `provideGooglePlacesClient returns null without google api key`() {
         val placesClient = module.provideGooglePlacesClient(
             context = mock<Context>(),
-            args = AddressElementActivityContract.Args(
+            args = AddressElementActivityContract.Args.Standalone(
                 publishableKey = "pk_123",
                 config = AddressLauncher.Configuration(billingAddress = null),
-                launchMode = AddressElementActivityContract.LaunchMode.Standalone,
             ),
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/AddressElementViewModelModuleTest.kt
@@ -21,6 +21,7 @@ class AddressElementViewModelModuleTest {
             args = AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
                 config = AddressLauncher.Configuration(),
+                launchMode = AddressElementActivityContract.LaunchMode.Standalone,
             ),
             stripeAutocompleteRepository = FakeStripeAutocompleteRepository(),
             googlePlacesClient = googlePlacesClient,
@@ -38,6 +39,7 @@ class AddressElementViewModelModuleTest {
             args = AddressElementActivityContract.Args(
                 publishableKey = "pk_123",
                 config = AddressLauncher.Configuration(billingAddress = null),
+                launchMode = AddressElementActivityContract.LaunchMode.Standalone,
             ),
         )
 


### PR DESCRIPTION
# Summary

Keep standalone AddressLauncher and Checkout Shipping behavior unchanged while making their shared Address Element Activity contracts mode-specific. Each owner now launches its own argument subtype and can receive only its valid result type.

This PR is stacked on #14427 and remains the parent of #14398.

# Motivation

AddressLauncher and ShippingAddressElement launch the same Activity, but they are separate owners with different success payloads. The previous shared contract exposed impossible cross-mode successes to both callbacks, forcing each caller to handle results that cannot occur in the intended runtime flow.

## What changed

- Replaced the free `launchMode` field with sealed `Args.Standalone` and `Args.CheckoutShipping` subtypes.
- Added standalone and Checkout-specific Activity contracts over the same `AddressElementActivity`.
- Made the standalone contract return public `AddressLauncherResult` directly and removed the shared callback adapter.
- Limited the Checkout callback to `CheckoutShippingResult`, whose exhaustive outcomes are Checkout success and shared cancellation.
- Shared Activity intent creation while each contract deserializes only its own result type. Missing or wrong-mode internal results fail closed as cancellation.
- Changed the retained result holder payload to the mode-specific internal `AddressElementActivityContract.Result`. Save, Close, root Back, and sheet dismissal publish directly to the holder, while the Activity serializes the result and owns teardown.

## What stays the same

- Standalone Save returns `AddressLauncherResult.Succeeded`; Back, close, and swipe return cancellation.
- Checkout Save commits the collected address through the existing address-only controller path; Back, close, and swipe clear presentation through cancellation.
- The same Activity, form UI, animation, and Activity-owned result serialization and lifecycle teardown remain in place.
- This parent carries no Checkout response, tax update, processing state, retry UI, or dismissal blocking. Those behaviors remain in #14398.
- No public API or changelog change is included.

## Coverage

- Contract tests verify each contract creates an `AddressElementActivity` intent carrying its argument subtype.
- Standalone parsing verifies success maps to public success, while missing, canceled, and Checkout-mode results map to public cancellation.
- Checkout parsing verifies Checkout success and cancellation, while missing and standalone-mode results map to cancellation.
- `AddressLauncherTest` verifies `present()` launches `Args.Standalone`; `ShippingAddressElementTest` verifies the Checkout contract is registered and launches `Args.CheckoutShipping`.
- `InputAddressViewModelTest` verifies each argument subtype publishes its matching internal success result to the holder; existing ShippingAddressElement tests verify presentation survives host recreation and lifecycle destruction unregisters its launcher.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

The normal pre-push hook passed static analysis and API checks, including release compilation. New CI is pending.

# Screenshots

No UI change. Screenshots are not applicable.

# Changelog

No changelog entry. This refactors internal Activity wiring without changing the public `AddressLauncher` contract or observable behavior; the Checkout owner is private preview.

Committed and created by Codex.
