### PR TITLE
Add Scalapay API bindings

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -2153,6 +2153,7 @@ public final class com/stripe/android/model/PaymentMethod$Type : java/lang/Enum,
 	public static final field PromptPay Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field RevolutPay Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Satispay Lcom/stripe/android/model/PaymentMethod$Type;
+	public static final field Scalapay Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field SepaDebit Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Sequra Lcom/stripe/android/model/PaymentMethod$Type;
 	public static final field Sunbit Lcom/stripe/android/model/PaymentMethod$Type;
@@ -2386,6 +2387,10 @@ public final class com/stripe/android/model/PaymentMethodCreateParams : android/
 	public static final fun createSatispay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createSatispay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createSatispay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createScalapay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createScalapay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createScalapay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static final fun createScalapay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createSequra ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createSequra (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static final fun createSequra (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
@@ -2675,6 +2680,11 @@ public final class com/stripe/android/model/PaymentMethodCreateParams$Companion 
 	public final fun createSatispay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createSatispay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public static synthetic fun createSatispay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createScalapay ()Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createScalapay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createScalapay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public final fun createScalapay (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;)Lcom/stripe/android/model/PaymentMethodCreateParams;
+	public static synthetic fun createScalapay$default (Lcom/stripe/android/model/PaymentMethodCreateParams$Companion;Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;Lcom/stripe/android/model/PaymentMethod$AllowRedisplay;ILjava/lang/Object;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createSequra ()Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createSequra (Lcom/stripe/android/model/PaymentMethod$BillingDetails;)Lcom/stripe/android/model/PaymentMethodCreateParams;
 	public final fun createSequra (Lcom/stripe/android/model/PaymentMethod$BillingDetails;Ljava/util/Map;)Lcom/stripe/android/model/PaymentMethodCreateParams;

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethod.kt
@@ -525,6 +525,14 @@ constructor(
             hasDelayedSettlement = false,
             requiresMandateForPaymentIntent = false,
         ),
+        Scalapay(
+            "scalapay",
+            isReusable = false,
+            isVoucher = false,
+            requiresMandate = false,
+            hasDelayedSettlement = false,
+            requiresMandateForPaymentIntent = false,
+        ),
         PayByBank(
             "pay_by_bank",
             isReusable = false,

--- a/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/PaymentMethodCreateParams.kt
@@ -1400,6 +1400,21 @@ constructor(
 
         @JvmStatic
         @JvmOverloads
+        fun createScalapay(
+            billingDetails: PaymentMethod.BillingDetails? = null,
+            metadata: Map<String, String>? = null,
+            allowRedisplay: PaymentMethod.AllowRedisplay? = null,
+        ): PaymentMethodCreateParams {
+            return PaymentMethodCreateParams(
+                type = PaymentMethod.Type.Scalapay,
+                billingDetails = billingDetails,
+                metadata = metadata,
+                allowRedisplay = allowRedisplay,
+            )
+        }
+
+        @JvmStatic
+        @JvmOverloads
         fun createPayByBank(
             billingDetails: PaymentMethod.BillingDetails? = null,
             metadata: Map<String, String>? = null,

--- a/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/model/PaymentMethodCreateParamsTest.kt
@@ -142,6 +142,12 @@ class PaymentMethodCreateParamsTest {
     }
 
     @Test
+    fun `createScalapay() without billing details creates expected map`() {
+        assertThat(PaymentMethodCreateParams.createScalapay().toParamMap())
+            .isEqualTo(mapOf("type" to "scalapay"))
+    }
+
+    @Test
     fun `createKakaoPay() without billing details creates expected map`() {
         assertThat(PaymentMethodCreateParams.createKakaoPay().toParamMap())
             .isEqualTo(mapOf("type" to "kakao_pay"))


### PR DESCRIPTION
# Summary
Adds Scalapay to the core payment method APIs. Merchants can create Scalapay payment method parameters and use the typed payment method value in direct integrations.

# Motivation
Scalapay

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

- `:payments-core:apiDump`
- `:payments-core:testDebugUnitTest --tests com.stripe.android.model.PaymentMethodCreateParamsTest`

# Screenshots
N/A

# Changelog
N/A

Committed and created by Codex.
