### PR TITLE
Use payment method metadata for passive challenge configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinition.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.challenge.passive.PassiveChallengeActivityContract
 import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
@@ -20,12 +19,10 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
 import javax.inject.Inject
 import javax.inject.Named
-import javax.inject.Provider
 
 internal class PassiveChallengeConfirmationDefinition @Inject constructor(
     private val errorReporter: ErrorReporter,
     private val passiveChallengeWarmer: PassiveChallengeWarmer,
-    private val apiConfigurationProvider: Provider<ApiConfiguration.State>,
     @Named(PRODUCT_USAGE) private val productUsage: Set<String>,
     private val isEligibleForConfirmationChallenge: IsEligibleForConfirmationChallenge
 ) : ConfirmationDefinition<
@@ -45,7 +42,7 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
         val passiveCaptchaParams = paymentMethodMetadata.passiveCaptchaParams ?: return
         passiveChallengeWarmer.start(
             passiveCaptchaParams = passiveCaptchaParams,
-            apiConfiguration = apiConfigurationProvider.get(),
+            apiConfiguration = paymentMethodMetadata.apiConfiguration,
             productUsage = productUsage
         )
     }
@@ -108,7 +105,7 @@ internal class PassiveChallengeConfirmationDefinition @Inject constructor(
             return ConfirmationDefinition.Action.Launch(
                 launcherArguments = PassiveChallengeActivityContract.Args(
                     passiveCaptchaParams,
-                    apiConfiguration = apiConfigurationProvider.get(),
+                    apiConfiguration = confirmationArgs.paymentMethodMetadata.apiConfiguration,
                     productUsage = productUsage
                 ),
                 receivesResultInProcess = false,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationModule.kt
@@ -1,15 +1,10 @@
 package com.stripe.android.paymentelement.confirmation.challenge
 
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmerModule
-import com.stripe.android.core.ApiConfiguration
-import com.stripe.android.core.injection.PUBLISHABLE_KEY
-import com.stripe.android.core.injection.STRIPE_ACCOUNT_ID
 import com.stripe.android.paymentelement.confirmation.ConfirmationDefinition
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.multibindings.IntoSet
-import javax.inject.Named
 
 @Module(includes = [PassiveChallengeWarmerModule::class])
 internal interface PassiveChallengeConfirmationModule {
@@ -19,15 +14,4 @@ internal interface PassiveChallengeConfirmationModule {
     fun bindsPassiveChallengeConfirmationDefinition(
         definition: PassiveChallengeConfirmationDefinition
     ): ConfirmationDefinition<*, *, *, *>
-
-    companion object {
-        @Provides
-        fun provideApiConfiguration(
-            @Named(PUBLISHABLE_KEY) publishableKeyProvider: () -> String,
-            @Named(STRIPE_ACCOUNT_ID) stripeAccountIdProvider: () -> String?,
-        ): ApiConfiguration.State = ApiConfiguration.State(
-            publishableKey = publishableKeyProvider(),
-            stripeAccountId = stripeAccountIdProvider(),
-        )
-    }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationDefinitionTest.kt
@@ -4,11 +4,11 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.challenge.passive.PassiveChallengeActivityContract
 import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
-import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.FeatureFlags
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.AndroidVerificationObject
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
@@ -192,6 +192,8 @@ internal class PassiveChallengeConfirmationDefinitionTest {
 
         assertThat(launchAction.launcherArguments.passiveCaptchaParams)
             .isEqualTo(CONFIRMATION_PARAMETERS.paymentMethodMetadata.passiveCaptchaParams)
+        assertThat(launchAction.launcherArguments.apiConfiguration)
+            .isEqualTo(CONFIRMATION_PARAMETERS.paymentMethodMetadata.apiConfiguration)
         assertThat(launchAction.receivesResultInProcess).isFalse()
     }
 
@@ -441,7 +443,8 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         )
 
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
-            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS
+            passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
+            apiConfiguration = DEFAULT_API_CONFIG,
         )
 
         definition.bootstrap(paymentMethodMetadata)
@@ -449,9 +452,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
         val startCall = fakePassiveChallengeWarmer.awaitStartCall()
 
         assertThat(startCall.passiveCaptchaParams).isEqualTo(PASSIVE_CAPTCHA_PARAMS)
-        assertThat(startCall.apiConfiguration).isEqualTo(
-            launcherArgs.apiConfiguration
-        )
+        assertThat(startCall.apiConfiguration).isEqualTo(paymentMethodMetadata.apiConfiguration)
         assertThat(startCall.productUsage).isEqualTo(launcherArgs.productUsage)
     }
 
@@ -608,14 +609,12 @@ internal class PassiveChallengeConfirmationDefinitionTest {
     private fun createPassiveChallengeConfirmationDefinition(
         errorReporter: ErrorReporter = FakeErrorReporter(),
         passiveChallengeWarmer: PassiveChallengeWarmer = FakePassiveChallengeWarmer(),
-        apiConfiguration: ApiConfiguration.State = launcherArgs.apiConfiguration,
         productUsage: Set<String> = launcherArgs.productUsage,
         isEligibleForConfirmationChallenge: IsEligibleForConfirmationChallenge =
             FakeIsEligibleForConfirmationChallenge()
     ): PassiveChallengeConfirmationDefinition {
         return PassiveChallengeConfirmationDefinition(
             errorReporter = errorReporter,
-            apiConfigurationProvider = { apiConfiguration },
             productUsage = productUsage,
             passiveChallengeWarmer = passiveChallengeWarmer,
             isEligibleForConfirmationChallenge = isEligibleForConfirmationChallenge
@@ -645,7 +644,7 @@ internal class PassiveChallengeConfirmationDefinitionTest {
 
         private val launcherArgs = PassiveChallengeActivityContract.Args(
             passiveCaptchaParams = PASSIVE_CAPTCHA_PARAMS,
-            apiConfiguration = ApiConfiguration.State("pk_123", "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
             productUsage = setOf("PaymentSheet")
         )
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationFlowTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/confirmation/challenge/PassiveChallengeConfirmationFlowTest.kt
@@ -3,7 +3,7 @@ package com.stripe.android.paymentelement.confirmation.challenge
 import com.stripe.android.challenge.passive.PassiveChallengeActivityContract
 import com.stripe.android.challenge.passive.PassiveChallengeActivityResult
 import com.stripe.android.challenge.passive.warmer.PassiveChallengeWarmer
-import com.stripe.android.core.ApiConfiguration
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.PassiveCaptchaParams
 import com.stripe.android.model.PaymentMethodCreateParamsFixtures
 import com.stripe.android.paymentelement.confirmation.CONFIRMATION_PARAMETERS
@@ -83,7 +83,7 @@ internal class PassiveChallengeConfirmationFlowTest {
                 rqData = null,
                 tokenTimeoutSeconds = null
             ),
-            apiConfiguration = ApiConfiguration.State("pk_123", "acct_123"),
+            apiConfiguration = DEFAULT_API_CONFIG,
             productUsage = setOf("PaymentSheet")
         )
     }
@@ -96,7 +96,6 @@ internal class PassiveChallengeConfirmationFlowTest {
     ) = PassiveChallengeConfirmationDefinition(
         errorReporter = errorReporter,
         passiveChallengeWarmer = passiveChallengeWarmer,
-        apiConfigurationProvider = { ApiConfiguration.State("pk_123", "acct_123") },
         productUsage = setOf("PaymentSheet"),
         isEligibleForConfirmationChallenge = isEligibleForConfirmationChallenge,
     )


### PR DESCRIPTION
## Summary

Use the API configuration already carried by `PaymentMethodMetadata` when warming and launching passive challenges. Remove the redundant injected API configuration provider and its Dagger binding.

## Motivation and Context

Passive challenge confirmation receives payment method metadata during both bootstrap and confirmation. Reading configuration from that metadata ensures the challenge uses the configuration resolved for the current PaymentSheet instance and avoids maintaining a separate graph-level binding.

## Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Committed and created by Codex.