### PR TITLE
Update WalletButtonHidden to show Link button on MPE for existing users

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ExpressCheckoutElement.kt
@@ -76,7 +76,8 @@ class ExpressCheckoutElement @Inject internal constructor(
                 Never,
 
                 /**
-                 * Link remains enabled but its button or row is hidden from the payment element UI.
+                 * Link remains enabled. Its button or row is shown when an existing Link user is
+                 * detected and hidden otherwise.
                  */
                 WalletButtonHidden,
             }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/PaymentElement.kt
@@ -366,7 +366,8 @@ class PaymentElement @Inject internal constructor(
                 Never,
 
                 /**
-                 * Link remains enabled but its button or row is hidden from the payment element UI.
+                 * Link remains enabled. Its button or row is shown when an existing Link user is
+                 * detected and hidden otherwise.
                  */
                 WalletButtonHidden,
             }

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/AvailableExpressButtonTypesFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/AvailableExpressButtonTypesFactory.kt
@@ -35,8 +35,7 @@ internal class DefaultAvailableExpressButtonTypesFactory @Inject internal constr
                         CheckoutGooglePayConfiguration.Display.Automatic
                 }
                 WalletType.Link -> ExpressButtonType.Link.takeIf {
-                    expressCheckoutElementConfiguration.linkConfiguration.display ==
-                        ExpressCheckoutElement.Configuration.LinkConfiguration.Display.Automatic &&
+                    paymentMethodMetadata.shouldShowLinkButton &&
                         !requiresShippingAddress
                 }
             }

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -126,10 +126,20 @@ internal data class PaymentMethodMetadata(
     /**
      * Canonical source of truth for whether the Link button/row should be rendered in the
      * payment element UI. Link may remain functionally enabled ([linkState] non-null) even when
-     * its button is hidden via [PaymentSheet.LinkConfiguration.Display.WalletButtonHidden].
+     * [PaymentSheet.LinkConfiguration.Display.WalletButtonHidden] is configured. In that case,
+     * the button is still shown if the load-time lookup found an existing Link user.
      */
     val shouldShowLinkButton: Boolean
-        get() = linkState != null && linkConfiguration.shouldShowButton
+        get() {
+            val linkState = linkState ?: return false
+
+            return when (linkConfiguration.display) {
+                PaymentSheet.LinkConfiguration.Display.Automatic -> true
+                PaymentSheet.LinkConfiguration.Display.Never -> false
+                PaymentSheet.LinkConfiguration.Display.WalletButtonHidden ->
+                    linkState.loginState != LinkState.LoginState.LoggedOut
+            }
+        }
 
     /**
      * Returns the consumer's LinkBrand if logged in, otherwise falls back to the metadata's brand.

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheet.kt
@@ -3718,18 +3718,6 @@ class PaymentSheet internal constructor(
                 Display.WalletButtonHidden -> true
             }
 
-        /**
-         * Canonical source of truth for whether the Link button/row should be rendered in the
-         * payment element UI. Link may remain functionally enabled (see [shouldDisplay]) even
-         * when its button is hidden, e.g. to support the returning-user flow and inline sign-up
-         * without a visible entry point.
-         */
-        internal val shouldShowButton: Boolean
-            get() = when (display) {
-                Display.Automatic -> true
-                Display.Never, Display.WalletButtonHidden -> false
-            }
-
         class Builder {
             private var display: Display = Display.Automatic
             private var collectMissingBillingDetailsForExistingPaymentMethods: Boolean = true
@@ -3777,9 +3765,8 @@ class PaymentSheet internal constructor(
             Never,
 
             /**
-             * Link's button/row is hidden from the payment element UI, but Link remains
-             * otherwise enabled: the returning-user flow and the inline sign-up checkbox are
-             * still shown.
+             * Link remains enabled, including automatic verification and inline sign-up.
+             * Its button or row is shown when an existing Link user is detected and hidden otherwise.
              */
             WalletButtonHidden;
 

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultAvailableExpressButtonTypesFactoryTest.kt
@@ -2,11 +2,15 @@
 package com.stripe.android.elements.ece
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.checkout.asPaymentSheet
 import com.stripe.android.elements.ExpressCheckoutElement
 import com.stripe.android.elements.ExpressCheckoutElement.Configuration.GooglePayConfiguration
+import com.stripe.android.link.TestFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.WalletType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.state.LinkState
 import org.junit.Test
 
 class DefaultAvailableExpressButtonTypesFactoryTest {
@@ -72,7 +76,7 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
     }
 
     @Test
-    fun `create filters out Link when its wallet button is hidden`() {
+    fun `create filters out Link for logged-out user when its wallet button is hidden`() {
         val availableExpressButtonTypes = create(
             availableWallets = listOf(WalletType.Link),
             configuration = ExpressCheckoutElement.Configuration()
@@ -83,6 +87,21 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
         )
 
         assertThat(availableExpressButtonTypes).isEmpty()
+    }
+
+    @Test
+    fun `create returns Link for existing user when its wallet button is hidden`() {
+        val availableExpressButtonTypes = create(
+            availableWallets = listOf(WalletType.Link),
+            configuration = ExpressCheckoutElement.Configuration()
+                .linkConfiguration(
+                    ExpressCheckoutElement.Configuration.LinkConfiguration()
+                        .display(ExpressCheckoutElement.Configuration.LinkConfiguration.Display.WalletButtonHidden)
+                ),
+            linkLoginState = LinkState.LoginState.NeedsVerification,
+        )
+
+        assertThat(availableExpressButtonTypes).containsExactly(ExpressButtonType.Link)
     }
 
     @Test
@@ -172,12 +191,21 @@ class DefaultAvailableExpressButtonTypesFactoryTest {
         availableWallets: List<WalletType>,
         configuration: ExpressCheckoutElement.Configuration? = ExpressCheckoutElement.Configuration(),
         requiresShippingAddress: Boolean = false,
+        linkLoginState: LinkState.LoginState = LinkState.LoginState.LoggedOut,
     ): List<ExpressButtonType> {
+        val configurationState = configuration?.build()
         return DefaultAvailableExpressButtonTypesFactory().create(
             paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                 availableWallets = availableWallets,
+                linkConfiguration = configurationState?.linkConfiguration?.asPaymentSheet()
+                    ?: PaymentSheet.LinkConfiguration(),
+                linkState = LinkState(
+                    configuration = TestFactory.LINK_CONFIGURATION,
+                    loginState = linkLoginState,
+                    signupMode = null,
+                ),
             ),
-            expressCheckoutElementConfiguration = configuration?.build(),
+            expressCheckoutElementConfiguration = configurationState,
             requiresShippingAddress = requiresShippingAddress,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1734,7 +1734,7 @@ internal class PaymentMethodMetadataTest {
         val metadata = PaymentMethodMetadataFactory.create(
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,
-                loginState = LinkState.LoginState.LoggedOut,
+                loginState = LinkState.LoginState.LoggedIn,
                 signupMode = null,
             ),
             linkConfiguration = PaymentSheet.LinkConfiguration(
@@ -1746,7 +1746,7 @@ internal class PaymentMethodMetadataTest {
     }
 
     @Test
-    fun `shouldShowLinkButton returns false when linkState is present and display is WalletButtonHidden`() {
+    fun `shouldShowLinkButton returns false for logged-out user when display is WalletButtonHidden`() {
         val metadata = PaymentMethodMetadataFactory.create(
             linkState = LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,
@@ -1759,6 +1759,38 @@ internal class PaymentMethodMetadataTest {
         )
 
         assertThat(metadata.shouldShowLinkButton).isFalse()
+    }
+
+    @Test
+    fun `shouldShowLinkButton returns true for user needing verification when display is WalletButtonHidden`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.NeedsVerification,
+                signupMode = null,
+            ),
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.WalletButtonHidden,
+            ),
+        )
+
+        assertThat(metadata.shouldShowLinkButton).isTrue()
+    }
+
+    @Test
+    fun `shouldShowLinkButton returns true for logged-in user when display is WalletButtonHidden`() {
+        val metadata = PaymentMethodMetadataFactory.create(
+            linkState = LinkState(
+                configuration = TestFactory.LINK_CONFIGURATION,
+                loginState = LinkState.LoginState.LoggedIn,
+                signupMode = null,
+            ),
+            linkConfiguration = PaymentSheet.LinkConfiguration(
+                display = PaymentSheet.LinkConfiguration.Display.WalletButtonHidden,
+            ),
+        )
+
+        assertThat(metadata.shouldShowLinkButton).isTrue()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -152,6 +152,31 @@ class DefaultWalletButtonsInteractorTest {
     }
 
     @Test
+    fun `on init with Link Display WalletButtonHidden, existing user should have Link button`() = runTest {
+        val interactor = createInteractor(
+            arguments = createArguments(
+                availableWallets = listOf(WalletType.Link),
+                linkEmail = null,
+                linkState = LinkState(
+                    configuration = TestFactory.LINK_CONFIGURATION,
+                    loginState = LinkState.LoginState.NeedsVerification,
+                    signupMode = null,
+                ),
+                linkConfiguration = PaymentSheet.LinkConfiguration(
+                    display = PaymentSheet.LinkConfiguration.Display.WalletButtonHidden,
+                ),
+            )
+        )
+
+        interactor.state.test {
+            val state = awaitItem()
+
+            assertThat(state.walletButtons).hasSize(1)
+            assertThat(state.walletButtons.first()).isInstanceOf<WalletButtonsInteractor.WalletButton.Link>()
+        }
+    }
+
+    @Test
     fun `on init with GPay & Link enabled in arguments, state should have both GPay & Link buttons`() = runTest {
         val interactor = createInteractor(
             arguments = createArguments(


### PR DESCRIPTION
# Summary

Tweaks the behavior of the `LinkConfiguration.Display.WalletButtonHidden` case to show the Link wallet button in MPE for existing users. Non-Link users will continue to not see the wallet button.

# Motivation

Allow users get back into Link after dismissing it.

# Testing


https://github.com/user-attachments/assets/b4f5e12d-bb4d-4bd5-bcbd-6cc168c7ec89


# Changelog

N/a