### PR TITLE
Fix deferred intent failure display race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ NEXT_VERSION_BUMP: PATCH
 
 ### PaymentSheet
 * [FIXED][14436](https://github.com/stripe/stripe-android/pull/14436) Fixed a rare race condition which could result in the payment sheet being half-visible on screen.
+* [FIXED][14248](https://github.com/stripe/stripe-android/issues/14248) Deferred intent failures are now displayed after pending PaymentSheet navigation completes.
 
 ## 23.18.0 - 2026-09-08
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/paymentsheet/PaymentSheetDeferredTest.kt
@@ -519,6 +519,51 @@ internal class PaymentSheetDeferredTest(
         testContext.markTestSucceeded()
     }
 
+    @Test
+    fun testDeferredIntentFailedCardPayment_forSetup() = runPaymentSheetTest(
+        apiConfigurationTestType = apiConfigurationTestType,
+        networkRule = networkRule,
+        integrationType = integrationType,
+        builder = {
+            createIntentCallback { _, _ ->
+                CreateIntentResult.Failure(
+                    cause = IllegalStateException("Unsupported funding"),
+                    displayMessage = "This card can't be used. Please choose another."
+                )
+            }
+        },
+        resultCallback = ::expectNoResult,
+    ) { testContext ->
+        networkRule.elementsSession { response ->
+            response.testBodyFromFile("elements-sessions-deferred_payment_intent_no_link.json")
+        }
+
+        testContext.presentPaymentSheet {
+            presentWithIntentConfiguration(
+                intentConfiguration = PaymentSheet.IntentConfiguration(
+                    mode = PaymentSheet.IntentConfiguration.Mode.Setup(
+                        setupFutureUse = PaymentSheet.IntentConfiguration.SetupFutureUse.OnSession,
+                    )
+                ),
+                configuration = defaultConfiguration,
+            )
+        }
+
+        page.fillOutCardDetails()
+
+        networkRule.enqueue(
+            method("POST"),
+            path("/v1/payment_methods"),
+        ) { response ->
+            response.testBodyFromFile("payment-methods-create.json")
+        }
+
+        page.clickPrimaryButton()
+
+        page.waitForText("This card can't be used. Please choose another.")
+        testContext.markTestSucceeded()
+    }
+
     @OptIn(DelicatePaymentSheetApi::class)
     @Test
     fun testDeferredIntentCardPaymentWithForcedSuccess() = runPaymentSheetTest(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -389,6 +389,9 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                         }
                     }
                     is ConfirmationHandler.State.Complete -> {
+                        if (state.result is ConfirmationHandler.Result.Failed) {
+                            navigationHandler.awaitTransition()
+                        }
                         paymentMethodMetadata.value?.let {
                             initializeNavigationStateIfNeeded(metadata = it)
                         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/navigation/NavigationHandler.kt
@@ -5,9 +5,11 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
 import java.io.Closeable
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration.Companion.milliseconds
@@ -39,6 +41,7 @@ internal class NavigationHandler<T : Any>(
     private val initialScreen = this.initialBackStack.first()
 
     private val isTransitioning = AtomicBoolean(false)
+    private val transitionCompleted = MutableStateFlow(true)
 
     // A screen queued by [transitionToWithDelay] whose transition has not been applied yet. Tracked
     // so it can still be closed if [closeScreens] runs (e.g. the activity is destroyed) before the
@@ -92,6 +95,10 @@ internal class NavigationHandler<T : Any>(
             // instead of leaking it, since it never enters the back stack.
             target.onClose()
         }
+    }
+
+    suspend fun awaitTransition() {
+        transitionCompleted.first { it }
     }
 
     private fun transitionToInternal(target: T) {
@@ -179,11 +186,18 @@ internal class NavigationHandler<T : Any>(
 
     private fun navigateWithDelay(action: () -> Unit): Boolean {
         return if (!isTransitioning.getAndSet(true)) {
+            transitionCompleted.value = false
             // Introduce a delay to show ripple.
             coroutineScope.launch {
-                delay(250.milliseconds)
-                action()
-                isTransitioning.set(false)
+                try {
+                    delay(250.milliseconds)
+                    action()
+                    // Let collectors react to the new screen before reporting that the transition is complete.
+                    yield()
+                } finally {
+                    isTransitioning.set(false)
+                    transitionCompleted.value = true
+                }
             }
             true
         } else {

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/navigation/NavigationHandlerTest.kt
@@ -7,9 +7,13 @@ import com.stripe.android.testing.CleanupTestRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import org.junit.Rule
 import org.junit.Test
 import java.io.Closeable
@@ -197,6 +201,41 @@ internal class NavigationHandlerTest {
             assertThat(awaitItem()).isEqualTo(screenTwo)
             assertThat(navigationHandler.canGoBack).isTrue()
         }
+    }
+
+    @Test
+    fun `awaitTransition resumes after screen observers handle delayed transition`() = runTest {
+        val testScope = TestScope()
+        val navigationHandler = NavigationHandler<TestScreen>(
+            coroutineScope = testScope,
+            initialScreen = LoadingScreen,
+        ) {}
+        val screenChangeHandled = MutableStateFlow(false)
+        val completion = Turbine<Boolean>()
+
+        testScope.launch {
+            navigationHandler.currentScreen.drop(1).collect {
+                yield()
+                screenChangeHandled.value = true
+            }
+        }
+        testScope.launch {
+            navigationHandler.awaitTransition()
+            completion.add(screenChangeHandled.value)
+        }
+
+        testScope.testScheduler.runCurrent()
+        navigationHandler.transitionToWithDelay(FakeScreen())
+        testScope.launch {
+            navigationHandler.awaitTransition()
+            completion.add(screenChangeHandled.value)
+        }
+
+        assertThat(completion.awaitItem()).isFalse()
+        completion.expectNoEvents()
+        testScope.testScheduler.advanceTimeBy(251.milliseconds)
+        assertThat(completion.awaitItem()).isTrue()
+        completion.ensureAllEventsConsumed()
     }
 
     @Test


### PR DESCRIPTION
# Summary
- Wait for pending PaymentSheet navigation and screen observers before displaying deferred intent failures.
- Add coverage for immediate `CreateIntentResult.Failure` responses in deferred Setup mode.

Committed and created by Codex.

# Motivation
Fixes [#14248](https://github.com/stripe/stripe-android/issues/14248). An immediate deferred-intent failure could be emitted before a pending navigation transition completed, allowing the transition's error reset to silently discard the merchant's `displayMessage`.

# Testing
- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

- `./gradlew :paymentsheet:compileDebugKotlin :paymentsheet:testDebugUnitTest :paymentsheet:detekt :paymentsheet:apiCheck :paymentsheet:verifyPaparazziDebug`
- `./gradlew :paymentsheet:connectedDebugAndroidTest "-Pandroid.testInstrumentationRunnerArguments.class=com.stripe.android.paymentsheet.PaymentSheetDeferredTest#testDeferredIntentFailedCardPayment_forSetup[PaymentConfigurationOnly]"`
- `./gradlew :paymentsheet:lintDebug` *(blocked by the existing `ViewModelConstructorInComposable` error in untouched `AutocompleteScreenTest.kt`)*

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| Not applicable | Not applicable |

# Changelog
Added a PaymentSheet bug-fix entry for deferred intent failure messages.
