### PR TITLE
Use request options in intent status poller

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.polling
 
 import androidx.annotation.RestrictTo
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.StripeIntent
 import com.stripe.android.networking.StripeRepository
@@ -19,7 +18,7 @@ import kotlin.time.Duration.Companion.seconds
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultIntentStatusPoller @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val paymentConfigProvider: Provider<PaymentConfiguration>,
+    private val requestOptionsProvider: Provider<ApiRequest.Options>,
     private val config: IntentStatusPoller.Config,
     private val dispatcher: CoroutineDispatcher,
 ) : IntentStatusPoller {
@@ -56,13 +55,9 @@ class DefaultIntentStatusPoller @Inject constructor(
     }
 
     private suspend fun fetchIntentStatus(): StripeIntent.Status? {
-        val paymentConfig = paymentConfigProvider.get()
         val paymentIntent = stripeRepository.retrievePaymentIntent(
             clientSecret = config.clientSecret,
-            options = ApiRequest.Options(
-                publishableKeyProvider = { paymentConfig.publishableKey },
-                stripeAccountIdProvider = { paymentConfig.stripeAccountId },
-            ),
+            options = requestOptionsProvider.get(),
         )
         return paymentIntent.getOrNull()?.status
     }

--- a/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
+++ b/payments-core/src/main/java/com/stripe/android/polling/DefaultIntentStatusPoller.kt
@@ -12,13 +12,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Provider
 import kotlin.time.Duration.Companion.seconds
 
 @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
 class DefaultIntentStatusPoller @Inject constructor(
     private val stripeRepository: StripeRepository,
-    private val requestOptionsProvider: Provider<ApiRequest.Options>,
+    private val requestOptions: ApiRequest.Options,
     private val config: IntentStatusPoller.Config,
     private val dispatcher: CoroutineDispatcher,
 ) : IntentStatusPoller {
@@ -57,7 +56,7 @@ class DefaultIntentStatusPoller @Inject constructor(
     private suspend fun fetchIntentStatus(): StripeIntent.Status? {
         val paymentIntent = stripeRepository.retrievePaymentIntent(
             clientSecret = config.clientSecret,
-            options = requestOptionsProvider.get(),
+            options = requestOptions,
         )
         return paymentIntent.getOrNull()?.status
     }

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.polling
 
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.StripeIntent
@@ -14,10 +13,10 @@ internal fun createIntentStatusPoller(
 ): DefaultIntentStatusPoller {
     return DefaultIntentStatusPoller(
         stripeRepository = FakeStripeRepository(enqueuedStatuses),
-        paymentConfigProvider = {
-            PaymentConfiguration(
-                publishableKey = "key",
-                stripeAccountId = "account_id",
+        requestOptionsProvider = {
+            ApiRequest.Options(
+                apiKey = "key",
+                stripeAccount = "acct_123",
             )
         },
         config = IntentStatusPoller.Config(

--- a/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
+++ b/payments-core/src/test/java/com/stripe/android/polling/PollingTestUtils.kt
@@ -13,12 +13,10 @@ internal fun createIntentStatusPoller(
 ): DefaultIntentStatusPoller {
     return DefaultIntentStatusPoller(
         stripeRepository = FakeStripeRepository(enqueuedStatuses),
-        requestOptionsProvider = {
-            ApiRequest.Options(
-                apiKey = "key",
-                stripeAccount = "acct_123",
-            )
-        },
+        requestOptions = ApiRequest.Options(
+            apiKey = "key",
+            stripeAccount = "acct_123",
+        ),
         config = IntentStatusPoller.Config(
             clientSecret = "secret",
         ),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/di/PollingViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/di/PollingViewModelModule.kt
@@ -16,7 +16,6 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
-import javax.inject.Provider
 
 @Module(
     subcomponents = [PollingViewModelSubcomponent::class],
@@ -46,7 +45,7 @@ internal interface PollingViewModelModule {
         @Provides
         @Named(PUBLISHABLE_KEY)
         fun providePublishableKeyProvider(
-            requestOptionsProvider: Provider<ApiRequest.Options>
-        ): () -> String = { requestOptionsProvider.get().apiKey }
+            requestOptions: ApiRequest.Options
+        ): () -> String = { requestOptions.apiKey }
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/di/PollingViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/di/PollingViewModelModule.kt
@@ -3,8 +3,9 @@ package com.stripe.android.paymentsheet.paymentdatacollection.polling.di
 import android.app.Application
 import android.content.Context
 import com.stripe.android.core.injection.ENABLE_LOGGING
+import com.stripe.android.core.injection.PUBLISHABLE_KEY
+import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.paymentdatacollection.polling.DefaultTimeProvider
 import com.stripe.android.paymentsheet.paymentdatacollection.polling.TimeProvider
@@ -15,10 +16,11 @@ import dagger.Binds
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
+import javax.inject.Provider
 
 @Module(
     subcomponents = [PollingViewModelSubcomponent::class],
-    includes = [PaymentConfigurationModule::class, PollingAnalyticsModule::class],
+    includes = [PollingAnalyticsModule::class],
 )
 internal interface PollingViewModelModule {
 
@@ -40,5 +42,11 @@ internal interface PollingViewModelModule {
         @Provides
         @Named(ENABLE_LOGGING)
         fun providesEnableLogging(): Boolean = BuildConfig.DEBUG
+
+        @Provides
+        @Named(PUBLISHABLE_KEY)
+        fun providePublishableKeyProvider(
+            requestOptionsProvider: Provider<ApiRequest.Options>
+        ): () -> String = { requestOptionsProvider.get().apiKey }
     }
 }


### PR DESCRIPTION
# Summary

Migrate `DefaultIntentStatusPoller` from `PaymentConfiguration` to injected `ApiRequest.Options` and connect the polling graph to the API configuration passed through polling arguments.

Changed classes and entry points:

- `DefaultIntentStatusPoller`: Uses injected request options when retrieving PaymentIntent status instead of reading `PaymentConfiguration`.
- `PollingComponent`: Derives named credentials and request options from its bound `ApiConfiguration.State`.
- `PollingViewModelModule`: Removes `PaymentConfigurationModule` from the polling graph.
- `PollingTestUtils`: Supplies request options to poller tests.

Committed and created by Codex.

# Motivation

Polling requests must use the credential snapshot passed to the polling activity rather than process-wide mutable configuration.

# Testing

- [x] `./gradlew :payments-core:testDebugUnitTest --tests "com.stripe.android.polling.DefaultIntentStatusPollerTest" :paymentsheet:kspDebugKotlin :paymentsheet:compileDebugUnitTestKotlin`
- [ ] Manually verified

# Screenshots

Not applicable — internal request configuration only.

# Changelog

Not applicable — no public or intended user-visible behavior change.