### PR TITLE
Add embedded sheet activity coordinator

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -17,15 +17,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         EmbeddedActivityArgs.fromIntent(intent)
     }
 
-    private val presentationDelegate = lazy {
-        val args = requireNotNull(args)
-        EmbeddedSheetViewModel.Factory { args }.createReadyPresentation(
-            activity = this,
-            args = args,
-            activityResultCaller = this,
-        )
-    }
-    private val presentation by presentationDelegate
+    private var coordinator: EmbeddedSheetActivityCoordinator? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -36,17 +28,23 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         }
 
         renderEdgeToEdge()
-        presentation.register()
+        val coordinator = EmbeddedSheetActivityCoordinator(
+            activity = this,
+            args = activityArgs,
+            presentationFactory = EmbeddedSheetPresentation,
+        )
+        this.coordinator = coordinator
+        coordinator.register()
         setContent {
             PaymentElementTheme(appearance = activityArgs.configuration.appearance) {
                 val bottomSheetState = rememberStripeBottomSheetState(
-                    confirmValueChange = { presentation.canDismiss() },
+                    confirmValueChange = { coordinator.canDismiss() },
                 )
                 ElementsBottomSheetLayout(
                     state = bottomSheetState,
-                    onDismissed = presentation::onDismissed,
+                    onDismissed = coordinator::onDismissed,
                 ) {
-                    presentation.Content()
+                    coordinator.Content()
                 }
             }
         }
@@ -59,8 +57,6 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
 
     override fun onDestroy() {
         super.onDestroy()
-        if (presentationDelegate.isInitialized()) {
-            presentation.onDestroy()
-        }
+        coordinator?.onDestroy()
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinator.kt
@@ -1,0 +1,37 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.compose.runtime.Composable
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+
+internal class EmbeddedSheetActivityCoordinator(
+    activity: EmbeddedSheetActivity,
+    args: EmbeddedActivityArgs,
+    presentationFactory: EmbeddedSheetPresentationFactory,
+) {
+    private val presentation = presentationFactory.create(
+        activity = activity,
+        args = args,
+        activityResultCaller = activity,
+    )
+
+    fun register() {
+        presentation.register()
+    }
+
+    fun canDismiss(): Boolean {
+        return presentation.canDismiss()
+    }
+
+    fun onDismissed() {
+        presentation.onDismissed()
+    }
+
+    @Composable
+    fun Content() {
+        presentation.Content()
+    }
+
+    fun onDestroy() {
+        presentation.onDestroy()
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
@@ -25,6 +25,28 @@ internal interface EmbeddedSheetPresentation {
             activityResultCaller: ActivityResultCaller,
         ): EmbeddedSheetPresentation
     }
+
+    companion object : EmbeddedSheetPresentationFactory {
+        override fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): EmbeddedSheetPresentation {
+            return EmbeddedSheetViewModel.Factory { args }.createReadyPresentation(
+                activity = activity,
+                args = args,
+                activityResultCaller = activityResultCaller,
+            )
+        }
+    }
+}
+
+internal interface EmbeddedSheetPresentationFactory {
+    fun create(
+        activity: EmbeddedSheetActivity,
+        args: EmbeddedActivityArgs,
+        activityResultCaller: ActivityResultCaller,
+    ): EmbeddedSheetPresentation
 }
 
 internal fun EmbeddedSheetActivity.finishWithResult(result: EmbeddedActivityResult) {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinatorTest.kt
@@ -1,0 +1,197 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import android.os.Bundle
+import androidx.activity.result.ActivityResultCaller
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.testing.CoroutineTestRule
+import com.stripe.android.testing.createComposeCleanupRule
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class EmbeddedSheetActivityCoordinatorTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @get:Rule
+    val composeCleanupRule = createComposeCleanupRule()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(UnconfinedTestDispatcher())
+
+    @Test
+    fun `construction creates the presentation`() = runScenario {
+        assertThat(createCall.activity).isSameInstanceAs(activity)
+        assertThat(createCall.args).isEqualTo(args)
+        assertThat(createCall.activityResultCaller).isSameInstanceAs(activity)
+    }
+
+    @Test
+    fun `register delegates to presentation`() = runScenario {
+        coordinator.register()
+
+        assertThat(presentation.registerCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `canDismiss delegates to presentation`() = runScenario {
+        presentation.canDismissResult = false
+
+        assertThat(coordinator.canDismiss()).isFalse()
+        assertThat(presentation.canDismissCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `onDismissed delegates to presentation`() = runScenario {
+        coordinator.onDismissed()
+
+        assertThat(presentation.onDismissedCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `Content delegates to presentation`() = runScenario {
+        composeRule.setContent {
+            coordinator.Content()
+        }
+
+        composeRule.onNodeWithTag(CONTENT_TEST_TAG).assertExists()
+    }
+
+    @Test
+    fun `onDestroy delegates to presentation`() = runScenario {
+        coordinator.onDestroy()
+
+        assertThat(presentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    private fun runScenario(block: suspend Scenario.() -> Unit) = runTest {
+        val activity = Robolectric.buildActivity(EmbeddedSheetActivity::class.java).get()
+        val args = createArgs()
+        val presentation = FakeEmbeddedSheetPresentation()
+        val presentationFactory = FakeEmbeddedSheetPresentationFactory(presentation)
+        val coordinator = EmbeddedSheetActivityCoordinator(
+            activity = activity,
+            args = args,
+            presentationFactory = presentationFactory,
+        )
+        val createCall = presentationFactory.createCalls.awaitItem()
+
+        Scenario(
+            activity = activity,
+            args = args,
+            coordinator = coordinator,
+            presentation = presentation,
+            createCall = createCall,
+        ).block()
+
+        presentationFactory.ensureAllEventsConsumed()
+        presentation.ensureAllEventsConsumed()
+    }
+
+    private data class Scenario(
+        val activity: EmbeddedSheetActivity,
+        val args: EmbeddedActivityArgs,
+        val coordinator: EmbeddedSheetActivityCoordinator,
+        val presentation: FakeEmbeddedSheetPresentation,
+        val createCall: FakeEmbeddedSheetPresentationFactory.CreateCall,
+    )
+
+    private class FakeEmbeddedSheetPresentationFactory(
+        private val presentation: EmbeddedSheetPresentation,
+    ) : EmbeddedSheetPresentationFactory {
+        val createCalls = Turbine<CreateCall>()
+
+        override fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): EmbeddedSheetPresentation {
+            createCalls.add(CreateCall(activity, args, activityResultCaller))
+            return presentation
+        }
+
+        fun ensureAllEventsConsumed() {
+            createCalls.ensureAllEventsConsumed()
+        }
+
+        data class CreateCall(
+            val activity: EmbeddedSheetActivity,
+            val args: EmbeddedActivityArgs,
+            val activityResultCaller: ActivityResultCaller,
+        )
+    }
+
+    private class FakeEmbeddedSheetPresentation : EmbeddedSheetPresentation {
+        var canDismissResult = true
+
+        val registerCalls = Turbine<Unit>()
+        val canDismissCalls = Turbine<Unit>()
+        val onDismissedCalls = Turbine<Unit>()
+        val onDestroyCalls = Turbine<Unit>()
+
+        override fun register() {
+            registerCalls.add(Unit)
+        }
+
+        override fun canDismiss(): Boolean {
+            canDismissCalls.add(Unit)
+            return canDismissResult
+        }
+
+        override fun onDismissed() {
+            onDismissedCalls.add(Unit)
+        }
+
+        @Composable
+        override fun Content() {
+            Box(modifier = Modifier.testTag(CONTENT_TEST_TAG))
+        }
+
+        override fun onDestroy() {
+            onDestroyCalls.add(Unit)
+        }
+
+        fun ensureAllEventsConsumed() {
+            registerCalls.ensureAllEventsConsumed()
+            canDismissCalls.ensureAllEventsConsumed()
+            onDismissedCalls.ensureAllEventsConsumed()
+            onDestroyCalls.ensureAllEventsConsumed()
+        }
+    }
+
+    private companion object {
+        const val CONTENT_TEST_TAG = "coordinator_content"
+
+        fun createArgs(): EmbeddedActivityArgs {
+            return EmbeddedActivityArgs(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+                configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+                productUsage = setOf("EmbeddedPaymentElement"),
+                paymentElementCallbackIdentifier = "callback_identifier",
+                statusBarColor = null,
+                selection = null,
+                previousNewSelections = Bundle(),
+                customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+                promotions = emptyList(),
+                launchMode = EmbeddedLaunchMode.PaymentOptions,
+            )
+        }
+    }
+}


### PR DESCRIPTION
# Summary

- Add `EmbeddedSheetActivityCoordinator` and `EmbeddedSheetPresentationFactory`.
- Delegate activity registration, content, dismissal checks, dismissal, and destruction to the coordinator.
- Keep the factory ready-only with no loading or new-intent behavior.
- Stack 2 of 4; depends on #14480.

# Motivation

Separating activity lifecycle orchestration from the ready presentation provides a focused seam for the later loading-to-ready transition while preserving current production behavior.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew :paymentsheet:compileDebugAndroidTestKotlin :paymentsheet:apiCheck`
- `./gradlew detekt`

No tests were newly ignored.

# Screenshots

Not applicable: this is an internal lifecycle refactor with no visual changes.

# Changelog

Not applicable: this changes no public API or user-visible behavior.

Committed and created by Codex.
