### PR TITLE
Add PaymentSheet API configuration setup

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -59,6 +59,7 @@ import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolverModule
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
@@ -117,6 +118,7 @@ import javax.inject.Singleton
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
         NfcScanningAvailabilityModule::class,
         PaymentOptionCardArtModule::class,
+        ApiConfigurationResolverModule::class,
     ],
 )
 internal interface CheckoutControllerComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/model/CommonConfiguration.kt
@@ -3,6 +3,7 @@ package com.stripe.android.common.model
 import android.os.Parcelable
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.link.LinkAppearance
 import com.stripe.android.link.LinkController
 import com.stripe.android.model.CardBrand
@@ -42,6 +43,7 @@ internal data class CommonConfiguration(
     val opensCardScannerAutomatically: Boolean,
     val userOverrideCountry: String?,
     val appearance: PaymentSheet.Appearance,
+    val apiConfiguration: ApiConfiguration.State? = null,
 ) : Parcelable {
 
     fun allowedCardFundingTypes(enabled: Boolean): List<PaymentSheet.CardFundingType> {
@@ -303,6 +305,10 @@ internal fun LinkController.Configuration.State.asCommonConfiguration(): CommonC
     userOverrideCountry = null,
     appearance = PaymentSheet.Appearance(),
     allowedCardFundingTypes = ConfigurationDefaults.allowedCardFundingTypes,
+    apiConfiguration = ApiConfiguration.State(
+        publishableKey = publishableKey,
+        stripeAccountId = stripeAccountId,
+    ),
 )
 
 private fun String.isEKClientSecretValid(): Boolean {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetLoader.kt
@@ -25,6 +25,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilt
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.validate
@@ -45,6 +46,7 @@ internal class DefaultCustomerSheetLoader(
     private val eventReporter: CustomerSheetEventReporter,
     private val errorReporter: ErrorReporter,
     private val workContext: CoroutineContext,
+    private val apiConfigurationResolver: ApiConfigurationResolver,
 ) : CustomerSheetLoader {
 
     @Inject
@@ -54,6 +56,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter: CustomerSheetEventReporter,
         errorReporter: ErrorReporter,
         @IOContext workContext: CoroutineContext,
+        apiConfigurationResolver: ApiConfigurationResolver,
     ) : this(
         googlePayRepositoryFactory = googlePayRepositoryFactory,
         isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
@@ -62,6 +65,7 @@ internal class DefaultCustomerSheetLoader(
         eventReporter = eventReporter,
         errorReporter = errorReporter,
         workContext = workContext,
+        apiConfigurationResolver = apiConfigurationResolver,
     )
 
     override suspend fun load(
@@ -137,6 +141,7 @@ internal class DefaultCustomerSheetLoader(
         val cardFundingFilter = DefaultCardFundingFilter
         val cardBrandFilter = PaymentSheetCardBrandFilter(configuration.cardBrandAcceptance)
 
+        val apiConfiguration = apiConfigurationResolver.resolve(apiConfiguration = null)
         val isGooglePaySupportedOnDevice = googlePayRepositoryFactory(
             environment = if (elementsSession.stripeIntent.isLiveMode) {
                 GooglePayEnvironment.Production
@@ -169,6 +174,7 @@ internal class DefaultCustomerSheetLoader(
                     IntegrationMetadata.CustomerSheet.AttachmentStyle.CreateAttach
                 }
             ),
+            apiConfiguration = apiConfiguration,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelModule.kt
@@ -33,6 +33,7 @@ import com.stripe.android.payments.financialconnections.DefaultIsFinancialConnec
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolverModule
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.repositories.RealElementsSessionRepository
@@ -51,6 +52,7 @@ import kotlin.coroutines.CoroutineContext
     includes = [
         PaymentConfigurationModule::class,
         StripeNetworkClientModule::class,
+        ApiConfigurationResolverModule::class,
     ]
 )
 internal interface CustomerSheetViewModelModule {

--- a/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadata.kt
@@ -5,6 +5,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.orEmpty
 import com.stripe.android.core.utils.FeatureFlags.enableNfcScanning
@@ -97,6 +98,7 @@ internal data class PaymentMethodMetadata(
     val cardArts: List<PaymentMethod.Card.CardArt>,
     val shouldUseAutocompleteProxyEndpoints: Boolean,
     private val paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+    val apiConfiguration: ApiConfiguration.State,
 ) : Parcelable {
 
     val requiresBillingAddressForAutomaticTax: Boolean
@@ -391,6 +393,7 @@ internal data class PaymentMethodMetadata(
             analyticsMetadata: AnalyticsMetadata,
             isTapToAddAvailable: Boolean,
             paymentMethodLayout: PaymentSheet.PaymentMethodLayout,
+            apiConfiguration: ApiConfiguration.State,
         ): PaymentMethodMetadata {
             val linkSettings = elementsSession.linkSettings
             val cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty()
@@ -452,6 +455,7 @@ internal data class PaymentMethodMetadata(
                 cardArts = cardArts,
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 paymentMethodLayout = paymentMethodLayout,
+                apiConfiguration = apiConfiguration,
             )
         }
 
@@ -462,6 +466,7 @@ internal data class PaymentMethodMetadata(
             isGooglePayReady: Boolean,
             customerMetadata: CustomerMetadata,
             integrationMetadata: IntegrationMetadata.CustomerSheet,
+            apiConfiguration: ApiConfiguration.State,
         ): PaymentMethodMetadata {
             return PaymentMethodMetadata(
                 stripeIntent = elementsSession.stripeIntent,
@@ -521,6 +526,7 @@ internal data class PaymentMethodMetadata(
                 cardArts = elementsSession.customer?.paymentMethods?.mapNotNull { it.card?.cardArt }.orEmpty(),
                 shouldUseAutocompleteProxyEndpoints = elementsSession.shouldUseAutocompleteProxyEndpoints,
                 paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+                apiConfiguration = apiConfiguration,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentElementViewModelComponent.kt
@@ -28,6 +28,7 @@ import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolverModule
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -77,6 +78,7 @@ import javax.inject.Singleton
         LinkHoldbackExposureModule::class,
         PaymentMethodMessagePromotionsHelperModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
+        ApiConfigurationResolverModule::class,
     ],
 )
 internal interface EmbeddedPaymentElementViewModelComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolver.kt
@@ -1,0 +1,23 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import javax.inject.Inject
+
+internal interface ApiConfigurationResolver {
+    fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State
+}
+
+internal class DefaultApiConfigurationResolver @Inject constructor(
+    private val context: Context,
+) : ApiConfigurationResolver {
+    override fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State {
+        if (apiConfiguration != null) return apiConfiguration
+        val config = PaymentConfiguration.getInstance(context)
+        return ApiConfiguration.State(
+            publishableKey = config.publishableKey,
+            stripeAccountId = config.stripeAccountId,
+        )
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolver.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolver.kt
@@ -9,6 +9,10 @@ internal interface ApiConfigurationResolver {
     fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State
 }
 
+/**
+ * Used to resolve an ApiConfiguration.State passed from public APIs, if not provided, falls back to
+ * PaymentConfiguration.
+ */
 internal class DefaultApiConfigurationResolver @Inject constructor(
     private val context: Context,
 ) : ApiConfigurationResolver {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolverModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationResolverModule.kt
@@ -1,0 +1,12 @@
+package com.stripe.android.paymentsheet.injection
+
+import dagger.Binds
+import dagger.Module
+
+@Module
+internal interface ApiConfigurationResolverModule {
+    @Binds
+    fun bindsApiConfigurationResolver(
+        resolver: DefaultApiConfigurationResolver,
+    ): ApiConfigurationResolver
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetCommonModule.kt
@@ -89,6 +89,7 @@ import javax.inject.Singleton
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
         NfcScanningAvailabilityModule::class,
+        ApiConfigurationResolverModule::class,
     ]
 )
 internal abstract class PaymentSheetCommonModule {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -4,7 +4,6 @@ import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.common.analytics.experiment.LogFcLiteExperiment
 import com.stripe.android.common.analytics.experiment.LogLinkHoldbackExperiment
@@ -12,6 +11,7 @@ import com.stripe.android.common.analytics.experiment.PaymentMethodMessagePromot
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.utils.DurationProvider
@@ -41,6 +41,7 @@ import com.stripe.android.paymentsheet.PaymentSheet.IntentConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.PaymentMethodLayout
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentIntentClientSecret
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
@@ -60,7 +61,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
-import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -276,7 +276,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     private val userFacingLogger: UserFacingLogger,
     private val integrityRequestManager: IntegrityRequestManager,
     private val tapToAddConnectionStarter: TapToAddConnectionStarter,
-    private val paymentConfiguration: Provider<PaymentConfiguration>,
+    private val apiConfigurationResolver: ApiConfigurationResolver,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val analyticsMetadataFactory: AnalyticsMetadataFactory,
     private val customerRepository: CustomerRepository,
@@ -310,11 +310,12 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         metadata: PaymentElementLoader.Metadata,
     ): Result<PaymentElementLoader.State> = workContext.runCatching(::reportFailedLoad) {
         val configuration = integrationConfiguration.commonConfiguration
+        val apiConfiguration = apiConfigurationResolver.resolve(configuration.apiConfiguration)
         // Validate configuration before loading
         initializationMode.validate()
         configuration.validate(
             initializationMode = initializationMode,
-            isLiveMode = paymentConfiguration.get().isLiveMode(),
+            isLiveMode = apiConfiguration.isLiveMode(),
             callbackIdentifier = paymentElementCallbackIdentifier,
             isTapToAddSupported = tapToAddConnectionStarter.isSupported,
         )
@@ -338,7 +339,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             }
         }
 
-        val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration)
+        val prefetchedPaymentMethods = prefetchPaymentMethodsForLegacyEphemeralKey(configuration, apiConfiguration)
 
         val savedPaymentMethodSelection = retrieveSavedPaymentMethodSelection(configuration)
         val elementsSession = loadSession(
@@ -411,6 +412,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     customerMetadata = customerMetadata,
                     clientAttributionMetadata = clientAttributionMetadata,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }
@@ -483,6 +485,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
 
     private fun CoroutineScope.prefetchPaymentMethodsForLegacyEphemeralKey(
         configuration: CommonConfiguration,
+        apiConfiguration: ApiConfiguration.State,
     ): PrefetchedPaymentMethods? {
         val customer = configuration.customer ?: return null
         val accessType = customer.accessType
@@ -498,7 +501,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                         PaymentMethod.Type.SepaDebit,
                         PaymentMethod.Type.USBankAccount,
                     ), // These are the only payment method types we support as saved payment methods.
-                    silentlyFail = paymentConfiguration.get().isLiveMode(),
+                    silentlyFail = apiConfiguration.isLiveMode(),
                 )
             }
         }
@@ -559,6 +562,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         customerMetadata: CustomerMetadata?,
         clientAttributionMetadata: ClientAttributionMetadata,
+        apiConfiguration: ApiConfiguration.State,
     ): PaymentMethodMetadata {
         val externalPaymentMethodSpecs = externalPaymentMethodsRepository.getExternalPaymentMethodSpecs(
             elementsSession.externalPaymentMethodData
@@ -606,6 +610,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             analyticsMetadata = analyticsMetadata,
             isTapToAddAvailable = isTapToAddAvailable,
             paymentMethodLayout = paymentMethodLayout,
+            apiConfiguration = apiConfiguration,
         )
 
         return paymentMethodMetadata
@@ -688,7 +693,9 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     // Default filters are used here because this only determines the ready state,
     // not what's presented to Google Pay. This check runs async before we fetch the
     // elements session, so using merchant-defined filters would add latency.
-    private suspend fun isGooglePayReadyForEnvironment(environment: GooglePayEnvironment): Boolean {
+    private suspend fun isGooglePayReadyForEnvironment(
+        environment: GooglePayEnvironment,
+    ): Boolean {
         return googlePayRepositoryFactory(
             environment = environment,
             cardFundingFilter = DefaultCardFundingFilter,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -693,9 +693,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
     // Default filters are used here because this only determines the ready state,
     // not what's presented to Google Pay. This check runs async before we fetch the
     // elements session, so using merchant-defined filters would add latency.
-    private suspend fun isGooglePayReadyForEnvironment(
-        environment: GooglePayEnvironment,
-    ): Boolean {
+    private suspend fun isGooglePayReadyForEnvironment(environment: GooglePayEnvironment): Boolean {
         return googlePayRepositoryFactory(
             environment = environment,
             cardFundingFilter = DefaultCardFundingFilter,

--- a/paymentsheet/src/test/java/com/stripe/android/ApiKeyFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/ApiKeyFixtures.kt
@@ -3,6 +3,7 @@ package com.stripe.android
 internal object ApiKeyFixtures {
     const val FAKE_PUBLISHABLE_KEY = "pk_test_123"
     const val FAKE_ACCOUNT_ID = "acct_123"
+    const val FAKE_LIVE_KEY = "pk_live_123"
     const val DEFAULT_PUBLISHABLE_KEY = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
     const val CONNECTED_ACCOUNT_PUBLISHABLE_KEY = "pk_test_fdjfCYpGSwAX24KUEiuaAAWX"
     const val FAKE_EPHEMERAL_KEY = "ek_test_123"

--- a/paymentsheet/src/test/java/com/stripe/android/ApiKeyFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/ApiKeyFixtures.kt
@@ -2,6 +2,7 @@ package com.stripe.android
 
 internal object ApiKeyFixtures {
     const val FAKE_PUBLISHABLE_KEY = "pk_test_123"
+    const val FAKE_ACCOUNT_ID = "acct_123"
     const val DEFAULT_PUBLISHABLE_KEY = "pk_test_vOo1umqsYxSrP5UXfOeL3ecm"
     const val CONNECTED_ACCOUNT_PUBLISHABLE_KEY = "pk_test_fdjfCYpGSwAX24KUEiuaAAWX"
     const val FAKE_EPHEMERAL_KEY = "ek_test_123"

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -838,7 +838,6 @@ internal class DefaultCustomerSheetLoaderTest {
         eventReporter: CustomerSheetEventReporter = FakeCustomerSheetEventReporter(),
         workContext: CoroutineContext = UnconfinedTestDispatcher()
     ): CustomerSheetLoader {
-        val apiConfigurationResolver = FakeApiConfigurationResolver()
         return DefaultCustomerSheetLoader(
             googlePayRepositoryFactory = object : GooglePayRepositoryFactory {
                 override fun invoke(
@@ -859,7 +858,7 @@ internal class DefaultCustomerSheetLoaderTest {
             eventReporter = eventReporter,
             errorReporter = errorReporter,
             workContext = workContext,
-            apiConfigurationResolver = apiConfigurationResolver,
+            apiConfigurationResolver = FakeApiConfigurationResolver(),
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -6,7 +6,6 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.model.PaymentMethodRemovePermission
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
@@ -839,12 +838,7 @@ internal class DefaultCustomerSheetLoaderTest {
         eventReporter: CustomerSheetEventReporter = FakeCustomerSheetEventReporter(),
         workContext: CoroutineContext = UnconfinedTestDispatcher()
     ): CustomerSheetLoader {
-        val apiConfigurationResolver = FakeApiConfigurationResolver(
-            resolvedApiConfiguration = ApiConfiguration.State(
-                publishableKey = "pk_test_123",
-                stripeAccountId = "acct_123",
-            ),
-        )
+        val apiConfigurationResolver = FakeApiConfigurationResolver()
         return DefaultCustomerSheetLoader(
             googlePayRepositoryFactory = object : GooglePayRepositoryFactory {
                 override fun invoke(

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.networking.AnalyticsEvent
 import com.stripe.android.customersheet.CustomerPermissions
 import com.stripe.android.customersheet.CustomerSheet
@@ -39,6 +40,7 @@ import com.stripe.android.model.StripeIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.financialconnections.IsFinancialConnectionsSdkAvailable
 import com.stripe.android.paymentsheet.PaymentSheet
+import com.stripe.android.paymentsheet.injection.FakeApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.testing.CoroutineTestRule
@@ -837,6 +839,12 @@ internal class DefaultCustomerSheetLoaderTest {
         eventReporter: CustomerSheetEventReporter = FakeCustomerSheetEventReporter(),
         workContext: CoroutineContext = UnconfinedTestDispatcher()
     ): CustomerSheetLoader {
+        val apiConfigurationResolver = FakeApiConfigurationResolver(
+            resolvedApiConfiguration = ApiConfiguration.State(
+                publishableKey = "pk_test_123",
+                stripeAccountId = "acct_123",
+            ),
+        )
         return DefaultCustomerSheetLoader(
             googlePayRepositoryFactory = object : GooglePayRepositoryFactory {
                 override fun invoke(
@@ -856,7 +864,8 @@ internal class DefaultCustomerSheetLoaderTest {
             isFinancialConnectionsAvailable = isFinancialConnectionsAvailable,
             eventReporter = eventReporter,
             errorReporter = errorReporter,
-            workContext = workContext
+            workContext = workContext,
+            apiConfigurationResolver = apiConfigurationResolver,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -5,6 +5,7 @@ import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.DefaultCardFundingFilter
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.LinkBrand
@@ -80,6 +81,10 @@ internal object PaymentMethodMetadataFactory {
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
         shouldUseAutocompleteProxyEndpoints: Boolean = false,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+        apiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
+            publishableKey = "pk_test_123",
+            stripeAccountId = "acct_123",
+        ),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,
@@ -152,6 +157,7 @@ internal object PaymentMethodMetadataFactory {
             cardArts = cardArts,
             shouldUseAutocompleteProxyEndpoints = shouldUseAutocompleteProxyEndpoints,
             paymentMethodLayout = paymentMethodLayout,
+            apiConfiguration = apiConfiguration,
         )
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
@@ -82,8 +83,8 @@ internal object PaymentMethodMetadataFactory {
         shouldUseAutocompleteProxyEndpoints: Boolean = false,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
         apiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
-            publishableKey = "pk_test_123",
-            stripeAccountId = "acct_123",
+            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
         ),
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -4,6 +4,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkConfiguration
@@ -61,6 +62,10 @@ import com.stripe.android.uicore.R as UiCoreR
 
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentMethodMetadataTest {
+    private val apiConfiguration = ApiConfiguration.State(
+        publishableKey = "pk_test_123",
+        stripeAccountId = "acct_123",
+    )
 
     @Test
     fun `hasIntentToSetup returns true for setup_intent`() {
@@ -1042,6 +1047,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1115,6 +1121,7 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1175,6 +1182,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
 
         // When flag is false, should use default funding types, not the configured ones
@@ -1213,6 +1221,7 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = true,
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = DEFAULT_CUSTOMER_INTEGRATION_METADATA,
+            apiConfiguration = apiConfiguration,
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1271,6 +1280,7 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -2021,6 +2031,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
 
         assertThat(metadata.availableWallets)
@@ -2090,6 +2101,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = true,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
 
         assertThat(metadata.isTapToAddSupported).isTrue()
@@ -2114,6 +2126,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = true,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
 
         assertThat(metadata.isTapToAddSupported).isTrue()
@@ -2142,6 +2155,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
 
         assertThat(metadata.isTapToAddSupported).isFalse()
@@ -2282,6 +2296,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
     }
 
@@ -2308,6 +2323,7 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = false,
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = DEFAULT_CUSTOMER_INTEGRATION_METADATA,
+            apiConfiguration = apiConfiguration,
         )
     }
 
@@ -2371,6 +2387,7 @@ internal class PaymentMethodMetadataTest {
     fun `paymentMethodOrientation returns Horizontal when layout is Horizontal`() {
         val metadata = PaymentMethodMetadataFactory.create(
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+            apiConfiguration = apiConfiguration,
         )
 
         assertThat(metadata.paymentMethodOrientation()).isEqualTo(PaymentMethodOrientation.Horizontal)

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.asCommonConfiguration
@@ -2486,7 +2487,7 @@ internal class PaymentMethodMetadataTest {
     )
 
     private val apiConfiguration = ApiConfiguration.State(
-        publishableKey = "pk_test_123",
-        stripeAccountId = "acct_123",
+        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -62,10 +62,6 @@ import com.stripe.android.uicore.R as UiCoreR
 
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentMethodMetadataTest {
-    private val apiConfiguration = ApiConfiguration.State(
-        publishableKey = "pk_test_123",
-        stripeAccountId = "acct_123",
-    )
 
     @Test
     fun `hasIntentToSetup returns true for setup_intent`() {
@@ -2487,5 +2483,10 @@ internal class PaymentMethodMetadataTest {
         customPaymentMethods = customPaymentMethods,
         cardBrandAcceptance = cardBrandAcceptance,
         allowedCardFundingTypes = allowedCardFundingTypes
+    )
+
+    private val apiConfiguration = ApiConfiguration.State(
+        publishableKey = "pk_test_123",
+        stripeAccountId = "acct_123",
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/DefaultApiConfigurationResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/DefaultApiConfigurationResolverTest.kt
@@ -9,6 +9,7 @@ import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertFailsWith
 
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultApiConfigurationResolverTest {
@@ -52,5 +53,27 @@ internal class DefaultApiConfigurationResolverTest {
                 stripeAccountId = "acct_from_payment_configuration",
             )
         )
+    }
+
+    @Test
+    fun `resolve does not require PaymentConfiguration when API configuration is provided`() {
+        PaymentConfiguration.clearInstance()
+        val apiConfiguration = ApiConfiguration.State(
+            publishableKey = "pk_test_from_api_configuration",
+            stripeAccountId = "acct_from_api_configuration",
+        )
+
+        val resolvedApiConfiguration = DefaultApiConfigurationResolver(context).resolve(apiConfiguration)
+
+        assertThat(resolvedApiConfiguration).isEqualTo(apiConfiguration)
+    }
+
+    @Test
+    fun `resolve throws when API configuration is null and PaymentConfiguration is not initialized`() {
+        PaymentConfiguration.clearInstance()
+
+        assertFailsWith<IllegalStateException> {
+            DefaultApiConfigurationResolver(context).resolve(apiConfiguration = null)
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/DefaultApiConfigurationResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/DefaultApiConfigurationResolverTest.kt
@@ -1,0 +1,56 @@
+package com.stripe.android.paymentsheet.injection
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class DefaultApiConfigurationResolverTest {
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+
+    @After
+    fun tearDown() {
+        PaymentConfiguration.clearInstance()
+    }
+
+    @Test
+    fun `resolve uses provided API configuration before PaymentConfiguration`() {
+        PaymentConfiguration.init(
+            context = context,
+            publishableKey = "pk_test_from_payment_configuration",
+            stripeAccountId = "acct_from_payment_configuration",
+        )
+        val apiConfiguration = ApiConfiguration.State(
+            publishableKey = "pk_test_from_api_configuration",
+            stripeAccountId = "acct_from_api_configuration",
+        )
+
+        val resolvedApiConfiguration = DefaultApiConfigurationResolver(context).resolve(apiConfiguration)
+
+        assertThat(resolvedApiConfiguration).isEqualTo(apiConfiguration)
+    }
+
+    @Test
+    fun `resolve falls back to PaymentConfiguration if apiConfiguration is null`() {
+        PaymentConfiguration.init(
+            context = context,
+            publishableKey = "pk_test_from_payment_configuration",
+            stripeAccountId = "acct_from_payment_configuration",
+        )
+
+        val resolvedApiConfiguration = DefaultApiConfigurationResolver(context).resolve(apiConfiguration = null)
+
+        assertThat(resolvedApiConfiguration).isEqualTo(
+            ApiConfiguration.State(
+                publishableKey = "pk_test_from_payment_configuration",
+                stripeAccountId = "acct_from_payment_configuration",
+            )
+        )
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/DefaultApiConfigurationResolverTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/DefaultApiConfigurationResolverTest.kt
@@ -63,17 +63,12 @@ internal class DefaultApiConfigurationResolverTest {
             stripeAccountId = "acct_from_api_configuration",
         )
 
+        assertFailsWith<IllegalStateException> {
+            PaymentConfiguration.getInstance(context)
+        }
+
         val resolvedApiConfiguration = DefaultApiConfigurationResolver(context).resolve(apiConfiguration)
 
         assertThat(resolvedApiConfiguration).isEqualTo(apiConfiguration)
-    }
-
-    @Test
-    fun `resolve throws when API configuration is null and PaymentConfiguration is not initialized`() {
-        PaymentConfiguration.clearInstance()
-
-        assertFailsWith<IllegalStateException> {
-            DefaultApiConfigurationResolver(context).resolve(apiConfiguration = null)
-        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/FakeApiConfigurationResolver.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/FakeApiConfigurationResolver.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.core.ApiConfiguration
+
+internal class FakeApiConfigurationResolver(
+    private val resolvedApiConfiguration: ApiConfiguration.State,
+) : ApiConfigurationResolver {
+    override fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State {
+        return apiConfiguration ?: resolvedApiConfiguration
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/FakeApiConfigurationResolver.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/FakeApiConfigurationResolver.kt
@@ -3,7 +3,10 @@ package com.stripe.android.paymentsheet.injection
 import com.stripe.android.core.ApiConfiguration
 
 internal class FakeApiConfigurationResolver(
-    private val resolvedApiConfiguration: ApiConfiguration.State,
+    private val resolvedApiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
+        publishableKey = "pk_test_123",
+        stripeAccountId = "acct_123"
+    ),
 ) : ApiConfigurationResolver {
     override fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State {
         return apiConfiguration ?: resolvedApiConfiguration

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/FakeApiConfigurationResolver.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/FakeApiConfigurationResolver.kt
@@ -1,11 +1,12 @@
 package com.stripe.android.paymentsheet.injection
 
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.core.ApiConfiguration
 
 internal class FakeApiConfigurationResolver(
     private val resolvedApiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
-        publishableKey = "pk_test_123",
-        stripeAccountId = "acct_123"
+        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
     ),
 ) : ApiConfigurationResolver {
     override fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -4,7 +4,6 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.common.analytics.experiment.DefaultPaymentMethodMessagePromotionsExperimentHandler
@@ -14,6 +13,7 @@ import com.stripe.android.common.analytics.experiment.PaymentMethodMessagePromot
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.model.CountryCode
@@ -76,6 +76,7 @@ import com.stripe.android.paymentsheet.analytics.FakeLoadingEventReporter
 import com.stripe.android.paymentsheet.analytics.FakeLogFcLiteExperiment
 import com.stripe.android.paymentsheet.analytics.FakeLogLinkHoldbackExperiment
 import com.stripe.android.paymentsheet.analytics.FakePaymentMethodMessagePromotionsExperimentHandler
+import com.stripe.android.paymentsheet.injection.FakeApiConfigurationResolver
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.model.toSavedSelection
@@ -173,6 +174,10 @@ internal class DefaultPaymentElementLoaderTest {
                     ),
                     integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_1234"),
                     elementsSessionId = "session_1234",
+                    apiConfiguration = ApiConfiguration.State(
+                        publishableKey = "pk_test",
+                        stripeAccountId = "acct_123",
+                    ),
                 ),
             )
         )
@@ -5043,7 +5048,12 @@ internal class DefaultPaymentElementLoaderTest {
             paymentElementCallbackIdentifier = PAYMENT_ELEMENT_CALLBACKS_IDENTIFIER,
             analyticsMetadataFactory = analyticsMetadataFactory,
             tapToAddConnectionStarter = tapToAddConnectionStarter,
-            paymentConfiguration = { PaymentConfiguration(publishableKey = if (isLiveMode) "pk_live" else "pk_test") },
+            apiConfigurationResolver = FakeApiConfigurationResolver(
+                resolvedApiConfiguration = ApiConfiguration.State(
+                    publishableKey = if (isLiveMode) "pk_live" else "pk_test",
+                    stripeAccountId = "acct_123",
+                ),
+            ),
             createCustomerState = CreateCustomerState(
                 paymentMethodFilter = paymentMethodFilter,
                 errorReporter = errorReporter,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
@@ -175,8 +176,8 @@ internal class DefaultPaymentElementLoaderTest {
                     integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_1234"),
                     elementsSessionId = "session_1234",
                     apiConfiguration = ApiConfiguration.State(
-                        publishableKey = "pk_test",
-                        stripeAccountId = "acct_123",
+                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+                        stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
                     ),
                 ),
             )
@@ -5050,8 +5051,12 @@ internal class DefaultPaymentElementLoaderTest {
             tapToAddConnectionStarter = tapToAddConnectionStarter,
             apiConfigurationResolver = FakeApiConfigurationResolver(
                 resolvedApiConfiguration = ApiConfiguration.State(
-                    publishableKey = if (isLiveMode) "pk_live" else "pk_test",
-                    stripeAccountId = "acct_123",
+                    publishableKey = if (isLiveMode) {
+                        ApiKeyFixtures.FAKE_LIVE_KEY
+                    } else {
+                        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
+                    },
+                    stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
                 ),
             ),
             createCustomerState = CreateCustomerState(


### PR DESCRIPTION
# Summary
Introduce the PaymentSheet API configuration resolution and metadata plumbing needed by later stack changes.

Changed classes and entry points:

- `CommonConfiguration`: Add an optional `ApiConfiguration.State` supplied by integrations.
- `ApiConfigurationResolver`: Define the resolver interface used by loaders.
- `DefaultApiConfigurationResolver`: Prefer explicit API configuration and otherwise resolve `PaymentConfiguration` lazily from application context.
- `ApiConfigurationResolverModule`: Bind the production resolver.
- `PaymentMethodMetadata`: Retain resolved configuration for downstream consumers.
- `DefaultPaymentElementLoader`: Resolve configuration once for validation, customer prefetching, and metadata.
- `DefaultCustomerSheetLoader`: Resolve global configuration for CustomerSheet metadata.
- PaymentSheet, Embedded, CustomerSheet, and Checkout component entry points: Install the resolver binding.
- `FakeApiConfigurationResolver`: Provide deterministic test configuration.

Committed and created by Codex.

# Motivation
Setup to remove PaymentConfiguration from paymentsheet

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — internal configuration plumbing only.

# Changelog
Not applicable — no public behavior change.