### PR TITLE
Separate Address Element terminal results from navigation

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressElementPage.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressElementPage.kt
@@ -1,7 +1,9 @@
 package com.stripe.android.paymentsheet.addresselement
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertTextContains
 import androidx.compose.ui.test.click
+import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isEnabled
 import androidx.compose.ui.test.isNotEnabled
@@ -34,6 +36,14 @@ internal class AddressElementPage(
         composeTestRule.onNodeWithText("Massachusetts").performScrollTo().performClick()
     }
 
+    fun assertCompleteAddress() {
+        assertTextFieldContains("Full name", "Real Name")
+        assertTextFieldContains("Address line 1", "1234 Main St")
+        assertTextFieldContains("City", "Boston")
+        assertTextFieldContains("ZIP Code", "12345")
+        composeTestRule.onNodeWithText("Massachusetts").performScrollTo().assertIsDisplayed()
+    }
+
     fun clickSave() {
         composeTestRule.waitForNode(hasText("Save address").and(isEnabled()))
         composeTestRule.onNodeWithText("Save address").performScrollTo().performClick()
@@ -64,5 +74,11 @@ internal class AddressElementPage(
 
     fun clickClose() {
         composeTestRule.onNodeWithContentDescription("Close").performClick()
+    }
+
+    private fun assertTextFieldContains(label: String, value: String) {
+        composeTestRule.onNode(hasText(label).and(hasSetTextAction()))
+            .performScrollTo()
+            .assertTextContains(value)
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressElementTest.kt
@@ -26,6 +26,21 @@ internal class AddressElementTest {
     }
 
     @Test
+    fun completedAddressSurvivesActivityRecreationAndReturnsSucceededResult() = runAddressElementTest(page) {
+        val activity = present()
+        page.fillCompleteAddress()
+
+        val recreatedActivity = recreate(activity)
+
+        assertThat(recreatedActivity).isNotSameInstanceAs(activity)
+        page.waitUntilVisible()
+        page.assertCompleteAddress()
+        page.clickSave()
+
+        assertThat(results.awaitItem()).isEqualTo(expectedResult)
+    }
+
+    @Test
     fun invalidAddressShowsErrorAndCanBeCorrected() = runAddressElementTest(page) {
         present()
         page.clickDisabledSave()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressElementTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/addresselement/AddressElementTestRunner.kt
@@ -2,6 +2,9 @@ package com.stripe.android.paymentsheet.addresselement
 
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
 import app.cash.turbine.Turbine
 import app.cash.turbine.withTurbineTimeout
 import com.stripe.android.paymentsheet.MainActivity
@@ -16,7 +19,7 @@ internal class AddressElementTestRunnerContext(
     val page: AddressElementPage,
     val results: Turbine<AddressLauncherResult>,
 ) {
-    fun present() {
+    fun present(): AddressElementActivity {
         val activityLaunchObserver = ActivityLaunchObserver(AddressElementActivity::class.java)
         scenario.onActivity {
             activityLaunchObserver.prepareForLaunch(it)
@@ -33,6 +36,28 @@ internal class AddressElementTestRunnerContext(
         }
         activityLaunchObserver.awaitLaunch()
         page.waitUntilVisible()
+        return resumedAddressElementActivity()
+    }
+
+    fun recreate(activity: AddressElementActivity): AddressElementActivity {
+        val activityLaunchObserver = ActivityLaunchObserver(AddressElementActivity::class.java)
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            activityLaunchObserver.prepareForLaunch(activity)
+            activity.recreate()
+        }
+        activityLaunchObserver.awaitLaunch()
+        return resumedAddressElementActivity()
+    }
+
+    private fun resumedAddressElementActivity(): AddressElementActivity {
+        lateinit var addressElementActivity: AddressElementActivity
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            addressElementActivity = ActivityLifecycleMonitorRegistry.getInstance()
+                .getActivitiesInStage(Stage.RESUMED)
+                .filterIsInstance<AddressElementActivity>()
+                .single()
+        }
+        return addressElementActivity
     }
 }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementActivity.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.core.view.WindowCompat
 import androidx.lifecycle.ViewModelProvider
@@ -27,7 +27,8 @@ import com.stripe.android.uicore.StripeTheme
 import com.stripe.android.uicore.elements.bottomsheet.StripeBottomSheetState
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.fadeOut
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.filterNotNull
 
 @OptIn(ExperimentalMaterialApi::class)
 internal class AddressElementActivity : ComponentActivity() {
@@ -58,22 +59,23 @@ internal class AddressElementActivity : ComponentActivity() {
         starterArgs.config?.appearance?.parseAppearance()
 
         setContent {
-            val coroutineScope = rememberCoroutineScope()
-
             val navController = rememberNavController()
             viewModel.navigator.navigationController = navController
 
             val bottomSheetState = rememberStripeBottomSheetState()
 
-            BackHandler {
-                viewModel.navigator.onBack()
+            LaunchedEffect(bottomSheetState) {
+                viewModel.resultStateHolder.result
+                    .filterNotNull()
+                    .collect { result ->
+                        bottomSheetState.hide()
+                        finishWithResult(result)
+                    }
             }
 
-            viewModel.navigator.onDismiss = { result ->
-                coroutineScope.launch {
-                    bottomSheetState.hide()
-                    setResult(result)
-                    finish()
+            BackHandler {
+                if (!viewModel.navigator.onBack()) {
+                    viewModel.resultStateHolder.setResult(AddressLauncherResult.Canceled())
                 }
             }
 
@@ -89,7 +91,9 @@ internal class AddressElementActivity : ComponentActivity() {
         StripeTheme {
             ElementsBottomSheetLayout(
                 state = bottomSheetState,
-                onDismissed = viewModel.navigator::dismiss,
+                onDismissed = {
+                    viewModel.resultStateHolder.setResult(AddressLauncherResult.Canceled())
+                },
             ) {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     NavHost(
@@ -124,13 +128,14 @@ internal class AddressElementActivity : ComponentActivity() {
         }
     }
 
-    private fun setResult(result: AddressLauncherResult = AddressLauncherResult.Canceled()) {
+    private fun finishWithResult(result: AddressLauncherResult) {
         setResult(
             result.resultCode,
             Intent().putExtras(
                 AddressElementActivityContract.Result(result).toBundle()
             )
         )
+        finish()
     }
 
     override fun finish() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementNavigator.kt
@@ -22,9 +22,7 @@ internal interface AddressElementNavigator {
 
     fun <T : Any?> getResultFlow(key: String): Flow<T>?
 
-    fun dismiss(result: AddressLauncherResult = AddressLauncherResult.Canceled())
-
-    fun onBack()
+    fun onBack(): Boolean
 
     sealed interface AutocompleteEvent : Parcelable {
         val address: PaymentSheet.Address?
@@ -44,7 +42,6 @@ internal interface AddressElementNavigator {
 @Singleton
 internal class NavHostAddressElementNavigator @Inject constructor() : AddressElementNavigator {
     var navigationController: NavHostController? = null
-    var onDismiss: ((AddressLauncherResult) -> Unit)? = null
 
     override fun navigateTo(
         target: AddressElementScreen
@@ -64,15 +61,7 @@ internal class NavHostAddressElementNavigator @Inject constructor() : AddressEle
             .filterNotNull()
     }
 
-    override fun dismiss(result: AddressLauncherResult) {
-        onDismiss?.invoke(result)
-    }
-
-    override fun onBack() {
-        navigationController?.let { navController ->
-            if (!navController.popBackStack()) {
-                dismiss()
-            }
-        }
+    override fun onBack(): Boolean {
+        return navigationController?.popBackStack() ?: false
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementResultStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementResultStateHolder.kt
@@ -1,0 +1,18 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class AddressElementResultStateHolder @Inject constructor() {
+    private val _result = MutableStateFlow<AddressLauncherResult?>(null)
+
+    val result: StateFlow<AddressLauncherResult?> = _result.asStateFlow()
+
+    fun setResult(result: AddressLauncherResult) {
+        _result.compareAndSet(expect = null, update = result)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/AddressElementViewModel.kt
@@ -11,6 +11,7 @@ import javax.inject.Provider
 
 internal class AddressElementViewModel @Inject internal constructor(
     val navigator: NavHostAddressElementNavigator,
+    val resultStateHolder: AddressElementResultStateHolder,
     val inputAddressViewModelSubcomponentFactoryProvider: Provider<InputAddressViewModelSubcomponent.Factory>,
     val autoCompleteViewModelSubcomponentFactoryProvider: Provider<AutocompleteViewModelSubcomponent.Factory>,
 ) : ViewModel() {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressScreen.kt
@@ -136,7 +136,9 @@ internal fun InputAddressScreen(
                 checkboxChecked = checkboxChecked
             )
         },
-        onCloseClick = { viewModel.navigator.dismiss() },
+        onCloseClick = {
+            viewModel.resultStateHolder.setResult(AddressLauncherResult.Canceled())
+        },
         topContent = {
             val currentState = billingSameAsShippingState
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModel.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.addresselement
 
-import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
@@ -26,6 +25,7 @@ import javax.inject.Provider
 internal class InputAddressViewModel @Inject constructor(
     val args: AddressElementActivityContract.Args,
     val navigator: AddressElementNavigator,
+    val resultStateHolder: AddressElementResultStateHolder,
     private val eventReporter: AddressLauncherEventReporter,
     @Named(AddressElementViewModelModule.INLINE_PLACES_CLIENT)
     private val placesClient: PlacesClientProxy?,
@@ -212,25 +212,24 @@ internal class InputAddressViewModel @Inject constructor(
             return
         }
         _formEnabled.value = false
-        dismissWithAddress(
+        completeWithAddress(
             AddressDetails(
-                name = completedFormValues?.get(FormFieldId.Name)?.value,
+                name = completedFormValues[FormFieldId.Name]?.value,
                 address = PaymentSheet.Address(
-                    city = completedFormValues?.get(FormFieldId.City)?.value,
-                    country = completedFormValues?.get(FormFieldId.Country)?.value,
-                    line1 = completedFormValues?.get(FormFieldId.Line1)?.value,
-                    line2 = completedFormValues?.get(FormFieldId.Line2)?.value,
-                    postalCode = completedFormValues?.get(FormFieldId.PostalCode)?.value,
-                    state = completedFormValues?.get(FormFieldId.State)?.value
+                    city = completedFormValues[FormFieldId.City]?.value,
+                    country = completedFormValues[FormFieldId.Country]?.value,
+                    line1 = completedFormValues[FormFieldId.Line1]?.value,
+                    line2 = completedFormValues[FormFieldId.Line2]?.value,
+                    postalCode = completedFormValues[FormFieldId.PostalCode]?.value,
+                    state = completedFormValues[FormFieldId.State]?.value
                 ),
-                phoneNumber = completedFormValues?.get(FormFieldId.Phone)?.value,
+                phoneNumber = completedFormValues[FormFieldId.Phone]?.value,
                 isCheckboxSelected = checkboxChecked
             )
         )
     }
 
-    @VisibleForTesting
-    fun dismissWithAddress(addressDetails: AddressDetails) {
+    private fun completeWithAddress(addressDetails: AddressDetails) {
         addressDetails.address?.country?.let { country ->
             eventReporter.onCompleted(
                 country = country,
@@ -238,9 +237,7 @@ internal class InputAddressViewModel @Inject constructor(
                 editDistance = addressDetails.editDistance(collectedAddress.value)
             )
         }
-        navigator.dismiss(
-            AddressLauncherResult.Succeeded(addressDetails)
-        )
+        resultStateHolder.setResult(AddressLauncherResult.Succeeded(addressDetails))
     }
 
     fun clickBillingSameAsShipping(newValue: Boolean) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementResultStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/AddressElementResultStateHolderTest.kt
@@ -1,0 +1,17 @@
+package com.stripe.android.paymentsheet.addresselement
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+internal class AddressElementResultStateHolderTest {
+    @Test
+    fun `first terminal result is retained`() {
+        val expectedResult = AddressLauncherResult.Succeeded(AddressDetails())
+        val resultStateHolder = AddressElementResultStateHolder()
+
+        resultStateHolder.setResult(expectedResult)
+        resultStateHolder.setResult(AddressLauncherResult.Canceled())
+
+        assertThat(resultStateHolder.result.value).isEqualTo(expectedResult)
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/InputAddressViewModelTest.kt
@@ -25,7 +25,6 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
@@ -33,6 +32,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class InputAddressViewModelTest {
     private val navigator = mock<AddressElementNavigator>()
+    private val resultStateHolder = AddressElementResultStateHolder()
     private val eventReporter = mock<AddressLauncherEventReporter>()
 
     private fun createViewModel(
@@ -47,6 +47,7 @@ class InputAddressViewModelTest {
                 config = config,
             ),
             navigator,
+            resultStateHolder,
             eventReporter,
             placesClient = null,
         ).also { viewModelStoreRule.track(it) }
@@ -164,7 +165,20 @@ class InputAddressViewModelTest {
         }
 
     @Test
-    fun `viewModel emits onComplete event`() = runTest(UnconfinedTestDispatcher()) {
+    fun `clickPrimaryButton publishes a succeeded result when form is valid`() = runTest(UnconfinedTestDispatcher()) {
+        val completedFormValues = mapOf(
+            FormFieldId.Line1 to FormFieldEntry(value = "99 Broadway St", isComplete = true),
+            FormFieldId.City to FormFieldEntry(value = "Seattle", isComplete = true),
+            FormFieldId.Country to FormFieldEntry(value = "US", isComplete = true),
+        )
+        val expectedAddress = AddressDetails(
+            address = PaymentSheet.Address(
+                line1 = "99 Broadway St",
+                city = "Seattle",
+                country = "US",
+            ),
+            isCheckboxSelected = true,
+        )
         val viewModel = createViewModel(
             AddressDetails(
                 address = PaymentSheet.Address(
@@ -174,15 +188,14 @@ class InputAddressViewModelTest {
                 )
             )
         )
-        viewModel.dismissWithAddress(
-            AddressDetails(
-                address = PaymentSheet.Address(
-                    line1 = "99 Broadway St",
-                    city = "Seattle",
-                    country = "US"
-                )
-            )
+        viewModel.clickPrimaryButton(
+            completedFormValues = completedFormValues,
+            checkboxChecked = true,
         )
+
+        assertThat(resultStateHolder.result.value)
+            .isEqualTo(AddressLauncherResult.Succeeded(expectedAddress))
+        assertThat(viewModel.formEnabled.value).isFalse()
         verify(eventReporter).onCompleted(
             country = eq("US"),
             autocompleteResultSelected = eq(true),
@@ -954,7 +967,7 @@ class InputAddressViewModelTest {
     }
 
     @Test
-    fun `clickPrimaryButton with null triggers validation errors without dismissing`() = runTest {
+    fun `clickPrimaryButton with null triggers validation errors without a result`() = runTest {
         val viewModel = createViewModel()
 
         val sectionElement = viewModel.addressFormController.elements[0] as SectionElement
@@ -970,7 +983,7 @@ class InputAddressViewModelTest {
 
         assertThat(controller.validationMessage.value).isNotNull()
         assertThat(viewModel.formEnabled.value).isTrue()
-        verify(navigator, never()).dismiss(any())
+        assertThat(resultStateHolder.result.value).isNull()
     }
 
     @Test
@@ -997,6 +1010,7 @@ class InputAddressViewModelTest {
                     .build(),
             ),
             navigator,
+            resultStateHolder,
             eventReporter,
             placesClient = FakePlacesClientProxy(
                 findPredictionsResult = Result.success(FindAutocompletePredictionsResponse(emptyList())),

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAddressElementNavigator.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/addresselement/TestAddressElementNavigator.kt
@@ -8,7 +8,6 @@ internal class TestAddressElementNavigator private constructor() : AddressElemen
     private val navigateToCalls = Turbine<Call.NavigateTo>()
     private val setResultCalls = Turbine<Call.SetResult>()
     private val getResultFlowCalls = Turbine<Call.GetResultFlow>()
-    private val dismissCalls = Turbine<Call.Dismiss>()
     private val onBackCalls = Turbine<Call.OnBack>()
 
     override fun navigateTo(target: AddressElementScreen) {
@@ -25,19 +24,15 @@ internal class TestAddressElementNavigator private constructor() : AddressElemen
         return null
     }
 
-    override fun dismiss(result: AddressLauncherResult) {
-        dismissCalls.add(Call.Dismiss(result))
-    }
-
-    override fun onBack() {
+    override fun onBack(): Boolean {
         onBackCalls.add(Call.OnBack)
+        return true
     }
 
     sealed interface Call {
         data class NavigateTo(val target: AddressElementScreen) : Call
         data class SetResult(val key: String, val value: Any?) : Call
         data class GetResultFlow(val key: String) : Call
-        data class Dismiss(val result: AddressLauncherResult) : Call
         data object OnBack : Call
     }
 
@@ -46,7 +41,6 @@ internal class TestAddressElementNavigator private constructor() : AddressElemen
         val navigateToCalls: ReceiveTurbine<Call.NavigateTo>,
         val setResultCalls: ReceiveTurbine<Call.SetResult>,
         val getResultFlowCalls: ReceiveTurbine<Call.GetResultFlow>,
-        val dismissCalls: ReceiveTurbine<Call.Dismiss>,
         val onBackCalls: ReceiveTurbine<Call.OnBack>,
     )
 
@@ -62,7 +56,6 @@ internal class TestAddressElementNavigator private constructor() : AddressElemen
                     navigateToCalls = navigator.navigateToCalls,
                     setResultCalls = navigator.setResultCalls,
                     getResultFlowCalls = navigator.getResultFlowCalls,
-                    dismissCalls = navigator.dismissCalls,
                     onBackCalls = navigator.onBackCalls,
                 )
             )
@@ -70,7 +63,6 @@ internal class TestAddressElementNavigator private constructor() : AddressElemen
             navigator.navigateToCalls.ensureAllEventsConsumed()
             navigator.setResultCalls.ensureAllEventsConsumed()
             navigator.getResultFlowCalls.ensureAllEventsConsumed()
-            navigator.dismissCalls.ensureAllEventsConsumed()
             navigator.onBackCalls.ensureAllEventsConsumed()
         }
     }


### PR DESCRIPTION
# Summary

Align Address Element cancellation with the existing bottom-sheet pattern in the codebase. Terminal results are published to a shared holder and consumed by `AddressElementActivity`, which remains responsible for dismissing the sheet and finishing.

Changes to `AddressElementNavigator` are mechanical. Its remaining responsibilities support full-screen autocomplete, and it will be removed separately.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- Address Element managed-device tests, including Activity recreation and exact public result delivery.
- API and static-analysis checks.

# Screenshots

N/A. No visual changes.

# Changelog

N/A. Internal implementation change with no public API change.

Committed and created by Codex.
