### PR TITLE
Fix Connect download coroutine cleanup

### DIFF
--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -120,8 +120,6 @@ internal class StripeConnectWebView private constructor(
         setDownloadListener(
             StripeDownloadListener(
                 context = context,
-                stripeDownloadManager = StripeDownloadManagerImpl(context),
-                stripeToastManager = StripeToastManagerImpl(),
                 coroutineScope = coroutineScope,
             )
         )

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebView.kt
@@ -47,6 +47,7 @@ import com.stripe.android.connect.webview.serialization.toJs
 import com.stripe.android.core.Logger
 import com.stripe.android.core.version.StripeSdkVersion
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.SerializationException
@@ -66,16 +67,19 @@ internal class StripeConnectWebView private constructor(
     private val mutableContext: MutableContextWrapper,
     @property:VisibleForTesting internal val delegate: Delegate,
     private val logger: Logger,
+    coroutineScope: CoroutineScope,
 ) : WebView(mutableContext), WebViewForPaparazzi {
 
     constructor(
         application: Application,
         delegate: Delegate,
         logger: Logger,
+        coroutineScope: CoroutineScope,
     ) : this(
         mutableContext = MutableContextWrapper(application),
         delegate = delegate,
         logger = logger,
+        coroutineScope = coroutineScope,
     )
 
     private val loggerTag = javaClass.simpleName
@@ -113,7 +117,14 @@ internal class StripeConnectWebView private constructor(
             mediaPlaybackRequiresUserGesture = false
         }
 
-        setDownloadListener(StripeDownloadListener(context))
+        setDownloadListener(
+            StripeDownloadListener(
+                context = context,
+                stripeDownloadManager = StripeDownloadManagerImpl(context),
+                stripeToastManager = StripeToastManagerImpl(),
+                coroutineScope = coroutineScope,
+            )
+        )
         addJavascriptInterface(stripeJsInterface, ANDROID_JS_INTERFACE)
     }
 

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModel.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModel.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelProvider.AndroidViewModelFactory.Companion.APPLICATION_KEY
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -38,6 +39,7 @@ import com.stripe.android.connect.webview.serialization.SetOnLoaderStart
 import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage.UnknownValue
 import com.stripe.android.core.Logger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -116,7 +118,8 @@ internal class StripeConnectWebViewContainerViewModel(
         createWebView(
             application = application,
             delegate = delegate,
-            logger = logger
+            logger = logger,
+            coroutineScope = viewModelScope,
         )
 
     /**
@@ -457,7 +460,12 @@ internal class StripeConnectWebViewContainerViewModel(
 }
 
 internal fun interface CreateWebView {
-    operator fun invoke(application: Application, delegate: Delegate, logger: Logger): StripeConnectWebView
+    operator fun invoke(
+        application: Application,
+        delegate: Delegate,
+        logger: Logger,
+        coroutineScope: CoroutineScope,
+    ): StripeConnectWebView
 }
 
 @Suppress("MagicNumber")

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeDownloadListener.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeDownloadListener.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.connect.webview
 
-import android.annotation.SuppressLint
 import android.app.DownloadManager.STATUS_PAUSED
 import android.app.DownloadManager.STATUS_PENDING
 import android.app.DownloadManager.STATUS_RUNNING
@@ -9,16 +8,14 @@ import android.webkit.DownloadListener
 import com.stripe.android.connect.R
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-@SuppressLint("TestResourceCleanup")
 internal class StripeDownloadListener(
     private val context: Context,
-    private val stripeDownloadManager: StripeDownloadManager = StripeDownloadManagerImpl(context),
-    private val stripeToastManager: StripeToastManager = StripeToastManagerImpl(),
-    private val ioScope: CoroutineScope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+    private val stripeDownloadManager: StripeDownloadManager,
+    private val stripeToastManager: StripeToastManager,
+    private val coroutineScope: CoroutineScope,
 ) : DownloadListener {
 
     override fun onDownloadStart(
@@ -33,7 +30,7 @@ internal class StripeDownloadListener(
             return
         }
 
-        ioScope.launch {
+        coroutineScope.launch(Dispatchers.IO) {
             val downloadId = stripeDownloadManager.enqueueDownload(url, contentDisposition, mimetype)
             if (downloadId == null) {
                 showErrorToast()

--- a/connect/src/main/java/com/stripe/android/connect/webview/StripeDownloadListener.kt
+++ b/connect/src/main/java/com/stripe/android/connect/webview/StripeDownloadListener.kt
@@ -13,9 +13,9 @@ import kotlinx.coroutines.launch
 
 internal class StripeDownloadListener(
     private val context: Context,
-    private val stripeDownloadManager: StripeDownloadManager,
-    private val stripeToastManager: StripeToastManager,
     private val coroutineScope: CoroutineScope,
+    private val stripeDownloadManager: StripeDownloadManager = StripeDownloadManagerImpl(context),
+    private val stripeToastManager: StripeToastManager = StripeToastManagerImpl(),
 ) : DownloadListener {
 
     override fun onDownloadStart(

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewContainerViewModelTest.kt
@@ -8,6 +8,7 @@ import android.content.pm.PackageManager
 import android.graphics.Color
 import android.net.Uri
 import android.webkit.PermissionRequest
+import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.connect.ComponentEvent
@@ -29,9 +30,11 @@ import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMess
 import com.stripe.android.core.Logger
 import com.stripe.android.financialconnections.FinancialConnectionsSheetResult
 import com.stripe.android.testing.ViewModelStoreTestRule
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.toCollection
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -106,13 +109,41 @@ class StripeConnectWebViewContainerViewModelTest {
             embeddedComponent = embeddedComponent,
             stripeIntentLauncher = mockStripeIntentLauncher,
             logger = mockLogger,
-            createWebView = { _, _, _ -> webView }
+            createWebView = { _, _, _, _ -> webView }
         ).also { viewModelStoreRule.track(it) }
     }
 
     @After
     fun cleanup() {
         Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `WebView coroutine scope is cancelled when ViewModel is cleared`() {
+        lateinit var coroutineScope: CoroutineScope
+        val viewModel = StripeConnectWebViewContainerViewModel(
+            application = RuntimeEnvironment.getApplication(),
+            clock = androidClock,
+            embeddedComponentManager = embeddedComponentManager,
+            embeddedComponent = embeddedComponent,
+            analyticsService = analyticsService,
+            logger = mockLogger,
+            createWebView = { _, _, _, scope ->
+                coroutineScope = scope
+                webView
+            },
+        )
+        val viewModelStore = ViewModelStore()
+
+        try {
+            @Suppress("RestrictedApi")
+            viewModelStore.put("viewModel", viewModel)
+            assertThat(coroutineScope.isActive).isTrue()
+        } finally {
+            viewModelStore.clear()
+        }
+
+        assertThat(coroutineScope.isActive).isFalse()
     }
 
     @Test

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeConnectWebViewTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.connect.webview.serialization.SetOnExit
 import com.stripe.android.connect.webview.serialization.SetterFunctionCalledMessage
 import com.stripe.android.core.Logger
 import com.stripe.android.core.version.StripeSdkVersion
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -58,7 +59,8 @@ class StripeConnectWebViewTest {
         webView = StripeConnectWebView(
             application = RuntimeEnvironment.getApplication(),
             delegate = mockDelegate,
-            logger = Logger.getInstance(enableLogging = true)
+            logger = Logger.getInstance(enableLogging = true),
+            coroutineScope = TestScope(),
         )
     }
 

--- a/connect/src/test/java/com/stripe/android/connect/webview/StripeDownloadListenerTest.kt
+++ b/connect/src/test/java/com/stripe/android/connect/webview/StripeDownloadListenerTest.kt
@@ -4,6 +4,8 @@ import android.app.DownloadManager
 import android.content.Context
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.job
+import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
@@ -50,13 +52,13 @@ class StripeDownloadListenerTest {
         context: Context = this.context,
         stripeDownloadManager: StripeDownloadManager = this.stripeDownloadManager,
         stripeToastManager: StripeToastManager = this.stripeToastManager,
-        ioScope: CoroutineScope = testScope,
+        coroutineScope: CoroutineScope = testScope,
     ) {
         stripeDownloadListener = StripeDownloadListener(
             context = context,
             stripeDownloadManager = stripeDownloadManager,
             stripeToastManager = stripeToastManager,
-            ioScope = ioScope,
+            coroutineScope = coroutineScope,
         )
     }
 
@@ -69,7 +71,7 @@ class StripeDownloadListenerTest {
         val contentLength = 1024L
 
         stripeDownloadListener.onDownloadStart(url, userAgent, contentDisposition, mimeType, contentLength)
-        testScope.testScheduler.advanceUntilIdle()
+        testScope.coroutineContext.job.children.toList().joinAll()
 
         verify(stripeDownloadManager).enqueueDownload(url, contentDisposition, mimeType)
         verify(stripeToastManager).showToast(any(), any())
@@ -78,7 +80,7 @@ class StripeDownloadListenerTest {
     @Test
     fun `onDownloadStart does nothing when URL is null`() = runTest {
         stripeDownloadListener.onDownloadStart(null, "", "", "", 0)
-        testScope.testScheduler.advanceUntilIdle()
+        testScope.coroutineContext.job.children.toList().joinAll()
 
         verifyNoInteractions(stripeDownloadManager)
         verify(stripeToastManager).showToast(any(), any())
@@ -95,7 +97,7 @@ class StripeDownloadListenerTest {
         val contentLength = 1024L
 
         stripeDownloadListener.onDownloadStart(url, userAgent, contentDisposition, mimeType, contentLength)
-        testScope.testScheduler.advanceUntilIdle()
+        testScope.coroutineContext.job.children.toList().joinAll()
 
         verify(stripeToastManager).showToast(any(), any())
     }


### PR DESCRIPTION
Committed-By-Agent: goose
Orbit-Session-Id: 0beddf7d-9821-4c39-8db6-278904c6f909

# Summary
<!-- Simple summary of what was changed. -->

Tie Connect download monitoring to the embedded component ViewModel's coroutine scope and remove the TestResourceCleanup suppression.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

StripeDownloadListener currently creates a standalone SupervisorJob-backed IO scope that is never cancelled. This can leave download-status polling alive after its owning Connect component is destroyed.

The listener now uses the owning StripeConnectWebViewContainerViewModel scope while continuing to dispatch download work to [Dispatchers.IO](http://Dispatchers.IO). This preserves monitoring across configuration changes and cancels it when the component is permanently cleared.

Fixes [RUN_MXMOBILE-20093](https://jira.corp.stripe.com/browse/RUN_MXMOBILE-20093).

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
Not applicable; there are no UI changes.

# Changelog
No changelog entry. This is internal lifecycle cleanup with no public API or intended user-visible behavior change.
