### PR TITLE
Add Stripe Account verification to RequestMatchers.stripeApiKey

### DIFF
--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -42,17 +42,19 @@ object RequestMatchers {
     fun stripeApiKey(
         publishableKey: String = TestApiKeys.PUBLISHABLE,
         ephemeralKey: String = TestApiKeys.EPHEMERAL,
+        accountId: String = TEST_STRIPE_ACCOUNT
     ): RequestMatcher {
         return ToStringRequestMatcher("stripeApiKey") { request ->
             when (request.headers[ORIGINAL_HOST_HEADER]) {
                 API_HOST -> {
                     val authorization = request.headers[AUTHORIZATION_HEADER]
-                    if (request.requiresEphemeralKey()) {
+                    val matchesApiKey = if (request.requiresEphemeralKey()) {
                         authorization == "Bearer $ephemeralKey"
                     } else {
                         authorization == "Bearer $publishableKey" ||
                             authorization == "Bearer ${TestApiKeys.LIVE_PUBLISHABLE}"
                     }
+                    matchesApiKey && request.headers[STRIPE_ACCOUNT_HEADER] == accountId
                 }
                 ANALYTICS_HOST -> {
                     request.headers[AUTHORIZATION_HEADER] == null &&
@@ -197,6 +199,8 @@ object RequestMatchers {
 
     private const val ORIGINAL_HOST_HEADER = "original-host"
     private const val AUTHORIZATION_HEADER = "Authorization"
+    private const val STRIPE_ACCOUNT_HEADER = "Stripe-Account"
+    private const val TEST_STRIPE_ACCOUNT = "acct_123"
     private const val API_HOST = "api.stripe.com"
     private const val ANALYTICS_HOST = "q.stripe.com"
     private const val PUBLISHABLE_KEY_QUERY = "publishable_key"

--- a/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/RequestMatchers.kt
@@ -42,7 +42,7 @@ object RequestMatchers {
     fun stripeApiKey(
         publishableKey: String = TestApiKeys.PUBLISHABLE,
         ephemeralKey: String = TestApiKeys.EPHEMERAL,
-        accountId: String = TEST_STRIPE_ACCOUNT
+        accountId: String = TestApiKeys.ACCOUNT,
     ): RequestMatcher {
         return ToStringRequestMatcher("stripeApiKey") { request ->
             when (request.headers[ORIGINAL_HOST_HEADER]) {
@@ -200,7 +200,6 @@ object RequestMatchers {
     private const val ORIGINAL_HOST_HEADER = "original-host"
     private const val AUTHORIZATION_HEADER = "Authorization"
     private const val STRIPE_ACCOUNT_HEADER = "Stripe-Account"
-    private const val TEST_STRIPE_ACCOUNT = "acct_123"
     private const val API_HOST = "api.stripe.com"
     private const val ANALYTICS_HOST = "q.stripe.com"
     private const val PUBLISHABLE_KEY_QUERY = "publishable_key"

--- a/network-testing/src/main/java/com/stripe/android/networktesting/TestApiKeys.kt
+++ b/network-testing/src/main/java/com/stripe/android/networktesting/TestApiKeys.kt
@@ -4,4 +4,5 @@ object TestApiKeys {
     const val PUBLISHABLE = "pk_test_123"
     const val LIVE_PUBLISHABLE = "pk_live_123"
     const val EPHEMERAL = "ek_test_123"
+    const val ACCOUNT = "acct_123"
 }

--- a/network-testing/src/test/java/com/stripe/android/networktesting/RequestMatchersTest.kt
+++ b/network-testing/src/test/java/com/stripe/android/networktesting/RequestMatchersTest.kt
@@ -12,6 +12,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.PUBLISHABLE}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
@@ -25,6 +26,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.LIVE_PUBLISHABLE}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
@@ -48,6 +50,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
@@ -61,6 +64,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
@@ -75,6 +79,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.PUBLISHABLE}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
@@ -89,6 +94,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
@@ -102,6 +108,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
@@ -117,6 +124,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
@@ -132,10 +140,38 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.PUBLISHABLE}",
+                "Stripe-Account" to "acct_123",
             ),
         )
 
         assertThat(RequestMatchers.stripeApiKey().matches(request)).isTrue()
+    }
+
+    @Test
+    fun `stripeApiKey rejects missing Stripe account for API request`() {
+        val request = createRequest(
+            path = "/v1/payment_intents/pi_123",
+            headers = mapOf(
+                "original-host" to "api.stripe.com",
+                "Authorization" to "Bearer ${TestApiKeys.PUBLISHABLE}",
+            ),
+        )
+
+        assertThat(RequestMatchers.stripeApiKey().matches(request)).isFalse()
+    }
+
+    @Test
+    fun `stripeApiKey rejects incorrect Stripe account for API request`() {
+        val request = createRequest(
+            path = "/v1/payment_intents/pi_123",
+            headers = mapOf(
+                "original-host" to "api.stripe.com",
+                "Authorization" to "Bearer ${TestApiKeys.PUBLISHABLE}",
+                "Stripe-Account" to "acct_456",
+            ),
+        )
+
+        assertThat(RequestMatchers.stripeApiKey().matches(request)).isFalse()
     }
 
     @Test

--- a/network-testing/src/test/java/com/stripe/android/networktesting/RequestMatchersTest.kt
+++ b/network-testing/src/test/java/com/stripe/android/networktesting/RequestMatchersTest.kt
@@ -12,7 +12,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.PUBLISHABLE}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 
@@ -26,7 +26,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.LIVE_PUBLISHABLE}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 
@@ -50,7 +50,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 
@@ -64,7 +64,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 
@@ -79,7 +79,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.PUBLISHABLE}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 
@@ -94,7 +94,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 
@@ -108,7 +108,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 
@@ -124,7 +124,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.EPHEMERAL}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 
@@ -140,7 +140,7 @@ class RequestMatchersTest {
             headers = mapOf(
                 "original-host" to "api.stripe.com",
                 "Authorization" to "Bearer ${TestApiKeys.PUBLISHABLE}",
-                "Stripe-Account" to "acct_123",
+                "Stripe-Account" to TestApiKeys.ACCOUNT,
             ),
         )
 

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentConfigurationTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentConfigurationTestRule.kt
@@ -8,7 +8,7 @@ import org.junit.runner.Description
 class PaymentConfigurationTestRule(
     private val context: Context,
     private val publishableKey: String = PUBLISHABLE_KEY,
-    private val stripeAccountId: String? = null,
+    private val stripeAccountId: String? = STRIPE_ACCOUNT,
 ) : TestWatcher() {
     override fun starting(description: Description) {
         PaymentConfiguration.init(context, publishableKey, stripeAccountId)
@@ -22,5 +22,6 @@ class PaymentConfigurationTestRule(
 
     private companion object {
         const val PUBLISHABLE_KEY = "pk_test_123"
+        const val STRIPE_ACCOUNT = "acct_123"
     }
 }

--- a/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentConfigurationTestRule.kt
+++ b/payments-core-testing/src/main/java/com/stripe/android/testing/PaymentConfigurationTestRule.kt
@@ -7,10 +7,11 @@ import org.junit.runner.Description
 
 class PaymentConfigurationTestRule(
     private val context: Context,
-    private val publishableKey: String = PUBLISHABLE_KEY
+    private val publishableKey: String = PUBLISHABLE_KEY,
+    private val stripeAccountId: String? = null,
 ) : TestWatcher() {
     override fun starting(description: Description) {
-        PaymentConfiguration.init(context, publishableKey)
+        PaymentConfiguration.init(context, publishableKey, stripeAccountId)
         super.starting(description)
     }
 

--- a/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/cards/DefaultCardAccountRangeRepositoryTest.kt
@@ -256,6 +256,7 @@ internal class DefaultCardAccountRangeRepositoryTest {
             header("Authorization", "Bearer ${DEFAULT_OPTIONS.apiKey}"),
             header("User-Agent", "Stripe/v1 ${StripeSdkVersion.VERSION}"),
             query("bin_prefix", binPrefix),
+            applyDefaultAuthorization = false
         ) { response ->
             response.setBody(
                 """

--- a/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
+++ b/payments-model/src/test/java/com/stripe/android/repository/ConsumersApiServiceImplTest.kt
@@ -443,7 +443,7 @@ class ConsumersApiServiceImplTest {
     }
 
     private companion object {
-        private val DEFAULT_OPTIONS = ApiRequest.Options(TestApiKeys.PUBLISHABLE)
+        private val DEFAULT_OPTIONS = ApiRequest.Options(TestApiKeys.PUBLISHABLE, TestApiKeys.ACCOUNT)
         private const val DEFAULT_SESSION_ID = "sess_123"
     }
 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTestRunner.kt
@@ -15,6 +15,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.MainActivity
 import kotlinx.coroutines.runBlocking
@@ -65,7 +66,11 @@ internal fun runCheckoutPaymentElementTest(
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
         scenario.moveToState(Lifecycle.State.CREATED)
 
-        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(), "pk_test_123")
+        PaymentConfiguration.init(
+            ApplicationProvider.getApplicationContext(),
+            TestApiKeys.PUBLISHABLE,
+            TestApiKeys.ACCOUNT,
+        )
         val controller: CheckoutController = CheckoutController.Builder(
             application = ApplicationProvider.getApplicationContext(),
             savedStateHandle = SavedStateHandle(),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/ExpressCheckoutElementTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/ExpressCheckoutElementTestRunner.kt
@@ -13,6 +13,7 @@ import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.checkouttesting.checkoutInit
 import com.stripe.android.elements.ExpressCheckoutElement
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.paymentsheet.MainActivity
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CountDownLatch
@@ -34,7 +35,11 @@ internal fun runExpressCheckoutElementTest(
     ActivityScenario.launch(MainActivity::class.java).use { scenario ->
         scenario.moveToState(Lifecycle.State.CREATED)
 
-        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(), "pk_test_123")
+        PaymentConfiguration.init(
+            ApplicationProvider.getApplicationContext(),
+            TestApiKeys.PUBLISHABLE,
+            TestApiKeys.ACCOUNT,
+        )
         val controller: CheckoutController = CheckoutController.Builder(
             application = ApplicationProvider.getApplicationContext(),
             savedStateHandle = SavedStateHandle(),

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentelement/EmbeddedPaymentElementTest.kt
@@ -11,6 +11,8 @@ import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.doesNotContainHeader
+import com.stripe.android.networktesting.RequestMatchers.header
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
@@ -568,7 +570,10 @@ internal class EmbeddedPaymentElementTest {
 
                 networkRule.enqueue(
                     method("GET"),
-                    path("edge-internal/card-metadata")
+                    path("edge-internal/card-metadata"),
+                    header("Authorization", "Bearer ${TestApiKeys.PUBLISHABLE}"),
+                    doesNotContainHeader("Stripe-Account"),
+                    applyDefaultAuthorization = false,
                 ) { response ->
                     response.testBodyFromFile("card-metadata-get.json")
                 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CardNumberControllerNetworkTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/CardNumberControllerNetworkTest.kt
@@ -5,9 +5,12 @@ import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import com.stripe.android.paymentsheet.utils.ApiConfigurationTestType
 import com.stripe.android.paymentsheet.utils.ApiConfigurationTestTypeProvider
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.RequestMatchers.doesNotContainHeader
+import com.stripe.android.networktesting.RequestMatchers.header
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.ResponseReplacement
+import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.utils.IntegrationType
@@ -106,7 +109,10 @@ internal class CardNumberControllerNetworkTest(
         // If this request is NOT made, the test will fail because we enqueued but didn't consume it
         networkRule.enqueue(
             method("GET"),
-            path("edge-internal/card-metadata")
+            path("edge-internal/card-metadata"),
+            header("Authorization", "Bearer ${TestApiKeys.PUBLISHABLE}"),
+            doesNotContainHeader("Stripe-Account"),
+            applyDefaultAuthorization = false,
         ) { response ->
             // Return a CREDIT card response - this should trigger the warning
             response.testBodyFromFile("card-metadata-visa-credit.json")
@@ -155,7 +161,10 @@ internal class CardNumberControllerNetworkTest(
         // Enqueue card-metadata response for a DEBIT card
         networkRule.enqueue(
             method("GET"),
-            path("edge-internal/card-metadata")
+            path("edge-internal/card-metadata"),
+            header("Authorization", "Bearer ${TestApiKeys.PUBLISHABLE}"),
+            doesNotContainHeader("Stripe-Account"),
+            applyDefaultAuthorization = false,
         ) { response ->
             response.testBodyFromFile("card-metadata-visa-debit.json")
         }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerRecreationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerRecreationTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.Turbine
 import app.cash.turbine.withTurbineTimeout
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.path
 import com.stripe.android.networktesting.elementsSession
@@ -22,7 +23,13 @@ import kotlin.time.Duration.Companion.seconds
 class FlowControllerRecreationTest {
     @get:Rule
     val testRules = TestRules.create {
-        around(PaymentConfigurationTestRule(ApplicationProvider.getApplicationContext()))
+        around(
+            PaymentConfigurationTestRule(
+                context = ApplicationProvider.getApplicationContext(),
+                publishableKey = TestApiKeys.PUBLISHABLE,
+                stripeAccountId = TestApiKeys.ACCOUNT,
+            )
+        )
     }
 
     private val networkRule = testRules.networkRule

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/FlowControllerTest.kt
@@ -366,7 +366,7 @@ internal class FlowControllerTest(
 
         scenario.moveToState(Lifecycle.State.CREATED)
         scenario.onActivity {
-            PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE)
+            PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE, TestApiKeys.ACCOUNT)
             @Suppress("Deprecation")
             flowController = PaymentSheet.FlowController.create(
                 activity = it,
@@ -455,7 +455,7 @@ internal class FlowControllerTest(
         fun initializeActivity() {
             scenario.moveToState(Lifecycle.State.CREATED)
             scenario.onActivity {
-                PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE)
+                PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE, TestApiKeys.ACCOUNT)
 
                 @Suppress("Deprecation")
                 val unsynchronizedController = PaymentSheet.FlowController.create(
@@ -523,7 +523,7 @@ internal class FlowControllerTest(
 
         scenario.moveToState(Lifecycle.State.CREATED)
         scenario.onActivity {
-            PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE)
+            PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE, TestApiKeys.ACCOUNT)
             @Suppress("Deprecation")
             flowController = PaymentSheet.FlowController.create(
                 activity = it,

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetBillingConfigurationTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.networktesting.RequestMatchers.bodyPart
 import com.stripe.android.networktesting.RequestMatchers.method
 import com.stripe.android.networktesting.RequestMatchers.not
 import com.stripe.android.networktesting.RequestMatchers.path
+import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.networktesting.elementsSession
 import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentsheet.PaymentSheet.Builder
@@ -55,7 +56,7 @@ internal class PaymentSheetBillingConfigurationTest(
         scenario.moveToState(Lifecycle.State.CREATED)
         lateinit var paymentSheet: PaymentSheet
         scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
+            PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE, TestApiKeys.ACCOUNT)
             paymentSheet = Builder { result ->
                 assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
                 countDownLatch.countDown()
@@ -129,7 +130,7 @@ internal class PaymentSheetBillingConfigurationTest(
         scenario.moveToState(Lifecycle.State.CREATED)
         lateinit var paymentSheet: PaymentSheet
         scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
+            PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE, TestApiKeys.ACCOUNT)
             paymentSheet = Builder { result ->
                 assertThat(result).isInstanceOf(PaymentSheetResult.Completed::class.java)
                 countDownLatch.countDown()

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.model.CardBrand
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.RequestMatchers.bodyPart
+import com.stripe.android.networktesting.RequestMatchers.doesNotContainHeader
 import com.stripe.android.networktesting.RequestMatchers.header
 import com.stripe.android.networktesting.RequestMatchers.host
 import com.stripe.android.networktesting.RequestMatchers.method
@@ -442,7 +443,10 @@ internal class PaymentSheetTest(
 
                 networkRule.enqueue(
                     method("GET"),
-                    path("edge-internal/card-metadata")
+                    path("edge-internal/card-metadata"),
+                    header("Authorization", "Bearer ${TestApiKeys.PUBLISHABLE}"),
+                    doesNotContainHeader("Stripe-Account"),
+                    applyDefaultAuthorization = false,
                 ) { response ->
                     response.testBodyFromFile("card-metadata-get.json")
                 }

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
@@ -14,7 +14,7 @@ internal sealed class ApiConfigurationTestType(
             PaymentConfiguration::class.java.canonicalName,
             Context.MODE_PRIVATE,
         ).edit().clear().commit()
-        PaymentConfiguration.init(context, paymentConfigurationPublishableKey)
+        PaymentConfiguration.init(context, paymentConfigurationPublishableKey, "acct_123")
     }
 
     fun withPublishableKey(publishableKey: String): ApiConfigurationTestType {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
@@ -14,7 +14,7 @@ internal sealed class ApiConfigurationTestType(
             PaymentConfiguration::class.java.canonicalName,
             Context.MODE_PRIVATE,
         ).edit().clear().commit()
-        PaymentConfiguration.init(context, paymentConfigurationPublishableKey, "acct_123")
+        PaymentConfiguration.init(context, paymentConfigurationPublishableKey, TestApiKeys.ACCOUNT)
     }
 
     fun withPublishableKey(publishableKey: String): ApiConfigurationTestType {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/ApiConfigurationTestType.kt
@@ -7,6 +7,7 @@ import com.stripe.android.networktesting.TestApiKeys
 
 internal sealed class ApiConfigurationTestType(
     val paymentConfigurationPublishableKey: String,
+    val paymentConfigurationStripeAccount: String
 ) {
     fun initializePaymentConfiguration(context: Context) {
         PaymentConfiguration.clearInstance()
@@ -14,20 +15,22 @@ internal sealed class ApiConfigurationTestType(
             PaymentConfiguration::class.java.canonicalName,
             Context.MODE_PRIVATE,
         ).edit().clear().commit()
-        PaymentConfiguration.init(context, paymentConfigurationPublishableKey, TestApiKeys.ACCOUNT)
+        PaymentConfiguration.init(context, paymentConfigurationPublishableKey, paymentConfigurationStripeAccount)
     }
 
     fun withPublishableKey(publishableKey: String): ApiConfigurationTestType {
-        return Configured(publishableKey)
+        return Configured(publishableKey, paymentConfigurationStripeAccount)
     }
 
     data object PaymentConfigurationOnly : ApiConfigurationTestType(
         paymentConfigurationPublishableKey = TestApiKeys.PUBLISHABLE,
+        paymentConfigurationStripeAccount = TestApiKeys.ACCOUNT
     )
 
     private class Configured(
         paymentConfigurationPublishableKey: String,
-    ) : ApiConfigurationTestType(paymentConfigurationPublishableKey)
+        paymentConfigurationStripeAccount: String
+    ) : ApiConfigurationTestType(paymentConfigurationPublishableKey, paymentConfigurationStripeAccount)
 }
 
 internal object ApiConfigurationTestTypeProvider : TestParameterValuesProvider() {

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/utils/CustomerSheetTestRunner.kt
@@ -10,6 +10,7 @@ import com.stripe.android.customersheet.CustomerSheetActivity
 import com.stripe.android.customersheet.CustomerSheetResultCallback
 import com.stripe.android.link.account.DefaultLinkStore
 import com.stripe.android.networktesting.NetworkRule
+import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.paymentsheet.MainActivity
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -73,7 +74,7 @@ private fun runCustomerSheetTest(
         scenario.moveToState(Lifecycle.State.CREATED)
 
         scenario.onActivity {
-            PaymentConfiguration.init(it, "pk_test_123")
+            PaymentConfiguration.init(it, TestApiKeys.PUBLISHABLE, TestApiKeys.ACCOUNT)
             DefaultLinkStore(it.applicationContext).clear()
         }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSessionTaxRegionUpdaterTest.kt
@@ -106,7 +106,7 @@ internal class CheckoutSessionTaxRegionUpdaterTest {
                 publishableKey = "pk_test_123",
             ),
             publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            stripeAccountIdProvider = { "acct_123" },
         )
 
         val updater = CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/intent/CheckoutSessionConfirmationInterceptorTest.kt
@@ -583,7 +583,7 @@ class CheckoutSessionConfirmationInterceptorTest {
                 publishableKey = "pk_test_123",
             ),
             publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            stripeAccountIdProvider = { "acct_123" },
         )
 
         val interceptor = CheckoutSessionConfirmationInterceptor(
@@ -603,7 +603,7 @@ class CheckoutSessionConfirmationInterceptorTest {
             stripeRepository = stripeRepository,
             checkoutSessionRepository = checkoutSessionRepository,
             checkoutSessionTaxRegionUpdater = CheckoutSessionTaxRegionUpdater(checkoutSessionRepository),
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123"),
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         runTest {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/link/LinkConfirmationActivityTest.kt
@@ -190,7 +190,7 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
                             paymentMethodMetadata = paymentMethodMetadata,
                             requestSurface = RequestSurface.PaymentElement,
                             publishableKey = PUBLISHABLE_KEY,
-                            stripeAccountId = null,
+                            stripeAccountId = STRIPE_ACCOUNT,
                             linkExpressMode = LinkExpressMode.ENABLED,
                             linkAccountInfo = LinkAccountUpdate.Value(null),
                             paymentElementCallbackIdentifier = "ConfirmationTestIdentifier",
@@ -244,5 +244,6 @@ internal class LinkConfirmationActivityTest(private val nativeLinkEnabled: Boole
             "com.stripe.android.payments.paymentlauncher.PaymentLauncherConfirmationActivity"
 
         const val PUBLISHABLE_KEY = "pk_123"
+        const val STRIPE_ACCOUNT = "acct_123"
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/DefaultSheetActivityContinueCoordinatorTest.kt
@@ -144,7 +144,7 @@ internal class DefaultSheetActivityContinueCoordinatorTest {
                 publishableKey = "pk_test_123",
             ),
             publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            stripeAccountIdProvider = { "acct_123" },
         )
 
         return CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/SheetTaxRegionUpdaterTest.kt
@@ -176,7 +176,7 @@ internal class SheetTaxRegionUpdaterTest {
                 publishableKey = "pk_test_123",
             ),
             publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            stripeAccountIdProvider = { "acct_123" },
         )
 
         return CheckoutSessionTaxRegionUpdater(checkoutSessionRepository)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CheckoutSessionRepositoryTest.kt
@@ -40,7 +40,7 @@ class CheckoutSessionRepositoryTest {
             publishableKey = "pk_test_123",
         ),
         publishableKeyProvider = { "pk_test_123" },
-        stripeAccountIdProvider = { null },
+        stripeAccountIdProvider = { "acct_123" },
     )
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -329,7 +329,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
                 publishableKey = "pk_test_123",
             ),
             publishableKeyProvider = { "pk_test_123" },
-            stripeAccountIdProvider = { null },
+            stripeAccountIdProvider = { "acct_123" },
         )
         val repository = DefaultSavedPaymentMethodRepository(
             customerRepository = customerRepository,


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
Add stripeAccountId header verification to default Network Rule request matcher

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Validate stripeAccountId is being sent in network requests

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
