### PR TITLE
Pass `ApiConfiguration.State` to CustomerRepository calls

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -59,6 +59,7 @@ import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.injection.ApiConfigurationResolverModule
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
@@ -118,6 +119,7 @@ import javax.inject.Singleton
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
         NfcScanningAvailabilityModule::class,
         PaymentOptionCardArtModule::class,
+        ApiConfigurationModule::class,
         ApiConfigurationResolverModule::class,
     ],
 )

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
@@ -185,6 +185,7 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
             configuration = config,
             customerMetadata = paymentMethodMetadata.customerMetadata,
             customerEmail = elementsSessionCustomerEmail,
+            stripeAccountId = paymentMethodMetadata.apiConfiguration.stripeAccountId,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/analytics/experiment/LogLinkHoldbackExperiment.kt
@@ -185,7 +185,7 @@ internal class DefaultLogLinkHoldbackExperiment @Inject constructor(
             configuration = config,
             customerMetadata = paymentMethodMetadata.customerMetadata,
             customerEmail = elementsSessionCustomerEmail,
-            stripeAccountId = paymentMethodMetadata.apiConfiguration.stripeAccountId,
+            apiConfiguration = paymentMethodMetadata.apiConfiguration,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -66,6 +66,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -94,6 +95,7 @@ import javax.inject.Singleton
         DefaultIntentConfirmationModule::class,
         LinkInlineSignupConfirmationModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,
         TapToAddModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -74,7 +74,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 types = requestedTypes,
                 silentlyFail = false,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -92,7 +92,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -110,7 +110,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -130,7 +130,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
                 params = params,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/StripeCustomerAdapter.kt
@@ -3,6 +3,7 @@ package com.stripe.android.customersheet
 import android.content.Context
 import com.stripe.android.common.coroutines.CoalescingOrchestrator
 import com.stripe.android.common.exception.stripeErrorMessage
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.model.PaymentMethod
@@ -14,6 +15,7 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 /**
@@ -32,6 +34,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
     private val timeProvider: () -> Long,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: (CustomerEphemeralKey) -> PrefsRepository,
+    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerAdapter {
 
@@ -71,6 +74,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 types = requestedTypes,
                 silentlyFail = false,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -88,6 +92,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -105,6 +110,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 customerId = customerEphemeralKey.customerId,
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,
@@ -124,6 +130,7 @@ internal class StripeCustomerAdapter @Inject internal constructor(
                 ephemeralKeySecret = customerEphemeralKey.ephemeralKey,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             ).getOrElse {
                 return CustomerAdapter.Result.failure(
                     cause = it,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -45,7 +45,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     paymentMethodId = paymentMethodId,
                     params = params,
-                    stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                    apiConfiguration = apiConfigurationProvider.get(),
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }
@@ -70,7 +70,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
                     paymentMethodId = paymentMethodId,
-                    stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                    apiConfiguration = apiConfigurationProvider.get(),
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.filterToSupportedPaymentMethods
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -9,12 +10,14 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
     private val errorReporter: ErrorReporter,
+    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetPaymentMethodDataSource {
     override suspend fun retrievePaymentMethods(): CustomerSheetDataResult<List<PaymentMethod>> {
@@ -42,6 +45,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     paymentMethodId = paymentMethodId,
                     params = params,
+                    stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }
@@ -66,6 +70,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
                     ephemeralKeySecret = ephemeralKey.ephemeralKey,
                     customerSessionClientSecret = ephemeralKey.customerSessionClientSecret,
                     paymentMethodId = paymentMethodId,
+                    stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 ).getOrThrow()
             }.toCustomerSheetDataResult()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -104,7 +104,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
             customerId = ephemeralKey.customerId,
             ephemeralKeySecret = ephemeralKey.ephemeralKey,
             paymentMethodId = paymentMethodId,
-            stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+            apiConfiguration = apiConfigurationProvider.get(),
         ).getOrThrow()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSource.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.customersheet.data
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodAsPaymentSelection
 import com.stripe.android.customersheet.util.getDefaultPaymentMethodsEnabledForCustomerSheet
@@ -11,12 +12,14 @@ import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import kotlinx.coroutines.withContext
 import java.io.IOException
 import javax.inject.Inject
+import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
     private val elementsSessionManager: CustomerSessionElementsSessionManager,
     private val customerRepository: CustomerRepository,
     private val prefsRepositoryFactory: PrefsRepository.Factory,
+    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetSavedSelectionDataSource {
     override suspend fun retrieveSavedSelection(
@@ -101,6 +104,7 @@ internal class CustomerSessionSavedSelectionDataSource @Inject constructor(
             customerId = ephemeralKey.customerId,
             ephemeralKeySecret = ephemeralKey.ephemeralKey,
             paymentMethodId = paymentMethodId,
+            stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
         ).getOrThrow()
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerSessionDataSourceComponent.kt
@@ -11,6 +11,7 @@ import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSourc
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import com.stripe.android.customersheet.injection.CustomerSheetDataCommonModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
@@ -27,6 +28,7 @@ import javax.inject.Singleton
         CoroutineContextModule::class,
         CoreCommonModule::class,
         ElementsSessionClientParamsModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
     ]
 )
 internal interface CustomerSessionDataSourceComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/StripeCustomerAdapterComponent.kt
@@ -9,6 +9,7 @@ import com.stripe.android.customersheet.CustomerEphemeralKeyProvider
 import com.stripe.android.customersheet.SetupIntentClientSecretProvider
 import com.stripe.android.customersheet.StripeCustomerAdapter
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -28,6 +29,7 @@ import kotlin.coroutines.CoroutineContext
         PaymentElementRequestSurfaceModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
     ]
 )
 internal interface StripeCustomerAdapterComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -31,6 +31,7 @@ import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -53,6 +54,7 @@ import kotlin.coroutines.CoroutineContext
         PaymentsIntegrityModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
         NfcScanningAvailabilityModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -19,6 +19,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.injection.PaymentSheetCommonModule
@@ -39,6 +40,7 @@ import javax.inject.Singleton
         ExtendedPaymentElementConfirmationModule::class,
         TapToAddConnectionStarterModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,
@@ -48,7 +50,7 @@ import javax.inject.Singleton
         ElementsSessionClientParamsModule::class,
         LinkHoldbackExposureModule::class,
         PaymentMethodMessagePromotionsHelperModule::class,
-        PaymentMethodMessagePromotionsExperimentHandlerModule::class
+        PaymentMethodMessagePromotionsExperimentHandlerModule::class,
     ]
 )
 internal interface FlowControllerStateComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import dagger.Module
+import dagger.Provides
+import javax.inject.Provider
+
+@Module
+internal object ApiConfigurationModule {
+    @Provides
+    fun provideApiConfiguration(
+        paymentMethodMetadata: Provider<PaymentMethodMetadata?>
+    ): ApiConfiguration.State = requireNotNull(paymentMethodMetadata.get()?.apiConfiguration)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
@@ -4,12 +4,11 @@ import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import dagger.Module
 import dagger.Provides
-import javax.inject.Provider
 
 @Module
 internal object ApiConfigurationModule {
     @Provides
     fun provideApiConfiguration(
-        paymentMethodMetadata: Provider<PaymentMethodMetadata?>
-    ): ApiConfiguration.State = requireNotNull(paymentMethodMetadata.get()?.apiConfiguration)
+        paymentMethodMetadata: PaymentMethodMetadata?
+    ): ApiConfiguration.State = requireNotNull(paymentMethodMetadata?.apiConfiguration)
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -6,7 +6,6 @@ import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
-import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
@@ -19,6 +18,7 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentOptionsViewModelModule::class,
         PaymentSheetAutocompleteModule::class,
@@ -26,7 +26,6 @@ import javax.inject.Singleton
         CoroutineContextModule::class,
         CoreCommonModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
-        ApiConfigurationFromPaymentConfigurationModule::class,
     ]
 )
 internal interface PaymentOptionsViewModelFactoryComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -6,6 +6,7 @@ import com.stripe.android.common.di.ElementsSessionClientParamsModule
 import com.stripe.android.core.injection.CoreCommonModule
 import com.stripe.android.core.injection.CoroutineContextModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionContract
 import com.stripe.android.paymentsheet.PaymentOptionsViewModel
@@ -24,7 +25,8 @@ import javax.inject.Singleton
         ElementsSessionClientParamsModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,
-        PaymentMethodMessagePromotionsExperimentHandlerModule::class
+        PaymentMethodMessagePromotionsExperimentHandlerModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
     ]
 )
 internal interface PaymentOptionsViewModelFactoryComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -23,6 +23,7 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentsheet.repositories
 
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
@@ -19,7 +18,6 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -29,7 +27,6 @@ import kotlin.coroutines.CoroutineContext
 @Singleton
 internal class CustomerApiRepository @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     private val logger: Logger,
     private val errorReporter: ErrorReporter,
     @IOContext private val workContext: CoroutineContext,
@@ -39,13 +36,14 @@ internal class CustomerApiRepository @Inject constructor(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer? {
         return stripeRepository.retrieveCustomer(
             customerId,
             productUsageTokens,
             ApiRequest.Options(
                 ephemeralKeySecret,
-                lazyPaymentConfig.get().stripeAccountId
+                stripeAccountId
             )
         ).getOrNull()
     }
@@ -55,6 +53,7 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>> = withContext(workContext) {
         val requests = types.filter { paymentMethodType ->
             paymentMethodType in setOf(
@@ -73,7 +72,7 @@ internal class CustomerApiRepository @Inject constructor(
                     productUsageTokens = productUsageTokens,
                     requestOptions = ApiRequest.Options(
                         apiKey = ephemeralKeySecret,
-                        stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                        stripeAccount = stripeAccountId,
                     ),
                 ).onFailure {
                     logger.error("Failed to retrieve payment methods.", it)
@@ -108,13 +107,14 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         return stripeRepository.detachPaymentMethod(
             productUsageTokens = productUsageTokens,
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             ),
         ).onFailure {
             logger.error("Failed to detach payment method $paymentMethodId.", it)
@@ -133,10 +133,11 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = with(CoroutineScope(workContext)) {
         val requestOptions = ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+            stripeAccount = stripeAccountId,
         )
 
         val detachOne: suspend (String) -> Result<PaymentMethod> = { pmId ->
@@ -154,6 +155,7 @@ internal class CustomerApiRepository @Inject constructor(
             // We only support removing duplicate cards.
             types = listOf(PaymentMethod.Type.Card),
             silentlyFail = false,
+            stripeAccountId = stripeAccountId,
         ).getOrElse {
             return Result.failure(it)
         }
@@ -212,6 +214,7 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.attachPaymentMethod(
             customerId = customerId,
@@ -219,7 +222,7 @@ internal class CustomerApiRepository @Inject constructor(
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             )
         ).onFailure {
             logger.error("Failed to attach payment method $paymentMethodId.", it)
@@ -230,13 +233,14 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.updatePaymentMethod(
             paymentMethodId = paymentMethodId,
             paymentMethodUpdateParams = params,
             options = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             )
         ).onFailure {
             logger.error("Failed to update payment method $paymentMethodId.", it)
@@ -246,12 +250,13 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer> = stripeRepository.setDefaultPaymentMethod(
         paymentMethodId = paymentMethodId,
         customerId = customerId,
         options = ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+            stripeAccount = stripeAccountId,
         )
     )
 
@@ -259,6 +264,7 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> =
         stripeRepository.retrieveCustomerPaymentMethod(
             customerId = customerId,
@@ -266,7 +272,7 @@ internal class CustomerApiRepository @Inject constructor(
             productUsageTokens = productUsageTokens,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = lazyPaymentConfig.get().stripeAccountId,
+                stripeAccount = stripeAccountId,
             ),
         ).onFailure {
             logger.error("Failed to retrieve payment method $paymentMethodId.", it)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerApiRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
@@ -36,14 +37,14 @@ internal class CustomerApiRepository @Inject constructor(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Customer? {
         return stripeRepository.retrieveCustomer(
             customerId,
             productUsageTokens,
             ApiRequest.Options(
                 ephemeralKeySecret,
-                stripeAccountId
+                apiConfiguration.stripeAccountId
             )
         ).getOrNull()
     }
@@ -53,7 +54,7 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<List<PaymentMethod>> = withContext(workContext) {
         val requests = types.filter { paymentMethodType ->
             paymentMethodType in setOf(
@@ -72,7 +73,7 @@ internal class CustomerApiRepository @Inject constructor(
                     productUsageTokens = productUsageTokens,
                     requestOptions = ApiRequest.Options(
                         apiKey = ephemeralKeySecret,
-                        stripeAccount = stripeAccountId,
+                        stripeAccount = apiConfiguration.stripeAccountId,
                     ),
                 ).onFailure {
                     logger.error("Failed to retrieve payment methods.", it)
@@ -107,14 +108,14 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> {
         return stripeRepository.detachPaymentMethod(
             productUsageTokens = productUsageTokens,
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = stripeAccountId,
+                stripeAccount = apiConfiguration.stripeAccountId,
             ),
         ).onFailure {
             logger.error("Failed to detach payment method $paymentMethodId.", it)
@@ -133,11 +134,11 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> = with(CoroutineScope(workContext)) {
         val requestOptions = ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = stripeAccountId,
+            stripeAccount = apiConfiguration.stripeAccountId,
         )
 
         val detachOne: suspend (String) -> Result<PaymentMethod> = { pmId ->
@@ -155,7 +156,7 @@ internal class CustomerApiRepository @Inject constructor(
             // We only support removing duplicate cards.
             types = listOf(PaymentMethod.Type.Card),
             silentlyFail = false,
-            stripeAccountId = stripeAccountId,
+            apiConfiguration = apiConfiguration,
         ).getOrElse {
             return Result.failure(it)
         }
@@ -214,7 +215,7 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> =
         stripeRepository.attachPaymentMethod(
             customerId = customerId,
@@ -222,7 +223,7 @@ internal class CustomerApiRepository @Inject constructor(
             paymentMethodId = paymentMethodId,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = stripeAccountId,
+                stripeAccount = apiConfiguration.stripeAccountId,
             )
         ).onFailure {
             logger.error("Failed to attach payment method $paymentMethodId.", it)
@@ -233,14 +234,14 @@ internal class CustomerApiRepository @Inject constructor(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> =
         stripeRepository.updatePaymentMethod(
             paymentMethodId = paymentMethodId,
             paymentMethodUpdateParams = params,
             options = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = stripeAccountId,
+                stripeAccount = apiConfiguration.stripeAccountId,
             )
         ).onFailure {
             logger.error("Failed to update payment method $paymentMethodId.", it)
@@ -250,13 +251,13 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<Customer> = stripeRepository.setDefaultPaymentMethod(
         paymentMethodId = paymentMethodId,
         customerId = customerId,
         options = ApiRequest.Options(
             apiKey = ephemeralKeySecret,
-            stripeAccount = stripeAccountId,
+            stripeAccount = apiConfiguration.stripeAccountId,
         )
     )
 
@@ -264,7 +265,7 @@ internal class CustomerApiRepository @Inject constructor(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> =
         stripeRepository.retrieveCustomerPaymentMethod(
             customerId = customerId,
@@ -272,7 +273,7 @@ internal class CustomerApiRepository @Inject constructor(
             productUsageTokens = productUsageTokens,
             requestOptions = ApiRequest.Options(
                 apiKey = ephemeralKeySecret,
-                stripeAccount = stripeAccountId,
+                stripeAccount = apiConfiguration.stripeAccountId,
             ),
         ).onFailure {
             logger.error("Failed to retrieve payment method $paymentMethodId.", it)

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -14,6 +14,7 @@ internal interface CustomerRepository {
     suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer?
 
     /**
@@ -26,6 +27,7 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>>
 
     /**
@@ -37,6 +39,7 @@ internal interface CustomerRepository {
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     /**
@@ -48,6 +51,7 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     /**
@@ -57,6 +61,7 @@ internal interface CustomerRepository {
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     suspend fun updatePaymentMethod(
@@ -64,17 +69,20 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 
     suspend fun setDefaultPaymentMethod(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer>
 
     suspend fun retrievePaymentMethod(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/CustomerRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.repositories
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -14,7 +15,7 @@ internal interface CustomerRepository {
     suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Customer?
 
     /**
@@ -27,7 +28,7 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<List<PaymentMethod>>
 
     /**
@@ -39,7 +40,7 @@ internal interface CustomerRepository {
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod>
 
     /**
@@ -51,7 +52,7 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod>
 
     /**
@@ -61,7 +62,7 @@ internal interface CustomerRepository {
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod>
 
     suspend fun updatePaymentMethod(
@@ -69,20 +70,20 @@ internal interface CustomerRepository {
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod>
 
     suspend fun setDefaultPaymentMethod(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<Customer>
 
     suspend fun retrievePaymentMethod(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod>
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
@@ -60,7 +60,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 customerSessionClientSecret = customerMetadata.customerSessionClientSecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -68,7 +68,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             )
         }
     }
@@ -94,7 +94,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -102,7 +102,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
                 params = params,
             )
         }
@@ -120,7 +120,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -128,7 +128,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             )
         }
     }
@@ -147,7 +147,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -155,7 +155,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
+                apiConfiguration = apiConfigurationProvider.get(),
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/SavedPaymentMethodRepository.kt
@@ -1,10 +1,12 @@
 package com.stripe.android.paymentsheet.repositories
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import javax.inject.Inject
+import javax.inject.Provider
 
 /**
  * Repository for managing saved payment methods. This abstracts over the underlying
@@ -37,6 +39,7 @@ internal interface SavedPaymentMethodRepository {
 internal class DefaultSavedPaymentMethodRepository @Inject constructor(
     private val customerRepository: CustomerRepository,
     private val checkoutSessionRepository: CheckoutSessionRepository,
+    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
 ) : SavedPaymentMethodRepository {
 
     override suspend fun detachPaymentMethod(
@@ -57,6 +60,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 customerSessionClientSecret = customerMetadata.customerSessionClientSecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -64,6 +68,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             )
         }
     }
@@ -89,6 +94,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
                 params = params,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -96,6 +102,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
                 params = params,
             )
         }
@@ -113,6 +120,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -120,6 +128,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             )
         }
     }
@@ -138,6 +147,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             )
         }
         is CustomerMetadata.LegacyEphemeralKey -> {
@@ -145,6 +155,7 @@ internal class DefaultSavedPaymentMethodRepository @Inject constructor(
                 customerId = customerMetadata.id,
                 ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
+                stripeAccountId = apiConfigurationProvider.get().stripeAccountId,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -36,6 +36,7 @@ internal interface CreateLinkState {
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        stripeAccountId: String?,
     ): LinkStateResult
 }
 
@@ -80,6 +81,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        stripeAccountId: String?,
     ): LinkStateResult {
         val linkDisabledReasons = getLinkDisabledReasons(
             elementsSession = elementsSession,
@@ -98,6 +100,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             initializationMode = initializationMode,
             customerMetadata = customerMetadata,
             clientAttributionMetadata = clientAttributionMetadata,
+            stripeAccountId = stripeAccountId,
         )
         val accountStatus = accountStatusProvider(linkConfiguration)
         val loginState = accountStatus.toLoginState()
@@ -224,6 +227,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        stripeAccountId: String?,
     ): LinkConfiguration {
         val cardBrandFilter = getCardBrandFilter(
             elementsSession = elementsSession,
@@ -236,6 +240,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             configuration,
             customerMetadata,
             customerEmail = elementsSession.customer?.email,
+            stripeAccountId = stripeAccountId,
         )
         val customerInfo = LinkConfiguration.CustomerInfo(
             name = configuration.defaultBillingDetails?.name,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CreateLinkState.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkConfiguration
 import com.stripe.android.link.account.LinkStore
 import com.stripe.android.link.gate.LinkGate
@@ -36,7 +37,7 @@ internal interface CreateLinkState {
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkStateResult
 }
 
@@ -81,7 +82,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkStateResult {
         val linkDisabledReasons = getLinkDisabledReasons(
             elementsSession = elementsSession,
@@ -100,7 +101,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             initializationMode = initializationMode,
             customerMetadata = customerMetadata,
             clientAttributionMetadata = clientAttributionMetadata,
-            stripeAccountId = stripeAccountId,
+            apiConfiguration = apiConfiguration,
         )
         val accountStatus = accountStatusProvider(linkConfiguration)
         val loginState = accountStatus.toLoginState()
@@ -227,7 +228,7 @@ internal class DefaultCreateLinkState @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): LinkConfiguration {
         val cardBrandFilter = getCardBrandFilter(
             elementsSession = elementsSession,
@@ -240,7 +241,7 @@ internal class DefaultCreateLinkState @Inject constructor(
             configuration,
             customerMetadata,
             customerEmail = elementsSession.customer?.email,
-            stripeAccountId = stripeAccountId,
+            apiConfiguration = apiConfiguration,
         )
         val customerInfo = LinkConfiguration.CustomerInfo(
             name = configuration.defaultBillingDetails?.name,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -394,6 +394,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
+                    stripeAccountId = apiConfiguration.stripeAccountId,
                 )
             }
         }
@@ -505,6 +506,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                         PaymentMethod.Type.USBankAccount,
                     ), // These are the only payment method types we support as saved payment methods.
                     silentlyFail = apiConfiguration.isLiveMode(),
+                    stripeAccountId = apiConfiguration.stripeAccountId,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -394,7 +394,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
-                    stripeAccountId = apiConfiguration.stripeAccountId,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }
@@ -506,7 +506,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                         PaymentMethod.Type.USBankAccount,
                     ), // These are the only payment method types we support as saved payment methods.
                     silentlyFail = apiConfiguration.isLiveMode(),
-                    stripeAccountId = apiConfiguration.stripeAccountId,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
@@ -19,6 +19,7 @@ internal interface RetrieveCustomerEmail {
         configuration: CommonConfiguration,
         customerMetadata: CustomerMetadata?,
         customerEmail: String?,
+        stripeAccountId: String?,
     ): String?
 }
 
@@ -31,6 +32,7 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
         configuration: CommonConfiguration,
         customerMetadata: CustomerMetadata?,
         customerEmail: String?,
+        stripeAccountId: String?,
     ): String? {
         return durationProvider.measureDuration(
             DurationProvider.Key.PaymentSheetLoadRetrieveCustomer,
@@ -44,6 +46,7 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
                     defaultEmail ?: retrieveEmailFromApi(
                         customerId = customerMetadata.id,
                         ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
+                        stripeAccountId = stripeAccountId,
                     )
                 }
                 is CustomerMetadata.CheckoutSession,
@@ -55,10 +58,12 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
     private suspend fun retrieveEmailFromApi(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): String? {
         return customerRepository.retrieveCustomer(
             customerId = customerId,
             ephemeralKeySecret = ephemeralKeySecret,
+            stripeAccountId = stripeAccountId,
         )?.email
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/RetrieveCustomerEmail.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
@@ -19,7 +20,7 @@ internal interface RetrieveCustomerEmail {
         configuration: CommonConfiguration,
         customerMetadata: CustomerMetadata?,
         customerEmail: String?,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): String?
 }
 
@@ -32,7 +33,7 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
         configuration: CommonConfiguration,
         customerMetadata: CustomerMetadata?,
         customerEmail: String?,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): String? {
         return durationProvider.measureDuration(
             DurationProvider.Key.PaymentSheetLoadRetrieveCustomer,
@@ -46,7 +47,7 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
                     defaultEmail ?: retrieveEmailFromApi(
                         customerId = customerMetadata.id,
                         ephemeralKeySecret = customerMetadata.ephemeralKeySecret,
-                        stripeAccountId = stripeAccountId,
+                        apiConfiguration = apiConfiguration,
                     )
                 }
                 is CustomerMetadata.CheckoutSession,
@@ -58,12 +59,12 @@ internal class DefaultRetrieveCustomerEmail @Inject constructor(
     private suspend fun retrieveEmailFromApi(
         customerId: String,
         ephemeralKeySecret: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): String? {
         return customerRepository.retrieveCustomer(
             customerId = customerId,
             ephemeralKeySecret = ephemeralKeySecret,
-            stripeAccountId = stripeAccountId,
+            apiConfiguration = apiConfiguration,
         )?.email
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -282,15 +282,18 @@ class CustomerAdapterTest {
 
     @Test
     fun `attachPaymentMethod succeeds when the payment method is attached`() = runTest {
+        val customerRepository = FakeCustomerRepository(
+            onAttachPaymentMethod = {
+                Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            }
+        )
         val adapter = createAdapter(
-            customerRepository = FakeCustomerRepository(
-                onAttachPaymentMethod = {
-                    Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-                }
-            )
+            customerRepository = customerRepository,
         )
         val result = adapter.attachPaymentMethod("pm_1234")
         assertThat(result.getOrNull()).isNotNull()
+        assertThat(customerRepository.attachRequests.awaitItem().stripeAccountId)
+            .isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -314,17 +317,20 @@ class CustomerAdapterTest {
 
     @Test
     fun `detachPaymentMethod succeeds when the payment method is detached`() = runTest {
+        val customerRepository = FakeCustomerRepository(
+            onDetachPaymentMethod = {
+                Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            }
+        )
         val adapter = createAdapter(
-            customerRepository = FakeCustomerRepository(
-                onDetachPaymentMethod = {
-                    Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-                }
-            )
+            customerRepository = customerRepository,
         )
         val result = adapter.detachPaymentMethod("pm_1234")
         assertThat(result.getOrNull()).isEqualTo(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
+        assertThat(customerRepository.detachRequests.awaitItem().stripeAccountId)
+            .isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -348,12 +354,13 @@ class CustomerAdapterTest {
 
     @Test
     fun `updatePaymentMethod succeeds when the payment method is update`() = runTest {
+        val customerRepository = FakeCustomerRepository(
+            onUpdatePaymentMethod = {
+                Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
+            }
+        )
         val adapter = createAdapter(
-            customerRepository = FakeCustomerRepository(
-                onUpdatePaymentMethod = {
-                    Result.success(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
-                }
-            )
+            customerRepository = customerRepository,
         )
         val result = adapter.updatePaymentMethod(
             paymentMethodId = "pm_1234",
@@ -362,6 +369,8 @@ class CustomerAdapterTest {
         assertThat(result.getOrNull()).isEqualTo(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
+        assertThat(customerRepository.updateRequests.awaitItem().stripeAccountId)
+            .isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -3,7 +3,6 @@ package com.stripe.android.customersheet
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
@@ -210,7 +209,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
-            stripeAccountId = eq(ApiKeyFixtures.FAKE_ACCOUNT_ID),
+            apiConfiguration = eq(DEFAULT_API_CONFIG),
         )
     }
 
@@ -262,7 +261,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
-            stripeAccountId = eq(ApiKeyFixtures.FAKE_ACCOUNT_ID),
+            apiConfiguration = eq(DEFAULT_API_CONFIG),
         )
     }
 
@@ -292,8 +291,8 @@ class CustomerAdapterTest {
         )
         val result = adapter.attachPaymentMethod("pm_1234")
         assertThat(result.getOrNull()).isNotNull()
-        assertThat(customerRepository.attachRequests.awaitItem().stripeAccountId)
-            .isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(customerRepository.attachRequests.awaitItem().apiConfiguration)
+            .isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -329,8 +328,8 @@ class CustomerAdapterTest {
         assertThat(result.getOrNull()).isEqualTo(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
-        assertThat(customerRepository.detachRequests.awaitItem().stripeAccountId)
-            .isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(customerRepository.detachRequests.awaitItem().apiConfiguration)
+            .isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -369,8 +368,8 @@ class CustomerAdapterTest {
         assertThat(result.getOrNull()).isEqualTo(
             PaymentMethodFixtures.CARD_PAYMENT_METHOD
         )
-        assertThat(customerRepository.updateRequests.awaitItem().stripeAccountId)
-            .isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(customerRepository.updateRequests.awaitItem().apiConfiguration)
+            .isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -3,13 +3,14 @@ package com.stripe.android.customersheet
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.StripeCustomerAdapter.Companion.CACHED_CUSTOMER_MAX_AGE_MILLIS
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -209,7 +210,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
-            stripeAccountId = eq("acct_123"),
+            stripeAccountId = eq(ApiKeyFixtures.FAKE_ACCOUNT_ID),
         )
     }
 
@@ -261,7 +262,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
-            stripeAccountId = eq("acct_123"),
+            stripeAccountId = eq(ApiKeyFixtures.FAKE_ACCOUNT_ID),
         )
     }
 
@@ -780,7 +781,7 @@ class CustomerAdapterTest {
             timeProvider = timeProvider,
             customerRepository = customerRepository,
             prefsRepositoryFactory = prefsRepositoryFactory,
-            apiConfigurationProvider = { ApiConfiguration.State("pk_test_123", "acct_123") },
+            apiConfigurationProvider = { DEFAULT_API_CONFIG },
             workContext = testDispatcher
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerAdapterTest.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
@@ -191,7 +192,7 @@ class CustomerAdapterTest {
     fun `retrievePaymentMethods filters with paymentMethodTypes`() = runTest {
         val customerRepository = mock<CustomerRepository>()
 
-        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any()))
+        whenever(customerRepository.getPaymentMethods(any(), any(), any(), any(), any()))
             .thenReturn(Result.success(emptyList()))
 
         val adapter = createAdapter(
@@ -208,6 +209,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = any(),
+            stripeAccountId = eq("acct_123"),
         )
     }
 
@@ -259,6 +261,7 @@ class CustomerAdapterTest {
                 )
             ),
             silentlyFail = eq(false),
+            stripeAccountId = eq("acct_123"),
         )
     }
 
@@ -777,6 +780,7 @@ class CustomerAdapterTest {
             timeProvider = timeProvider,
             customerRepository = customerRepository,
             prefsRepositoryFactory = prefsRepositoryFactory,
+            apiConfigurationProvider = { ApiConfiguration.State("pk_test_123", "acct_123") },
             workContext = testDispatcher
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -267,7 +267,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
             elementsSessionManager = elementsSessionManager,
             customerRepository = customerRepository,
             errorReporter = errorReporter,
-            apiConfigurationProvider = { ApiConfiguration.State("pk_test_123", "acct_123") },
+            apiConfigurationProvider = { DEFAULT_API_CONFIG },
             workContext = coroutineContext,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -266,6 +267,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
             elementsSessionManager = elementsSessionManager,
             customerRepository = customerRepository,
             errorReporter = errorReporter,
+            apiConfigurationProvider = { ApiConfiguration.State("pk_test_123", "acct_123") },
             workContext = coroutineContext,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -105,7 +105,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
         assertThat(detachRequest.customerId).isEqualTo("cus_1")
         assertThat(detachRequest.ephemeralKeySecret).isEqualTo("ek_123")
         assertThat(detachRequest.customerSessionClientSecret).isEqualTo("cuss_123")
-        assertThat(detachRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(detachRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()
 
@@ -198,7 +198,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
         assertThat(detachRequest.customerId).isEqualTo("cus_1")
         assertThat(detachRequest.ephemeralKeySecret).isEqualTo("ek_123")
         assertThat(detachRequest.params).isEqualTo(updateParams)
-        assertThat(detachRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(detachRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSourceTest.kt
@@ -105,6 +105,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
         assertThat(detachRequest.customerId).isEqualTo("cus_1")
         assertThat(detachRequest.ephemeralKeySecret).isEqualTo("ek_123")
         assertThat(detachRequest.customerSessionClientSecret).isEqualTo("cuss_123")
+        assertThat(detachRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()
 
@@ -197,6 +198,7 @@ class CustomerSessionPaymentMethodDataSourceTest {
         assertThat(detachRequest.customerId).isEqualTo("cus_1")
         assertThat(detachRequest.ephemeralKeySecret).isEqualTo("ek_123")
         assertThat(detachRequest.params).isEqualTo(updateParams)
+        assertThat(detachRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<PaymentMethod>>()
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -116,7 +116,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<Unit>>()
         val setDefaultRequest = customerRepository.setDefaultPaymentMethodRequests.awaitItem()
         assertThat(setDefaultRequest.paymentMethodId).isEqualTo(expectedNewDefaultPaymentMethodId)
-        assertThat(setDefaultRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(setDefaultRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -1,8 +1,8 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentsheet.FakePrefsRepository
@@ -242,7 +242,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
             prefsRepositoryFactory = {
                 prefsRepository
             },
-            apiConfigurationProvider = { ApiConfiguration.State("pk_test_123", "acct_123") },
+            apiConfigurationProvider = { DEFAULT_API_CONFIG },
             workContext = coroutineContext
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethodFixtures
@@ -241,6 +242,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
             prefsRepositoryFactory = {
                 prefsRepository
             },
+            apiConfigurationProvider = { ApiConfiguration.State("pk_test_123", "acct_123") },
             workContext = coroutineContext
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerSessionSavedSelectionDataSourceTest.kt
@@ -116,6 +116,7 @@ class CustomerSessionSavedSelectionDataSourceTest {
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<Unit>>()
         val setDefaultRequest = customerRepository.setDefaultPaymentMethodRequests.awaitItem()
         assertThat(setDefaultRequest.paymentMethodId).isEqualTo(expectedNewDefaultPaymentMethodId)
+        assertThat(setDefaultRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.ListPaymentMethodsParams
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
@@ -62,7 +63,7 @@ internal class CustomerRepositoryTest {
         repository.retrieveCustomer(
             customerId = "customer_id",
             ephemeralKeySecret = "ephemeral_key",
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeRepository).retrieveCustomer(
@@ -84,7 +85,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+                apiConfiguration = DEFAULT_API_CONFIG,
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -114,7 +115,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.PayPal),
                 true,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -188,7 +189,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             ).getOrThrow()
 
             assertThat(result).hasSize(1)
@@ -246,7 +247,7 @@ internal class CustomerRepositoryTest {
             ephemeralKeySecret = "ephemeral_key",
             listOf(PaymentMethod.Type.Card),
             true,
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+            apiConfiguration = DEFAULT_API_CONFIG
         ).getOrThrow()
 
         assertThat(result).hasSize(2)
@@ -266,7 +267,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = true,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result.getOrNull()).isEmpty()
@@ -286,7 +287,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = false,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -312,7 +313,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = true,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result.getOrNull()).containsExactly(
@@ -345,7 +346,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = false,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -372,7 +373,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -394,7 +395,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result.isFailure).isTrue()
@@ -417,7 +418,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 customerSessionClientSecret = "cuss_123",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -449,7 +450,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethodToRemove.id,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(paymentMethodsToRemove)
@@ -476,7 +477,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = usBankAccount.id,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(listOf(usBankAccount))
@@ -501,7 +502,7 @@ internal class CustomerRepositoryTest {
                 customerId = FAKE_CUSTOMER_ID,
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = paymentMethodToRemove.id,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             val duplicates = paymentMethods.filter { paymentMethod ->
@@ -532,7 +533,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethods.first().id,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result.isFailure).isTrue()
@@ -561,7 +562,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result).isEqualTo(
@@ -585,7 +586,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result).isEqualTo(error)
@@ -602,7 +603,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
                 params = PaymentMethodUpdateParams.createCard(),
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result).isEqualTo(success)
@@ -627,7 +628,7 @@ internal class CustomerRepositoryTest {
             customerId = "customer_id",
             ephemeralKeySecret = "ephemeral_key",
             paymentMethodId = "payment_method_id",
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeRepository).setDefaultPaymentMethod(
@@ -652,7 +653,7 @@ internal class CustomerRepositoryTest {
             customerId = "customer_id",
             ephemeralKeySecret = "ephemeral_key",
             paymentMethodId = "payment_method_id",
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeRepository).retrieveCustomerPaymentMethod(
@@ -674,7 +675,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
                 params = PaymentMethodUpdateParams.createCard(),
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
+                apiConfiguration = DEFAULT_API_CONFIG
             )
 
             assertThat(result).isEqualTo(error)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -114,7 +114,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.PayPal),
                 true,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -188,7 +188,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             ).getOrThrow()
 
             assertThat(result).hasSize(1)
@@ -246,7 +246,7 @@ internal class CustomerRepositoryTest {
             ephemeralKeySecret = "ephemeral_key",
             listOf(PaymentMethod.Type.Card),
             true,
-            stripeAccountId = "acct_123"
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
         ).getOrThrow()
 
         assertThat(result).hasSize(2)
@@ -266,7 +266,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = true,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result.getOrNull()).isEmpty()
@@ -286,7 +286,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = false,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -312,7 +312,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = true,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result.getOrNull()).containsExactly(
@@ -345,7 +345,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = false,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -372,7 +372,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -394,7 +394,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result.isFailure).isTrue()
@@ -417,7 +417,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 customerSessionClientSecret = "cuss_123",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -449,7 +449,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethodToRemove.id,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(paymentMethodsToRemove)
@@ -476,7 +476,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = usBankAccount.id,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(listOf(usBankAccount))
@@ -501,7 +501,7 @@ internal class CustomerRepositoryTest {
                 customerId = FAKE_CUSTOMER_ID,
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = paymentMethodToRemove.id,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             val duplicates = paymentMethods.filter { paymentMethod ->
@@ -532,7 +532,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethods.first().id,
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result.isFailure).isTrue()
@@ -561,7 +561,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result).isEqualTo(
@@ -585,7 +585,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result).isEqualTo(error)
@@ -602,7 +602,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
                 params = PaymentMethodUpdateParams.createCard(),
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result).isEqualTo(success)
@@ -674,7 +674,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
                 params = PaymentMethodUpdateParams.createCard(),
-                stripeAccountId = "acct_123"
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
             )
 
             assertThat(result).isEqualTo(error)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/CustomerRepositoryTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.repositories
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ApiKeyFixtures
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.ListPaymentMethodsParams
@@ -40,12 +39,6 @@ internal class CustomerRepositoryTest {
 
     private val repository = CustomerApiRepository(
         stripeRepository,
-        {
-            PaymentConfiguration(
-                publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
-            )
-        },
         Logger.getInstance(false),
         workContext = testDispatcher,
         errorReporter = errorReporter
@@ -57,7 +50,7 @@ internal class CustomerRepositoryTest {
     }
 
     @Test
-    fun `retrieveCustomer() should use PaymentConfiguration stripe account ID`() = runTest {
+    fun `retrieveCustomer() should use provided stripe account ID`() = runTest {
         whenever(
             stripeRepository.retrieveCustomer(
                 customerId = any(),
@@ -69,6 +62,7 @@ internal class CustomerRepositoryTest {
         repository.retrieveCustomer(
             customerId = "customer_id",
             ephemeralKeySecret = "ephemeral_key",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         verify(stripeRepository).retrieveCustomer(
@@ -90,6 +84,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
+                stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -119,6 +114,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.PayPal),
                 true,
+                stripeAccountId = "acct_123"
             )
 
             verify(stripeRepository).getPaymentMethods(
@@ -192,6 +188,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 true,
+                stripeAccountId = "acct_123"
             ).getOrThrow()
 
             assertThat(result).hasSize(1)
@@ -249,6 +246,7 @@ internal class CustomerRepositoryTest {
             ephemeralKeySecret = "ephemeral_key",
             listOf(PaymentMethod.Type.Card),
             true,
+            stripeAccountId = "acct_123"
         ).getOrThrow()
 
         assertThat(result).hasSize(2)
@@ -268,6 +266,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = true,
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result.getOrNull()).isEmpty()
@@ -287,6 +286,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card),
                 silentlyFail = false,
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -301,7 +301,6 @@ internal class CustomerRepositoryTest {
             val errorReporter = FakeErrorReporter()
             val repository = CustomerApiRepository(
                 failsOnceStripeRepository(),
-                { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                 Logger.getInstance(false),
                 workContext = testDispatcher,
                 errorReporter = errorReporter
@@ -313,6 +312,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = true,
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result.getOrNull()).containsExactly(
@@ -334,7 +334,6 @@ internal class CustomerRepositoryTest {
             val errorReporter = FakeErrorReporter()
             val repository = CustomerApiRepository(
                 failsOnceStripeRepository(),
-                { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY) },
                 Logger.getInstance(false),
                 workContext = testDispatcher,
                 errorReporter = errorReporter
@@ -346,6 +345,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 listOf(PaymentMethod.Type.Card, PaymentMethod.Type.Card, PaymentMethod.Type.Card),
                 silentlyFail = false,
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result.exceptionOrNull()?.message)
@@ -372,6 +372,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -393,6 +394,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result.isFailure).isTrue()
@@ -415,6 +417,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = "ephemeral_key",
                 customerSessionClientSecret = "cuss_123",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result.getOrNull()).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
@@ -446,6 +449,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethodToRemove.id,
+                stripeAccountId = "acct_123"
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(paymentMethodsToRemove)
@@ -472,6 +476,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = usBankAccount.id,
+                stripeAccountId = "acct_123"
             )
 
             assertThat(removedPaymentMethods).containsExactlyElementsIn(listOf(usBankAccount))
@@ -496,6 +501,7 @@ internal class CustomerRepositoryTest {
                 customerId = FAKE_CUSTOMER_ID,
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 paymentMethodId = paymentMethodToRemove.id,
+                stripeAccountId = "acct_123"
             )
 
             val duplicates = paymentMethods.filter { paymentMethod ->
@@ -526,6 +532,7 @@ internal class CustomerRepositoryTest {
                 ephemeralKeySecret = FAKE_EPHEMERAL_KEY,
                 customerSessionClientSecret = FAKE_CUSTOMER_SESSION_CLIENT_SECRET,
                 paymentMethodId = paymentMethods.first().id,
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result.isFailure).isTrue()
@@ -554,6 +561,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result).isEqualTo(
@@ -577,6 +585,7 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result).isEqualTo(error)
@@ -592,7 +601,8 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                params = PaymentMethodUpdateParams.createCard()
+                params = PaymentMethodUpdateParams.createCard(),
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result).isEqualTo(success)
@@ -604,7 +614,7 @@ internal class CustomerRepositoryTest {
         }
 
     @Test
-    fun `setDefaultPaymentMethod() should use PaymentConfiguration stripe account ID`() = runTest {
+    fun `setDefaultPaymentMethod() should use provided stripe account ID`() = runTest {
         whenever(
             stripeRepository.setDefaultPaymentMethod(
                 customerId = any(),
@@ -617,6 +627,7 @@ internal class CustomerRepositoryTest {
             customerId = "customer_id",
             ephemeralKeySecret = "ephemeral_key",
             paymentMethodId = "payment_method_id",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         verify(stripeRepository).setDefaultPaymentMethod(
@@ -627,7 +638,7 @@ internal class CustomerRepositoryTest {
     }
 
     @Test
-    fun `retrievePaymentMethod() should use PaymentConfiguration stripe account ID`() = runTest {
+    fun `retrievePaymentMethod() should use provided stripe account ID`() = runTest {
         whenever(
             stripeRepository.retrieveCustomerPaymentMethod(
                 customerId = any(),
@@ -641,6 +652,7 @@ internal class CustomerRepositoryTest {
             customerId = "customer_id",
             ephemeralKeySecret = "ephemeral_key",
             paymentMethodId = "payment_method_id",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         verify(stripeRepository).retrieveCustomerPaymentMethod(
@@ -661,7 +673,8 @@ internal class CustomerRepositoryTest {
                 customerId = "customer_id",
                 ephemeralKeySecret = "ephemeral_key",
                 paymentMethodId = "payment_method_id",
-                params = PaymentMethodUpdateParams.createCard()
+                params = PaymentMethodUpdateParams.createCard(),
+                stripeAccountId = "acct_123"
             )
 
             assertThat(result).isEqualTo(error)
@@ -674,7 +687,6 @@ internal class CustomerRepositoryTest {
             workContext = coroutineContext,
             errorReporter = errorReporter,
             stripeRepository = stripeRepository,
-            lazyPaymentConfig = { PaymentConfiguration(ApiKeyFixtures.FAKE_PUBLISHABLE_KEY, "acct_123") },
             logger = Logger.getInstance(false),
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -3,9 +3,9 @@ package com.stripe.android.paymentsheet.repositories
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.PaymentMethodRemovePermission
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
 import com.stripe.android.model.PaymentMethod
@@ -336,7 +336,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         val repository = DefaultSavedPaymentMethodRepository(
             customerRepository = customerRepository,
             checkoutSessionRepository = checkoutSessionRepository,
-            apiConfigurationProvider = { ApiConfiguration.State("pk_test_123", "acct_123") },
+            apiConfigurationProvider = { DEFAULT_API_CONFIG },
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -67,7 +67,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         val detachRequest = customerRepository.detachRequests.awaitItem()
         assertThat(detachRequest.paymentMethodId).isEqualTo("pm_123")
         assertThat(detachRequest.customerSessionClientSecret).isEqualTo("css_456")
-        assertThat(detachRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(detachRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -84,7 +84,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         val detachRequest = customerRepository.detachRequests.awaitItem()
         assertThat(detachRequest.paymentMethodId).isEqualTo("pm_123")
         assertThat(detachRequest.customerSessionClientSecret).isNull()
-        assertThat(detachRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(detachRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -101,7 +101,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         val updateRequest = customerRepository.updateRequests.awaitItem()
         assertThat(updateRequest.paymentMethodId).isEqualTo("pm_123")
-        assertThat(updateRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(updateRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -194,7 +194,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         val updateRequest = customerRepository.updateRequests.awaitItem()
         assertThat(updateRequest.paymentMethodId).isEqualTo("pm_123")
-        assertThat(updateRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(updateRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -210,7 +210,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         val setDefaultRequest = customerRepository.setDefaultPaymentMethodRequests.awaitItem()
         assertThat(setDefaultRequest.paymentMethodId).isEqualTo("pm_123")
-        assertThat(setDefaultRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(setDefaultRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -239,7 +239,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         val setDefaultRequest = customerRepository.setDefaultPaymentMethodRequests.awaitItem()
         assertThat(setDefaultRequest.paymentMethodId).isEqualTo("pm_123")
-        assertThat(setDefaultRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(setDefaultRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -258,7 +258,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         assertThat(result.getOrThrow().id).isEqualTo("pm_123")
 
         val retrieveRequest = customerRepository.retrievePaymentMethodRequests.awaitItem()
-        assertThat(retrieveRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(retrieveRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -277,7 +277,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         assertThat(result.getOrThrow().id).isEqualTo("pm_456")
 
         val retrieveRequest = customerRepository.retrievePaymentMethodRequests.awaitItem()
-        assertThat(retrieveRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(retrieveRequest.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.paymentsheet.repositories
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.DefaultStripeNetworkClient
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
@@ -335,6 +336,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         val repository = DefaultSavedPaymentMethodRepository(
             customerRepository = customerRepository,
             checkoutSessionRepository = checkoutSessionRepository,
+            apiConfigurationProvider = { ApiConfiguration.State("pk_test_123", "acct_123") },
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/DefaultSavedPaymentMethodRepositoryTest.kt
@@ -67,6 +67,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         val detachRequest = customerRepository.detachRequests.awaitItem()
         assertThat(detachRequest.paymentMethodId).isEqualTo("pm_123")
         assertThat(detachRequest.customerSessionClientSecret).isEqualTo("css_456")
+        assertThat(detachRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -83,6 +84,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
         val detachRequest = customerRepository.detachRequests.awaitItem()
         assertThat(detachRequest.paymentMethodId).isEqualTo("pm_123")
         assertThat(detachRequest.customerSessionClientSecret).isNull()
+        assertThat(detachRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -99,6 +101,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         val updateRequest = customerRepository.updateRequests.awaitItem()
         assertThat(updateRequest.paymentMethodId).isEqualTo("pm_123")
+        assertThat(updateRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -191,6 +194,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         val updateRequest = customerRepository.updateRequests.awaitItem()
         assertThat(updateRequest.paymentMethodId).isEqualTo("pm_123")
+        assertThat(updateRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -206,6 +210,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         val setDefaultRequest = customerRepository.setDefaultPaymentMethodRequests.awaitItem()
         assertThat(setDefaultRequest.paymentMethodId).isEqualTo("pm_123")
+        assertThat(setDefaultRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -234,6 +239,7 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         val setDefaultRequest = customerRepository.setDefaultPaymentMethodRequests.awaitItem()
         assertThat(setDefaultRequest.paymentMethodId).isEqualTo("pm_123")
+        assertThat(setDefaultRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -250,6 +256,9 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrThrow().id).isEqualTo("pm_123")
+
+        val retrieveRequest = customerRepository.retrievePaymentMethodRequests.awaitItem()
+        assertThat(retrieveRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test
@@ -266,6 +275,9 @@ class DefaultSavedPaymentMethodRepositoryTest {
 
         assertThat(result.isSuccess).isTrue()
         assertThat(result.getOrThrow().id).isEqualTo("pm_456")
+
+        val retrieveRequest = customerRepository.retrievePaymentMethodRequests.awaitItem()
+        assertThat(retrieveRequest.stripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
@@ -47,11 +48,12 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = "acct_123",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         assertThat(retrieveCustomerEmail.invokedWith?.customerEmail).isEqualTo(customerWithEmail.email)
-        assertThat(retrieveCustomerEmail.invokedWith?.stripeAccountId).isEqualTo("acct_123")
+        assertThat(retrieveCustomerEmail.invokedWith?.stripeAccountId)
+            .isEqualTo(ApiKeyFixtures.FAKE_ACCOUNT_ID)
     }
 
     @Test
@@ -107,7 +109,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = initializationMode,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = "acct_123",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         assertThat(result).isInstanceOf<LinkDisabledState>()
@@ -137,7 +139,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = initializationMode,
             customerMetadata = customerMetadata,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = "acct_123",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         assertThat(result).isInstanceOf<LinkState>()
@@ -158,7 +160,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = "acct_123",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         assertThat(linkStateResult).isInstanceOf<LinkState>()
@@ -196,7 +198,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = "acct_123",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         assertThat(cardFundingFilterFactory.invokedWith).isEqualTo(expectedFundingTypes)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -47,9 +47,11 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            stripeAccountId = "acct_123",
         )
 
         assertThat(retrieveCustomerEmail.invokedWith?.customerEmail).isEqualTo(customerWithEmail.email)
+        assertThat(retrieveCustomerEmail.invokedWith?.stripeAccountId).isEqualTo("acct_123")
     }
 
     @Test
@@ -105,6 +107,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = initializationMode,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            stripeAccountId = "acct_123",
         )
 
         assertThat(result).isInstanceOf<LinkDisabledState>()
@@ -134,6 +137,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = initializationMode,
             customerMetadata = customerMetadata,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            stripeAccountId = "acct_123",
         )
 
         assertThat(result).isInstanceOf<LinkState>()
@@ -154,6 +158,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            stripeAccountId = "acct_123",
         )
 
         assertThat(linkStateResult).isInstanceOf<LinkState>()
@@ -191,6 +196,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
+            stripeAccountId = "acct_123",
         )
 
         assertThat(cardFundingFilterFactory.invokedWith).isEqualTo(expectedFundingTypes)
@@ -271,11 +277,13 @@ internal class DefaultCreateLinkStateTest {
             configuration: CommonConfiguration,
             customerMetadata: CustomerMetadata?,
             customerEmail: String?,
+            stripeAccountId: String?,
         ): String? {
             invokedWith = Invocation(
                 configuration = configuration,
                 customerMetadata = customerMetadata,
                 customerEmail = customerEmail,
+                stripeAccountId = stripeAccountId,
             )
             return customerEmail
         }
@@ -284,6 +292,7 @@ internal class DefaultCreateLinkStateTest {
             val configuration: CommonConfiguration,
             val customerMetadata: CustomerMetadata?,
             val customerEmail: String?,
+            val stripeAccountId: String?,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultCreateLinkStateTest.kt
@@ -1,16 +1,17 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.isInstanceOf
 import com.stripe.android.link.gate.FakeLinkGate
 import com.stripe.android.link.model.AccountStatus
 import com.stripe.android.link.ui.inline.LinkSignupMode
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilter
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardFundingFilterFactory
@@ -48,12 +49,11 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(retrieveCustomerEmail.invokedWith?.customerEmail).isEqualTo(customerWithEmail.email)
-        assertThat(retrieveCustomerEmail.invokedWith?.stripeAccountId)
-            .isEqualTo(ApiKeyFixtures.FAKE_ACCOUNT_ID)
+        assertThat(retrieveCustomerEmail.invokedWith?.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -109,7 +109,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = initializationMode,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(result).isInstanceOf<LinkDisabledState>()
@@ -139,7 +139,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = initializationMode,
             customerMetadata = customerMetadata,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(result).isInstanceOf<LinkState>()
@@ -160,7 +160,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(linkStateResult).isInstanceOf<LinkState>()
@@ -198,7 +198,7 @@ internal class DefaultCreateLinkStateTest {
             initializationMode = PAYMENT_INTENT_INIT_MODE,
             customerMetadata = null,
             clientAttributionMetadata = DEFAULT_CLIENT_ATTRIBUTION_METADATA,
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(cardFundingFilterFactory.invokedWith).isEqualTo(expectedFundingTypes)
@@ -279,13 +279,13 @@ internal class DefaultCreateLinkStateTest {
             configuration: CommonConfiguration,
             customerMetadata: CustomerMetadata?,
             customerEmail: String?,
-            stripeAccountId: String?,
+            apiConfiguration: ApiConfiguration.State,
         ): String? {
             invokedWith = Invocation(
                 configuration = configuration,
                 customerMetadata = customerMetadata,
                 customerEmail = customerEmail,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
             return customerEmail
         }
@@ -294,7 +294,7 @@ internal class DefaultCreateLinkStateTest {
             val configuration: CommonConfiguration,
             val customerMetadata: CustomerMetadata?,
             val customerEmail: String?,
-            val stripeAccountId: String?,
+            val apiConfiguration: ApiConfiguration.State,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -14,6 +14,7 @@ import com.stripe.android.common.analytics.experiment.PaymentMethodMessagePromot
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.model.CountryCode
@@ -1053,7 +1054,7 @@ internal class DefaultPaymentElementLoaderTest {
     @Test
     fun `load() with customer should allow sepa`() = runScenario {
         var requestPaymentMethodTypes: List<PaymentMethod.Type>? = null
-        var requestStripeAccountId: String? = null
+        var requestApiConfiguration: ApiConfiguration.State? = null
         val result = createPaymentElementLoader(
             customerRepo = object : FakeCustomerRepository() {
                 override suspend fun getPaymentMethods(
@@ -1061,10 +1062,10 @@ internal class DefaultPaymentElementLoaderTest {
                     ephemeralKeySecret: String,
                     types: List<PaymentMethod.Type>,
                     silentlyFail: Boolean,
-                    stripeAccountId: String?,
+                    apiConfiguration: ApiConfiguration.State,
                 ): Result<List<PaymentMethod>> {
                     requestPaymentMethodTypes = types
-                    requestStripeAccountId = stripeAccountId
+                    requestApiConfiguration = apiConfiguration
                     return Result.success(
                         listOf(
                             PaymentMethodFixtures.CARD_PAYMENT_METHOD,
@@ -1099,7 +1100,7 @@ internal class DefaultPaymentElementLoaderTest {
                 PaymentMethod.Type.SepaDebit,
                 PaymentMethod.Type.USBankAccount,
             )
-        assertThat(requestStripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
+        assertThat(requestApiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
 
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1053,6 +1053,7 @@ internal class DefaultPaymentElementLoaderTest {
     @Test
     fun `load() with customer should allow sepa`() = runScenario {
         var requestPaymentMethodTypes: List<PaymentMethod.Type>? = null
+        var requestStripeAccountId: String? = null
         val result = createPaymentElementLoader(
             customerRepo = object : FakeCustomerRepository() {
                 override suspend fun getPaymentMethods(
@@ -1063,6 +1064,7 @@ internal class DefaultPaymentElementLoaderTest {
                     stripeAccountId: String?,
                 ): Result<List<PaymentMethod>> {
                     requestPaymentMethodTypes = types
+                    requestStripeAccountId = stripeAccountId
                     return Result.success(
                         listOf(
                             PaymentMethodFixtures.CARD_PAYMENT_METHOD,
@@ -1097,6 +1099,7 @@ internal class DefaultPaymentElementLoaderTest {
                 PaymentMethod.Type.SepaDebit,
                 PaymentMethod.Type.USBankAccount,
             )
+        assertThat(requestStripeAccountId).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
 
         assertThat(eventReporter.loadStartedTurbine.awaitItem()).isNotNull()
         assertThat(eventReporter.loadSucceededTurbine.awaitItem()).isNotNull()

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1060,6 +1060,7 @@ internal class DefaultPaymentElementLoaderTest {
                     ephemeralKeySecret: String,
                     types: List<PaymentMethod.Type>,
                     silentlyFail: Boolean,
+                    stripeAccountId: String?,
                 ): Result<List<PaymentMethod>> {
                     requestPaymentMethodTypes = types
                     return Result.success(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
@@ -100,6 +100,7 @@ internal class DefaultRetrieveCustomerEmailTest {
             configuration = configuration,
             customerMetadata = customerMetadata,
             customerEmail = customerEmail,
+            stripeAccountId = "acct_123",
         )
 
         Scenario(
@@ -127,6 +128,7 @@ internal class DefaultRetrieveCustomerEmailTest {
         override suspend fun retrieveCustomer(
             customerId: String,
             ephemeralKeySecret: String,
+            stripeAccountId: String?,
         ) = null.also {
             retrieveCalls.add(RetrieveCall(customerId, ephemeralKeySecret))
         }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
@@ -2,11 +2,12 @@ package com.stripe.android.paymentsheet.state
 
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -34,7 +35,7 @@ internal class DefaultRetrieveCustomerEmailTest {
         val call = customerRepository.retrieveCalls.awaitItem()
         assertThat(call.customerId).isEqualTo("cus_123")
         assertThat(call.ephemeralKeySecret).isEqualTo(PaymentSheetFixtures.DEFAULT_EPHEMERAL_KEY)
-        assertThat(call.stripeAccountId).isEqualTo(ApiKeyFixtures.FAKE_ACCOUNT_ID)
+        assertThat(call.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
     }
 
     @Test
@@ -102,7 +103,7 @@ internal class DefaultRetrieveCustomerEmailTest {
             configuration = configuration,
             customerMetadata = customerMetadata,
             customerEmail = customerEmail,
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         Scenario(
@@ -126,7 +127,7 @@ internal class DefaultRetrieveCustomerEmailTest {
         data class RetrieveCall(
             val customerId: String,
             val ephemeralKeySecret: String,
-            val stripeAccountId: String?,
+            val apiConfiguration: ApiConfiguration.State,
         )
 
         val retrieveCalls = Turbine<RetrieveCall>()
@@ -134,9 +135,9 @@ internal class DefaultRetrieveCustomerEmailTest {
         override suspend fun retrieveCustomer(
             customerId: String,
             ephemeralKeySecret: String,
-            stripeAccountId: String?,
+            apiConfiguration: ApiConfiguration.State,
         ) = null.also {
-            retrieveCalls.add(RetrieveCall(customerId, ephemeralKeySecret, stripeAccountId))
+            retrieveCalls.add(RetrieveCall(customerId, ephemeralKeySecret, apiConfiguration))
         }
 
         override fun ensureAllEventsConsumed() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
@@ -34,6 +34,7 @@ internal class DefaultRetrieveCustomerEmailTest {
         val call = customerRepository.retrieveCalls.awaitItem()
         assertThat(call.customerId).isEqualTo("cus_123")
         assertThat(call.ephemeralKeySecret).isEqualTo(PaymentSheetFixtures.DEFAULT_EPHEMERAL_KEY)
+        assertThat(call.stripeAccountId).isEqualTo(ApiKeyFixtures.FAKE_ACCOUNT_ID)
     }
 
     @Test
@@ -122,7 +123,11 @@ internal class DefaultRetrieveCustomerEmailTest {
      * Returns null for all calls (Customer has an internal constructor in payments-core).
      */
     private class CallTrackingCustomerRepository : FakeCustomerRepository() {
-        data class RetrieveCall(val customerId: String, val ephemeralKeySecret: String)
+        data class RetrieveCall(
+            val customerId: String,
+            val ephemeralKeySecret: String,
+            val stripeAccountId: String?,
+        )
 
         val retrieveCalls = Turbine<RetrieveCall>()
 
@@ -131,7 +136,7 @@ internal class DefaultRetrieveCustomerEmailTest {
             ephemeralKeySecret: String,
             stripeAccountId: String?,
         ) = null.also {
-            retrieveCalls.add(RetrieveCall(customerId, ephemeralKeySecret))
+            retrieveCalls.add(RetrieveCall(customerId, ephemeralKeySecret, stripeAccountId))
         }
 
         override fun ensureAllEventsConsumed() {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultRetrieveCustomerEmailTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
@@ -100,7 +101,7 @@ internal class DefaultRetrieveCustomerEmailTest {
             configuration = configuration,
             customerMetadata = customerMetadata,
             customerEmail = customerEmail,
-            stripeAccountId = "acct_123",
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -60,6 +60,7 @@ internal open class FakeCustomerRepository(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
+        stripeAccountId: String?,
     ): Customer? {
         _retrieveCustomerRequests.add(
             RetrieveCustomerRequest(
@@ -76,6 +77,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
+        stripeAccountId: String?,
     ): Result<List<PaymentMethod>> {
         _getPaymentMethodsRequests.add(
             GetPaymentMethodsRequest(
@@ -93,6 +95,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -110,6 +113,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -127,6 +131,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = onAttachPaymentMethod()
 
     override suspend fun updatePaymentMethod(
@@ -134,6 +139,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> {
         _updateRequests.add(
             UpdateRequest(
@@ -151,6 +157,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
+        stripeAccountId: String?,
     ): Result<Customer> {
         _setDefaultPaymentMethodRequests.add(
             SetDefaultRequest(
@@ -167,6 +174,7 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
+        stripeAccountId: String?,
     ): Result<PaymentMethod> = onRetrievePaymentMethod(paymentMethodId)
 
     data class RetrieveCustomerRequest(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -43,9 +43,6 @@ internal open class FakeCustomerRepository(
     private val _detachRequests = Turbine<DetachRequest>()
     val detachRequests: ReceiveTurbine<DetachRequest> = _detachRequests
 
-    private val _attachRequests = Turbine<AttachRequest>()
-    val attachRequests: ReceiveTurbine<AttachRequest> = _attachRequests
-
     private val _updateRequests = Turbine<UpdateRequest>()
     val updateRequests: ReceiveTurbine<UpdateRequest> = _updateRequests
 
@@ -59,7 +56,6 @@ internal open class FakeCustomerRepository(
         _retrieveCustomerRequests.ensureAllEventsConsumed()
         _getPaymentMethodsRequests.ensureAllEventsConsumed()
         _detachRequests.ensureAllEventsConsumed()
-        _attachRequests.ensureAllEventsConsumed()
         _updateRequests.ensureAllEventsConsumed()
         _setDefaultPaymentMethodRequests.ensureAllEventsConsumed()
         _retrievePaymentMethodRequests.ensureAllEventsConsumed()
@@ -144,18 +140,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         stripeAccountId: String?,
-    ): Result<PaymentMethod> {
-        _attachRequests.add(
-            AttachRequest(
-                customerId = customerId,
-                ephemeralKeySecret = ephemeralKeySecret,
-                paymentMethodId = paymentMethodId,
-                stripeAccountId = stripeAccountId,
-            )
-        )
-
-        return onAttachPaymentMethod()
-    }
+    ): Result<PaymentMethod> = onAttachPaymentMethod()
 
     override suspend fun updatePaymentMethod(
         customerId: String,
@@ -232,13 +217,6 @@ internal open class FakeCustomerRepository(
         val customerId: String,
         val ephemeralKeySecret: String,
         val customerSessionClientSecret: String? = null,
-        val stripeAccountId: String?,
-    )
-
-    data class AttachRequest(
-        val customerId: String,
-        val ephemeralKeySecret: String,
-        val paymentMethodId: String,
         val stripeAccountId: String?,
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -43,6 +43,9 @@ internal open class FakeCustomerRepository(
     private val _detachRequests = Turbine<DetachRequest>()
     val detachRequests: ReceiveTurbine<DetachRequest> = _detachRequests
 
+    private val _attachRequests = Turbine<AttachRequest>()
+    val attachRequests: ReceiveTurbine<AttachRequest> = _attachRequests
+
     private val _updateRequests = Turbine<UpdateRequest>()
     val updateRequests: ReceiveTurbine<UpdateRequest> = _updateRequests
 
@@ -56,6 +59,7 @@ internal open class FakeCustomerRepository(
         _retrieveCustomerRequests.ensureAllEventsConsumed()
         _getPaymentMethodsRequests.ensureAllEventsConsumed()
         _detachRequests.ensureAllEventsConsumed()
+        _attachRequests.ensureAllEventsConsumed()
         _updateRequests.ensureAllEventsConsumed()
         _setDefaultPaymentMethodRequests.ensureAllEventsConsumed()
         _retrievePaymentMethodRequests.ensureAllEventsConsumed()
@@ -140,7 +144,18 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         stripeAccountId: String?,
-    ): Result<PaymentMethod> = onAttachPaymentMethod()
+    ): Result<PaymentMethod> {
+        _attachRequests.add(
+            AttachRequest(
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
+                paymentMethodId = paymentMethodId,
+                stripeAccountId = stripeAccountId,
+            )
+        )
+
+        return onAttachPaymentMethod()
+    }
 
     override suspend fun updatePaymentMethod(
         customerId: String,
@@ -217,6 +232,13 @@ internal open class FakeCustomerRepository(
         val customerId: String,
         val ephemeralKeySecret: String,
         val customerSessionClientSecret: String? = null,
+        val stripeAccountId: String?,
+    )
+
+    data class AttachRequest(
+        val customerId: String,
+        val ephemeralKeySecret: String,
+        val paymentMethodId: String,
         val stripeAccountId: String?,
     )
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -43,18 +43,26 @@ internal open class FakeCustomerRepository(
     private val _detachRequests = Turbine<DetachRequest>()
     val detachRequests: ReceiveTurbine<DetachRequest> = _detachRequests
 
+    private val _attachRequests = Turbine<AttachRequest>()
+    val attachRequests: ReceiveTurbine<AttachRequest> = _attachRequests
+
     private val _updateRequests = Turbine<UpdateRequest>()
     val updateRequests: ReceiveTurbine<UpdateRequest> = _updateRequests
 
     private val _setDefaultPaymentMethodRequests = Turbine<SetDefaultRequest>()
     val setDefaultPaymentMethodRequests: ReceiveTurbine<SetDefaultRequest> = _setDefaultPaymentMethodRequests
 
+    private val _retrievePaymentMethodRequests = Turbine<RetrievePaymentMethodRequest>()
+    val retrievePaymentMethodRequests: ReceiveTurbine<RetrievePaymentMethodRequest> = _retrievePaymentMethodRequests
+
     open fun ensureAllEventsConsumed() {
         _retrieveCustomerRequests.ensureAllEventsConsumed()
         _getPaymentMethodsRequests.ensureAllEventsConsumed()
         _detachRequests.ensureAllEventsConsumed()
+        _attachRequests.ensureAllEventsConsumed()
         _updateRequests.ensureAllEventsConsumed()
         _setDefaultPaymentMethodRequests.ensureAllEventsConsumed()
+        _retrievePaymentMethodRequests.ensureAllEventsConsumed()
     }
 
     override suspend fun retrieveCustomer(
@@ -66,6 +74,7 @@ internal open class FakeCustomerRepository(
             RetrieveCustomerRequest(
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
+                stripeAccountId = stripeAccountId,
             )
         )
 
@@ -85,6 +94,7 @@ internal open class FakeCustomerRepository(
                 ephemeralKeySecret = ephemeralKeySecret,
                 types = types,
                 silentlyFail = silentlyFail,
+                stripeAccountId = stripeAccountId,
             )
         )
 
@@ -102,6 +112,7 @@ internal open class FakeCustomerRepository(
                 paymentMethodId = paymentMethodId,
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
+                stripeAccountId = stripeAccountId,
             )
         )
 
@@ -121,6 +132,7 @@ internal open class FakeCustomerRepository(
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
                 customerSessionClientSecret = customerSessionClientSecret,
+                stripeAccountId = stripeAccountId,
             )
         )
 
@@ -132,7 +144,18 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         stripeAccountId: String?,
-    ): Result<PaymentMethod> = onAttachPaymentMethod()
+    ): Result<PaymentMethod> {
+        _attachRequests.add(
+            AttachRequest(
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
+                paymentMethodId = paymentMethodId,
+                stripeAccountId = stripeAccountId,
+            )
+        )
+
+        return onAttachPaymentMethod()
+    }
 
     override suspend fun updatePaymentMethod(
         customerId: String,
@@ -147,6 +170,7 @@ internal open class FakeCustomerRepository(
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
                 params = params,
+                stripeAccountId = stripeAccountId,
             )
         )
 
@@ -164,6 +188,7 @@ internal open class FakeCustomerRepository(
                 paymentMethodId = paymentMethodId,
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
+                stripeAccountId = stripeAccountId,
             )
         )
 
@@ -175,11 +200,23 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         stripeAccountId: String?,
-    ): Result<PaymentMethod> = onRetrievePaymentMethod(paymentMethodId)
+    ): Result<PaymentMethod> {
+        _retrievePaymentMethodRequests.add(
+            RetrievePaymentMethodRequest(
+                customerId = customerId,
+                ephemeralKeySecret = ephemeralKeySecret,
+                paymentMethodId = paymentMethodId,
+                stripeAccountId = stripeAccountId,
+            )
+        )
+
+        return onRetrievePaymentMethod(paymentMethodId)
+    }
 
     data class RetrieveCustomerRequest(
         val customerId: String,
         val ephemeralKeySecret: String,
+        val stripeAccountId: String?,
     )
 
     data class GetPaymentMethodsRequest(
@@ -187,6 +224,7 @@ internal open class FakeCustomerRepository(
         val ephemeralKeySecret: String,
         val types: List<PaymentMethod.Type>,
         val silentlyFail: Boolean,
+        val stripeAccountId: String?,
     )
 
     data class DetachRequest(
@@ -194,6 +232,14 @@ internal open class FakeCustomerRepository(
         val customerId: String,
         val ephemeralKeySecret: String,
         val customerSessionClientSecret: String? = null,
+        val stripeAccountId: String?,
+    )
+
+    data class AttachRequest(
+        val customerId: String,
+        val ephemeralKeySecret: String,
+        val paymentMethodId: String,
+        val stripeAccountId: String?,
     )
 
     data class UpdateRequest(
@@ -201,11 +247,20 @@ internal open class FakeCustomerRepository(
         val customerId: String,
         val ephemeralKeySecret: String,
         val params: PaymentMethodUpdateParams,
+        val stripeAccountId: String?,
     )
 
     data class SetDefaultRequest(
         val paymentMethodId: String?,
         val customerId: String,
         val ephemeralKeySecret: String,
+        val stripeAccountId: String?,
+    )
+
+    data class RetrievePaymentMethodRequest(
+        val customerId: String,
+        val ephemeralKeySecret: String,
+        val paymentMethodId: String,
+        val stripeAccountId: String?,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeCustomerRepository.kt
@@ -2,6 +2,7 @@ package com.stripe.android.utils
 
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.Customer
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -68,13 +69,13 @@ internal open class FakeCustomerRepository(
     override suspend fun retrieveCustomer(
         customerId: String,
         ephemeralKeySecret: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Customer? {
         _retrieveCustomerRequests.add(
             RetrieveCustomerRequest(
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
         )
 
@@ -86,7 +87,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         types: List<PaymentMethod.Type>,
         silentlyFail: Boolean,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<List<PaymentMethod>> {
         _getPaymentMethodsRequests.add(
             GetPaymentMethodsRequest(
@@ -94,7 +95,7 @@ internal open class FakeCustomerRepository(
                 ephemeralKeySecret = ephemeralKeySecret,
                 types = types,
                 silentlyFail = silentlyFail,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
         )
 
@@ -105,14 +106,14 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
                 paymentMethodId = paymentMethodId,
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
         )
 
@@ -124,7 +125,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         customerSessionClientSecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> {
         _detachRequests.add(
             DetachRequest(
@@ -132,7 +133,7 @@ internal open class FakeCustomerRepository(
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
                 customerSessionClientSecret = customerSessionClientSecret,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
         )
 
@@ -143,14 +144,14 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> {
         _attachRequests.add(
             AttachRequest(
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
         )
 
@@ -162,7 +163,7 @@ internal open class FakeCustomerRepository(
         ephemeralKeySecret: String,
         paymentMethodId: String,
         params: PaymentMethodUpdateParams,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> {
         _updateRequests.add(
             UpdateRequest(
@@ -170,7 +171,7 @@ internal open class FakeCustomerRepository(
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
                 params = params,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
         )
 
@@ -181,14 +182,14 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String?,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<Customer> {
         _setDefaultPaymentMethodRequests.add(
             SetDefaultRequest(
                 paymentMethodId = paymentMethodId,
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
         )
 
@@ -199,14 +200,14 @@ internal open class FakeCustomerRepository(
         customerId: String,
         ephemeralKeySecret: String,
         paymentMethodId: String,
-        stripeAccountId: String?,
+        apiConfiguration: ApiConfiguration.State,
     ): Result<PaymentMethod> {
         _retrievePaymentMethodRequests.add(
             RetrievePaymentMethodRequest(
                 customerId = customerId,
                 ephemeralKeySecret = ephemeralKeySecret,
                 paymentMethodId = paymentMethodId,
-                stripeAccountId = stripeAccountId,
+                apiConfiguration = apiConfiguration,
             )
         )
 
@@ -216,7 +217,7 @@ internal open class FakeCustomerRepository(
     data class RetrieveCustomerRequest(
         val customerId: String,
         val ephemeralKeySecret: String,
-        val stripeAccountId: String?,
+        val apiConfiguration: ApiConfiguration.State,
     )
 
     data class GetPaymentMethodsRequest(
@@ -224,7 +225,7 @@ internal open class FakeCustomerRepository(
         val ephemeralKeySecret: String,
         val types: List<PaymentMethod.Type>,
         val silentlyFail: Boolean,
-        val stripeAccountId: String?,
+        val apiConfiguration: ApiConfiguration.State,
     )
 
     data class DetachRequest(
@@ -232,14 +233,14 @@ internal open class FakeCustomerRepository(
         val customerId: String,
         val ephemeralKeySecret: String,
         val customerSessionClientSecret: String? = null,
-        val stripeAccountId: String?,
+        val apiConfiguration: ApiConfiguration.State,
     )
 
     data class AttachRequest(
         val customerId: String,
         val ephemeralKeySecret: String,
         val paymentMethodId: String,
-        val stripeAccountId: String?,
+        val apiConfiguration: ApiConfiguration.State,
     )
 
     data class UpdateRequest(
@@ -247,20 +248,20 @@ internal open class FakeCustomerRepository(
         val customerId: String,
         val ephemeralKeySecret: String,
         val params: PaymentMethodUpdateParams,
-        val stripeAccountId: String?,
+        val apiConfiguration: ApiConfiguration.State,
     )
 
     data class SetDefaultRequest(
         val paymentMethodId: String?,
         val customerId: String,
         val ephemeralKeySecret: String,
-        val stripeAccountId: String?,
+        val apiConfiguration: ApiConfiguration.State,
     )
 
     data class RetrievePaymentMethodRequest(
         val customerId: String,
         val ephemeralKeySecret: String,
         val paymentMethodId: String,
-        val stripeAccountId: String?,
+        val apiConfiguration: ApiConfiguration.State,
     )
 }


### PR DESCRIPTION
# Summary

Pass the ApiConfiguration.State into every `CustomerRepository` operation instead of having `CustomerApiRepository` read global `PaymentConfiguration`. Add a PaymentSheet-scoped API configuration binding so saved-payment-method operations use the configuration associated with the current loaded session.

Changed classes and entry points:

- `ApiConfigurationModule`: Provides `ApiConfiguration.State` from the current `PaymentMethodMetadata`.

- `CustomerRepository`: Adds an explicit `ApiConfiguration.State` parameter to every customer and saved-payment-method operation.
- `CustomerApiRepository`: Removes its `PaymentConfiguration` dependency and builds each `ApiRequest.Options` from the ApiConfiguration.State supplied by the caller.
- `DefaultSavedPaymentMethodRepository`: Reads the current `ApiConfiguration.State` and forwards it for customer-session and legacy ephemeral-key operations.
- `DefaultPaymentElementLoader`: Passes the `ApiConfiguration.State` when prefetching legacy customer payment methods and constructing Link state.
- `DefaultRetrieveCustomerEmail`: Accepts and forwards the `ApiConfiguration.State` when retrieving a legacy customer.
- `DefaultCreateLinkState`: Accepts the `ApiConfiguration.State` and passes to RetrieveCustomerEmail.
- `DefaultLogLinkHoldbackExperiment`: Includes the `ApiConfiguration.State` from `PaymentMethodMetadata` when constructing its Link configuration.
- `StripeCustomerAdapter`: Uses a lazily injected API configuration for retrieve, detach, attach, and update operations.
- `CustomerSessionPaymentMethodDataSource`: Passes the `ApiConfiguration.State` for update and duplicate-detach operations.
- `CustomerSessionSavedSelectionDataSource`: Passes the `ApiConfiguration.State` when setting the default payment method.
-  Add `ApiConfigurationModule` to graphs that construct `DefaultSavedPaymentMethodRepository`.
- `StripeCustomerAdapterComponent` and `CustomerSessionDataSourceComponent`: Install the `ApiConfigurationFromPaymentConfiguration` compatibility bridge for standalone CustomerSheet entry points that do not have `PaymentMethodMetadata`.

Committed and created by Codex.

# Motivation

- CustomerRepository operations often happen before load, explicitly requiring `ApiConfiguration.State` prevents requesting ApiConfiguraiton provider before PaymentMethodMetadata is availalbe.
- Post load consumers (`DefaultSavedPaymentMethodRepository`) can safely source ApiConfig from metadata
- CustomerSheet classes source ApiConfig from PaymentConfiguration

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots

Not applicable — repository and dependency wiring only.

# Changelog

Not applicable — no public or intended user-visible behavior change.