### PR TITLE
Derive ECE email collection from checkout data

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -43,7 +43,9 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
                 configuration.toExpressCheckoutElementGooglePayConfiguration(checkoutSessionResponse),
             linkConfiguration = expressCheckoutElementConfiguration.linkConfiguration.asPaymentSheet(),
             billingDetailsCollectionConfiguration = PaymentSheetBillingDetails(
-                email = if (expressCheckoutElementConfiguration.emailRequired) {
+                email = if (
+                    checkoutSessionResponse.customerEmail == null && configuration.defaults.email == null
+                ) {
                     PaymentSheetBillingDetails.CollectionMode.Always
                 } else {
                     PaymentSheetBillingDetails.CollectionMode.Automatic

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
@@ -342,7 +342,6 @@ class ExpressCheckoutElement @Inject internal constructor(
         private var linkConfiguration: LinkConfiguration = LinkConfiguration()
         private var googlePayConfiguration: GooglePayConfiguration = GooglePayConfiguration()
 
-        private var emailRequired: Boolean = false
         private var paymentMethodOrder: List<String> = emptyList()
         private var appearance: Appearance = Appearance()
 
@@ -357,17 +356,6 @@ class ExpressCheckoutElement @Inject internal constructor(
             googlePayConfiguration: GooglePayConfiguration
         ): Configuration = apply {
             this.googlePayConfiguration = googlePayConfiguration
-        }
-
-        /**
-         * Sets whether an email address is required.
-         *
-         * @param emailRequired If true, the customer's email will be collected.
-         */
-        fun emailRequired(
-            emailRequired: Boolean,
-        ): Configuration = apply {
-            this.emailRequired = emailRequired
         }
 
         /**
@@ -394,7 +382,6 @@ class ExpressCheckoutElement @Inject internal constructor(
         internal data class State(
             val linkConfiguration: LinkConfiguration.State,
             val googlePayConfiguration: CheckoutGooglePayConfiguration,
-            val emailRequired: Boolean,
             val paymentMethodOrder: List<PaymentMethodType>,
             val appearance: Appearance.State,
         ) : Parcelable
@@ -407,7 +394,6 @@ class ExpressCheckoutElement @Inject internal constructor(
         internal fun build(): State = State(
             linkConfiguration = linkConfiguration.build(),
             googlePayConfiguration = googlePayConfiguration.build(),
-            emailRequired = emailRequired,
             paymentMethodOrder = paymentMethodOrder.mapNotNull { paymentMethod ->
                 when (paymentMethod) {
                     "google_pay" -> PaymentMethodType.GooglePay

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactoryTest.kt
@@ -186,14 +186,16 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
-    fun `createForExpressCheckoutElement uses automatic billing collection`() {
+    fun `createForExpressCheckoutElement uses automatic billing collection when session has email`() {
         val configuration = CheckoutController.Configuration()
             .expressCheckoutElement(ExpressCheckoutElement.Configuration())
             .build()
 
         val result = factory().createForExpressCheckoutElement(
             configuration = configuration,
-            checkoutSessionResponse = CheckoutSessionResponseFactory.create(),
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                customerEmail = "customer@example.com",
+            ),
             collectedDetails = collectedDetails(),
         )
 
@@ -224,11 +226,9 @@ internal class CheckoutCommonConfigurationFactoryTest {
     }
 
     @Test
-    fun `createForExpressCheckoutElement always collects email when required`() {
+    fun `createForExpressCheckoutElement always collects email when no email is provided`() {
         val configuration = CheckoutController.Configuration()
-            .expressCheckoutElement(
-                ExpressCheckoutElement.Configuration().emailRequired(true)
-            )
+            .expressCheckoutElement(ExpressCheckoutElement.Configuration())
             .build()
 
         val result = factory().createForExpressCheckoutElement(
@@ -239,6 +239,25 @@ internal class CheckoutCommonConfigurationFactoryTest {
 
         assertThat(result?.billingDetailsCollectionConfiguration?.email)
             .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always)
+    }
+
+    @Test
+    fun `createForExpressCheckoutElement uses automatic email collection when default email is provided`() {
+        val configuration = CheckoutController.Configuration()
+            .defaults(
+                CheckoutController.Configuration.Defaults().email("default@example.com")
+            )
+            .expressCheckoutElement(ExpressCheckoutElement.Configuration())
+            .build()
+
+        val result = factory().createForExpressCheckoutElement(
+            configuration = configuration,
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(customerEmail = null),
+            collectedDetails = collectedDetails(email = "default@example.com"),
+        )
+
+        assertThat(result?.billingDetailsCollectionConfiguration?.email)
+            .isEqualTo(PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -122,7 +122,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
     }
 
     @Test
-    fun `confirm uses automatic billing details collection configuration`() {
+    fun `confirm collects email when unavailable and uses automatic collection for other billing details`() {
         val state = createState()
 
         runScenario(
@@ -143,7 +143,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
                 PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
             )
             assertThat(billingDetails.email).isEqualTo(
-                PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Automatic
+                PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode.Always
             )
             assertThat(billingDetails.address).isEqualTo(
                 PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic


### PR DESCRIPTION
# Summary
Remove `emailRequired` from the Express Checkout Element configuration API. Email is now collected when neither the Checkout Session response nor the Checkout Controller defaults provide one.

# Motivation
Match the stripe-js behavior and API: https://docs.stripe.com/js/custom_checkout/create_express_checkout_element

Committed and created by Codex.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified
