### PR TITLE
Simplify checkout playground setting factories

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutCurrencySelectorDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutCurrencySelectorDefinitions.kt
@@ -8,7 +8,6 @@ internal object CheckoutCurrencySelectorDefinitions {
     val shouldSetConfiguration = boolean(
         key = "controller.currency_selector.should_set_configuration",
         displayName = "Set configuration",
-        defaultValue = false,
     )
 
     val appearance = AppearanceDefinitions()
@@ -18,17 +17,14 @@ internal object CheckoutCurrencySelectorDefinitions {
             key = "currency.appearance.vertical_padding",
             displayName = "Vertical padding",
             defaultValue = 4f,
-            minimum = 0f,
         )
         val cornerRadius = optionalFloat(
             key = "currency.appearance.corner_radius",
             displayName = "Corner radius",
-            minimum = 0f,
         )
         val borderWidth = optionalFloat(
             key = "currency.appearance.border_width",
             displayName = "Border width",
-            minimum = 0f,
         )
         val borderColor = optionalColor(
             key = "currency.appearance.border_color",
@@ -63,7 +59,6 @@ internal object CheckoutCurrencySelectorDefinitions {
             key = "currency.appearance.scale",
             displayName = "Size scale factor",
             defaultValue = 1f,
-            minimum = 0f,
             minimumExclusive = true,
         )
         val label = enumChoice(

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutExpressDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutExpressDefinitions.kt
@@ -8,7 +8,6 @@ internal object CheckoutExpressDefinitions {
     val shouldSetConfiguration = boolean(
         key = "controller.express_checkout.should_set_configuration",
         displayName = "Set configuration",
-        defaultValue = false,
     )
 
     val link = LinkDefinitions()
@@ -38,9 +37,7 @@ internal object CheckoutExpressDefinitions {
     val googlePay = CheckoutGooglePayDefinitions(
         key = "express.google_pay",
         displayName = "Google Pay",
-        defaultDisplay = ExpressCheckoutElement.Configuration.GooglePayConfiguration.Display.Automatic,
         displayOptions = ExpressCheckoutElement.Configuration.GooglePayConfiguration.Display.entries,
-        defaultButtonType = ExpressCheckoutElement.Configuration.GooglePayConfiguration.ButtonType.Pay,
         buttonTypeOptions = ExpressCheckoutElement.Configuration.GooglePayConfiguration.ButtonType.entries,
     )
     val appearance = AppearanceDefinitions()

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPaymentDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPaymentDefinitions.kt
@@ -27,7 +27,6 @@ internal object CheckoutPaymentDefinitions {
     val opensCardScanner = boolean(
         key = "payment.opens_card_scanner",
         displayName = "Open card scanner automatically",
-        defaultValue = false,
     )
     val preferredNetworks = csv(
         key = "payment.preferred_networks",
@@ -47,32 +46,26 @@ internal object CheckoutPaymentDefinitions {
     val cardBrandAcceptance = CardBrandAcceptanceDefinitions()
 
     internal class CardBrandAcceptanceDefinitions {
-        val mode = choice(
+        val mode = enumChoice(
             key = "payment.card_brand_acceptance.mode",
             displayName = "Mode",
             defaultValue = CheckoutCardBrandAcceptanceMode.All,
-            options = CheckoutCardBrandAcceptanceMode.entries.map { it.name to it },
-            serialize = CheckoutCardBrandAcceptanceMode::name,
         )
         val visa = boolean(
             key = "payment.card_brand_acceptance.visa",
             displayName = "Visa",
-            defaultValue = false,
         )
         val mastercard = boolean(
             key = "payment.card_brand_acceptance.mastercard",
             displayName = "Mastercard",
-            defaultValue = false,
         )
         val amex = boolean(
             key = "payment.card_brand_acceptance.amex",
             displayName = "Amex",
-            defaultValue = false,
         )
         val discover = boolean(
             key = "payment.card_brand_acceptance.discover",
             displayName = "Discover",
-            defaultValue = false,
         )
         val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
             key = "payment.card_brand_acceptance",
@@ -143,17 +136,14 @@ internal object CheckoutPaymentDefinitions {
                 val cornerRadius = optionalFloat(
                     key = "payment.appearance.primary_button.shape.corner",
                     displayName = "Corner radius",
-                    minimum = 0f,
                 )
                 val borderWidth = optionalFloat(
                     key = "payment.appearance.primary_button.shape.border",
                     displayName = "Border width",
-                    minimum = 0f,
                 )
                 val height = optionalFloat(
                     key = "payment.appearance.primary_button.shape.height",
                     displayName = "Height",
-                    minimum = 0f,
                 )
                 val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
                     key = "payment.appearance.primary_button.shape",
@@ -169,7 +159,6 @@ internal object CheckoutPaymentDefinitions {
                 val size = optionalFloat(
                     key = "payment.appearance.primary_button.typography.size",
                     displayName = "Font size",
-                    minimum = 0f,
                     minimumExclusive = true,
                 )
                 val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
@@ -198,13 +187,10 @@ internal object CheckoutPaymentDefinitions {
                 key = "payment.appearance.insets.horizontal",
                 displayName = "Horizontal",
                 defaultValue = 20f,
-                minimum = 0f,
             )
             val vertical = decimal(
                 key = "payment.appearance.insets.vertical",
                 displayName = "Vertical",
-                defaultValue = 0f,
-                minimum = 0f,
             )
             val configuration: CheckoutPlaygroundSettingDefinition.Configuration = configuration(
                 key = "payment.appearance.insets",
@@ -229,9 +215,7 @@ internal object CheckoutPaymentDefinitions {
     val googlePay = CheckoutGooglePayDefinitions(
         key = "payment.google_pay",
         displayName = "Google Pay",
-        defaultDisplay = PaymentElement.Configuration.GooglePayConfiguration.Display.Automatic,
         displayOptions = PaymentElement.Configuration.GooglePayConfiguration.Display.entries,
-        defaultButtonType = PaymentElement.Configuration.GooglePayConfiguration.ButtonType.Pay,
         buttonTypeOptions = PaymentElement.Configuration.GooglePayConfiguration.ButtonType.entries,
     )
 

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundDefinitionGroups.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundDefinitionGroups.kt
@@ -13,7 +13,6 @@ internal class CheckoutContactDetailsDefinitions(
     val enabled = boolean(
         key = "$key.enabled",
         displayName = "Provide details",
-        defaultValue = false,
     )
     val name = optionalText(
         key = "$key.name",
@@ -31,7 +30,6 @@ internal class CheckoutAddressDefinitions(key: String) {
     val enabled = boolean(
         key = "$key.enabled",
         displayName = "Provide address",
-        defaultValue = false,
     )
     val country = text(
         key = "$key.country",
@@ -168,10 +166,10 @@ internal class CheckoutPrimaryButtonColorsDefinitions(
 internal class CheckoutGooglePayDefinitions<DisplayType : Enum<DisplayType>, ButtonTypeValue : Enum<ButtonTypeValue>>(
     key: String,
     displayName: String,
-    defaultDisplay: DisplayType,
     displayOptions: List<DisplayType>,
-    defaultButtonType: ButtonTypeValue,
     buttonTypeOptions: List<ButtonTypeValue>,
+    defaultDisplay: DisplayType = displayOptions.first { it.name == "Automatic" },
+    defaultButtonType: ButtonTypeValue = buttonTypeOptions.first { it.name == "Pay" },
 ) {
     val display = choice(
         key = "$key.display",

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingFactories.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundSettingFactories.kt
@@ -13,7 +13,7 @@ internal fun configuration(
 internal fun boolean(
     key: String,
     displayName: String,
-    defaultValue: Boolean,
+    defaultValue: Boolean = false,
     updateRequest: CheckoutPlaygroundRequestUpdater<Boolean> = {},
     isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean = { true },
     applyFeatureFlags: (Boolean) -> Unit = {},
@@ -22,7 +22,6 @@ internal fun boolean(
     displayName = displayName,
     defaultValue = defaultValue,
     options = listOf("On" to true, "Off" to false),
-    serialize = Boolean::toString,
     updateRequest = updateRequest,
     isApplicable = isApplicable,
     applyFeatureFlags = applyFeatureFlags,
@@ -47,9 +46,9 @@ internal inline fun <reified T : Enum<T>> enumChoice(
 internal fun <T> choice(
     key: String,
     displayName: String,
-    defaultValue: T,
     options: List<Pair<String, T>>,
-    serialize: (T) -> String,
+    defaultValue: T = options.first().second,
+    serialize: (T) -> String = { it.toString() },
     updateRequest: CheckoutPlaygroundRequestUpdater<T> = {},
     isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean = { true },
     applyFeatureFlags: (T) -> Unit = {},

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundValueFactories.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutPlaygroundValueFactories.kt
@@ -10,7 +10,7 @@ internal val optionalEmail: (String) -> String? = { value ->
 internal fun text(
     key: String,
     displayName: String,
-    defaultValue: String,
+    defaultValue: String = "",
     updateRequest: CheckoutPlaygroundRequestUpdater<String> = {},
     validate: (String) -> String? = { null },
 ): CheckoutPlaygroundSettingDefinition.Value<String> {
@@ -29,29 +29,15 @@ internal fun text(
 internal fun optionalText(
     key: String,
     displayName: String,
+    defaultValue: String? = null,
     updateRequest: CheckoutPlaygroundRequestUpdater<String?> = {},
     validate: (String) -> String? = { null },
-): CheckoutPlaygroundSettingDefinition.Value<String?> {
-    return optionalText(
-        key = key,
-        displayName = displayName,
-        updateRequest = updateRequest,
-        validate = validate,
-        isApplicable = { true },
-    )
-}
-
-internal fun optionalText(
-    key: String,
-    displayName: String,
-    updateRequest: CheckoutPlaygroundRequestUpdater<String?> = {},
-    validate: (String) -> String?,
-    isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean,
+    isApplicable: (CheckoutPlaygroundSettingValues) -> Boolean = { true },
 ): CheckoutPlaygroundSettingDefinition.Value<String?> {
     return value(
         key = key,
         displayName = displayName,
-        defaultValue = null,
+        defaultValue = defaultValue,
         isApplicable = isApplicable,
         updateRequest = updateRequest,
         encode = { it.orEmpty() },
@@ -64,13 +50,14 @@ internal fun optionalText(
 internal fun optionalInt(
     key: String,
     displayName: String,
+    defaultValue: Int? = null,
+    minimum: Int = 1,
     updateRequest: CheckoutPlaygroundRequestUpdater<Int?> = {},
 ): CheckoutPlaygroundSettingDefinition.Value<Int?> {
-    val minimum = 1
     return value(
         key = key,
         displayName = displayName,
-        defaultValue = null,
+        defaultValue = defaultValue,
         input = CheckoutPlaygroundSettingDefinition.Value.Input.Integer,
         updateRequest = updateRequest,
         encode = { it?.toString().orEmpty() },
@@ -88,8 +75,8 @@ internal fun optionalInt(
 internal fun decimal(
     key: String,
     displayName: String,
-    defaultValue: Float,
-    minimum: Float,
+    defaultValue: Float = 0f,
+    minimum: Float = 0f,
     minimumExclusive: Boolean = false,
     updateRequest: CheckoutPlaygroundRequestUpdater<Float> = {},
 ): CheckoutPlaygroundSettingDefinition.Value<Float> {
@@ -113,14 +100,15 @@ internal fun decimal(
 internal fun optionalFloat(
     key: String,
     displayName: String,
-    minimum: Float,
+    defaultValue: Float? = null,
+    minimum: Float = 0f,
     minimumExclusive: Boolean = false,
     updateRequest: CheckoutPlaygroundRequestUpdater<Float?> = {},
 ): CheckoutPlaygroundSettingDefinition.Value<Float?> {
     return value(
         key = key,
         displayName = displayName,
-        defaultValue = null,
+        defaultValue = defaultValue,
         input = CheckoutPlaygroundSettingDefinition.Value.Input.Decimal,
         updateRequest = updateRequest,
         encode = { it?.let(::formatFloat).orEmpty() },
@@ -138,24 +126,11 @@ internal fun optionalFloat(
     )
 }
 
-internal fun optionalColor(
-    key: String,
-    displayName: String,
-    updateRequest: CheckoutPlaygroundRequestUpdater<Color?> = {},
-): CheckoutPlaygroundSettingDefinition.Value<Color?> {
-    return optionalColor(
-        key = key,
-        displayName = displayName,
-        defaultValue = null,
-        updateRequest = updateRequest
-    )
-}
-
 @Suppress("MagicNumber")
 internal fun optionalColor(
     key: String,
     displayName: String,
-    defaultValue: Color?,
+    defaultValue: Color? = null,
     updateRequest: CheckoutPlaygroundRequestUpdater<Color?> = {},
 ): CheckoutPlaygroundSettingDefinition.Value<Color?> {
     return value(
@@ -208,6 +183,7 @@ internal fun stringCsv(
 internal fun <T> csv(
     key: String,
     displayName: String,
+    defaultValue: List<T> = emptyList(),
     updateRequest: CheckoutPlaygroundRequestUpdater<List<T>> = {},
     decodeItem: (String) -> Result<T>,
     encodeItem: (T) -> String,
@@ -215,7 +191,7 @@ internal fun <T> csv(
     return value(
         key = key,
         displayName = displayName,
-        defaultValue = emptyList(),
+        defaultValue = defaultValue,
         updateRequest = updateRequest,
         encode = { values -> values.joinToString(", ", transform = encodeItem) },
         decode = { serialized ->

--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/settings/CheckoutSessionDefinitions.kt
@@ -24,7 +24,6 @@ internal object CheckoutSessionDefinitions {
     val customer = choice(
         key = "session.customer",
         displayName = "Customer",
-        defaultValue = CheckoutCustomer.Guest,
         options = CheckoutCustomer.entries.map { it.displayName to it },
         serialize = CheckoutCustomer::serializedValue,
         updateRequest = { customer -> put("customer", customer.serializedValue) },
@@ -76,7 +75,6 @@ internal object CheckoutSessionDefinitions {
     val merchant = choice(
         key = "session.merchant",
         displayName = "Merchant",
-        defaultValue = Merchant.US,
         options = Merchant.entries.filter { it != Merchant.Custom }.map { it.name to it },
         serialize = Merchant::value,
         updateRequest = { merchant -> put("merchant_country_code", merchant.value) },
@@ -108,7 +106,6 @@ internal object CheckoutSessionDefinitions {
     val automaticTax = boolean(
         key = "session.automatic_tax",
         displayName = "Automatic tax",
-        defaultValue = false,
         updateRequest = { enabled ->
             put("automatic_tax", enabled)
         },
@@ -116,7 +113,6 @@ internal object CheckoutSessionDefinitions {
     val adaptivePricingCountry = choice(
         key = "session.adaptive_pricing_country",
         displayName = "Adaptive pricing country",
-        defaultValue = AdaptivePricingCountry.None,
         options = AdaptivePricingCountry.entries.map { it.displayName to it },
         serialize = AdaptivePricingCountry::serializedValue,
         updateRequest = { country ->
@@ -129,19 +125,16 @@ internal object CheckoutSessionDefinitions {
     val shippingAddressCollection = boolean(
         key = "session.shipping_address_collection",
         displayName = "Collect shipping address",
-        defaultValue = false,
         updateRequest = { enabled -> put("shipping_address_collection", enabled) },
     )
     val billingAddressCollection = boolean(
         key = "session.billing_address_collection",
         displayName = "Collect billing address",
-        defaultValue = false,
         updateRequest = { enabled -> put("billing_address_collection", enabled) },
     )
     val linkType = choice(
         key = "controller.link_type",
         displayName = "Link Type",
-        defaultValue = LinkType.ServerControlled,
         options = LinkType.entries.map { it.value to it },
         serialize = LinkType::value,
         applyFeatureFlags = LinkType::applyFeatureFlags,


### PR DESCRIPTION
# Summary

- Add sensible defaults to checkout playground setting factories.
- Remove forwarding overloads and redundant arguments from setting definitions.
- Reuse the enum choice factory for card-brand acceptance mode.

# Motivation

The checkout playground repeated default values throughout its setting definitions and maintained overloads whose only purpose was forwarding those defaults. Centralizing the defaults makes the definitions shorter and keeps their behavior consistent.

# Testing

- [ ] Added tests
- [ ] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew detekt`
- `./gradlew :paymentsheet-example:compileBaseDebugKotlin`
- `./gradlew :paymentsheet-example:testBaseDebugUnitTest --tests 'com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundSettingsTest' --tests 'com.stripe.android.paymentsheet.example.playground.checkout.settings.CheckoutPlaygroundConfigurationFactoryTest' --tests 'com.stripe.android.paymentsheet.example.playground.checkout.CheckoutControllerExampleRequestFactoryTest'` (31 tests)

No tests were added, modified, or ignored because this is a behavior-preserving refactor covered by the existing tests.

# Screenshots

Not applicable; this refactor does not change the UI.

# Changelog

Not applicable; this is an internal example-app refactor with no customer-facing SDK change.

Committed and created by Codex.
