### PR TITLE
Handle JSON failures separate from callback failures in & clean up `GooglePayPaymentDataCallbackHandler`

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandler.kt
@@ -5,6 +5,7 @@ import com.google.android.gms.wallet.callback.OnCompleteListener
 import com.google.android.gms.wallet.callback.PaymentDataRequestUpdate
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.R
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
@@ -27,8 +28,16 @@ internal object GooglePayPaymentDataCallbackHandler {
         val hasNoRequest = request == null
 
         if (hasNoRequest || selection == null) {
-            handleMissingRequestOrSelection(
-                hasNoRequest = hasNoRequest,
+            val event = if (hasNoRequest) {
+                ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_REQUEST
+            } else {
+                ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK
+            }
+
+            handleUnexpectedError(
+                event = event,
+                throwable = null,
+                callbackTrigger = null,
                 googlePayJsonFactory = googlePayJsonFactory,
                 errorReporter = errorReporter,
                 stringResolver = stringResolver,
@@ -39,57 +48,76 @@ internal object GooglePayPaymentDataCallbackHandler {
         }
 
         selection.workScope.launch {
-            val update = GooglePayPaymentDataUpdate.fromIntermediatePaymentData(request)
+            val update = runCatching {
+                GooglePayPaymentDataUpdate.fromIntermediatePaymentData(request)
+            }.getOrElse { error ->
+                handleUnexpectedError(
+                    event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE,
+                    throwable = error,
+                    callbackTrigger = null,
+                    googlePayJsonFactory = googlePayJsonFactory,
+                    errorReporter = errorReporter,
+                    stringResolver = stringResolver,
+                    onCompleteListener = onCompleteListener,
+                )
 
-            runCatching {
-                val update = GooglePayPaymentDataUpdate.fromIntermediatePaymentData(request)
-                val response = selection.callback.onPaymentDataChanged(update)
+                return@launch
+            }
+
+            val response = runCatching {
+                selection.callback.onPaymentDataChanged(update)
+            }.getOrElse { error ->
+                merchantFailureResponse(error, update.callbackTrigger, stringResolver)
+            }
+
+            val json = runCatching {
                 response.toJson(googlePayJsonFactory)
-            }.fold(
-                onSuccess = { json ->
-                    onCompleteListener.complete(PaymentDataRequestUpdate.fromJson(json.toString()))
-                },
-                onFailure = { error ->
-                    onCompleteListener.complete(
-                        PaymentDataRequestUpdate.fromJson(
-                            GooglePayPaymentDataUpdateResponse(
-                                newTransactionInfo = null,
-                                error = GooglePayPaymentDataError(
-                                    reason = GooglePayPaymentDataError.Reason.OtherError,
-                                    message = error.message.orEmpty(),
-                                    intent = when (update.callbackTrigger) {
-                                        null,
-                                        GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
-                                        GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress ->
-                                            GooglePayPaymentDataError.Intent.ShippingAddress
-                                        GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption ->
-                                            GooglePayPaymentDataError.Intent.ShippingOption
-                                        GooglePayPaymentDataUpdate.CallbackTrigger.Offer ->
-                                            GooglePayPaymentDataError.Intent.Offer
-                                    },
-                                ),
-                            ).toJson(googlePayJsonFactory = googlePayJsonFactory).toString()
-                        )
-                    )
-                }
-            )
+            }.getOrElse { error ->
+                handleUnexpectedError(
+                    event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE,
+                    throwable = error,
+                    callbackTrigger = update.callbackTrigger,
+                    googlePayJsonFactory = googlePayJsonFactory,
+                    errorReporter = errorReporter,
+                    stringResolver = stringResolver,
+                    onCompleteListener = onCompleteListener,
+                )
+
+                return@launch
+            }
+
+            onCompleteListener.complete(PaymentDataRequestUpdate.fromJson(json.toString()))
         }
     }
 
-    private fun handleMissingRequestOrSelection(
-        hasNoRequest: Boolean,
+    private fun merchantFailureResponse(
+        error: Throwable,
+        callbackTrigger: GooglePayPaymentDataUpdate.CallbackTrigger?,
+        stringResolver: (ResolvableString) -> String,
+    ): GooglePayPaymentDataUpdateResponse {
+        return GooglePayPaymentDataUpdateResponse(
+            newTransactionInfo = null,
+            error = GooglePayPaymentDataError(
+                reason = GooglePayPaymentDataError.Reason.OtherError,
+                message = error.message ?: stringResolver(R.string.stripe_internal_error.resolvableString),
+                intent = callbackTrigger.toErrorIntent(),
+            ),
+        )
+    }
+
+    private fun handleUnexpectedError(
+        event: ErrorReporter.UnexpectedErrorEvent,
+        throwable: Throwable?,
+        callbackTrigger: GooglePayPaymentDataUpdate.CallbackTrigger?,
         onCompleteListener: OnCompleteListener<PaymentDataRequestUpdate>,
         googlePayJsonFactory: GooglePayJsonFactory,
         errorReporter: ErrorReporter,
-        stringResolver: (ResolvableString) -> String
+        stringResolver: (ResolvableString) -> String,
     ) {
-        val event = if (hasNoRequest) {
-            ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_REQUEST
-        } else {
-            ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK
-        }
-
-        errorReporter.report(event)
+        errorReporter.report(
+            errorEvent = event,
+            stripeException = throwable?.let { StripeException.create(it) }
+        )
 
         onCompleteListener.complete(
             PaymentDataRequestUpdate.fromJson(
@@ -98,11 +126,25 @@ internal object GooglePayPaymentDataCallbackHandler {
                     error = GooglePayPaymentDataError(
                         reason = GooglePayPaymentDataError.Reason.OtherError,
                         message = stringResolver(R.string.stripe_internal_error.resolvableString),
+                        intent = callbackTrigger.toErrorIntent(),
                     ),
                 ).toJson(
                     googlePayJsonFactory = googlePayJsonFactory,
                 ).toString()
             )
         )
+    }
+
+    private fun GooglePayPaymentDataUpdate.CallbackTrigger?.toErrorIntent(): GooglePayPaymentDataError.Intent {
+        return when (this) {
+            null,
+            GooglePayPaymentDataUpdate.CallbackTrigger.Initialize,
+            GooglePayPaymentDataUpdate.CallbackTrigger.ShippingAddress ->
+                GooglePayPaymentDataError.Intent.ShippingAddress
+            GooglePayPaymentDataUpdate.CallbackTrigger.ShippingOption ->
+                GooglePayPaymentDataError.Intent.ShippingOption
+            GooglePayPaymentDataUpdate.CallbackTrigger.Offer ->
+                GooglePayPaymentDataError.Intent.Offer
+        }
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandler.kt
@@ -28,8 +28,6 @@ internal object GooglePayPaymentDataCallbackHandler {
         if (request == null) {
             handleUnexpectedError(
                 event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_REQUEST,
-                throwable = null,
-                callbackTrigger = null,
                 googlePayJsonFactory = googlePayJsonFactory,
                 errorReporter = errorReporter,
                 stringResolver = stringResolver,
@@ -40,8 +38,6 @@ internal object GooglePayPaymentDataCallbackHandler {
         } else if (selection == null) {
             handleUnexpectedError(
                 event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK,
-                throwable = null,
-                callbackTrigger = null,
                 googlePayJsonFactory = googlePayJsonFactory,
                 errorReporter = errorReporter,
                 stringResolver = stringResolver,
@@ -58,7 +54,6 @@ internal object GooglePayPaymentDataCallbackHandler {
                 handleUnexpectedError(
                     event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE,
                     throwable = error,
-                    callbackTrigger = null,
                     googlePayJsonFactory = googlePayJsonFactory,
                     errorReporter = errorReporter,
                     stringResolver = stringResolver,
@@ -111,8 +106,8 @@ internal object GooglePayPaymentDataCallbackHandler {
 
     private fun handleUnexpectedError(
         event: ErrorReporter.UnexpectedErrorEvent,
-        throwable: Throwable?,
-        callbackTrigger: GooglePayPaymentDataUpdate.CallbackTrigger?,
+        throwable: Throwable? = null,
+        callbackTrigger: GooglePayPaymentDataUpdate.CallbackTrigger? = null,
         onCompleteListener: OnCompleteListener<PaymentDataRequestUpdate>,
         googlePayJsonFactory: GooglePayJsonFactory,
         errorReporter: ErrorReporter,

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandler.kt
@@ -25,17 +25,21 @@ internal object GooglePayPaymentDataCallbackHandler {
     ) {
         val selection = GooglePayPaymentDataUpdateCallbackRegistry.get()
 
-        val hasNoRequest = request == null
-
-        if (hasNoRequest || selection == null) {
-            val event = if (hasNoRequest) {
-                ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_REQUEST
-            } else {
-                ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK
-            }
-
+        if (request == null) {
             handleUnexpectedError(
-                event = event,
+                event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_REQUEST,
+                throwable = null,
+                callbackTrigger = null,
+                googlePayJsonFactory = googlePayJsonFactory,
+                errorReporter = errorReporter,
+                stringResolver = stringResolver,
+                onCompleteListener = onCompleteListener,
+            )
+
+            return
+        } else if (selection == null) {
+            handleUnexpectedError(
+                event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK,
                 throwable = null,
                 callbackTrigger = null,
                 googlePayJsonFactory = googlePayJsonFactory,

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -392,6 +392,9 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK(
             partialEventName = "google_pay.dynamic_callbacks.missing_callback"
+        ),
+        GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE(
+            partialEventName = "google_pay.dynamic_callbacks.parsing_failure"
         );
 
         override val eventName: String

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/callback/FakeGooglePayPaymentDataUpdateCallback.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/callback/FakeGooglePayPaymentDataUpdateCallback.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.googlepaylauncher.callback
+
+import app.cash.turbine.Turbine
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
+
+internal class FakeGooglePayPaymentDataUpdateCallback(
+    private val result: (GooglePayPaymentDataUpdate) -> GooglePayPaymentDataUpdateResponse,
+) : GooglePayPaymentDataUpdateCallback {
+    val updates = Turbine<GooglePayPaymentDataUpdate>()
+
+    override suspend fun onPaymentDataChanged(
+        paymentDataUpdate: GooglePayPaymentDataUpdate,
+    ): GooglePayPaymentDataUpdateResponse {
+        updates.add(paymentDataUpdate)
+        return result(paymentDataUpdate)
+    }
+
+    fun ensureAllEventsConsumed() {
+        updates.ensureAllEventsConsumed()
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/callback/FakeOnCompleteListener.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/callback/FakeOnCompleteListener.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.googlepaylauncher.callback
+
+import app.cash.turbine.Turbine
+import com.google.android.gms.wallet.callback.OnCompleteListener
+import com.google.android.gms.wallet.callback.PaymentDataRequestUpdate
+
+internal class FakeOnCompleteListener : OnCompleteListener<PaymentDataRequestUpdate> {
+    val completions = Turbine<PaymentDataRequestUpdate>()
+
+    override fun complete(result: PaymentDataRequestUpdate) {
+        completions.add(result)
+    }
+
+    fun ensureAllEventsConsumed() {
+        completions.ensureAllEventsConsumed()
+    }
+}

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandlerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandlerTest.kt
@@ -1,15 +1,12 @@
 package com.stripe.android.googlepaylauncher.callback
 
-import app.cash.turbine.Turbine
 import com.google.android.gms.wallet.callback.IntermediatePaymentData
-import com.google.android.gms.wallet.callback.OnCompleteListener
 import com.google.android.gms.wallet.callback.PaymentDataRequestUpdate
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.GooglePayConfig
 import com.stripe.android.GooglePayJsonFactory
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
-import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallback
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallbackRegistry
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -84,6 +81,42 @@ class GooglePayPaymentDataCallbackHandlerTest {
         assertThat(transactionInfo.getString("currencyCode")).isEqualTo("USD")
         assertThat(transactionInfo.getString("totalPriceStatus")).isEqualTo("FINAL")
         assertThat(transactionInfo.getString("totalPrice")).isEqualTo("10.99")
+    }
+
+    @Test
+    fun `invalid intermediate payment data reports parsing failure and stops callback`() = runScenario(
+        callbackResult = { error("Should not be called!") }
+    ) {
+        onPaymentDataChanged(malformedRequest())
+
+        val report = errorReporter.awaitCall()
+        assertThat(report.errorEvent)
+            .isEqualTo(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE)
+        assertThat(report.stripeException).isNotNull()
+        assertErrorUpdate(listener.completions.awaitItem())
+    }
+
+    @Test
+    fun `response serialization failure reports parsing failure and stops flow`() = runScenario(
+        callbackResult = {
+            GooglePayPaymentDataUpdateResponse(
+                newTransactionInfo = GooglePayJsonFactory.TransactionInfo(
+                    currencyCode = "not-a-currency",
+                    totalPriceStatus = GooglePayJsonFactory.TransactionInfo.TotalPriceStatus.Final,
+                    totalPrice = 1099,
+                ),
+                error = null,
+            )
+        }
+    ) {
+        onPaymentDataChanged(request())
+
+        assertThat(callback.updates.awaitItem()).isNotNull()
+        val report = errorReporter.awaitCall()
+        assertThat(report.errorEvent)
+            .isEqualTo(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE)
+        assertThat(report.stripeException).isNotNull()
+        assertErrorUpdate(listener.completions.awaitItem())
     }
 
     @Test
@@ -204,35 +237,6 @@ class GooglePayPaymentDataCallbackHandlerTest {
         }
     }
 
-    private class FakeGooglePayPaymentDataUpdateCallback(
-        private val result: (GooglePayPaymentDataUpdate) -> GooglePayPaymentDataUpdateResponse,
-    ) : GooglePayPaymentDataUpdateCallback {
-        val updates = Turbine<GooglePayPaymentDataUpdate>()
-
-        override suspend fun onPaymentDataChanged(
-            update: GooglePayPaymentDataUpdate,
-        ): GooglePayPaymentDataUpdateResponse {
-            updates.add(update)
-            return result(update)
-        }
-
-        fun ensureAllEventsConsumed() {
-            updates.ensureAllEventsConsumed()
-        }
-    }
-
-    private class FakeOnCompleteListener : OnCompleteListener<PaymentDataRequestUpdate> {
-        val completions = Turbine<PaymentDataRequestUpdate>()
-
-        override fun complete(result: PaymentDataRequestUpdate) {
-            completions.add(result)
-        }
-
-        fun ensureAllEventsConsumed() {
-            completions.ensureAllEventsConsumed()
-        }
-    }
-
     private companion object {
         const val CALLBACK_KEY = "callback-key"
         const val INTERNAL_ERROR_MESSAGE = "An internal error occurred."
@@ -265,6 +269,12 @@ class GooglePayPaymentDataCallbackHandlerTest {
                     }
                     """.trimIndent()
                 )
+            }
+        }
+
+        fun malformedRequest(): IntermediatePaymentData {
+            return mock<IntermediatePaymentData>().also {
+                whenever(it.toJson()).thenReturn("not-json")
             }
         }
     }


### PR DESCRIPTION
# Summary
Handle JSON failures separate from callback failures in & clean up `GooglePayPaymentDataCallbackHandler`

# Motivation
`GooglePayPaymentDataCallbackHandler` clean up & proper error handling

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified