### PR TITLE
Provide API configuration from payment method metadata

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/injection/CheckoutControllerComponent.kt
@@ -59,6 +59,7 @@ import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.injection.ApiConfigurationResolverModule
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
@@ -118,6 +119,7 @@ import javax.inject.Singleton
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
         NfcScanningAvailabilityModule::class,
         PaymentOptionCardArtModule::class,
+        ApiConfigurationModule::class,
         ApiConfigurationResolverModule::class,
     ],
 )

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddViewModelComponent.kt
@@ -66,6 +66,7 @@ import com.stripe.android.paymentsheet.DefaultPrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -94,6 +95,7 @@ import javax.inject.Singleton
         DefaultIntentConfirmationModule::class,
         LinkInlineSignupConfirmationModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         TapToAddViewModelModule::class,
         TapToAddModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/injection/CustomerSheetViewModelComponent.kt
@@ -10,6 +10,7 @@ import com.stripe.android.customersheet.CustomerSheetViewModel
 import com.stripe.android.googlepaylauncher.injection.GooglePayLauncherModule
 import com.stripe.android.networking.PaymentElementRequestSurfaceModule
 import com.stripe.android.paymentelement.confirmation.injection.CustomerSheetConfirmationModule
+import com.stripe.android.payments.core.injection.ApiConfigurationFromNamedModule
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import dagger.BindsInstance
@@ -25,6 +26,7 @@ import dagger.Component
         PaymentElementRequestSurfaceModule::class,
         GooglePayLauncherModule::class,
         PaymentOptionCardArtModule::class,
+        ApiConfigurationFromNamedModule::class,
     ],
 )
 internal interface CustomerSheetViewModelComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/LinkControllerComponent.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.link.LinkController
 import com.stripe.android.networking.RequestSurface
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import dagger.BindsInstance
 import dagger.Component
@@ -14,6 +15,7 @@ import javax.inject.Singleton
 @Component(
     modules = [
         LinkControllerModule::class,
+        ApiConfigurationModule::class,
         PaymentMethodMessagePromotionsExperimentHandlerModule::class,
     ]
 )

--- a/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/injection/NativeLinkComponent.kt
@@ -32,6 +32,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.addresselement.AutocompleteLauncher
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.uicore.navigation.NavigationManager
 import dagger.BindsInstance
 import dagger.Component
@@ -50,6 +51,7 @@ internal annotation class NativeLinkScope
         DefaultConfirmationModule::class,
         DefaultIntentConfirmationModule::class,
         LinkPassthroughConfirmationModule::class,
+        ApiConfigurationModule::class,
     ]
 )
 internal interface NativeLinkComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationModule.kt
@@ -1,15 +1,10 @@
 package com.stripe.android.paymentelement.confirmation.challenge
 
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmerModule
-import com.stripe.android.core.ApiConfiguration
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.multibindings.IntoSet
-import javax.inject.Named
 
 @Module(includes = [PassiveChallengeWarmerModule::class])
 internal interface PassiveChallengeConfirmationModule {
@@ -19,15 +14,4 @@ internal interface PassiveChallengeConfirmationModule {
     fun bindsPassiveChallengeConfirmationDefinition(
         definition: PassiveChallengeConfirmationDefinition
     ): ConfirmationDefinition<*, *, *, *>
-
-    companion object {
-        @Provides
-        fun provideApiConfiguration(
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-            @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
-        ): ApiConfiguration.State = ApiConfiguration.State(
-            publishableKey = publishableKeyProvider(),
-            stripeAccountId = stripeAccountIdProvider(),
-        )
-    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedCommonModule.kt
@@ -31,6 +31,7 @@ import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
 import com.stripe.android.paymentsheet.analytics.DefaultEventReporter
 import com.stripe.android.paymentsheet.analytics.EventReporter
 import com.stripe.android.paymentsheet.analytics.LoadingEventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.repositories.CustomerApiRepository
 import com.stripe.android.paymentsheet.repositories.CustomerRepository
 import com.stripe.android.paymentsheet.repositories.DefaultSavedPaymentMethodRepository
@@ -53,6 +54,7 @@ import kotlin.coroutines.CoroutineContext
         PaymentsIntegrityModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentConfigurationModule::class,
+        ApiConfigurationModule::class,
         StripeNetworkClientModule::class,
         PaymentOptionCardArtModule::class,
         NfcScanningAvailabilityModule::class,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/FlowControllerStateComponent.kt
@@ -19,6 +19,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.LinkHandler
 import com.stripe.android.paymentsheet.analytics.EventReporter
+import com.stripe.android.paymentsheet.injection.ApiConfigurationModule
 import com.stripe.android.paymentsheet.injection.LinkHoldbackExposureModule
 import com.stripe.android.paymentsheet.injection.PaymentMethodMessagePromotionsExperimentHandlerModule
 import com.stripe.android.paymentsheet.injection.PaymentSheetCommonModule
@@ -39,6 +40,7 @@ import javax.inject.Singleton
         ExtendedPaymentElementConfirmationModule::class,
         TapToAddConnectionStarterModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         FlowControllerModule::class,
         GooglePayLauncherModule::class,
@@ -48,7 +50,7 @@ import javax.inject.Singleton
         ElementsSessionClientParamsModule::class,
         LinkHoldbackExposureModule::class,
         PaymentMethodMessagePromotionsHelperModule::class,
-        PaymentMethodMessagePromotionsExperimentHandlerModule::class
+        PaymentMethodMessagePromotionsExperimentHandlerModule::class,
     ]
 )
 internal interface FlowControllerStateComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/ApiConfigurationModule.kt
@@ -1,0 +1,15 @@
+package com.stripe.android.paymentsheet.injection
+
+import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
+import dagger.Module
+import dagger.Provides
+import javax.inject.Provider
+
+@Module
+internal object ApiConfigurationModule {
+    @Provides
+    fun provideApiConfiguration(
+        paymentMethodMetadata: Provider<PaymentMethodMetadata?>
+    ): ApiConfiguration.State = requireNotNull(paymentMethodMetadata.get()?.apiConfiguration)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentOptionsViewModelFactoryComponent.kt
@@ -18,13 +18,14 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentOptionsViewModelModule::class,
         PaymentSheetAutocompleteModule::class,
         ElementsSessionClientParamsModule::class,
         CoroutineContextModule::class,
         CoreCommonModule::class,
-        PaymentMethodMessagePromotionsExperimentHandlerModule::class
+        PaymentMethodMessagePromotionsExperimentHandlerModule::class,
     ]
 )
 internal interface PaymentOptionsViewModelFactoryComponent {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/injection/PaymentSheetLauncherComponent.kt
@@ -23,6 +23,7 @@ import javax.inject.Singleton
     modules = [
         StripeRepositoryModule::class,
         PaymentSheetCommonModule::class,
+        ApiConfigurationModule::class,
         PaymentElementRequestSurfaceModule::class,
         PaymentSheetLauncherModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/ExtendedPaymentElementConfirmationTestActivity.kt
@@ -45,6 +45,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.ExtendedPaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationFromNamedModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PaymentOptionCardArtModule
@@ -128,6 +129,7 @@ internal class ExtendedPaymentElementConfirmationTestActivity : AppCompatActivit
 @Component(
     modules = [
         ElementsSessionClientParamsModule::class,
+        ApiConfigurationFromNamedModule::class,
         ExtendedPaymentElementConfirmationModule::class,
         ExtendedPaymentElementConfirmationTestModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/PaymentElementConfirmationTestActivity.kt
@@ -44,6 +44,7 @@ import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentif
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayPaymentDataUpdateNoOpModule
 import com.stripe.android.paymentelement.confirmation.injection.PaymentElementConfirmationModule
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationFromNamedModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PrefsRepository
@@ -124,6 +125,7 @@ internal class PaymentElementConfirmationTestActivity : AppCompatActivity() {
 @Component(
     modules = [
         ElementsSessionClientParamsModule::class,
+        ApiConfigurationFromNamedModule::class,
         PaymentElementConfirmationModule::class,
         PaymentElementConfirmationTestModule::class,
         GooglePayLauncherModule::class,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/lpms/foundations/LpmNetworkTestActivity.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentelement.confirmation.injection.DefaultConfirmat
 import com.stripe.android.paymentelement.confirmation.intent.DefaultIntentConfirmationModule
 import com.stripe.android.paymentelement.confirmation.lpms.foundations.network.StripeNetworkTestClient
 import com.stripe.android.payments.core.analytics.ErrorReporter
+import com.stripe.android.payments.core.injection.ApiConfigurationFromNamedModule
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import com.stripe.android.payments.core.injection.StripeRepositoryModule
 import com.stripe.android.paymentsheet.FakePrefsRepository
@@ -132,6 +133,7 @@ internal class LpmNetworkTestActivity : AppCompatActivity() {
 @Component(
     modules = [
         ElementsSessionClientParamsModule::class,
+        ApiConfigurationFromNamedModule::class,
         StripeRepositoryModule::class,
         PaymentElementRequestSurfaceModule::class,
         DefaultConfirmationModule::class,


### PR DESCRIPTION
# Summary

Provide `ApiConfiguration.State` canonically from `PaymentMethodMetadata` in PaymentSheet-owned graphs.

Changed classes and entry points:

- `ApiConfigurationModule`: Add a lazy metadata-backed API configuration binding.
- `PassiveChallengeConfirmationModule`: Remove its unrelated named-key API configuration binding.
- `PaymentSheetLauncherComponent`, `PaymentOptionsViewModelFactoryComponent`, and `FlowControllerStateComponent`: Install the canonical metadata-backed binding.
- `EmbeddedCommonModule` and `TapToAddViewModelComponent`: Install the canonical binding for Embedded and Tap-to-Add graphs.
- `CheckoutControllerComponent`, `LinkControllerComponent`, and `NativeLinkComponent`: Install the canonical binding for their metadata-owning confirmation graphs.
- `CustomerSheetViewModelComponent`: Explicitly retain named-key configuration because this graph does not own `PaymentMethodMetadata`.
- Confirmation test components: Explicitly use the named-key binding because their test graphs provide named keys rather than metadata.

Committed and created by Codex.

# Motivation

Several Dagger graphs obtained API configuration accidentally from `PassiveChallengeConfirmationModule`. Centralizing the metadata-backed binding makes configuration ownership explicit and ensures PaymentSheet integrations use the resolved API configuration instead of global `PaymentConfiguration`.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

# Screenshots

Not applicable — dependency injection changes only.

# Changelog

Not applicable — no public or intended user-visible behavior change.
