### PR TITLE
Add dormant embedded sheet loading presentation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -179,6 +179,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
             ),
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -208,6 +209,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.Manage,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -237,6 +239,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
@@ -23,7 +23,13 @@ internal data class EmbeddedActivityArgs(
     val customerState: CustomerState?,
     val promotions: List<PaymentMethodMessagePromotion>,
     val launchMode: EmbeddedLaunchMode,
+    val presentationState: PresentationState,
 ) : Parcelable {
+    internal enum class PresentationState {
+        Loading,
+        Ready,
+    }
+
     companion object {
         internal const val EXTRA_ARGS: String = "extra_activity_args"
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -194,6 +194,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
             ),
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -223,6 +224,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.Manage,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -252,6 +254,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -1,9 +1,11 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.ExperimentalMaterialApi
+import androidx.core.os.BundleCompat
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentsheet.ui.PaymentElementTheme
@@ -13,16 +15,14 @@ import com.stripe.android.uicore.utils.fadeOut
 
 @OptIn(ExperimentalMaterialApi::class)
 internal class EmbeddedSheetActivity : AppCompatActivity() {
-    private val args: EmbeddedActivityArgs? by lazy {
-        EmbeddedActivityArgs.fromIntent(intent)
-    }
-
     private var coordinator: EmbeddedSheetActivityCoordinator? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val activityArgs = args ?: run {
+        val activityArgs = savedInstanceState?.let {
+            BundleCompat.getParcelable(it, STATE_ACTIVITY_ARGS, EmbeddedActivityArgs::class.java)
+        } ?: EmbeddedActivityArgs.fromIntent(intent) ?: run {
             finish()
             return
         }
@@ -30,7 +30,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         renderEdgeToEdge()
         val coordinator = EmbeddedSheetActivityCoordinator(
             activity = this,
-            args = activityArgs,
+            initialArgs = activityArgs,
             presentationFactory = EmbeddedSheetPresentation,
         )
         this.coordinator = coordinator
@@ -55,8 +55,28 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         fadeOut()
     }
 
+    public override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleNewIntent(intent)
+    }
+
+    internal fun handleNewIntent(intent: Intent) {
+        coordinator?.handleNewIntent(intent)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        EmbeddedActivityArgs.fromIntent(intent)?.let {
+            outState.putParcelable(STATE_ACTIVITY_ARGS, it)
+        }
+        super.onSaveInstanceState(outState)
+    }
+
     override fun onDestroy() {
         super.onDestroy()
         coordinator?.onDestroy()
+    }
+
+    private companion object {
+        const val STATE_ACTIVITY_ARGS = "embedded_sheet_activity_args"
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinator.kt
@@ -1,37 +1,79 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import android.content.Intent
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.stripe.android.common.ui.PaymentElementActivityResultCaller
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 
 internal class EmbeddedSheetActivityCoordinator(
-    activity: EmbeddedSheetActivity,
-    args: EmbeddedActivityArgs,
-    presentationFactory: EmbeddedSheetPresentationFactory,
+    private val activity: EmbeddedSheetActivity,
+    initialArgs: EmbeddedActivityArgs,
+    private val presentationFactory: EmbeddedSheetPresentationFactory,
 ) {
-    private val presentation = presentationFactory.create(
-        activity = activity,
-        args = args,
-        activityResultCaller = activity,
+    private var state by mutableStateOf(
+        State(
+            args = initialArgs,
+            presentation = presentationFactory.create(
+                activity = activity,
+                args = initialArgs,
+                activityResultCaller = activity,
+            ),
+        ),
     )
 
     fun register() {
-        presentation.register()
+        state.presentation.register()
     }
 
     fun canDismiss(): Boolean {
-        return presentation.canDismiss()
+        return state.presentation.canDismiss()
     }
 
     fun onDismissed() {
-        presentation.onDismissed()
+        state.presentation.onDismissed()
     }
 
     @Composable
     fun Content() {
-        presentation.Content()
+        state.presentation.Content()
+    }
+
+    fun handleNewIntent(intent: Intent) {
+        val updatedArgs = EmbeddedActivityArgs.fromIntent(intent) ?: return
+        val isValidTransition =
+            !activity.isFinishing &&
+                state.args.presentationState == EmbeddedActivityArgs.PresentationState.Loading &&
+                state.args.launchMode is EmbeddedLaunchMode.PaymentOptions &&
+                updatedArgs.presentationState == EmbeddedActivityArgs.PresentationState.Ready &&
+                updatedArgs.launchMode is EmbeddedLaunchMode.PaymentOptions
+        if (!isValidTransition) return
+
+        activity.intent = intent
+        state.presentation.onDestroy()
+        state = State(
+            args = updatedArgs,
+            presentation = presentationFactory.create(
+                activity = activity,
+                args = updatedArgs,
+                activityResultCaller = PaymentElementActivityResultCaller(
+                    key = "EmbeddedSheetActivity_${updatedArgs.paymentElementCallbackIdentifier}",
+                    registryOwner = activity,
+                ),
+            ),
+        )
+        state.presentation.register()
     }
 
     fun onDestroy() {
-        presentation.onDestroy()
+        state.presentation.onDestroy()
     }
+
+    private data class State(
+        val args: EmbeddedActivityArgs,
+        val presentation: EmbeddedSheetPresentation,
+    )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetContract.kt
@@ -9,6 +9,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 internal object EmbeddedSheetContract : ActivityResultContract<EmbeddedActivityArgs, EmbeddedActivityResult>() {
     override fun createIntent(context: Context, input: EmbeddedActivityArgs): Intent {
         return Intent(context, EmbeddedSheetActivity::class.java)
+            .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
             .putExtra(EmbeddedActivityArgs.EXTRA_ARGS, input)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
@@ -32,11 +32,19 @@ internal interface EmbeddedSheetPresentation {
             args: EmbeddedActivityArgs,
             activityResultCaller: ActivityResultCaller,
         ): EmbeddedSheetPresentation {
-            return EmbeddedSheetViewModel.Factory { args }.createReadyPresentation(
-                activity = activity,
-                args = args,
-                activityResultCaller = activityResultCaller,
-            )
+            return when (args.presentationState) {
+                EmbeddedActivityArgs.PresentationState.Loading -> LoadingEmbeddedSheetPresentation.Factory.create(
+                    activity = activity,
+                    args = args,
+                    activityResultCaller = activityResultCaller,
+                )
+                EmbeddedActivityArgs.PresentationState.Ready ->
+                    EmbeddedSheetViewModel.Factory { args }.createReadyPresentation(
+                        activity = activity,
+                        args = args,
+                        activityResultCaller = activityResultCaller,
+                    )
+            }
         }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/LoadingEmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/LoadingEmbeddedSheetPresentation.kt
@@ -1,0 +1,66 @@
+package com.stripe.android.paymentelement.embedded.sheet
+
+import androidx.activity.OnBackPressedCallback
+import androidx.activity.addCallback
+import androidx.activity.result.ActivityResultCaller
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.stripe.android.common.ui.BottomSheetLoadingIndicator
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+
+internal class LoadingEmbeddedSheetPresentation(
+    private val activity: EmbeddedSheetActivity,
+    private val args: EmbeddedActivityArgs,
+) : EmbeddedSheetPresentation {
+    private var backCallback: OnBackPressedCallback? = null
+
+    override fun register() {
+        backCallback = activity.onBackPressedDispatcher.addCallback {
+            activity.finishWithResult(createCancellationResult())
+        }
+    }
+
+    override fun canDismiss(): Boolean {
+        return true
+    }
+
+    override fun onDismissed() {
+        activity.finishWithResult(createCancellationResult())
+    }
+
+    @Composable
+    override fun Content() {
+        BottomSheetLoadingIndicator(
+            modifier = Modifier.testTag(EMBEDDED_SHEET_LOADING_TEST_TAG),
+        )
+    }
+
+    override fun onDestroy() {
+        backCallback?.remove()
+    }
+
+    private fun createCancellationResult(): EmbeddedActivityResult {
+        return EmbeddedActivityResult.Cancelled(
+            customerState = args.customerState,
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+        )
+    }
+
+    object Factory : EmbeddedSheetPresentation.Factory {
+        override fun create(
+            activity: EmbeddedSheetActivity,
+            args: EmbeddedActivityArgs,
+            activityResultCaller: ActivityResultCaller,
+        ): LoadingEmbeddedSheetPresentation {
+            return LoadingEmbeddedSheetPresentation(
+                activity = activity,
+                args = args,
+            )
+        }
+    }
+}
+
+internal const val EMBEDDED_SHEET_LOADING_TEST_TAG = "embedded_sheet_loading"

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -81,6 +81,7 @@ internal class CheckoutSheetLauncherTest {
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
             ),
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
@@ -372,6 +373,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.Manage,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchManage(
@@ -500,6 +502,7 @@ internal class CheckoutSheetLauncherTest {
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchPaymentOptions(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -84,6 +84,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             launchMode = EmbeddedLaunchMode.Form(
                 selectedPaymentMethodCode = code,
             ),
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
@@ -408,6 +409,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.Manage,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchManage(
@@ -588,6 +590,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchPaymentOptions(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -265,6 +265,7 @@ internal class EmbeddedSheetActivityTest {
                     launchMode = EmbeddedLaunchMode.Form(
                         selectedPaymentMethodCode = selectedPaymentMethodCode,
                     ),
+                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinatorTest.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.result.ActivityResultCaller
 import androidx.compose.foundation.layout.Box
@@ -47,22 +48,22 @@ internal class EmbeddedSheetActivityCoordinatorTest {
     fun `register delegates to presentation`() = runScenario {
         coordinator.register()
 
-        assertThat(presentation.registerCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(initialPresentation.registerCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
     fun `canDismiss delegates to presentation`() = runScenario {
-        presentation.canDismissResult = false
+        initialPresentation.canDismissResult = false
 
         assertThat(coordinator.canDismiss()).isFalse()
-        assertThat(presentation.canDismissCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(initialPresentation.canDismissCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
     fun `onDismissed delegates to presentation`() = runScenario {
         coordinator.onDismissed()
 
-        assertThat(presentation.onDismissedCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(initialPresentation.onDismissedCalls.awaitItem()).isEqualTo(Unit)
     }
 
     @Test
@@ -78,43 +79,134 @@ internal class EmbeddedSheetActivityCoordinatorTest {
     fun `onDestroy delegates to presentation`() = runScenario {
         coordinator.onDestroy()
 
-        assertThat(presentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(initialPresentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
     }
 
-    private fun runScenario(block: suspend Scenario.() -> Unit) = runTest {
+    @Test
+    fun `valid loading to ready transition replaces and registers presentation`() = runScenario {
+        val readyArgs = createArgs(
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            callbackIdentifier = "updated_callback_identifier",
+        )
+        val readyIntent = createIntent(readyArgs)
+
+        coordinator.handleNewIntent(readyIntent)
+
+        assertThat(initialPresentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
+        val createCall = presentationFactory.createCalls.awaitItem()
+        assertThat(createCall.activity).isSameInstanceAs(activity)
+        assertThat(createCall.args).isEqualTo(readyArgs)
+        assertThat(createCall.activityResultCaller).isNotSameInstanceAs(activity)
+        assertThat(readyPresentation.registerCalls.awaitItem()).isEqualTo(Unit)
+        assertThat(activity.intent).isSameInstanceAs(readyIntent)
+
+        coordinator.onDestroy()
+        assertThat(readyPresentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
+    }
+
+    @Test
+    fun `intent without args is ignored`() = runScenario {
+        assertTransitionIgnored(Intent())
+    }
+
+    @Test
+    fun `loading intent is ignored`() = runScenario {
+        assertTransitionIgnored(
+            createIntent(createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Loading))
+        )
+    }
+
+    @Test
+    fun `ready manage intent is ignored`() = runScenario {
+        assertTransitionIgnored(
+            createIntent(
+                createArgs(
+                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+                    launchMode = EmbeddedLaunchMode.Manage,
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `ready coordinator ignores later ready intent`() = runScenario(
+        initialArgs = createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready),
+    ) {
+        assertTransitionIgnored(
+            createIntent(createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready))
+        )
+    }
+
+    @Test
+    fun `finishing activity ignores ready intent`() = runScenario {
+        activity.finish()
+
+        assertTransitionIgnored(
+            createIntent(createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready))
+        )
+    }
+
+    private fun runScenario(
+        initialArgs: EmbeddedActivityArgs = createArgs(
+            presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+        ),
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
         val activity = Robolectric.buildActivity(EmbeddedSheetActivity::class.java).get()
-        val args = createArgs()
-        val presentation = FakeEmbeddedSheetPresentation()
-        val presentationFactory = FakeEmbeddedSheetPresentationFactory(presentation)
+        val initialPresentation = FakeEmbeddedSheetPresentation()
+        val readyPresentation = FakeEmbeddedSheetPresentation()
+        val presentationFactory = FakeEmbeddedSheetPresentationFactory(
+            initialPresentation = initialPresentation,
+            readyPresentation = readyPresentation,
+        )
         val coordinator = EmbeddedSheetActivityCoordinator(
             activity = activity,
-            args = args,
+            initialArgs = initialArgs,
             presentationFactory = presentationFactory,
         )
         val createCall = presentationFactory.createCalls.awaitItem()
 
         Scenario(
             activity = activity,
-            args = args,
+            args = initialArgs,
             coordinator = coordinator,
-            presentation = presentation,
+            initialPresentation = initialPresentation,
+            readyPresentation = readyPresentation,
+            presentationFactory = presentationFactory,
             createCall = createCall,
         ).block()
 
         presentationFactory.ensureAllEventsConsumed()
-        presentation.ensureAllEventsConsumed()
+        initialPresentation.ensureAllEventsConsumed()
+        readyPresentation.ensureAllEventsConsumed()
     }
 
     private data class Scenario(
         val activity: EmbeddedSheetActivity,
         val args: EmbeddedActivityArgs,
         val coordinator: EmbeddedSheetActivityCoordinator,
-        val presentation: FakeEmbeddedSheetPresentation,
+        val initialPresentation: FakeEmbeddedSheetPresentation,
+        val readyPresentation: FakeEmbeddedSheetPresentation,
+        val presentationFactory: FakeEmbeddedSheetPresentationFactory,
         val createCall: FakeEmbeddedSheetPresentationFactory.CreateCall,
-    )
+    ) {
+        suspend fun assertTransitionIgnored(intent: Intent) {
+            val originalIntent = activity.intent
+
+            coordinator.handleNewIntent(intent)
+
+            assertThat(activity.intent).isSameInstanceAs(originalIntent)
+            presentationFactory.createCalls.expectNoEvents()
+            initialPresentation.registerCalls.expectNoEvents()
+            initialPresentation.onDestroyCalls.expectNoEvents()
+            readyPresentation.registerCalls.expectNoEvents()
+            readyPresentation.onDestroyCalls.expectNoEvents()
+        }
+    }
 
     private class FakeEmbeddedSheetPresentationFactory(
-        private val presentation: EmbeddedSheetPresentation,
+        private val initialPresentation: EmbeddedSheetPresentation,
+        private val readyPresentation: EmbeddedSheetPresentation,
     ) : EmbeddedSheetPresentationFactory {
         val createCalls = Turbine<CreateCall>()
 
@@ -124,7 +216,10 @@ internal class EmbeddedSheetActivityCoordinatorTest {
             activityResultCaller: ActivityResultCaller,
         ): EmbeddedSheetPresentation {
             createCalls.add(CreateCall(activity, args, activityResultCaller))
-            return presentation
+            return when (args.presentationState) {
+                EmbeddedActivityArgs.PresentationState.Loading -> initialPresentation
+                EmbeddedActivityArgs.PresentationState.Ready -> readyPresentation
+            }
         }
 
         fun ensureAllEventsConsumed() {
@@ -179,19 +274,28 @@ internal class EmbeddedSheetActivityCoordinatorTest {
     private companion object {
         const val CONTENT_TEST_TAG = "coordinator_content"
 
-        fun createArgs(): EmbeddedActivityArgs {
+        fun createArgs(
+            presentationState: EmbeddedActivityArgs.PresentationState,
+            launchMode: EmbeddedLaunchMode = EmbeddedLaunchMode.PaymentOptions,
+            callbackIdentifier: String = "callback_identifier",
+        ): EmbeddedActivityArgs {
             return EmbeddedActivityArgs(
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
                 configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                 productUsage = setOf("EmbeddedPaymentElement"),
-                paymentElementCallbackIdentifier = "callback_identifier",
+                paymentElementCallbackIdentifier = callbackIdentifier,
                 statusBarColor = null,
                 selection = null,
                 previousNewSelections = Bundle(),
                 customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
                 promotions = emptyList(),
-                launchMode = EmbeddedLaunchMode.PaymentOptions,
+                launchMode = launchMode,
+                presentationState = presentationState,
             )
+        }
+
+        fun createIntent(args: EmbeddedActivityArgs): Intent {
+            return Intent().putExtra(EmbeddedActivityArgs.EXTRA_ARGS, args)
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -276,6 +276,7 @@ internal class EmbeddedSheetActivityTest {
                     ),
                     promotions = emptyList(),
                     launchMode = EmbeddedLaunchMode.Manage,
+                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -42,6 +42,7 @@ import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.ui.PRIMARY_BUTTON_TEST_TAG
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_NEW_PAYMENT_METHOD_ROW_BUTTON
 import com.stripe.android.testing.PaymentConfigurationTestRule
+import com.stripe.android.uicore.elements.bottomsheet.BottomSheetContentTestTag
 import com.stripe.paymentelementtestpages.FormPage
 import com.stripe.paymentelementtestpages.ManagePage
 import com.stripe.paymentelementtestpages.VerticalModePage
@@ -67,6 +68,80 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         .outerRule(composeTestRule)
         .around(networkRule)
         .around(PaymentConfigurationTestRule(applicationContext))
+
+    @Test
+    fun `loading renders and cancellation returns PaymentOptions`() = launch(
+        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+    ) { scenario ->
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
+
+        Espresso.pressBack()
+        onIdle()
+
+        val result = EmbeddedSheetContract.parseResult(
+            scenario.result.resultCode,
+            scenario.result.resultData,
+        ) as EmbeddedActivityResult.Cancelled
+        assertThat(result.customerState).isEqualTo(PaymentSheetFixtures.EMPTY_CUSTOMER_STATE)
+        assertThat(result.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
+    }
+
+    @Test
+    fun `recreated loading activity remains loading`() = launch(
+        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+    ) { scenario ->
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
+
+        scenario.recreate()
+        onIdle()
+
+        scenario.onActivity { activity ->
+            assertThat(activity.isFinishing).isFalse()
+        }
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
+    }
+
+    @Test
+    fun `ready intent updates loading content without replacing composition and survives recreation`() = launch(
+        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+    ) { scenario ->
+        val readyIntent = EmbeddedSheetContract.createIntent(
+            applicationContext,
+            createArgs(
+                paymentMethodMetadata = PaymentMethodMetadataFactory.create(
+                    paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
+                ),
+                presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            ),
+        )
+
+        scenario.recreate()
+        onIdle()
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
+
+        val initialBottomSheetNodeId = composeTestRule
+            .onNodeWithTag(BottomSheetContentTestTag)
+            .fetchSemanticsNode()
+            .id
+        scenario.onActivity { activity ->
+            activity.onNewIntent(readyIntent)
+        }
+        composeTestRule.waitForIdle()
+
+        formPage.waitUntilVisible()
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertDoesNotExist()
+        val currentBottomSheetNodeId = composeTestRule
+            .onNodeWithTag(BottomSheetContentTestTag)
+            .fetchSemanticsNode()
+            .id
+        assertThat(currentBottomSheetNodeId).isEqualTo(initialBottomSheetNodeId)
+
+        scenario.recreate()
+        onIdle()
+
+        formPage.waitUntilVisible()
+        composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertDoesNotExist()
+    }
 
     @Test
     fun `pressing back returns cancelled result with PaymentOptions launch mode`() = launch { scenario ->
@@ -241,6 +316,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         ),
+        presentationState: EmbeddedActivityArgs.PresentationState = EmbeddedActivityArgs.PresentationState.Ready,
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) = launch(
         selection = selection,
@@ -251,6 +327,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                 listOf(it.paymentMethod)
             }.orEmpty(),
         ),
+        presentationState = presentationState,
         block = block,
     )
 
@@ -272,27 +349,47 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         previousNewSelections: Bundle,
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
+        presentationState: EmbeddedActivityArgs.PresentationState = EmbeddedActivityArgs.PresentationState.Ready,
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) {
         ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
             EmbeddedSheetContract.createIntent(
                 context = applicationContext,
-                input = EmbeddedActivityArgs(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
-                    productUsage = setOf("EmbeddedPaymentElement"),
-                    statusBarColor = null,
-                    paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
+                input = createArgs(
                     selection = selection,
                     previousNewSelections = previousNewSelections,
+                    paymentMethodMetadata = paymentMethodMetadata,
                     customerState = customerState,
-                    promotions = emptyList(),
-                    launchMode = EmbeddedLaunchMode.PaymentOptions,
+                    presentationState = presentationState,
                 ),
             )
         ).use { scenario ->
             block(scenario)
         }
+    }
+
+    private fun createArgs(
+        selection: PaymentSelection? = null,
+        previousNewSelections: Bundle = Bundle(),
+        paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
+            paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
+        ),
+        customerState: CustomerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+        presentationState: EmbeddedActivityArgs.PresentationState,
+    ): EmbeddedActivityArgs {
+        return EmbeddedActivityArgs(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+            productUsage = setOf("EmbeddedPaymentElement"),
+            statusBarColor = null,
+            paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
+            selection = selection,
+            previousNewSelections = previousNewSelections,
+            customerState = customerState,
+            promotions = emptyList(),
+            launchMode = EmbeddedLaunchMode.PaymentOptions,
+            presentationState = presentationState,
+        )
     }
 
     private fun checkoutPaymentMethodMetadata(): PaymentMethodMetadata {


### PR DESCRIPTION
# Summary

- Add required internal loading/ready presentation arguments and mark every existing launcher ready.
- Add the embedded-sheet loading presentation and the Payment Options loading-to-ready coordinator transition.
- Add single-top relaunch, latest-argument restoration, and the distinct ready activity-result caller.
- Stack 3 of 4; depends on the coordinator layer.

# Motivation

This creates independently testable loading-to-ready activity infrastructure while leaving production behavior unchanged: no launcher emits loading in this layer.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew :paymentsheet:compileDebugAndroidTestKotlin :paymentsheet:apiCheck`
- `./gradlew detekt`

No tests were newly ignored.

# Screenshots

Not applicable: this uses the existing loading indicator and remains dormant in production.

# Changelog

Not applicable: this changes no public API or production behavior.

Committed and created by Codex.
