### PR TITLE
Treat captcha and attestation failures as expected

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporter.kt
@@ -41,7 +41,7 @@ internal class DefaultCaptchaEventsReporter @Inject constructor(
                 errorReporter.report(ErrorReporter.ExpectedErrorEvent.HCAPTCHA_FAILURE)
             }
             else -> {
-                errorReporter.report(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE)
+                errorReporter.report(ErrorReporter.ExpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE)
             }
         }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -209,8 +209,14 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         HCAPTCHA_FAILURE(
             eventName = "elements.captcha.passive.expected_failure"
         ),
+        HCAPTCHA_UNEXPECTED_FAILURE(
+            eventName = "elements.captcha.passive.unexpected_failure"
+        ),
         INTENT_CONFIRMATION_CHALLENGE_CHALLENGE_CANCELLATION_REQUEST_FAILED(
             eventName = "intent_confirmation_challenge.challenge_cancellation_request_failed"
+        ),
+        INTENT_CONFIRMATION_HANDLER_ATTESTATION_FAILED_TO_PREPARE(
+            eventName = "intent_confirmation_handler.attestation.failed_to_prepare"
         ),
         INTENT_CONFIRMATION_HANDLER_ATTESTATION_REQUEST_TOKEN_FAILED(
             eventName = "intent_confirmation_handler.attestation.request_token_failed"
@@ -327,9 +333,6 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         INTENT_CONFIRMATION_HANDLER_ATTESTATION_INVOKED_WHEN_DISABLED(
             partialEventName = "intent_confirmation_handler.attestation.invoked_when_disabled"
         ),
-        INTENT_CONFIRMATION_HANDLER_ATTESTATION_FAILED_TO_PREPARE(
-            partialEventName = "intent_confirmation_handler.attestation.failed_to_prepare"
-        ),
         INTENT_CONFIRMATION_CHALLENGE_FAILED_TO_PARSE_SUCCESS_CALLBACK_PARAMS(
             partialEventName = "intent_confirmation_challenge.failed_to_parse_success_callback_params"
         ),
@@ -341,9 +344,6 @@ interface ErrorReporter : FraudDetectionErrorReporter {
         ),
         INTENT_CONFIRMATION_CHALLENGE_INTENT_NO_ATTESTATION_RESULT(
             partialEventName = "intent_confirmation_challenge.attestation.no_attestation_result"
-        ),
-        HCAPTCHA_UNEXPECTED_FAILURE(
-            partialEventName = "elements.captcha.passive.unexpected_failure"
         ),
         PAYMENT_METHOD_MESSAGING_ELEMENT_UNABLE_TO_PARSE_RESPONSE(
             partialEventName = "paymentmethodmessaging.element.unable_to_parse_response"

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporterTest.kt
@@ -89,9 +89,9 @@ internal class DefaultCaptchaEventsReporterTest {
             assertThat(loggedParams["error_message"]).isEqualTo("test error")
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
 
-            // Verify unexpected error was reported
+            // Verify expected error was reported
             assertThat(fakeErrorReporter.getLoggedErrors())
-                .contains(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
+                .contains(ErrorReporter.ExpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
         }
 
     @Test
@@ -111,9 +111,9 @@ internal class DefaultCaptchaEventsReporterTest {
             assertThat(loggedParams["error_message"]).isNull()
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
 
-            // Verify unexpected error was reported for null error
+            // Verify expected error was reported for null error
             assertThat(fakeErrorReporter.getLoggedErrors())
-                .contains(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
+                .contains(ErrorReporter.ExpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
         }
 
     @Test
@@ -130,9 +130,9 @@ internal class DefaultCaptchaEventsReporterTest {
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
             assertThat(loggedParams["duration"]).isEqualTo(0f)
 
-            // Verify unexpected error was reported
+            // Verify expected error was reported
             assertThat(fakeErrorReporter.getLoggedErrors())
-                .contains(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
+                .contains(ErrorReporter.ExpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
         }
 
     @Test

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.IsEligibleForConfirmationChallenge
 import com.stripe.android.paymentelement.confirmation.PaymentMethodConfirmationOption
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.analytics.ErrorReporter.ExpectedErrorEvent
 import com.stripe.android.payments.core.analytics.ErrorReporter.UnexpectedErrorEvent
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.attestation.IntegrityRequestManager
@@ -60,7 +61,7 @@ internal class AttestationConfirmationDefinition @Inject constructor(
                 }.onFailure { error ->
                     attestationAnalyticsEventsReporter.prepareFailed(error)
                     errorReporter.report(
-                        UnexpectedErrorEvent.INTENT_CONFIRMATION_HANDLER_ATTESTATION_FAILED_TO_PREPARE,
+                        ExpectedErrorEvent.INTENT_CONFIRMATION_HANDLER_ATTESTATION_FAILED_TO_PREPARE,
                         stripeException = StripeException.create(error)
                     )
                 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinitionTest.kt
@@ -518,7 +518,7 @@ internal class AttestationConfirmationDefinitionTest {
 
         val call = fakeErrorReporter.awaitCall()
         assertThat(call.errorEvent).isEqualTo(
-            ErrorReporter.UnexpectedErrorEvent.INTENT_CONFIRMATION_HANDLER_ATTESTATION_FAILED_TO_PREPARE
+            ErrorReporter.ExpectedErrorEvent.INTENT_CONFIRMATION_HANDLER_ATTESTATION_FAILED_TO_PREPARE
         )
         assertThat(call.stripeException?.message).isEqualTo("Preparation failed")
     }


### PR DESCRIPTION
# Summary
Reclassify the passive captcha unexpected-failure event and intent-confirmation attestation preparation failure event as expected errors.

Committed and created by Codex.

# Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5610

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified