### PR TITLE
Activate embedded sheet loading for Checkout

### DIFF
--- a/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/ConfirmationControls.kt
+++ b/paymentsheet-example/src/main/java/com/stripe/android/paymentsheet/example/playground/checkout/ConfirmationControls.kt
@@ -44,7 +44,6 @@ internal fun ConfirmationControls(
         ) { Text("Clear") }
         Button(
             onClick = onSelectPaymentMethod,
-            enabled = !isUpdating,
             modifier = Modifier.weight(1f),
         ) { Text("Select") }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -4,6 +4,8 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.lifecycleScope
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -16,6 +18,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
@@ -28,20 +31,41 @@ import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
+import javax.inject.Singleton
+
+@Singleton
+internal class CheckoutSheetLauncherState @Inject constructor(
+    private val savedStateHandle: SavedStateHandle,
+) {
+    var isAwaitingPaymentOptionsReady: Boolean
+        get() = savedStateHandle.get<Boolean>(AWAITING_PAYMENT_OPTIONS_READY_KEY) == true
+        set(value) {
+            savedStateHandle[AWAITING_PAYMENT_OPTIONS_READY_KEY] = value
+        }
+
+    private companion object {
+        const val AWAITING_PAYMENT_OPTIONS_READY_KEY =
+            "CheckoutSheetLauncherState_AWAITING_PAYMENT_OPTIONS_READY"
+    }
+}
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutSheetLauncher @Inject constructor(
     activityResultCaller: ActivityResultCaller,
-    lifecycleOwner: LifecycleOwner,
+    private val lifecycleOwner: LifecycleOwner,
     private val selectionHolder: EmbeddedSelectionHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
     private val errorReporter: ErrorReporter,
     private val sessionRefresher: CheckoutSessionRefresher,
     private val operationCoordinator: CheckoutOperationCoordinator,
+    private val launcherState: CheckoutSheetLauncherState,
+    private val embeddedContentState: StateFlow<EmbeddedContentHelperStateHolder.State?>,
     private val logger: Logger,
     @ViewModelScope private val coroutineScope: CoroutineScope,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
@@ -63,6 +87,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
     private val activityLauncher: ActivityResultLauncher<EmbeddedActivityArgs> =
         activityResultCaller.registerForActivityResult(EmbeddedSheetContract) { result ->
+            launcherState.isAwaitingPaymentOptionsReady = false
             sheetStateHolder.sheetIsOpen = false
             when (result.launchMode) {
                 is EmbeddedLaunchMode.Form -> {
@@ -73,6 +98,10 @@ internal class CheckoutSheetLauncher @Inject constructor(
                 is EmbeddedLaunchMode.PaymentOptions -> handlePaymentOptionsResult(result)
             }
         }
+
+    init {
+        resumePendingReadyLaunch()
+    }
 
     private fun handleFormResult(result: EmbeddedActivityResult) {
         when (result) {
@@ -228,7 +257,62 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
-        val args = EmbeddedActivityArgs(
+        val initialArgs = createPaymentOptionsArgs(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = configuration,
+            selection = selection,
+            customerState = customerState,
+            presentationState = if (operationCoordinator.isUpdating.value) {
+                EmbeddedActivityArgs.PresentationState.Loading
+            } else {
+                EmbeddedActivityArgs.PresentationState.Ready
+            },
+        )
+        launcherState.isAwaitingPaymentOptionsReady =
+            initialArgs.presentationState == EmbeddedActivityArgs.PresentationState.Loading
+        activityLauncher.launch(initialArgs)
+
+        resumePendingReadyLaunch()
+    }
+
+    private fun resumePendingReadyLaunch() {
+        if (!launcherState.isAwaitingPaymentOptionsReady) return
+
+        lifecycleOwner.lifecycleScope.launch {
+            operationCoordinator.isUpdating.first { isUpdating -> !isUpdating }
+            if (!sheetStateHolder.sheetIsOpen) {
+                launcherState.isAwaitingPaymentOptionsReady = false
+                return@launch
+            }
+
+            val refreshedState = embeddedContentState.value
+            if (refreshedState == null) {
+                errorReporter.report(
+                    ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                )
+                return@launch
+            }
+            activityLauncher.launch(
+                createPaymentOptionsArgs(
+                    paymentMethodMetadata = refreshedState.paymentMethodMetadata,
+                    configuration = refreshedState.configuration,
+                    selection = selectionHolder.selection.value,
+                    customerState = customerStateHolder.customer.value,
+                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+                )
+            )
+            launcherState.isAwaitingPaymentOptionsReady = false
+        }
+    }
+
+    private fun createPaymentOptionsArgs(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        customerState: CustomerState?,
+        selection: PaymentSelection?,
+        configuration: EmbeddedPaymentElement.Configuration,
+        presentationState: EmbeddedActivityArgs.PresentationState,
+    ): EmbeddedActivityArgs {
+        return EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
             productUsage = productUsage,
@@ -239,8 +323,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             customerState = customerState,
             promotions = emptyList(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            presentationState = presentationState,
         )
-        activityLauncher.launch(args)
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationFactory
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentelement.embedded.previousNewSelection
@@ -39,6 +40,10 @@ import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.asCallbackFor
 import com.stripe.android.uicore.utils.stateFlowOf
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -518,6 +523,180 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
+    fun `updating launch sends loading then refreshed ready arguments`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                mutationGate.await()
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+
+        val initialState = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = initialState.paymentMethodMetadata,
+            customerState = null,
+            selection = null,
+            configuration = initialState.configuration,
+        )
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(loadingArgs.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
+        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+
+        val refreshedMetadata = PaymentMethodMetadataFactory.create()
+        val refreshedConfiguration = EmbeddedConfigurationFactory.create(merchantDisplayName = "Refreshed merchant")
+        val refreshedCustomer = createCustomerState()
+        embeddedContentState.value = EmbeddedContentHelperStateHolder.State(
+            paymentMethodMetadata = refreshedMetadata,
+            embeddedViewDisplaysMandateText = true,
+            configuration = refreshedConfiguration,
+        )
+        customerStateHolder.setCustomerState(refreshedCustomer)
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(readyArgs.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
+        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
+        assertThat(readyArgs.paymentMethodMetadata).isEqualTo(refreshedMetadata)
+        assertThat(readyArgs.configuration).isEqualTo(refreshedConfiguration)
+        assertThat(readyArgs.customerState).isEqualTo(refreshedCustomer)
+        assertThat(readyArgs.selection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `recreated launcher sends ready arguments when mutation finishes`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                mutationGate.await()
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+
+        val initialState = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = initialState.paymentMethodMetadata,
+            customerState = null,
+            selection = null,
+            configuration = initialState.configuration,
+        )
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+        assertThat(launcherState.isAwaitingPaymentOptionsReady).isTrue()
+
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        dummyActivityResultCallerScenario.awaitNextUnregisteredLauncher()
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        val recreatedLauncherState = CheckoutSheetLauncherState(savedStateHandle)
+        recreateSheetLauncher(TestLifecycleOwner(), recreatedLauncherState)
+        runCurrent()
+
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
+        assertThat(recreatedLauncherState.isAwaitingPaymentOptionsReady).isFalse()
+    }
+
+    @Test
+    fun `failed mutation sends retained state as ready arguments`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation<Unit> {
+                mutationGate.await()
+                Result.failure(IllegalStateException("Failed mutation"))
+            }
+        }
+        runCurrent()
+
+        val retainedState = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = retainedState.paymentMethodMetadata,
+            customerState = customerStateHolder.customer.value,
+            selection = selectionHolder.selection.value,
+            configuration = retainedState.configuration,
+        )
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
+        assertThat(readyArgs.paymentMethodMetadata).isEqualTo(retainedState.paymentMethodMetadata)
+        assertThat(readyArgs.configuration).isEqualTo(retainedState.configuration)
+    }
+
+    @Test
+    fun `missing refreshed state does not crash when mutation finishes`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                mutationGate.await()
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+
+        val initialState = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = initialState.paymentMethodMetadata,
+            customerState = null,
+            selection = null,
+            configuration = initialState.configuration,
+        )
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+
+        embeddedContentState.value = null
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        assertThat(errorReporter.getLoggedErrors()).containsExactly(
+            "unexpected_error.embedded.embedded_sheet_launcher.embedded_state_is_null"
+        )
+        assertThat(launcherState.isAwaitingPaymentOptionsReady).isTrue()
+    }
+
+    @Test
+    fun `cancelling loading suppresses ready launch`() = testScenario {
+        val mutationGate = CompletableDeferred<Unit>()
+        coroutineScope.launch {
+            operationCoordinator.runMutation {
+                mutationGate.await()
+                Result.success(Unit)
+            }
+        }
+        runCurrent()
+
+        val state = requireNotNull(embeddedContentState.value)
+        sheetLauncher.launchPaymentOptions(
+            paymentMethodMetadata = state.paymentMethodMetadata,
+            customerState = null,
+            selection = null,
+            configuration = state.configuration,
+        )
+        dummyActivityResultCallerScenario.awaitLaunchCall()
+
+        registerCall.callback.asCallbackFor<EmbeddedActivityResult>().onActivityResult(
+            EmbeddedActivityResult.Cancelled(
+                customerState = null,
+                launchMode = EmbeddedLaunchMode.PaymentOptions,
+            )
+        )
+        mutationGate.complete(Unit)
+        runCurrent()
+
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(launcherState.isAwaitingPaymentOptionsReady).isFalse()
+    }
+
+    @Test
     fun `launchPaymentOptions forwards previously entered new selections into the sheet`() = testScenario {
         selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
@@ -742,24 +921,41 @@ internal class CheckoutSheetLauncherTest {
             logger = logger,
             resultCallback = CheckoutController.ResultCallback {},
         )
+        val launcherState = CheckoutSheetLauncherState(savedStateHandle)
+        val embeddedContentState = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(
+            EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata = paymentMethodMetadata,
+                embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedConfigurationFactory.create(),
+            )
+        )
 
         DummyActivityResultCaller.test {
-            val sheetLauncher = CheckoutSheetLauncher(
-                activityResultCaller = activityResultCaller,
-                lifecycleOwner = lifecycleOwner,
-                selectionHolder = selectionHolder,
-                customerStateHolder = customerStateHolder,
-                sheetStateHolder = sheetStateHolder,
-                errorReporter = errorReporter,
-                sessionRefresher = sessionRefresher,
-                operationCoordinator = operationCoordinator,
-                logger = logger,
-                coroutineScope = testScope,
-                productUsage = setOf("Checkout"),
-                statusBarColor = null,
-                paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
-                rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
-            )
+            fun createSheetLauncher(
+                owner: TestLifecycleOwner,
+                state: CheckoutSheetLauncherState,
+            ): CheckoutSheetLauncher {
+                return CheckoutSheetLauncher(
+                    activityResultCaller = activityResultCaller,
+                    lifecycleOwner = owner,
+                    selectionHolder = selectionHolder,
+                    customerStateHolder = customerStateHolder,
+                    sheetStateHolder = sheetStateHolder,
+                    errorReporter = errorReporter,
+                    sessionRefresher = sessionRefresher,
+                    operationCoordinator = operationCoordinator,
+                    launcherState = state,
+                    embeddedContentState = embeddedContentState,
+                    logger = logger,
+                    coroutineScope = testScope,
+                    productUsage = setOf("Checkout"),
+                    statusBarColor = null,
+                    paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+                    rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
+                )
+            }
+
+            val sheetLauncher = createSheetLauncher(lifecycleOwner, launcherState)
             val registerCall = awaitRegisterCall()
             val launcher = awaitNextRegisteredLauncher()
 
@@ -780,6 +976,11 @@ internal class CheckoutSheetLauncherTest {
                 sessionRefresher = sessionRefresher,
                 logger = logger,
                 operationCoordinator = operationCoordinator,
+                launcherState = launcherState,
+                savedStateHandle = savedStateHandle,
+                embeddedContentState = embeddedContentState,
+                coroutineScope = testScope,
+                createSheetLauncher = ::createSheetLauncher,
                 runCurrent = testScheduler::runCurrent,
             ).block()
         }
@@ -802,10 +1003,27 @@ internal class CheckoutSheetLauncherTest {
         val sessionRefresher: FakeCheckoutSessionRefresher,
         val logger: FakeLogger,
         val operationCoordinator: CheckoutOperationCoordinator,
+        val launcherState: CheckoutSheetLauncherState,
+        val savedStateHandle: SavedStateHandle,
+        val embeddedContentState: MutableStateFlow<EmbeddedContentHelperStateHolder.State?>,
+        val coroutineScope: CoroutineScope,
+        private val createSheetLauncher: (
+            TestLifecycleOwner,
+            CheckoutSheetLauncherState,
+        ) -> CheckoutSheetLauncher,
         private val runCurrent: () -> Unit,
     ) {
         fun runCurrent() {
             runCurrent.invoke()
+        }
+
+        suspend fun recreateSheetLauncher(
+            lifecycleOwner: TestLifecycleOwner,
+            launcherState: CheckoutSheetLauncherState,
+        ) {
+            createSheetLauncher(lifecycleOwner, launcherState)
+            dummyActivityResultCallerScenario.awaitRegisterCall()
+            dummyActivityResultCallerScenario.awaitNextRegisteredLauncher()
         }
 
         suspend fun awaitRefreshCall(): FakeCheckoutSessionRefresher.Call {


### PR DESCRIPTION
# Summary

- Allow Checkout payment-option selection while a session mutation is updating.
- Launch the loading embedded sheet immediately, then relaunch ready with refreshed metadata, configuration, customer state, and selection.
- Persist and restore the pending relaunch, clear it on results, and retain state after failed mutations.
- Stack 4 of 4; depends on the dormant loading infrastructure.

# Motivation

Checkout mutations can refresh the arguments used to construct long-lived embedded-sheet dependencies. Showing loading immediately and delaying ready construction avoids initializing the sheet with stale state.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :paymentsheet:testDebugUnitTest`
- `./gradlew :paymentsheet:compileDebugAndroidTestKotlin :paymentsheet:apiCheck`
- `./gradlew detekt`

Covered idle launch, updating launch, refreshed success, failed mutation, cancellation, missing refreshed state, and host recreation. No tests were newly ignored.

# Screenshots

Not applicable: this reuses the existing embedded-sheet loading indicator.

# Changelog

Not applicable: this is an internal Checkout initialization fix with no public API change.

Committed and created by Codex.
