### PR TITLE
Pass `ApiConfiguration.State` to elements session repository

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -2,7 +2,6 @@ package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.PaymentMethodRemovePermission
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -2,8 +2,10 @@ package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.CustomerPermissions
@@ -21,6 +23,7 @@ import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -29,6 +32,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
     private val elementsSessionRepository: ElementsSessionRepository,
     private val customerAdapter: CustomerAdapter,
     private val errorReporter: ErrorReporter,
+    private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetInitializationDataSource,
     CustomerSheetSavedSelectionDataSource,
@@ -132,6 +136,12 @@ internal class CustomerAdapterDataSource @Inject constructor(
             customPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = paymentConfigurationProvider.get().let {
+                ApiRequest.Options(
+                    apiKey = it.publishableKey,
+                    stripeAccount = it.stripeAccountId,
+                )
+            },
         ).onSuccess {
             errorReporter.report(
                 errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerAdapterDataSource.kt
@@ -3,9 +3,9 @@ package com.stripe.android.customersheet.data
 import com.stripe.android.common.coroutines.runCatching
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerAdapter.PaymentOption.Companion.toPaymentOption
 import com.stripe.android.customersheet.CustomerPermissions
@@ -32,7 +32,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
     private val elementsSessionRepository: ElementsSessionRepository,
     private val customerAdapter: CustomerAdapter,
     private val errorReporter: ErrorReporter,
-    private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
+    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSheetInitializationDataSource,
     CustomerSheetSavedSelectionDataSource,
@@ -136,12 +136,7 @@ internal class CustomerAdapterDataSource @Inject constructor(
             customPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = paymentConfigurationProvider.get().let {
-                ApiRequest.Options(
-                    apiKey = it.publishableKey,
-                    stripeAccount = it.stripeAccountId,
-                )
-            },
+            apiConfiguration = apiConfigurationProvider.get(),
         ).onSuccess {
             errorReporter.report(
                 errorEvent = ErrorReporter.SuccessEvent.CUSTOMER_SHEET_ELEMENTS_SESSION_LOAD_SUCCESS,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -2,9 +2,9 @@ package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
 import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -37,7 +37,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
     private val prefsRepositoryFactory: PrefsRepository.Factory,
     private val customerSessionProvider: CustomerSheet.CustomerSessionProvider,
     private val errorReporter: ErrorReporter,
-    private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
+    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
     private val timeProvider: () -> Long,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSessionElementsSessionManager {
@@ -94,12 +94,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                     customPaymentMethods = listOf(),
                     externalPaymentMethods = listOf(),
                     countryOverride = null,
-                    requestOptions = paymentConfigurationProvider.get().let {
-                        ApiRequest.Options(
-                            apiKey = it.publishableKey,
-                            stripeAccount = it.stripeAccountId,
-                        )
-                    },
+                    apiConfiguration = apiConfigurationProvider.get(),
                 ).onSuccess {
                     reportSuccessfulElementsSessionLoad()
                 }.onFailure {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -1,8 +1,10 @@
 package com.stripe.android.customersheet.data
 
 import com.stripe.android.common.validation.CustomerSessionClientSecretValidator
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.payments.core.analytics.ErrorReporter
@@ -13,6 +15,7 @@ import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
+import javax.inject.Provider
 import javax.inject.Singleton
 import kotlin.coroutines.CoroutineContext
 
@@ -34,6 +37,7 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
     private val prefsRepositoryFactory: PrefsRepository.Factory,
     private val customerSessionProvider: CustomerSheet.CustomerSessionProvider,
     private val errorReporter: ErrorReporter,
+    private val paymentConfigurationProvider: Provider<PaymentConfiguration>,
     private val timeProvider: () -> Long,
     @IOContext private val workContext: CoroutineContext,
 ) : CustomerSessionElementsSessionManager {
@@ -90,6 +94,12 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
                     customPaymentMethods = listOf(),
                     externalPaymentMethods = listOf(),
                     countryOverride = null,
+                    requestOptions = paymentConfigurationProvider.get().let {
+                        ApiRequest.Options(
+                            apiKey = it.publishableKey,
+                            stripeAccount = it.stripeAccountId,
+                        )
+                    },
                 ).onSuccess {
                     reportSuccessfulElementsSessionLoad()
                 }.onFailure {

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/injection/CustomerAdapterDataSourceComponent.kt
@@ -11,6 +11,7 @@ import com.stripe.android.customersheet.data.CustomerSheetPaymentMethodDataSourc
 import com.stripe.android.customersheet.data.CustomerSheetSavedSelectionDataSource
 import com.stripe.android.customersheet.injection.CustomerSheetDataCommonModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
+import com.stripe.android.payments.core.injection.ApiConfigurationFromPaymentConfigurationModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import dagger.BindsInstance
 import dagger.Component
@@ -27,6 +28,7 @@ import javax.inject.Singleton
         CoroutineContextModule::class,
         CoreCommonModule::class,
         ElementsSessionClientParamsModule::class,
+        ApiConfigurationFromPaymentConfigurationModule::class,
     ]
 )
 internal interface CustomerAdapterDataSourceComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentsheet.repositories
 
 import android.app.Application
 import com.stripe.android.DefaultFraudDetectionDataRepository
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.Stripe
 import com.stripe.android.core.exception.StripeException
@@ -28,7 +27,6 @@ import com.stripe.android.paymentsheet.toDeferredIntentParams
 import kotlinx.coroutines.withContext
 import java.util.Calendar
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.coroutines.CoroutineContext
 
 internal interface ElementsSessionRepository {
@@ -39,6 +37,7 @@ internal interface ElementsSessionRepository {
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        requestOptions: ApiRequest.Options,
         linkDisallowedFundingSourceCreation: Set<String> = emptySet(),
     ): Result<ElementsSession>
 }
@@ -47,7 +46,6 @@ internal class RealElementsSessionRepository @Inject constructor(
     application: Application,
     private val stripeNetworkClient: StripeNetworkClient,
     private val stripeRepository: StripeRepository,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     @IOContext private val workContext: CoroutineContext,
     private val clientParams: ElementsSessionClientParams,
 ) : ElementsSessionRepository {
@@ -62,14 +60,6 @@ internal class RealElementsSessionRepository @Inject constructor(
     )
     private val stripeErrorJsonParser = StripeErrorJsonParser()
 
-    // The PaymentConfiguration can change after initialization, so this needs to get a new
-    // request options each time requested.
-    private val requestOptions: ApiRequest.Options
-        get() = ApiRequest.Options(
-            apiKey = lazyPaymentConfig.get().publishableKey,
-            stripeAccount = lazyPaymentConfig.get().stripeAccountId,
-        )
-
     override suspend fun get(
         initializationMode: PaymentElementLoader.InitializationMode,
         customer: PaymentSheet.CustomerConfiguration?,
@@ -77,6 +67,7 @@ internal class RealElementsSessionRepository @Inject constructor(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        requestOptions: ApiRequest.Options,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
         fraudDetectionDataRepository.refresh()
@@ -91,12 +82,11 @@ internal class RealElementsSessionRepository @Inject constructor(
             linkDisallowedFundingSourceCreation = linkDisallowedFundingSourceCreation,
         )
 
-        val options = requestOptions
-        val elementsSession = retrieveElementsSession(params, options)
+        val elementsSession = retrieveElementsSession(params, requestOptions)
 
         return elementsSession.getResultOrElse { elementsSessionFailure ->
             if (shouldFallback(elementsSession)) {
-                fallback(params, elementsSessionFailure)
+                fallback(params, elementsSessionFailure, requestOptions)
             } else {
                 elementsSession
             }
@@ -148,6 +138,7 @@ internal class RealElementsSessionRepository @Inject constructor(
     private suspend fun fallback(
         params: ElementsSessionParams,
         elementsSessionFailure: Throwable,
+        requestOptions: ApiRequest.Options,
     ): Result<ElementsSession> = withContext(workContext) {
         val stripeIntent = when (params) {
             is ElementsSessionParams.PaymentIntentType -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepository.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.stripe.android.DefaultFraudDetectionDataRepository
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.Stripe
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.model.parsers.StripeErrorJsonParser
@@ -37,7 +38,7 @@ internal interface ElementsSessionRepository {
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
-        requestOptions: ApiRequest.Options,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String> = emptySet(),
     ): Result<ElementsSession>
 }
@@ -67,7 +68,7 @@ internal class RealElementsSessionRepository @Inject constructor(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
-        requestOptions: ApiRequest.Options,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
         fraudDetectionDataRepository.refresh()
@@ -82,6 +83,10 @@ internal class RealElementsSessionRepository @Inject constructor(
             linkDisallowedFundingSourceCreation = linkDisallowedFundingSourceCreation,
         )
 
+        val requestOptions = ApiRequest.Options(
+            apiKey = apiConfiguration.publishableKey,
+            stripeAccount = apiConfiguration.stripeAccountId,
+        )
         val elementsSession = retrieveElementsSession(params, requestOptions)
 
         return elementsSession.getResultOrElse { elementsSessionFailure ->

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -31,6 +32,7 @@ internal class ElementsSessionLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         configuration: CommonConfiguration,
         savedPaymentMethodSelection: SavedSelection.PaymentMethod?,
+        requestOptions: ApiRequest.Options,
     ): ElementsSession {
         return elementsSessionRepository.get(
             initializationMode = initializationMode,
@@ -39,6 +41,7 @@ internal class ElementsSessionLoader @Inject constructor(
             customPaymentMethods = configuration.customPaymentMethods,
             savedPaymentMethodSelectionId = savedPaymentMethodSelection?.id,
             countryOverride = configuration.userOverrideCountry,
+            requestOptions = requestOptions,
             linkDisallowedFundingSourceCreation = configuration.link.disallowFundingSourceCreation,
         ).getOrThrow()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/LoadSession.kt
@@ -1,7 +1,7 @@
 package com.stripe.android.paymentsheet.state
 
 import com.stripe.android.common.model.CommonConfiguration
-import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.paymentsheet.model.SavedSelection
 import com.stripe.android.paymentsheet.repositories.ElementsSessionRepository
@@ -32,7 +32,7 @@ internal class ElementsSessionLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         configuration: CommonConfiguration,
         savedPaymentMethodSelection: SavedSelection.PaymentMethod?,
-        requestOptions: ApiRequest.Options,
+        apiConfiguration: ApiConfiguration.State,
     ): ElementsSession {
         return elementsSessionRepository.get(
             initializationMode = initializationMode,
@@ -41,7 +41,7 @@ internal class ElementsSessionLoader @Inject constructor(
             customPaymentMethods = configuration.customPaymentMethods,
             savedPaymentMethodSelectionId = savedPaymentMethodSelection?.id,
             countryOverride = configuration.userOverrideCountry,
-            requestOptions = requestOptions,
+            apiConfiguration = apiConfiguration,
             linkDisallowedFundingSourceCreation = configuration.link.disallowFundingSourceCreation,
         ).getOrThrow()
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -14,7 +14,6 @@ import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
-import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.FeatureFlag
 import com.stripe.android.core.utils.FeatureFlags
@@ -350,10 +349,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             initializationMode = initializationMode,
             configuration = configuration,
             savedPaymentMethodSelection = savedPaymentMethodSelection,
-            requestOptions = ApiRequest.Options(
-                apiKey = apiConfiguration.publishableKey,
-                stripeAccount = apiConfiguration.stripeAccountId,
-            ),
+            apiConfiguration = apiConfiguration,
         )
 
         // Preemptively prepare Integrity asynchronously if needed, as warm up can take
@@ -521,7 +517,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         configuration: CommonConfiguration,
         savedPaymentMethodSelection: SavedSelection.PaymentMethod?,
-        requestOptions: ApiRequest.Options,
+        apiConfiguration: ApiConfiguration.State,
     ): ElementsSession {
         return durationProvider.measureDuration(
             DurationProvider.Key.PaymentSheetLoadSessionLoad
@@ -533,7 +529,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     configuration = configuration,
                     savedPaymentMethodSelection = savedPaymentMethodSelection,
-                    requestOptions = requestOptions,
+                    apiConfiguration = apiConfiguration,
                 )
             }
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/PaymentElementLoader.kt
@@ -14,6 +14,7 @@ import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.IOContext
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.core.utils.DurationProvider
 import com.stripe.android.core.utils.FeatureFlag
 import com.stripe.android.core.utils.FeatureFlags
@@ -349,6 +350,10 @@ internal class DefaultPaymentElementLoader @Inject constructor(
             initializationMode = initializationMode,
             configuration = configuration,
             savedPaymentMethodSelection = savedPaymentMethodSelection,
+            requestOptions = ApiRequest.Options(
+                apiKey = apiConfiguration.publishableKey,
+                stripeAccount = apiConfiguration.stripeAccountId,
+            ),
         )
 
         // Preemptively prepare Integrity asynchronously if needed, as warm up can take
@@ -516,6 +521,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
         initializationMode: PaymentElementLoader.InitializationMode,
         configuration: CommonConfiguration,
         savedPaymentMethodSelection: SavedSelection.PaymentMethod?,
+        requestOptions: ApiRequest.Options,
     ): ElementsSession {
         return durationProvider.measureDuration(
             DurationProvider.Key.PaymentSheetLoadSessionLoad
@@ -527,6 +533,7 @@ internal class DefaultPaymentElementLoader @Inject constructor(
                     initializationMode = initializationMode,
                     configuration = configuration,
                     savedPaymentMethodSelection = savedPaymentMethodSelection,
+                    requestOptions = requestOptions,
                 )
             }
         }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerSheet
@@ -721,6 +722,9 @@ class CustomerAdapterDataSourceTest {
             customerAdapter = adapter,
             elementsSessionRepository = elementsSessionRepository,
             errorReporter = errorReporter,
+            paymentConfigurationProvider = {
+                PaymentConfiguration(publishableKey = "pk_test_123", stripeAccountId = "acct_123")
+            },
             workContext = coroutineContext,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/CustomerAdapterDataSourceTest.kt
@@ -2,13 +2,13 @@ package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.ExperimentalAllowsRemovalOfLastSavedPaymentMethodApi
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.customersheet.CustomerAdapter
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.CustomerSheetFixtures
 import com.stripe.android.customersheet.FakeCustomerAdapter
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodUpdateParams
@@ -525,6 +525,7 @@ class CustomerAdapterDataSourceTest {
         val lastParams = elementsSessionRepository.lastParams
 
         assertThat(lastParams?.customPaymentMethods).isEmpty()
+        assertThat(lastParams?.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
 
         assertThat(result).isInstanceOf<CustomerSheetDataResult.Success<CustomerSheetSession>>()
 
@@ -722,9 +723,7 @@ class CustomerAdapterDataSourceTest {
             customerAdapter = adapter,
             elementsSessionRepository = elementsSessionRepository,
             errorReporter = errorReporter,
-            paymentConfigurationProvider = {
-                PaymentConfiguration(publishableKey = "pk_test_123", stripeAccountId = "acct_123")
-            },
+            apiConfigurationProvider = { DEFAULT_API_CONFIG },
             workContext = coroutineContext,
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.utils.FakeCustomerSessionProvider
 import com.stripe.android.isInstanceOf
@@ -511,6 +512,9 @@ class DefaultCustomerSessionElementsSessionManagerTest {
                 onIntentConfiguration = onIntentConfiguration,
                 onProvidesCustomerSessionClientSecret = onCustomerSessionClientSecret,
             ),
+            paymentConfigurationProvider = {
+                PaymentConfiguration(publishableKey = "pk_test_123", stripeAccountId = "acct_123")
+            },
             timeProvider = timeProvider,
             workContext = coroutineContext,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
@@ -1,10 +1,10 @@
 package com.stripe.android.customersheet.data
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.customersheet.utils.FakeCustomerSessionProvider
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.FakePrefsRepository
@@ -55,6 +55,7 @@ class DefaultCustomerSessionElementsSessionManagerTest {
         assertThat(lastParams?.savedPaymentMethodSelectionId).isEqualTo("pm_123")
         assertThat(lastParams?.externalPaymentMethods).isEmpty()
         assertThat(lastParams?.customPaymentMethods).isEmpty()
+        assertThat(lastParams?.apiConfiguration).isEqualTo(DEFAULT_API_CONFIG)
 
         val initializationMode = lastParams?.initializationMode
         assertThat(initializationMode).isInstanceOf(InitializationMode.DeferredIntent::class.java)
@@ -512,9 +513,7 @@ class DefaultCustomerSessionElementsSessionManagerTest {
                 onIntentConfiguration = onIntentConfiguration,
                 onProvidesCustomerSessionClientSecret = onCustomerSessionClientSecret,
             ),
-            paymentConfigurationProvider = {
-                PaymentConfiguration(publishableKey = "pk_test_123", stripeAccountId = "acct_123")
-            },
+            apiConfigurationProvider = { DEFAULT_API_CONFIG },
             timeProvider = timeProvider,
             workContext = coroutineContext,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -4,7 +4,6 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.core.networking.AnalyticsEvent

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.common.coroutines.Single
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.core.networking.AnalyticsEvent
@@ -450,6 +451,12 @@ internal class DefaultCustomerSheetLoaderTest {
                 workContext = coroutineContext,
                 customerAdapter = FakeCustomerAdapter(),
                 errorReporter = FakeErrorReporter(),
+                paymentConfigurationProvider = {
+                    PaymentConfiguration(
+                        publishableKey = "pk_test_123",
+                        stripeAccountId = "acct_123",
+                    )
+                },
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/state/DefaultCustomerSheetLoaderTest.kt
@@ -28,6 +28,7 @@ import com.stripe.android.googlepaylauncher.GooglePayRepository
 import com.stripe.android.googlepaylauncher.injection.GooglePayRepositoryFactory
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
 import com.stripe.android.model.CardBrand
@@ -451,12 +452,7 @@ internal class DefaultCustomerSheetLoaderTest {
                 workContext = coroutineContext,
                 customerAdapter = FakeCustomerAdapter(),
                 errorReporter = FakeErrorReporter(),
-                paymentConfigurationProvider = {
-                    PaymentConfiguration(
-                        publishableKey = "pk_test_123",
-                        stripeAccountId = "acct_123",
-                    )
-                },
+                apiConfigurationProvider = { DEFAULT_API_CONFIG },
             )
         )
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -41,6 +41,34 @@ internal class ElementsSessionRepositoryTest {
     private val requestCaptor = argumentCaptor<StripeRequest>()
 
     @Test
+    fun `get constructs request options from API configuration`() = runTest {
+        whenever(stripeNetworkClient.executeRequest(any())).thenReturn(
+            StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())
+        )
+        val apiConfiguration = DEFAULT_API_CONFIG.copy(
+            publishableKey = "pk_test_request_options",
+            stripeAccountId = "acct_request_options",
+        )
+
+        createRepository().get(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = "client_secret",
+            ),
+            customer = null,
+            externalPaymentMethods = emptyList(),
+            customPaymentMethods = emptyList(),
+            savedPaymentMethodSelectionId = null,
+            countryOverride = null,
+            apiConfiguration = apiConfiguration,
+        ).getOrThrow()
+
+        verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
+        val requestOptions = (requestCaptor.firstValue as ApiRequest).options
+        assertThat(requestOptions.apiKey).isEqualTo(apiConfiguration.publishableKey)
+        assertThat(requestOptions.stripeAccount).isEqualTo(apiConfiguration.stripeAccountId)
+    }
+
+    @Test
     fun `get with locale should retrieve with element session`() = runTest {
         whenever(stripeNetworkClient.executeRequest(any())).thenReturn(
             StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.core.networking.StripeNetworkClient
 import com.stripe.android.core.networking.StripeRequest
 import com.stripe.android.core.networking.StripeResponse
 import com.stripe.android.core.strings.resolvableString
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.ElementsSessionFixtures
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethod
@@ -56,7 +57,7 @@ internal class ElementsSessionRepositoryTest {
                 customPaymentMethods = emptyList(),
                 savedPaymentMethodSelectionId = null,
                 countryOverride = null,
-                requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+                apiConfiguration = DEFAULT_API_CONFIG,
             ).getOrThrow()
         }
 
@@ -90,10 +91,7 @@ internal class ElementsSessionRepositoryTest {
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
                     countryOverride = null,
-                    requestOptions = ApiRequest.Options(
-                        apiKey = "pk_test_123",
-                        stripeAccount = "acct_123",
-                    ),
+                    apiConfiguration = DEFAULT_API_CONFIG,
                 ).getOrThrow()
             }
 
@@ -122,10 +120,7 @@ internal class ElementsSessionRepositoryTest {
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
                     countryOverride = null,
-                    requestOptions = ApiRequest.Options(
-                        apiKey = "pk_test_123",
-                        stripeAccount = "acct_123",
-                    ),
+                    apiConfiguration = DEFAULT_API_CONFIG,
                 ).getOrThrow()
             }
 
@@ -155,7 +150,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -195,7 +190,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -217,7 +212,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(any())
@@ -239,7 +234,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(any())
@@ -274,7 +269,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -307,7 +302,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -342,7 +337,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -374,7 +369,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -422,7 +417,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -463,7 +458,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -514,7 +509,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -555,7 +550,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -603,7 +598,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -640,7 +635,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -669,7 +664,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
             linkDisallowedFundingSourceCreation = setOf("somethingThatsNotAllowed"),
         )
 
@@ -694,7 +689,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -717,7 +712,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -745,7 +740,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -779,7 +774,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -810,7 +805,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -834,7 +829,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -858,7 +853,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -882,7 +877,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -911,7 +906,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -936,7 +931,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -960,7 +955,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "uk_12345", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG.copy(publishableKey = "uk_12345"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -987,7 +982,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "uk_12345", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG.copy(publishableKey = "uk_12345"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -1020,7 +1015,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            requestOptions = ApiRequest.Options(apiKey = "uk_12345", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG.copy(publishableKey = "uk_12345"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -45,10 +45,6 @@ internal class ElementsSessionRepositoryTest {
         whenever(stripeNetworkClient.executeRequest(any())).thenReturn(
             StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())
         )
-        val apiConfiguration = DEFAULT_API_CONFIG.copy(
-            publishableKey = "pk_test_request_options",
-            stripeAccountId = "acct_request_options",
-        )
 
         createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
@@ -59,13 +55,13 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = DEFAULT_API_CONFIG,
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
         val requestOptions = (requestCaptor.firstValue as ApiRequest).options
-        assertThat(requestOptions.apiKey).isEqualTo(apiConfiguration.publishableKey)
-        assertThat(requestOptions.stripeAccount).isEqualTo(apiConfiguration.stripeAccountId)
+        assertThat(requestOptions.apiKey).isEqualTo(DEFAULT_API_CONFIG.publishableKey)
+        assertThat(requestOptions.stripeAccount).isEqualTo(DEFAULT_API_CONFIG.stripeAccountId)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/repositories/ElementsSessionRepositoryTest.kt
@@ -3,9 +3,7 @@ package com.stripe.android.paymentsheet.repositories
 import androidx.core.os.LocaleListCompat
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.LinkDisallowFundingSourceCreationPreview
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.SharedPaymentTokenSessionPreview
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.networking.ApiRequest
@@ -58,6 +56,7 @@ internal class ElementsSessionRepositoryTest {
                 customPaymentMethods = emptyList(),
                 savedPaymentMethodSelectionId = null,
                 countryOverride = null,
+                requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
             ).getOrThrow()
         }
 
@@ -91,6 +90,10 @@ internal class ElementsSessionRepositoryTest {
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
                     countryOverride = null,
+                    requestOptions = ApiRequest.Options(
+                        apiKey = "pk_test_123",
+                        stripeAccount = "acct_123",
+                    ),
                 ).getOrThrow()
             }
 
@@ -119,6 +122,10 @@ internal class ElementsSessionRepositoryTest {
                     customPaymentMethods = emptyList(),
                     savedPaymentMethodSelectionId = null,
                     countryOverride = null,
+                    requestOptions = ApiRequest.Options(
+                        apiKey = "pk_test_123",
+                        stripeAccount = "acct_123",
+                    ),
                 ).getOrThrow()
             }
 
@@ -137,7 +144,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -149,6 +155,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -172,7 +179,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -189,6 +195,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -210,6 +217,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(any())
@@ -231,6 +239,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(any())
@@ -248,7 +257,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         ).get(
@@ -266,6 +274,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         assertThat(session.isSuccess).isTrue()
@@ -282,7 +291,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -299,6 +307,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -317,7 +326,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -334,6 +342,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -352,7 +361,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -366,6 +374,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -384,7 +393,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -414,6 +422,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -433,7 +442,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -455,6 +463,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -476,7 +485,6 @@ internal class ElementsSessionRepositoryTest {
             ApplicationProvider.getApplicationContext(),
             stripeNetworkClient,
             stripeRepository,
-            { PaymentConfiguration(ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY) },
             testDispatcher,
             clientParams = TEST_CLIENT_PARAMS
         )
@@ -506,6 +514,7 @@ internal class ElementsSessionRepositoryTest {
             ),
             savedPaymentMethodSelectionId = "pm_123",
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -546,6 +555,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -593,6 +603,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -629,6 +640,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = listOf(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         ).getOrThrow()
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -657,6 +669,7 @@ internal class ElementsSessionRepositoryTest {
             externalPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
             linkDisallowedFundingSourceCreation = setOf("somethingThatsNotAllowed"),
         )
 
@@ -681,6 +694,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -703,6 +717,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -730,6 +745,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -763,6 +779,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -793,6 +810,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -816,6 +834,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -839,6 +858,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -862,6 +882,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -890,6 +911,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -914,6 +936,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -928,7 +951,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.EXPANDED_PAYMENT_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
                 clientSecret = "client_secret",
             ),
@@ -937,6 +960,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "uk_12345", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -954,7 +978,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.DEFERRED_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.SetupIntent(
                 clientSecret = "client_secret",
             ),
@@ -963,6 +987,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "uk_12345", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -980,7 +1005,7 @@ internal class ElementsSessionRepositoryTest {
             StripeResponse(200, ElementsSessionFixtures.DEFERRED_INTENT_JSON.toString(), emptyMap())
         )
 
-        createRepository(publishableKey = "uk_12345").get(
+        createRepository().get(
             initializationMode = PaymentElementLoader.InitializationMode.DeferredIntent(
                 intentConfiguration = PaymentSheet.IntentConfiguration(
                     mode = PaymentSheet.IntentConfiguration.Mode.Payment(
@@ -995,6 +1020,7 @@ internal class ElementsSessionRepositoryTest {
             customPaymentMethods = emptyList(),
             savedPaymentMethodSelectionId = null,
             countryOverride = null,
+            requestOptions = ApiRequest.Options(apiKey = "uk_12345", stripeAccount = "acct_123"),
         )
 
         verify(stripeNetworkClient).executeRequest(requestCaptor.capture())
@@ -1005,13 +1031,10 @@ internal class ElementsSessionRepositoryTest {
         assertThat(params["mobile_app_id"]).isEqualTo(APP_ID)
     }
 
-    private fun createRepository(
-        publishableKey: String = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
-    ) = RealElementsSessionRepository(
+    private fun createRepository() = RealElementsSessionRepository(
         ApplicationProvider.getApplicationContext(),
         stripeNetworkClient,
         stripeRepository,
-        { PaymentConfiguration(publishableKey) },
         testDispatcher,
         clientParams = TEST_CLIENT_PARAMS,
     )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.asCommonConfiguration
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -20,6 +21,7 @@ internal class ElementsSessionLoaderTest {
             ),
             configuration = DEFAULT_CONFIG,
             savedPaymentMethodSelection = null,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         assertThat(result.stripeIntent)
@@ -36,6 +38,7 @@ internal class ElementsSessionLoaderTest {
             ),
             configuration = DEFAULT_CONFIG,
             savedPaymentMethodSelection = savedSelection,
+            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
         )
 
         assertThat(elementsSessionRepository.lastParams?.savedPaymentMethodSelectionId)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
@@ -2,7 +2,7 @@ package com.stripe.android.paymentsheet.state
 
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.common.model.asCommonConfiguration
-import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -21,7 +21,7 @@ internal class ElementsSessionLoaderTest {
             ),
             configuration = DEFAULT_CONFIG,
             savedPaymentMethodSelection = null,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(result.stripeIntent)
@@ -38,7 +38,7 @@ internal class ElementsSessionLoaderTest {
             ),
             configuration = DEFAULT_CONFIG,
             savedPaymentMethodSelection = savedSelection,
-            requestOptions = ApiRequest.Options(apiKey = "pk_test_123", stripeAccount = "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         assertThat(elementsSessionRepository.lastParams?.savedPaymentMethodSelectionId)

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/ElementsSessionLoaderTest.kt
@@ -29,6 +29,22 @@ internal class ElementsSessionLoaderTest {
     }
 
     @Test
+    fun `passes API configuration to repository`() = runScenario {
+        val apiConfiguration = DEFAULT_API_CONFIG
+
+        loader(
+            initializationMode = PaymentElementLoader.InitializationMode.PaymentIntent(
+                clientSecret = PaymentSheetFixtures.PAYMENT_INTENT_CLIENT_SECRET.value,
+            ),
+            configuration = DEFAULT_CONFIG,
+            savedPaymentMethodSelection = null,
+            apiConfiguration = apiConfiguration,
+        )
+
+        assertThat(elementsSessionRepository.lastParams?.apiConfiguration).isEqualTo(apiConfiguration)
+    }
+
+    @Test
     fun `passes savedPaymentMethodSelection to repository`() = runScenario {
         val savedSelection = SavedSelection.PaymentMethod(id = "pm_123")
 

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -1,6 +1,6 @@
 package com.stripe.android.utils
 
-import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.StripeIntent
@@ -33,6 +33,7 @@ internal class FakeElementsSessionRepository(
         val savedPaymentMethodSelectionId: String?,
         val userOverrideCountry: String?,
         val linkDisallowedFundingSourceCreation: Set<String>,
+        val apiConfiguration: ApiConfiguration.State,
     )
 
     var lastParams: Params? = null
@@ -44,7 +45,7 @@ internal class FakeElementsSessionRepository(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
-        requestOptions: ApiRequest.Options,
+        apiConfiguration: ApiConfiguration.State,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
         lastParams = Params(
@@ -55,6 +56,7 @@ internal class FakeElementsSessionRepository(
             savedPaymentMethodSelectionId = savedPaymentMethodSelectionId,
             userOverrideCountry = countryOverride,
             linkDisallowedFundingSourceCreation = linkDisallowedFundingSourceCreation,
+            apiConfiguration = apiConfiguration,
         )
         return if (error != null) {
             Result.failure(error)

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakeElementsSessionRepository.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.utils
 
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.ElementsSession
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.StripeIntent
@@ -43,6 +44,7 @@ internal class FakeElementsSessionRepository(
         externalPaymentMethods: List<String>,
         savedPaymentMethodSelectionId: String?,
         countryOverride: String?,
+        requestOptions: ApiRequest.Options,
         linkDisallowedFundingSourceCreation: Set<String>,
     ): Result<ElementsSession> {
         lastParams = Params(


### PR DESCRIPTION
# Summary
Pass `ApiConfiguration.State` through PaymentSheet elements-session loading.

Changed classes and entry points:

- `ElementsSessionRepository`: Accept `ApiConfiguration.State`, construct request options for each load and reuse them for the primary and fallback requests.
- `ElementsSessionLoader`: Pass `ApiConfiguration.State` through to the repository.
- `DefaultPaymentElementLoader`: Pass `ApiConfiguration.State` at the load boundary.
- `CustomerAdapterDataSource` and `DefaultCustomerSessionElementsSessionManager`: Pass `ApiConfiguration.State`.
- `FakeElementsSessionRepository`: Adopt the explicit request-options contract.

Committed and created by Codex.

# Motivation
The elements-session repository needs request authorization, not the broader API-configuration abstraction. Passing `ApiRequest.Options` keeps credential resolution in orchestration layers and guarantees fallback requests reuse the same options.

# Testing
- [X] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots
Not applicable — repository request configuration only.

# Changelog
Not applicable — no public API change.
