### PR TITLE
Prevent passive challenge warmer from taking focus

### DIFF
--- a/payments-core/src/androidTest/java/com/stripe/android/challenge/passive/PassiveChallengeWarmerFocusTest.kt
+++ b/payments-core/src/androidTest/java/com/stripe/android/challenge/passive/PassiveChallengeWarmerFocusTest.kt
@@ -1,0 +1,152 @@
+package com.stripe.android.challenge.passive
+
+import android.app.Activity
+import android.text.InputType
+import android.widget.EditText
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.runner.lifecycle.ActivityLifecycleCallback
+import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
+import androidx.test.runner.lifecycle.Stage
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import com.stripe.android.TestActivity
+import com.stripe.android.challenge.passive.warmer.activity.PassiveChallengeWarmerActivity
+import com.stripe.android.challenge.passive.warmer.activity.PassiveChallengeWarmerArgs
+import com.stripe.android.challenge.passive.warmer.activity.PassiveChallengeWarmerViewModel
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.hcaptcha.HCaptchaService
+import com.stripe.android.model.PassiveCaptchaParams
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+internal class PassiveChallengeWarmerFocusTest {
+
+    @Test
+    fun warmerWindowDoesNotGainFocusOverHostInput() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val hCaptchaService = BlockingHCaptchaService()
+        val warmerResumed = CountDownLatch(1)
+        val warmerGainedFocus = CountDownLatch(1)
+
+        val lifecycleCallback = object : ActivityLifecycleCallback {
+            override fun onActivityLifecycleChanged(activity: Activity?, stage: Stage?) {
+                if (activity !is PassiveChallengeWarmerActivity) return
+
+                when (stage) {
+                    Stage.PRE_ON_CREATE -> {
+                        activity.viewModelFactory = createViewModelFactory(hCaptchaService)
+                    }
+                    Stage.CREATED -> {
+                        activity.window.decorView.viewTreeObserver.addOnWindowFocusChangeListener { hasFocus ->
+                            if (hasFocus) {
+                                warmerGainedFocus.countDown()
+                            }
+                        }
+                    }
+                    Stage.RESUMED -> {
+                        warmerResumed.countDown()
+                    }
+                    else -> Unit
+                }
+            }
+        }
+
+        val lifecycleMonitor = ActivityLifecycleMonitorRegistry.getInstance()
+        lifecycleMonitor.addLifecycleCallback(lifecycleCallback)
+
+        try {
+            ActivityScenario.launch(TestActivity::class.java).use { scenario ->
+                scenario.onActivity { activity ->
+                    val cardField = EditText(activity).apply {
+                        inputType = InputType.TYPE_CLASS_NUMBER
+                        isFocusableInTouchMode = true
+                    }
+                    activity.setContentView(cardField)
+                    assertThat(cardField.requestFocus()).isTrue()
+                    assertThat(activity.hasWindowFocus()).isTrue()
+                    activity.startActivity(PassiveChallengeWarmerActivity.createIntent(activity, ARGS))
+                }
+
+                assertThat(hCaptchaService.warmUpStarted.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue()
+                assertThat(warmerResumed.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)).isTrue()
+                instrumentation.waitForIdleSync()
+                assertWithMessage("Passive challenge warmer gained window focus")
+                    .that(warmerGainedFocus.await(FOCUS_OBSERVATION_SECONDS, TimeUnit.SECONDS))
+                    .isFalse()
+
+                hCaptchaService.completeWarmUp()
+            }
+        } finally {
+            hCaptchaService.completeWarmUp()
+            lifecycleMonitor.removeLifecycleCallback(lifecycleCallback)
+        }
+    }
+
+    private fun createViewModelFactory(
+        hCaptchaService: HCaptchaService,
+    ): ViewModelProvider.Factory {
+        return object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return PassiveChallengeWarmerViewModel(
+                    passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
+                    hCaptchaService = hCaptchaService,
+                ) as T
+            }
+        }
+    }
+
+    private class BlockingHCaptchaService : HCaptchaService {
+        val warmUpStarted = CountDownLatch(1)
+        private val warmUpCompleted = CompletableDeferred<Unit>()
+
+        override suspend fun warmUp(
+            activity: FragmentActivity,
+            siteKey: String,
+            rqData: String?,
+        ) {
+            warmUpStarted.countDown()
+            warmUpCompleted.await()
+        }
+
+        override suspend fun performPassiveHCaptcha(
+            activity: FragmentActivity,
+            siteKey: String,
+            rqData: String?,
+            tokenTimeoutSeconds: Int?,
+        ): HCaptchaService.Result {
+            error("Not expected to be called")
+        }
+
+        fun completeWarmUp() {
+            warmUpCompleted.complete(Unit)
+        }
+    }
+
+    private companion object {
+        private const val FOCUS_OBSERVATION_SECONDS = 1L
+        private const val TIMEOUT_SECONDS = 5L
+        private val PASSIVE_CAPTCHA_PARAMS = PassiveCaptchaParams(
+            siteKey = "test_site_key",
+            rqData = "test_rq_data",
+            tokenTimeoutSeconds = null,
+        )
+        private val ARGS = PassiveChallengeWarmerArgs(
+            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
+            apiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = null,
+            ),
+            productUsage = listOf("PaymentSheet"),
+        )
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/challenge/passive/warmer/activity/PassiveChallengeWarmerActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/passive/warmer/activity/PassiveChallengeWarmerActivity.kt
@@ -3,6 +3,7 @@ package com.stripe.android.challenge.passive.warmer.activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.WindowManager
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatActivity
@@ -21,6 +22,11 @@ internal class PassiveChallengeWarmerActivity : AppCompatActivity() {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        // The warmer has no UI, so keep input focus directed to the host window behind it.
+        window.addFlags(
+            WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+        )
         super.onCreate(savedInstanceState)
 
         // Check if required args are present, finish gracefully if not

--- a/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeWarmerActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeWarmerActivityTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.challenge.passive
 
 import android.content.Context
 import android.content.Intent
+import android.view.WindowManager
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
@@ -58,6 +59,30 @@ internal class PassiveChallengeWarmerActivityTest {
             scenario.close()
             hCaptchaService.ensureAllEventsConsumed()
         }
+    }
+
+    @Test
+    fun `activity window should not accept focus or touch input while warming up`() = runTest {
+        val hCaptchaService = FakeHCaptchaService().apply {
+            warmUpResult = {
+                delay(5.seconds)
+            }
+        }
+
+        val scenario = launchActivityForResult(hCaptchaService)
+        hCaptchaService.awaitWarmUpCall()
+
+        scenario.onActivity { activity ->
+            val flags = activity.window.attributes.flags
+
+            assertThat(flags and WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+                .isEqualTo(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+            assertThat(flags and WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
+                .isEqualTo(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
+        }
+
+        scenario.close()
+        hCaptchaService.ensureAllEventsConsumed()
     }
 
     @Test

--- a/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeWarmerActivityTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/challenge/passive/PassiveChallengeWarmerActivityTest.kt
@@ -24,6 +24,7 @@ import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.utils.InjectableActivityScenario
 import com.stripe.android.utils.injectableActivityScenario
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -65,7 +66,7 @@ internal class PassiveChallengeWarmerActivityTest {
     fun `activity window should not accept focus or touch input while warming up`() = runTest {
         val hCaptchaService = FakeHCaptchaService().apply {
             warmUpResult = {
-                delay(5.seconds)
+                awaitCancellation()
             }
         }
 


### PR DESCRIPTION
## Summary

- Make PassiveChallengeWarmerActivity non-focusable and non-touchable before lifecycle creation so PaymentSheet retains input focus during passive hCaptcha warm-up.
- Add Robolectric coverage for the window flags and an on-device regression test for the asynchronous host focus transition.

## Motivation

https://stripe.slack.com/archives/C01CY476ESJ/p1788518379278429

## Testing

Added `PassiveChallengeWarmerFocusTest` and ran with shampoo rule

## Screenshots

N/A

## Changelog

N/A

Committed and created by Codex.