### PR TITLE
Add default API configuration test fixture

### DIFF
--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFactory.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.CardBrandFilter
 import com.stripe.android.CardFundingFilter
 import com.stripe.android.DefaultCardBrandFilter
@@ -82,10 +81,7 @@ internal object PaymentMethodMetadataFactory {
         cardArts: List<PaymentMethod.Card.CardArt> = emptyList(),
         shouldUseAutocompleteProxyEndpoints: Boolean = false,
         paymentMethodLayout: PaymentSheet.PaymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-        apiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
-            publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
-        ),
+        apiConfiguration: ApiConfiguration.State = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
     ): PaymentMethodMetadata {
         return PaymentMethodMetadata(
             stripeIntent = stripeIntent,

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFixtures.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataFixtures.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
+import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.common.model.PaymentMethodRemovePermission
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentIntentCreationFlow
 import com.stripe.android.model.PaymentMethodSelectionFlow
@@ -39,6 +41,11 @@ internal object PaymentMethodMetadataFixtures {
         saveConsent = PaymentMethodSaveConsentBehavior.Legacy,
         canRemoveLastPaymentMethod = true,
         canUpdateCardExpiryAndBillingDetails = false,
+    )
+
+    internal val DEFAULT_API_CONFIG = ApiConfiguration.State(
+        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
+        stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
     )
 
     internal fun getDefaultCustomerMetadata(

--- a/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/lpmfoundations/paymentmethod/PaymentMethodMetadataTest.kt
@@ -1,11 +1,9 @@
 package com.stripe.android.lpmfoundations.paymentmethod
 
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.DefaultCardBrandFilter
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.asCommonConfiguration
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.customersheet.CustomerSheet
 import com.stripe.android.link.LinkConfiguration
@@ -1044,7 +1042,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1118,7 +1116,7 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         assertThat(metadata).isEqualTo(expectedMetadata)
@@ -1179,7 +1177,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         // When flag is false, should use default funding types, not the configured ones
@@ -1218,7 +1216,7 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = true,
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = DEFAULT_CUSTOMER_INTEGRATION_METADATA,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         val expectedMetadata = PaymentMethodMetadata(
@@ -1277,7 +1275,7 @@ internal class PaymentMethodMetadataTest {
             cardArts = emptyList(),
             shouldUseAutocompleteProxyEndpoints = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
         assertThat(metadata).isEqualTo(expectedMetadata)
     }
@@ -2028,7 +2026,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         assertThat(metadata.availableWallets)
@@ -2098,7 +2096,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = true,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         assertThat(metadata.isTapToAddSupported).isTrue()
@@ -2123,7 +2121,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = true,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         assertThat(metadata.isTapToAddSupported).isTrue()
@@ -2152,7 +2150,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         assertThat(metadata.isTapToAddSupported).isFalse()
@@ -2291,7 +2289,7 @@ internal class PaymentMethodMetadataTest {
             analyticsMetadata = AnalyticsMetadata(emptyMap()),
             isTapToAddAvailable = false,
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
     }
 
@@ -2318,7 +2316,7 @@ internal class PaymentMethodMetadataTest {
             isGooglePayReady = false,
             customerMetadata = DEFAULT_CUSTOMER_METADATA,
             integrationMetadata = DEFAULT_CUSTOMER_INTEGRATION_METADATA,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
     }
 
@@ -2382,7 +2380,7 @@ internal class PaymentMethodMetadataTest {
     fun `paymentMethodOrientation returns Horizontal when layout is Horizontal`() {
         val metadata = PaymentMethodMetadataFactory.create(
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
-            apiConfiguration = apiConfiguration,
+            apiConfiguration = PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG,
         )
 
         assertThat(metadata.paymentMethodOrientation()).isEqualTo(PaymentMethodOrientation.Horizontal)
@@ -2482,10 +2480,5 @@ internal class PaymentMethodMetadataTest {
         customPaymentMethods = customPaymentMethods,
         cardBrandAcceptance = cardBrandAcceptance,
         allowedCardFundingTypes = allowedCardFundingTypes
-    )
-
-    private val apiConfiguration = ApiConfiguration.State(
-        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-        stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/FakeApiConfigurationResolver.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/injection/FakeApiConfigurationResolver.kt
@@ -1,13 +1,10 @@
 package com.stripe.android.paymentsheet.injection
 
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 
 internal class FakeApiConfigurationResolver(
-    private val resolvedApiConfiguration: ApiConfiguration.State = ApiConfiguration.State(
-        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-        stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID
-    ),
+    private val resolvedApiConfiguration: ApiConfiguration.State = DEFAULT_API_CONFIG,
 ) : ApiConfigurationResolver {
     override fun resolve(apiConfiguration: ApiConfiguration.State?): ApiConfiguration.State {
         return apiConfiguration ?: resolvedApiConfiguration

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/state/DefaultPaymentElementLoaderTest.kt
@@ -14,7 +14,6 @@ import com.stripe.android.common.analytics.experiment.PaymentMethodMessagePromot
 import com.stripe.android.common.configuration.ConfigurationDefaults
 import com.stripe.android.common.model.PaymentMethodRemovePermission
 import com.stripe.android.common.model.asCommonConfiguration
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.core.model.CountryCode
@@ -37,6 +36,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.CustomerMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.DisplayableCustomPaymentMethod
 import com.stripe.android.lpmfoundations.paymentmethod.IntegrationMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodOrientation
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
@@ -175,10 +175,7 @@ internal class DefaultPaymentElementLoaderTest {
                     ),
                     integrationMetadata = IntegrationMetadata.IntentFirst("pi_1234_secret_1234"),
                     elementsSessionId = "session_1234",
-                    apiConfiguration = ApiConfiguration.State(
-                        publishableKey = ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-                        stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
-                    ),
+                    apiConfiguration = DEFAULT_API_CONFIG,
                 ),
             )
         )
@@ -5050,14 +5047,11 @@ internal class DefaultPaymentElementLoaderTest {
             analyticsMetadataFactory = analyticsMetadataFactory,
             tapToAddConnectionStarter = tapToAddConnectionStarter,
             apiConfigurationResolver = FakeApiConfigurationResolver(
-                resolvedApiConfiguration = ApiConfiguration.State(
-                    publishableKey = if (isLiveMode) {
-                        ApiKeyFixtures.FAKE_LIVE_KEY
-                    } else {
-                        ApiKeyFixtures.FAKE_PUBLISHABLE_KEY
-                    },
-                    stripeAccountId = ApiKeyFixtures.FAKE_ACCOUNT_ID,
-                ),
+                resolvedApiConfiguration = if (isLiveMode) {
+                    DEFAULT_API_CONFIG.copy(publishableKey = ApiKeyFixtures.FAKE_LIVE_KEY)
+                } else {
+                    DEFAULT_API_CONFIG
+                },
             ),
             createCustomerState = CreateCustomerState(
                 paymentMethodFilter = paymentMethodFilter,


### PR DESCRIPTION
# Summary

Add a shared default API configuration fixture and use it throughout PaymentMethodMetadata and PaymentElementLoader tests.

Committed and created by Codex.

# Motivation
Setup. This will need to be added to many tests

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots

Not applicable — test utility changes only.

# Changelog

Not applicable — test-only change.
