### PR TITLE
Remove return URL setters from public API

### DIFF
--- a/payments-core/api/payments-core.api
+++ b/payments-core/api/payments-core.api
@@ -1380,7 +1380,6 @@ public final class com/stripe/android/model/ConfirmPaymentIntentParams : com/str
 	public final fun setMandateId (Ljava/lang/String;)V
 	public final fun setPaymentMethodOptions (Lcom/stripe/android/model/PaymentMethodOptionsParams;)V
 	public final fun setReceiptEmail (Ljava/lang/String;)V
-	public fun setReturnUrl (Ljava/lang/String;)V
 	public final fun setSavePaymentMethod (Ljava/lang/Boolean;)V
 	public final fun setSetupFutureUsage (Lcom/stripe/android/model/ConfirmPaymentIntentParams$SetupFutureUsage;)V
 	public final fun setShipping (Lcom/stripe/android/model/ConfirmPaymentIntentParams$Shipping;)V
@@ -1473,7 +1472,6 @@ public final class com/stripe/android/model/ConfirmSetupIntentParams : com/strip
 	public fun hashCode ()I
 	public final fun setMandateData (Lcom/stripe/android/model/MandateDataParams;)V
 	public final fun setMandateId (Ljava/lang/String;)V
-	public fun setReturnUrl (Ljava/lang/String;)V
 	public fun shouldUseStripeSdk ()Z
 	public fun toParamMap ()Ljava/util/Map;
 	public fun toString ()Ljava/lang/String;
@@ -1499,7 +1497,6 @@ public abstract interface class com/stripe/android/model/ConfirmStripeIntentPara
 	public static final field Companion Lcom/stripe/android/model/ConfirmStripeIntentParams$Companion;
 	public abstract fun getClientSecret ()Ljava/lang/String;
 	public abstract fun getReturnUrl ()Ljava/lang/String;
-	public abstract fun setReturnUrl (Ljava/lang/String;)V
 	public abstract fun shouldUseStripeSdk ()Z
 	public abstract fun withShouldUseStripeSdk (Z)Lcom/stripe/android/model/ConfirmStripeIntentParams;
 }

--- a/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
+++ b/payments-core/src/main/java/com/stripe/android/StripePaymentController.kt
@@ -161,17 +161,13 @@ constructor(
         val result = when (confirmStripeIntentParams) {
             is ConfirmPaymentIntentParams -> {
                 confirmPaymentIntent(
-                    confirmStripeIntentParams.also {
-                        it.returnUrl = returnUrl
-                    },
+                    confirmStripeIntentParams.copy(returnUrl = returnUrl),
                     requestOptions
                 )
             }
             is ConfirmSetupIntentParams -> {
                 confirmSetupIntent(
-                    confirmStripeIntentParams.also {
-                        it.returnUrl = returnUrl
-                    },
+                    confirmStripeIntentParams.copy(returnUrl = returnUrl),
                     requestOptions
                 )
             }

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmPaymentIntentParams.kt
@@ -58,7 +58,7 @@ constructor(
      *
      * See [return_url](https://stripe.com/docs/api/payment_intents/confirm#confirm_payment_intent-return_url).
      */
-    override var returnUrl: String? = null,
+    override val returnUrl: String? = null,
     /**
      * If the PaymentIntent has a `payment_method` and a `customer` or if you’re attaching a payment
      * method to the PaymentIntent in this request, you can pass `save_payment_method=true` to save

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmSetupIntentParams.kt
@@ -36,7 +36,7 @@ constructor(
      * supply an application URI scheme. This parameter is only used for cards and other
      * redirect-based payment methods.
      */
-    override var returnUrl: String? = null,
+    override val returnUrl: String? = null,
     private val useStripeSdk: Boolean = false,
     /**
      * ID of the mandate to be used for this payment.

--- a/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
+++ b/payments-core/src/main/java/com/stripe/android/model/ConfirmStripeIntentParams.kt
@@ -11,7 +11,7 @@ sealed interface ConfirmStripeIntentParams : StripeParamsModel, Parcelable {
 
     val clientSecret: String
 
-    var returnUrl: String?
+    val returnUrl: String?
 
     fun shouldUseStripeSdk(): Boolean
 

--- a/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModel.kt
@@ -176,8 +176,9 @@ internal class PaymentLauncherViewModel @Inject constructor(
         confirmStripeIntentParams: ConfirmStripeIntentParams,
         returnUrl: String?
     ): Result<StripeIntent> {
-        val decoratedParams = confirmStripeIntentParams.also {
-            it.returnUrl = returnUrl
+        val decoratedParams = when (confirmStripeIntentParams) {
+            is ConfirmPaymentIntentParams -> confirmStripeIntentParams.copy(returnUrl = returnUrl)
+            is ConfirmSetupIntentParams -> confirmStripeIntentParams.copy(returnUrl = returnUrl)
         }.withShouldUseStripeSdk(true)
 
         return when (decoratedParams) {

--- a/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/paymentlauncher/PaymentLauncherViewModelTest.kt
@@ -202,9 +202,7 @@ class PaymentLauncherViewModelTest {
             whenever(paymentIntent.requiresAction()).thenReturn(true)
 
             createViewModel().confirmStripeIntent(
-                confirmPaymentIntentParams.also {
-                    it.returnUrl = RETURN_URL
-                },
+                confirmPaymentIntentParams.copy(returnUrl = RETURN_URL),
                 authHost
             )
 
@@ -236,9 +234,7 @@ class PaymentLauncherViewModelTest {
 
             val viewModel = createViewModel()
             viewModel.confirmStripeIntent(
-                confirmPaymentIntentParams.also {
-                    it.returnUrl = RETURN_URL
-                },
+                confirmPaymentIntentParams.copy(returnUrl = RETURN_URL),
                 authHost
             )
 
@@ -300,9 +296,7 @@ class PaymentLauncherViewModelTest {
             whenever(setupIntent.requiresAction()).thenReturn(true)
 
             createViewModel().confirmStripeIntent(
-                confirmSetupIntentParams.also {
-                    it.returnUrl = RETURN_URL
-                },
+                confirmSetupIntentParams.copy(returnUrl = RETURN_URL),
                 authHost
             )
 


### PR DESCRIPTION
# Summary
Make `returnUrl` immutable on confirmation parameters so `setReturnUrl` is no longer exposed by `payments-core`.

Committed and created by Codex.

# Motivation
The return URL setters were unintentionally part of the public API. Internal callers now create copies with the resolved return URL instead of mutating confirmation parameters.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :payments-core:apiDump`

`./gradlew :payments-core:compileDebugKotlin :payments-core:testDebugUnitTest :payments-core:detekt :payments-core:apiCheck :payments-core:lintDebug`

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| N/A | N/A |

# Changelog
No changelog entry. This removes unintentionally exposed setters without changing confirmation behavior.
