### PR TITLE
Extract ready embedded sheet presentation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -1,79 +1,31 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
-import android.app.Activity
 import android.os.Bundle
-import androidx.activity.addCallback
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.animation.animateContentSize
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.MaterialTheme
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.dp
-import androidx.lifecycle.lifecycleScope
-import com.stripe.android.common.ui.BottomSheetScaffold
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
-import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentsheet.CustomerStateHolder
-import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.ui.PaymentElementTheme
-import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
-import com.stripe.android.paymentsheet.utils.EventReporterProvider
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
-import com.stripe.android.ui.core.elements.H4Text
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
-import com.stripe.android.uicore.getOuterFormInsets
-import com.stripe.android.uicore.strings.resolve
-import com.stripe.android.uicore.stripeFormInsets
-import com.stripe.android.uicore.utils.collectAsState
 import com.stripe.android.uicore.utils.fadeOut
-import kotlinx.coroutines.launch
-import javax.inject.Inject
 
+@OptIn(ExperimentalMaterialApi::class)
 internal class EmbeddedSheetActivity : AppCompatActivity() {
     private val args: EmbeddedActivityArgs? by lazy {
         EmbeddedActivityArgs.fromIntent(intent)
     }
 
-    private val viewModel: EmbeddedSheetViewModel by viewModels {
-        EmbeddedSheetViewModel.Factory {
-            requireNotNull(args)
-        }
+    private val presentationDelegate = lazy {
+        val args = requireNotNull(args)
+        EmbeddedSheetViewModel.Factory { args }.createReadyPresentation(
+            activity = this,
+            args = args,
+            activityResultCaller = this,
+        )
     }
-
-    @Inject
-    lateinit var eventReporter: EventReporter
-
-    @Inject
-    lateinit var customerStateHolder: CustomerStateHolder
-
-    @Inject
-    lateinit var embeddedNavigator: EmbeddedNavigator
-
-    @Inject
-    lateinit var selectionHolder: EmbeddedSelectionHolder
-
-    @Inject
-    lateinit var sheetActivityRegistrar: SheetActivityRegistrar
-
-    @Inject
-    lateinit var sheetActivityStateHolder: SheetActivityStateHolder
+    private val presentation by presentationDelegate
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -84,66 +36,17 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         }
 
         renderEdgeToEdge()
-        viewModel.component.inject(this)
-
-        sheetActivityRegistrar.registerAndBootstrap(
-            activityResultCaller = this,
-            lifecycleOwner = this,
-        )
-
-        lifecycleScope.launch {
-            sheetActivityStateHolder.result.collect {
-                setActivityResult(it)
-                finish()
-            }
-        }
-
-        onBackPressedDispatcher.addCallback {
-            if (!embeddedNavigator.screen.value.isPerformingNetworkOperation().value) {
-                embeddedNavigator.performAction(EmbeddedNavigator.Action.Back)
-            }
-        }
-
+        presentation.register()
         setContent {
             PaymentElementTheme(appearance = activityArgs.configuration.appearance) {
-                EventReporterProvider(eventReporter) {
-                    SheetContent()
-                }
-            }
-        }
-    }
-
-    @OptIn(ExperimentalMaterialApi::class)
-    @Composable
-    private fun SheetContent() {
-        val screen by embeddedNavigator.screen.collectAsState()
-        val bottomSheetState = rememberStripeBottomSheetState(
-            confirmValueChange = { !screen.isPerformingNetworkOperation().value }
-        )
-        ElementsBottomSheetLayout(
-            state = bottomSheetState,
-            onDismissed = ::dismissAndFinish,
-        ) {
-            var hasResult by remember { mutableStateOf(false) }
-            if (!hasResult) {
-                Box(modifier = Modifier.padding(bottom = 20.dp)) {
-                    EmbeddedSheetScreenContent(embeddedNavigator, screen)
-                }
-                LaunchedEffect(Unit) {
-                    embeddedNavigator.result.collect { result ->
-                        hasResult = true
-                        when (args?.launchMode) {
-                            is EmbeddedLaunchMode.Form -> dismissAndFinish()
-                            is EmbeddedLaunchMode.PaymentOptions -> {
-                                setCancelledPaymentOptionsResult()
-                                finish()
-                            }
-                            is EmbeddedLaunchMode.Manage, null -> {
-                                setManageResult(shouldInvokeSelectionCallback = result == true)
-                                finish()
-                            }
-                        }
-                    }
+                val bottomSheetState = rememberStripeBottomSheetState(
+                    confirmValueChange = { presentation.canDismiss() },
+                )
+                ElementsBottomSheetLayout(
+                    state = bottomSheetState,
+                    onDismissed = presentation::onDismissed,
+                ) {
+                    presentation.Content()
                 }
             }
         }
@@ -156,111 +59,8 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-
-        if (isFinishing) {
-            if (::eventReporter.isInitialized) {
-                eventReporter.onDismiss()
-            }
+        if (presentationDelegate.isInitialized()) {
+            presentation.onDestroy()
         }
     }
-
-    private fun dismissAndFinish() {
-        when (val launchMode = args?.launchMode) {
-            is EmbeddedLaunchMode.Form -> {
-                setActivityResult(
-                    EmbeddedActivityResult.Cancelled(
-                        customerState = customerStateHolder.customer.value,
-                        launchMode = launchMode,
-                    )
-                )
-            }
-            is EmbeddedLaunchMode.Manage, null -> {
-                setManageResult(shouldInvokeSelectionCallback = false)
-            }
-            is EmbeddedLaunchMode.PaymentOptions -> {
-                setCancelledPaymentOptionsResult()
-            }
-        }
-        finish()
-    }
-
-    private fun setManageResult(
-        shouldInvokeSelectionCallback: Boolean,
-    ) {
-        setActivityResult(
-            EmbeddedActivityResult.Complete(
-                selection = selectionHolder.selection.value,
-                previousNewSelections = selectionHolder.previousNewSelections,
-                hasBeenConfirmed = false,
-                customerState = customerStateHolder.customer.value,
-                checkoutSessionResponse = null,
-                shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
-                launchMode = args?.launchMode ?: EmbeddedLaunchMode.Manage,
-            )
-        )
-    }
-
-    private fun setCancelledPaymentOptionsResult() {
-        setActivityResult(
-            EmbeddedActivityResult.Cancelled(
-                customerState = customerStateHolder.customer.value,
-                launchMode = EmbeddedLaunchMode.PaymentOptions,
-            )
-        )
-    }
-
-    private fun setActivityResult(result: EmbeddedActivityResult) {
-        setResult(
-            Activity.RESULT_OK,
-            EmbeddedActivityResult.toIntent(intent, result)
-        )
-    }
-}
-
-@Composable
-internal fun EmbeddedSheetScreenContent(
-    navigator: EmbeddedNavigator,
-    screen: EmbeddedNavigator.Screen,
-) {
-    val density = LocalDensity.current
-    var contentHeight by remember { mutableStateOf(0.dp) }
-    val scrollState = rememberScrollState()
-    BottomSheetScaffold(
-        topBar = {
-            val topBarState by remember(screen) {
-                screen.topBarState()
-            }.collectAsState()
-            val isPerformingNetworkOperation by remember(screen) {
-                screen.isPerformingNetworkOperation()
-            }.collectAsState()
-            PaymentSheetTopBar(
-                state = topBarState,
-                canNavigateBack = navigator.canGoBack,
-                isEnabled = !isPerformingNetworkOperation,
-                handleBackPressed = { navigator.performAction(EmbeddedNavigator.Action.Back) },
-            )
-        },
-        content = {
-            val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
-            val headerText by remember(screen) {
-                screen.title()
-            }.collectAsState()
-            headerText?.let { text ->
-                H4Text(
-                    text = text.resolve(),
-                    modifier = Modifier
-                        .padding(bottom = 16.dp)
-                        .padding(horizontalPadding),
-                )
-            }
-
-            Column(modifier = Modifier.animateContentSize()) {
-                screen.Content()
-            }
-        },
-        modifier = Modifier.onGloballyPositioned {
-            contentHeight = with(density) { it.size.height.toDp() }
-        },
-        scrollState = scrollState,
-    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetComponent.kt
@@ -42,10 +42,9 @@ import javax.inject.Singleton
 )
 @Singleton
 internal interface EmbeddedSheetComponent {
+    val viewModel: EmbeddedSheetViewModel
     val selectionHolder: EmbeddedSelectionHolder
     val customerStateHolder: CustomerStateHolder
-
-    fun inject(activity: EmbeddedSheetActivity)
 
     @Component.Factory
     interface Factory {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import android.app.Activity
+import androidx.activity.result.ActivityResultCaller
+import androidx.compose.runtime.Composable
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+
+internal interface EmbeddedSheetPresentation {
+    fun register()
+
+    fun canDismiss(): Boolean
+
+    fun onDismissed()
+
+    @Composable
+    fun Content()
+
+    fun onDestroy()
+
+    interface Factory {
+        fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): EmbeddedSheetPresentation
+    }
+}
+
+internal fun EmbeddedSheetActivity.finishWithResult(result: EmbeddedActivityResult) {
+    setResult(
+        Activity.RESULT_OK,
+        EmbeddedActivityResult.toIntent(intent, result),
+    )
+    finish()
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
@@ -11,9 +12,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import javax.inject.Inject
 
-internal class EmbeddedSheetViewModel(
-    val component: EmbeddedSheetComponent,
+internal class EmbeddedSheetViewModel @Inject constructor(
+    private val embeddedSheetPresentationFactory: ReadyEmbeddedSheetPresentation.Factory,
     @ViewModelScope private val customViewModelScope: CoroutineScope,
 ) : ViewModel() {
     override fun onCleared() {
@@ -23,6 +25,19 @@ internal class EmbeddedSheetViewModel(
     class Factory(
         private val argsSupplier: () -> EmbeddedActivityArgs,
     ) : ViewModelProvider.Factory {
+        fun createReadyPresentation(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): EmbeddedSheetPresentation {
+            val viewModel = ViewModelProvider(activity, this)[EmbeddedSheetViewModel::class.java]
+            return viewModel.embeddedSheetPresentationFactory.create(
+                activity = activity,
+                args = args,
+                activityResultCaller = activityResultCaller,
+            )
+        }
+
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
             val args = argsSupplier()
@@ -44,10 +59,7 @@ internal class EmbeddedSheetViewModel(
             component.selectionHolder.setPreviousNewSelections(args.previousNewSelections)
             component.selectionHolder.setSelection(args.selection)
 
-            return EmbeddedSheetViewModel(
-                component = component,
-                customViewModelScope = customViewModelScope,
-            ) as T
+            return component.viewModel as T
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/ReadyEmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/ReadyEmbeddedSheetPresentation.kt
@@ -1,0 +1,218 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.activity.addCallback
+import androidx.activity.result.ActivityResultCaller
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.lifecycleScope
+import com.stripe.android.common.ui.BottomSheetScaffold
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentsheet.CustomerStateHolder
+import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.ui.PaymentSheetTopBar
+import com.stripe.android.paymentsheet.utils.EventReporterProvider
+import com.stripe.android.ui.core.elements.H4Text
+import com.stripe.android.uicore.getOuterFormInsets
+import com.stripe.android.uicore.strings.resolve
+import com.stripe.android.uicore.stripeFormInsets
+import com.stripe.android.uicore.utils.collectAsState
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.launch
+
+internal class ReadyEmbeddedSheetPresentation @AssistedInject constructor(
+    @Assisted private val activity: EmbeddedSheetActivity,
+    @Assisted private val args: EmbeddedActivityArgs,
+    @Assisted private val activityResultCaller: ActivityResultCaller,
+    private val eventReporter: EventReporter,
+    private val customerStateHolder: CustomerStateHolder,
+    private val embeddedNavigator: EmbeddedNavigator,
+    private val selectionHolder: EmbeddedSelectionHolder,
+    private val sheetActivityRegistrar: SheetActivityRegistrar,
+    private val sheetActivityStateHolder: SheetActivityStateHolder,
+) : EmbeddedSheetPresentation {
+    override fun register() {
+        sheetActivityRegistrar.registerAndBootstrap(
+            activityResultCaller = activityResultCaller,
+            lifecycleOwner = activity,
+        )
+
+        activity.lifecycleScope.launch {
+            sheetActivityStateHolder.result.collect(activity::finishWithResult)
+        }
+
+        activity.onBackPressedDispatcher.addCallback {
+            if (!embeddedNavigator.screen.value.isPerformingNetworkOperation().value) {
+                embeddedNavigator.performAction(EmbeddedNavigator.Action.Back)
+            }
+        }
+    }
+
+    override fun canDismiss(): Boolean {
+        return !embeddedNavigator.screen.value.isPerformingNetworkOperation().value
+    }
+
+    override fun onDismissed() {
+        activity.finishWithResult(createDismissalResult())
+    }
+
+    @Composable
+    override fun Content() {
+        EventReporterProvider(eventReporter) {
+            EmbeddedSheetReadyContent(
+                navigator = embeddedNavigator,
+                onResult = { result ->
+                    activity.finishWithResult(createNavigatorResult(result))
+                },
+            )
+        }
+    }
+
+    override fun onDestroy() {
+        if (activity.isFinishing) {
+            eventReporter.onDismiss()
+        }
+    }
+
+    private fun createDismissalResult(): EmbeddedActivityResult {
+        return when (val launchMode = args.launchMode) {
+            is EmbeddedLaunchMode.Form -> EmbeddedActivityResult.Cancelled(
+                customerState = customerStateHolder.customer.value,
+                launchMode = launchMode,
+            )
+            is EmbeddedLaunchMode.Manage -> createManageResult(
+                shouldInvokeSelectionCallback = false,
+                launchMode = launchMode,
+            )
+            is EmbeddedLaunchMode.PaymentOptions -> createPaymentOptionsCancellationResult()
+        }
+    }
+
+    private fun createNavigatorResult(result: Boolean?): EmbeddedActivityResult {
+        return when (val launchMode = args.launchMode) {
+            is EmbeddedLaunchMode.Form -> createDismissalResult()
+            is EmbeddedLaunchMode.Manage -> createManageResult(
+                shouldInvokeSelectionCallback = result == true,
+                launchMode = launchMode,
+            )
+            is EmbeddedLaunchMode.PaymentOptions -> createPaymentOptionsCancellationResult()
+        }
+    }
+
+    private fun createManageResult(
+        shouldInvokeSelectionCallback: Boolean,
+        launchMode: EmbeddedLaunchMode.Manage,
+    ): EmbeddedActivityResult {
+        return EmbeddedActivityResult.Complete(
+            selection = selectionHolder.selection.value,
+            previousNewSelections = selectionHolder.previousNewSelections,
+            hasBeenConfirmed = false,
+            customerState = customerStateHolder.customer.value,
+            checkoutSessionResponse = null,
+            shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
+            launchMode = launchMode,
+        )
+    }
+
+    private fun createPaymentOptionsCancellationResult(): EmbeddedActivityResult {
+        return EmbeddedActivityResult.Cancelled(
+            customerState = customerStateHolder.customer.value,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+    }
+
+    @Composable
+    private fun EmbeddedSheetReadyContent(
+        navigator: EmbeddedNavigator,
+        onResult: (Boolean?) -> Unit,
+    ) {
+        val screen by navigator.screen.collectAsState()
+        var hasResult by remember { mutableStateOf(false) }
+        if (!hasResult) {
+            Box(modifier = Modifier.padding(bottom = 20.dp)) {
+                EmbeddedSheetScreenContent(navigator, screen)
+            }
+            LaunchedEffect(navigator) {
+                navigator.result.collect { result ->
+                    hasResult = true
+                    onResult(result)
+                }
+            }
+        }
+    }
+
+    @AssistedFactory
+    interface Factory : EmbeddedSheetPresentation.Factory {
+        override fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): ReadyEmbeddedSheetPresentation
+    }
+}
+
+@Composable
+internal fun EmbeddedSheetScreenContent(
+    navigator: EmbeddedNavigator,
+    screen: EmbeddedNavigator.Screen,
+) {
+    val density = LocalDensity.current
+    var contentHeight by remember { mutableStateOf(0.dp) }
+    val scrollState = rememberScrollState()
+    BottomSheetScaffold(
+        topBar = {
+            val topBarState by remember(screen) {
+                screen.topBarState()
+            }.collectAsState()
+            val isPerformingNetworkOperation by remember(screen) {
+                screen.isPerformingNetworkOperation()
+            }.collectAsState()
+            PaymentSheetTopBar(
+                state = topBarState,
+                canNavigateBack = navigator.canGoBack,
+                isEnabled = !isPerformingNetworkOperation,
+                handleBackPressed = { navigator.performAction(EmbeddedNavigator.Action.Back) },
+            )
+        },
+        content = {
+            val horizontalPadding = MaterialTheme.stripeFormInsets.getOuterFormInsets()
+            val headerText by remember(screen) {
+                screen.title()
+            }.collectAsState()
+            headerText?.let { text ->
+                H4Text(
+                    text = text.resolve(),
+                    modifier = Modifier
+                        .padding(bottom = 16.dp)
+                        .padding(horizontalPadding),
+                )
+            }
+
+            Column(modifier = Modifier.animateContentSize()) {
+                screen.Content()
+            }
+        },
+        modifier = Modifier.onGloballyPositioned {
+            contentHeight = with(density) { it.size.height.toDp() }
+        },
+        scrollState = scrollState,
+    )
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -33,7 +33,6 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.sheet.EmbeddedNavigator
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetActivity
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.paymentsheet.createCustomerState
@@ -49,6 +48,8 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import com.stripe.android.paymentsheet.R as PaymentSheetR
 
 @RunWith(RobolectricTestRunner::class)
@@ -90,32 +91,13 @@ internal class EmbeddedSheetActivityTest {
     }
 
     @Test
-    fun `processing shows spinner and blocks back on form`() = launch { scenario ->
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.updateProcessing(true)
-        }
-        composeTestRule.waitForIdle()
-        primaryButton.performScrollTo()
-
-        composeTestRule.onNodeWithText(
-            applicationContext.getString(PaymentSheetR.string.stripe_paymentsheet_primary_button_processing)
-        ).assertIsDisplayed()
-        pressBack()
-        onIdle()
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.Form>()
-        }
-    }
-
-    @Test
     fun `checkout Continue displays error and keeps form open`() {
         networkRule.checkoutUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error":{"message":"Invalid tax region"}}""")
         }
 
-        launch(paymentMethodMetadata = checkoutPaymentMethodMetadata()) { scenario ->
+        launch(paymentMethodMetadata = checkoutPaymentMethodMetadata()) {
             val expectedError = applicationContext.getString(PaymentSheetR.string.stripe_something_went_wrong)
             fillOutCheckoutCard()
             primaryButton.performScrollTo().assertIsEnabled().performClick()
@@ -127,9 +109,45 @@ internal class EmbeddedSheetActivityTest {
             }
             composeTestRule.onNodeWithText(expectedError).performScrollTo().assertIsDisplayed()
             primaryButton.assertIsEnabled()
-            scenario.onActivity { activity ->
-                assertThat(activity.embeddedNavigator.screen.value)
-                    .isInstanceOf<EmbeddedNavigator.Screen.Form>()
+            formPage.waitUntilVisible()
+        }
+    }
+
+    @Test
+    fun `processing shows progress and blocks back on form`() {
+        val requestReceived = CountDownLatch(1)
+        val releaseResponse = CountDownLatch(1)
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"Invalid tax region"}}""")
+            requestReceived.countDown()
+            check(releaseResponse.await(10, TimeUnit.SECONDS))
+        }
+
+        launch(paymentMethodMetadata = checkoutPaymentMethodMetadata()) { scenario ->
+            try {
+                fillOutCheckoutCard()
+                primaryButton.performScrollTo().assertIsEnabled().performClick()
+                val processingLabel = applicationContext.getString(
+                    PaymentSheetR.string.stripe_paymentsheet_primary_button_processing
+                )
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    composeTestRule.onAllNodes(hasText(processingLabel))
+                        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                        .isNotEmpty()
+                }
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    requestReceived.count == 0L
+                }
+                composeTestRule.onNodeWithText(processingLabel).assertIsDisplayed()
+
+                scenario.onActivity { activity ->
+                    activity.onBackPressedDispatcher.onBackPressed()
+                }
+
+                formPage.waitUntilVisible()
+            } finally {
+                releaseResponse.countDown()
             }
         }
     }
@@ -183,31 +201,6 @@ internal class EmbeddedSheetActivityTest {
                 checkoutSessionResponse = response,
             ),
         )
-    }
-
-    @Test
-    fun `When SheetActivityStateHolder has result, activity finishes with that result`() = launch { scenario ->
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.setResult(
-                EmbeddedActivityResult.Complete(
-                    previousNewSelections = Bundle(),
-                    selection = null,
-                    hasBeenConfirmed = true,
-                    customerState = null,
-                    checkoutSessionResponse = null,
-                    shouldInvokeSelectionCallback = false,
-                    launchMode = EmbeddedLaunchMode.Form(
-                        selectedPaymentMethodCode = "card",
-                    ),
-                )
-            )
-        }
-
-        onIdle()
-
-        assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_OK)
-        val result = EmbeddedSheetContract.parseResult(scenario.result.resultCode, scenario.result.resultData)
-        assertThat(result).isInstanceOf<EmbeddedActivityResult.Complete>()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -6,7 +6,7 @@ import android.os.Bundle
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -18,7 +18,6 @@ import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onIdle
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.checkoutUpdate
-import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -31,6 +30,7 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -40,9 +40,9 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
-import com.stripe.android.paymentsheet.verticalmode.FakeSavedPaymentMethodConfirmInteractor
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.paymentelementtestpages.FormPage
 import com.stripe.paymentelementtestpages.ManagePage
 import com.stripe.paymentelementtestpages.VerticalModePage
 import org.junit.Rule
@@ -50,11 +50,14 @@ import org.junit.Test
 import org.junit.rules.RuleChain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 internal class PaymentOptionsEmbeddedSheetActivityTest {
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
-    private val composeTestRule = createAndroidComposeRule<EmbeddedSheetActivity>()
+    private val composeTestRule = createEmptyComposeRule()
+    private val formPage = FormPage(composeTestRule)
     private val managePage = ManagePage(composeTestRule)
     private val verticalModePage = VerticalModePage(composeTestRule)
     private val networkRule = NetworkRule()
@@ -81,80 +84,48 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     }
 
     @Test
-    fun `when SheetActivityStateHolder has result, activity finishes with that result`() = launch { scenario ->
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.setResult(
-                EmbeddedActivityResult.Complete(
-                    previousNewSelections = Bundle(),
-                    selection = null,
-                    hasBeenConfirmed = false,
-                    customerState = null,
-                    checkoutSessionResponse = null,
-                    shouldInvokeSelectionCallback = false,
-                    launchMode = EmbeddedLaunchMode.PaymentOptions,
-                )
-            )
-        }
+    fun `continue returns the selection and previous new selections`() {
+        val previousNewSelection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION
+        val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
 
-        onIdle()
+        launch(
+            selection = selection,
+            previousNewSelections = Bundle().apply {
+                stashNewSelection(previousNewSelection)
+            },
+        ) { scenario ->
+            composeTestRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG)
+                .performScrollTo()
+                .assertIsEnabled()
+                .performClick()
+            onIdle()
 
-        assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_OK)
-        val result = EmbeddedSheetContract.parseResult(scenario.result.resultCode, scenario.result.resultData)
-        assertThat(result).isInstanceOf<EmbeddedActivityResult.Complete>()
-        val complete = result as EmbeddedActivityResult.Complete
-        assertThat(complete.launchMode).isEqualTo(
-            EmbeddedLaunchMode.PaymentOptions
-        )
-    }
-
-    @Test
-    fun `navigator back emits cancelled result`() = launch { scenario ->
-        scenario.onActivity { activity ->
-            activity.embeddedNavigator.performAction(EmbeddedNavigator.Action.Back)
-        }
-
-        onIdle()
-
-        assertThat(scenario.result.resultCode).isEqualTo(Activity.RESULT_OK)
-        val result = EmbeddedSheetContract.parseResult(scenario.result.resultCode, scenario.result.resultData)
-        assertThat(result).isInstanceOf<EmbeddedActivityResult.Cancelled>()
-        val cancelled = result as EmbeddedActivityResult.Cancelled
-        assertThat(cancelled.launchMode).isEqualTo(
-            EmbeddedLaunchMode.PaymentOptions
-        )
-    }
-
-    @Test
-    fun `restores previously entered new selections into the selection holder`() = launch(
-        previousNewSelections = Bundle().apply {
-            stashNewSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-        },
-    ) { scenario ->
-        scenario.onActivity { activity ->
-            assertThat(activity.selectionHolder.getPreviousNewSelection("cashapp"))
-                .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+            val result = EmbeddedSheetContract.parseResult(
+                scenario.result.resultCode,
+                scenario.result.resultData,
+            ) as EmbeddedActivityResult.Complete
+            assertThat(result.selection).isEqualTo(selection)
+            assertThat(result.previousNewSelections.previousNewSelection("cashapp"))
+                .isEqualTo(previousNewSelection)
+            assertThat(result.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
         }
     }
 
     @Test
-    fun `new selection requiring a form opens on the form and back returns to the list`() = launch(
+    fun `new selection requiring a form survives recreation and back returns to the list`() = launch(
         selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
     ) { scenario ->
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.canGoBack).isTrue()
-            assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.Form>()
-        }
+        formPage.waitUntilVisible()
+
+        scenario.recreate()
+        onIdle()
+        formPage.waitUntilVisible()
 
         Espresso.pressBack()
         onIdle()
 
-        // Back returns to the payment options list rather than cancelling the sheet.
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.canGoBack).isFalse()
-            assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
-        }
+        formPage.assertIsNotDisplayed()
+        verticalModePage.waitUntilVisible()
     }
 
     @Test
@@ -165,7 +136,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                 paymentMethods = paymentMethods,
             ),
-        ) { scenario ->
+        ) {
             verticalModePage.clickViewMore()
             managePage.waitUntilVisible()
 
@@ -174,41 +145,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
             managePage.assertNotVisible()
             verticalModePage.waitUntilVisible()
-            scenario.onActivity { activity ->
-                assertThat(activity.embeddedNavigator.canGoBack).isFalse()
-                assertThat(activity.embeddedNavigator.screen.value)
-                    .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
-            }
         }
-    }
-
-    @Test
-    fun `configuration change keeps saved payment method confirmation screen`() = launch { scenario ->
-        val interactor = FakeSavedPaymentMethodConfirmInteractor()
-        lateinit var originalScreen: EmbeddedNavigator.Screen.SavedPaymentMethodConfirm
-        scenario.onActivity { activity ->
-            originalScreen = EmbeddedNavigator.Screen.SavedPaymentMethodConfirm(
-                interactor = interactor,
-                isLiveMode = true,
-                sheetActivityStateHolder = activity.sheetActivityStateHolder,
-                confirmationHelper = FakeSheetActivityConfirmationHelper(),
-                embeddedSelectionHolder = activity.selectionHolder,
-                customerStateHolder = activity.customerStateHolder,
-                launchMode = EmbeddedLaunchMode.PaymentOptions,
-            )
-            activity.embeddedNavigator.performAction(
-                EmbeddedNavigator.Action.ReplaceCurrentScreen(originalScreen)
-            )
-        }
-        onIdle()
-
-        scenario.recreate()
-        onIdle()
-
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.screen.value).isSameInstanceAs(originalScreen)
-        }
-        interactor.validate()
     }
 
     @Test
@@ -223,40 +160,6 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
     }
 
     @Test
-    fun `processing blocks back and disables vertical payment method rows`() = launch { scenario ->
-        val cardRow = composeTestRule.onNodeWithTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_card")
-        cardRow.assertIsEnabled()
-
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.updateProcessing(true)
-        }
-        composeTestRule.waitForIdle()
-
-        cardRow.assertIsNotEnabled()
-        composeTestRule.onNodeWithText(
-            applicationContext.getString(R.string.stripe_paymentsheet_primary_button_processing)
-        ).assertIsDisplayed()
-        Espresso.pressBack()
-        onIdle()
-        scenario.onActivity { activity ->
-            assertThat(activity.embeddedNavigator.screen.value)
-                .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
-        }
-    }
-
-    @Test
-    fun `vertical payment options displays activity error`() = launch { scenario ->
-        val errorMessage = "Unable to update the tax region."
-
-        scenario.onActivity { activity ->
-            activity.sheetActivityStateHolder.updateError(errorMessage.resolvableString)
-        }
-        composeTestRule.waitForIdle()
-
-        composeTestRule.onNodeWithText(errorMessage).assertIsDisplayed()
-    }
-
-    @Test
     fun `saved checkout selection displays update error and re-enables payment options`() {
         val selection = savedSelectionWithBillingAddress()
         networkRule.checkoutUpdate { response ->
@@ -267,7 +170,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         launch(
             selection = selection,
             paymentMethodMetadata = checkoutPaymentMethodMetadata(),
-        ) { scenario ->
+        ) {
             val primaryButton = composeTestRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG)
             val expectedError = applicationContext.getString(R.string.stripe_something_went_wrong)
             primaryButton.performScrollTo().assertIsDisplayed().assertIsEnabled().performClick()
@@ -280,10 +183,54 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
             composeTestRule.onNodeWithText(expectedError).performScrollTo().assertIsDisplayed()
             primaryButton.assertIsEnabled()
             composeTestRule.onNodeWithTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_card").assertIsEnabled()
-            scenario.onActivity { activity ->
-                assertThat(activity.embeddedNavigator.screen.value)
-                    .isInstanceOf<EmbeddedNavigator.Screen.VerticalPaymentOptions>()
-                assertThat(activity.sheetActivityStateHolder.state.value.isProcessing).isFalse()
+            verticalModePage.waitUntilVisible()
+        }
+    }
+
+    @Test
+    fun `processing disables payment options and blocks back`() {
+        val requestReceived = CountDownLatch(1)
+        val releaseResponse = CountDownLatch(1)
+        networkRule.checkoutUpdate { response ->
+            response.setResponseCode(400)
+            response.setBody("""{"error":{"message":"Invalid tax region"}}""")
+            requestReceived.countDown()
+            check(releaseResponse.await(10, TimeUnit.SECONDS))
+        }
+
+        launch(
+            selection = savedSelectionWithBillingAddress(),
+            paymentMethodMetadata = checkoutPaymentMethodMetadata(),
+        ) { scenario ->
+            try {
+                val cardRow = composeTestRule.onNodeWithTag("${TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON}_card")
+                cardRow.assertIsEnabled()
+                composeTestRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG)
+                    .performScrollTo()
+                    .assertIsEnabled()
+                    .performClick()
+                val processingLabel = applicationContext.getString(
+                    R.string.stripe_paymentsheet_primary_button_processing
+                )
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    composeTestRule.onAllNodesWithText(processingLabel)
+                        .fetchSemanticsNodes(atLeastOneRootRequired = false)
+                        .isNotEmpty()
+                }
+                composeTestRule.waitUntil(timeoutMillis = 5_000) {
+                    requestReceived.count == 0L
+                }
+                cardRow.assertIsNotEnabled()
+                composeTestRule.onNodeWithText(processingLabel).assertIsDisplayed()
+
+                scenario.onActivity { activity ->
+                    activity.onBackPressedDispatcher.onBackPressed()
+                }
+
+                verticalModePage.waitUntilVisible()
+                cardRow.assertIsNotEnabled()
+            } finally {
+                releaseResponse.countDown()
             }
         }
     }


### PR DESCRIPTION
# Summary

- Extract the ready embedded-sheet UI and behavior from `EmbeddedSheetActivity` into `ReadyEmbeddedSheetPresentation`.
- Introduce the internal `EmbeddedSheetPresentation` contract and expose the view model and assisted presentation factory through Dagger.
- Keep the activity ready-only while preserving Form, Manage, and Payment Options behavior.
- Stack 1 of 4; the coordinator layer follows this PR.

# Motivation

This is the first layer splitting #14329. Isolating the existing ready presentation creates a stable boundary for the next activity-coordinator PR without introducing loading, new-intent, or Checkout behavior.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :paymentsheet:testDebugUnitTest` (6,989 tests)
- `./gradlew :paymentsheet:compileDebugAndroidTestKotlin :paymentsheet:apiCheck`
- `./gradlew detekt`

No tests were newly ignored.

# Screenshots

Not applicable: this is a behavior-preserving internal extraction with no visual changes.

# Changelog

Not applicable: this changes no public API or user-visible behavior.

Committed and created by Codex.
