### PR TITLE
Pass API configuration through ACH flows

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -41,7 +41,6 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentSheetCardBrandFilter
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.CardBrand
-import com.stripe.android.model.ClientAttributionMetadata
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethod.Type.USBankAccount
 import com.stripe.android.model.PaymentMethodCode
@@ -848,7 +847,7 @@ internal class CustomerSheetViewModel(
                 formArguments = formArguments,
                 usBankAccountFormArguments = createDefaultUsBankArguments(
                     stripeIntent,
-                    paymentMethodMetadata.clientAttributionMetadata,
+                    paymentMethodMetadata,
                 ),
                 draftPaymentSelection = null,
                 enabled = true,
@@ -867,7 +866,7 @@ internal class CustomerSheetViewModel(
 
     private fun createDefaultUsBankArguments(
         stripeIntent: StripeIntent?,
-        clientAttributionMetadata: ClientAttributionMetadata,
+        paymentMethodMetadata: PaymentMethodMetadata,
     ): USBankAccountFormArguments {
         return USBankAccountFormArguments(
             instantDebits = false,
@@ -904,7 +903,8 @@ internal class CustomerSheetViewModel(
             termsDisplay = PaymentSheet.TermsDisplay.AUTOMATIC,
             sellerBusinessName = null,
             forceSetupFutureUseBehavior = false,
-            clientAttributionMetadata = clientAttributionMetadata,
+            clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+            apiConfiguration = paymentMethodMetadata.apiConfiguration,
         )
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountForm.kt
@@ -92,6 +92,7 @@ internal fun USBankAccountForm(
                 isPaymentFlow = usBankAccountFormArgs.isPaymentFlow,
                 stripeIntentId = usBankAccountFormArgs.stripeIntentId,
                 clientSecret = usBankAccountFormArgs.clientSecret,
+                apiConfiguration = usBankAccountFormArgs.apiConfiguration,
                 onBehalfOf = usBankAccountFormArgs.onBehalfOf,
                 savedPaymentMethod = usBankAccountFormArgs.draftPaymentSelection as? New.USBankAccount,
                 shippingDetails = usBankAccountFormArgs.shippingDetails,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArguments.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.paymentsheet.paymentdatacollection.ach
 
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.ClientAttributionMetadata
@@ -66,6 +67,7 @@ internal class USBankAccountFormArguments(
     val sellerBusinessName: String?,
     val forceSetupFutureUseBehavior: Boolean,
     val clientAttributionMetadata: ClientAttributionMetadata,
+    val apiConfiguration: ApiConfiguration.State,
 ) {
     companion object {
         fun create(

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormArgumentsFactory.kt
@@ -75,6 +75,7 @@ internal object USBankAccountFormArgumentsFactory {
             sellerBusinessName = paymentMethodMetadata.sellerBusinessName,
             forceSetupFutureUseBehavior = paymentMethodMetadata.forceSetupFutureUseBehaviorAndNewMandate,
             clientAttributionMetadata = paymentMethodMetadata.clientAttributionMetadata,
+            apiConfiguration = paymentMethodMetadata.apiConfiguration,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModel.kt
@@ -9,7 +9,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.CreationExtras
-import com.stripe.android.PaymentConfiguration
+import com.stripe.android.core.ApiConfiguration
 import com.stripe.android.core.strings.ResolvableString
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.core.utils.requireApplication
@@ -69,12 +69,10 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import javax.inject.Provider
 
 internal class USBankAccountFormViewModel @Inject internal constructor(
     private val args: Args,
     private val application: Application,
-    private val lazyPaymentConfig: Provider<PaymentConfiguration>,
     private val savedStateHandle: SavedStateHandle,
     autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory?,
 ) : ViewModel() {
@@ -556,15 +554,15 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
         if (args.isPaymentFlow) {
             collectBankAccountLauncher?.presentWithPaymentIntent(
-                publishableKey = lazyPaymentConfig.get().publishableKey,
-                stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
+                publishableKey = args.apiConfiguration.publishableKey,
+                stripeAccountId = args.apiConfiguration.stripeAccountId,
                 clientSecret = clientSecret,
                 configuration = configuration,
             )
         } else {
             collectBankAccountLauncher?.presentWithSetupIntent(
-                publishableKey = lazyPaymentConfig.get().publishableKey,
-                stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
+                publishableKey = args.apiConfiguration.publishableKey,
+                stripeAccountId = args.apiConfiguration.stripeAccountId,
                 clientSecret = clientSecret,
                 configuration = configuration,
             )
@@ -675,8 +673,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
 
         if (args.isPaymentFlow) {
             collectBankAccountLauncher?.presentWithDeferredPayment(
-                publishableKey = lazyPaymentConfig.get().publishableKey,
-                stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
+                publishableKey = args.apiConfiguration.publishableKey,
+                stripeAccountId = args.apiConfiguration.stripeAccountId,
                 configuration = configuration,
                 elementsSessionId = elementsSessionId,
                 customerId = null,
@@ -686,8 +684,8 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
             )
         } else {
             collectBankAccountLauncher?.presentWithDeferredSetup(
-                publishableKey = lazyPaymentConfig.get().publishableKey,
-                stripeAccountId = lazyPaymentConfig.get().stripeAccountId,
+                publishableKey = args.apiConfiguration.publishableKey,
+                stripeAccountId = args.apiConfiguration.stripeAccountId,
                 configuration = configuration,
                 elementsSessionId = elementsSessionId,
                 customerId = null,
@@ -862,6 +860,7 @@ internal class USBankAccountFormViewModel @Inject internal constructor(
         val isPaymentFlow: Boolean,
         val stripeIntentId: String?,
         val clientSecret: String?,
+        val apiConfiguration: ApiConfiguration.State,
         val onBehalfOf: String?,
         val savedPaymentMethod: PaymentSelection.New.USBankAccount?,
         val shippingDetails: AddressDetails?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/di/USBankAccountFormViewModelModule.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/di/USBankAccountFormViewModelModule.kt
@@ -6,14 +6,12 @@ import android.content.res.Resources
 import com.stripe.android.BuildConfig
 import com.stripe.android.core.injection.ENABLE_LOGGING
 import com.stripe.android.payments.core.injection.PRODUCT_USAGE
-import com.stripe.android.payments.core.injection.PaymentConfigurationModule
 import dagger.Module
 import dagger.Provides
 import javax.inject.Named
 
 @Module(
     subcomponents = [USBankAccountFormViewModelSubcomponent::class],
-    includes = [PaymentConfigurationModule::class],
 )
 internal class USBankAccountFormViewModelModule {
     @Provides

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/CustomerSheetScreenshotTest.kt
@@ -12,6 +12,7 @@ import com.stripe.android.customersheet.ui.CustomerSheetScreen
 import com.stripe.android.lpmfoundations.SupportedPaymentMethodFixtures
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.lpmfoundations.paymentmethod.UiDefinitionFactory
 import com.stripe.android.model.CardBrand
@@ -124,6 +125,7 @@ internal class CustomerSheetScreenshotTest {
         sellerBusinessName = null,
         forceSetupFutureUseBehavior = false,
         clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+        apiConfiguration = DEFAULT_API_CONFIG,
     )
 
     private val selectPaymentMethodViewState = CustomerSheetViewState.SelectPaymentMethod(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -273,7 +273,7 @@ class USBankAccountFormViewModelTest {
 
             viewModel.handlePrimaryButtonClick()
 
-            verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(any(), anyOrNull(), any(), any())
+            verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(any(), any(), any(), any())
         }
 
     @Test
@@ -888,7 +888,7 @@ class USBankAccountFormViewModelTest {
 
         verify(mockCollectBankAccountLauncher).presentWithDeferredPayment(
             publishableKey = any(),
-            stripeAccountId = anyOrNull(),
+            stripeAccountId = any(),
             configuration = eq(
                 CollectBankAccountConfiguration.USBankAccountInternal(
                     name = "Jenny Rose",
@@ -938,7 +938,7 @@ class USBankAccountFormViewModelTest {
 
         verify(mockCollectBankAccountLauncher).presentWithDeferredSetup(
             publishableKey = any(),
-            stripeAccountId = anyOrNull(),
+            stripeAccountId = any(),
             configuration = eq(
                 CollectBankAccountConfiguration.USBankAccountInternal(
                     name = "Jenny Rose",

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -155,18 +155,12 @@ class USBankAccountFormViewModelTest {
     @Test
     fun `collect bank account is callable with initial screen state`() =
         runTest(UnconfinedTestDispatcher()) {
-            val apiConfiguration = DEFAULT_API_CONFIG.copy(
-                publishableKey = "pk_test_view_model_args",
-                stripeAccountId = "acct_view_model_args",
-            )
-            val viewModel = createViewModel(
-                args = defaultArgs.copy(apiConfiguration = apiConfiguration),
-            )
+            val viewModel = createViewModel()
             viewModel.collectBankAccountLauncher = mockCollectBankAccountLauncher
             viewModel.handlePrimaryButtonClick()
             verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(
-                eq(apiConfiguration.publishableKey),
-                eq(apiConfiguration.stripeAccountId),
+                eq(DEFAULT_API_CONFIG.publishableKey),
+                eq(DEFAULT_API_CONFIG.stripeAccountId),
                 any(),
                 any(),
             )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -6,7 +6,6 @@ import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.ApiKeyFixtures
 import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.financialconnections.ElementsSessionContext
@@ -16,6 +15,7 @@ import com.stripe.android.financialconnections.model.FinancialConnectionsSession
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.IS_PAYMENT_METHOD_SET_AS_DEFAULT_ENABLED_DEFAULT_VALUE
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodSaveConsentBehavior
 import com.stripe.android.model.Address
 import com.stripe.android.model.ConfirmPaymentIntentParams
@@ -48,6 +48,7 @@ import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.utils.BankFormScreenStateFactory
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -95,6 +96,7 @@ class USBankAccountFormViewModelTest {
         sellerBusinessName = null,
         forceSetupFutureUseBehavior = false,
         clientAttributionMetadata = PaymentMethodMetadataFixtures.CLIENT_ATTRIBUTION_METADATA,
+        apiConfiguration = DEFAULT_API_CONFIG,
     )
 
     private val mockCollectBankAccountLauncher = mock<CollectBankAccountLauncher>()
@@ -105,6 +107,11 @@ class USBankAccountFormViewModelTest {
 
     @get:Rule
     val viewModelStoreRule = ViewModelStoreTestRule()
+
+    @Before
+    fun setup() {
+        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(), "pk_test_123")
+    }
 
     @Test
     fun `when email and name is valid then required fields are filled`() =
@@ -158,7 +165,7 @@ class USBankAccountFormViewModelTest {
             val viewModel = createViewModel()
             viewModel.collectBankAccountLauncher = mockCollectBankAccountLauncher
             viewModel.handlePrimaryButtonClick()
-            verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(any(), any(), any(), any())
+            verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(any(), anyOrNull(), any(), any())
         }
 
     @Test
@@ -268,7 +275,7 @@ class USBankAccountFormViewModelTest {
 
             viewModel.handlePrimaryButtonClick()
 
-            verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(any(), any(), any(), any())
+            verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(any(), anyOrNull(), any(), any())
         }
 
     @Test
@@ -883,7 +890,7 @@ class USBankAccountFormViewModelTest {
 
         verify(mockCollectBankAccountLauncher).presentWithDeferredPayment(
             publishableKey = any(),
-            stripeAccountId = any(),
+            stripeAccountId = anyOrNull(),
             configuration = eq(
                 CollectBankAccountConfiguration.USBankAccountInternal(
                     name = "Jenny Rose",
@@ -933,7 +940,7 @@ class USBankAccountFormViewModelTest {
 
         verify(mockCollectBankAccountLauncher).presentWithDeferredSetup(
             publishableKey = any(),
-            stripeAccountId = any(),
+            stripeAccountId = anyOrNull(),
             configuration = eq(
                 CollectBankAccountConfiguration.USBankAccountInternal(
                     name = "Jenny Rose",
@@ -2124,14 +2131,9 @@ class USBankAccountFormViewModelTest {
         args: USBankAccountFormViewModel.Args = defaultArgs,
         autocompleteAddressInteractorFactory: AutocompleteAddressInteractor.Factory? = null,
     ): USBankAccountFormViewModel {
-        val paymentConfiguration = PaymentConfiguration(
-            ApiKeyFixtures.FAKE_PUBLISHABLE_KEY,
-            STRIPE_ACCOUNT_ID
-        )
         return USBankAccountFormViewModel(
             args = args,
             application = ApplicationProvider.getApplicationContext(),
-            lazyPaymentConfig = { paymentConfiguration },
             savedStateHandle = savedStateHandle,
             autocompleteAddressInteractorFactory = autocompleteAddressInteractorFactory,
         ).also { viewModelStoreRule.track(it) }
@@ -2194,7 +2196,6 @@ class USBankAccountFormViewModelTest {
         const val MERCHANT_NAME = "merchantName"
         const val CUSTOMER_NAME = "Jenny Rose"
         const val CUSTOMER_EMAIL = "email@email.com"
-        const val STRIPE_ACCOUNT_ID = "stripe_account_id"
         const val CUSTOMER_COUNTRY = "US"
         const val CUSTOMER_PHONE = "+13105551234"
         val CUSTOMER_ADDRESS = PaymentSheet.Address(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/paymentdatacollection/ach/USBankAccountFormViewModelTest.kt
@@ -6,7 +6,6 @@ import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import app.cash.turbine.turbineScope
 import com.google.common.truth.Truth.assertThat
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.model.CountryUtils
 import com.stripe.android.financialconnections.ElementsSessionContext
 import com.stripe.android.financialconnections.model.BankAccount
@@ -48,7 +47,6 @@ import com.stripe.android.uicore.elements.FormFieldId
 import com.stripe.android.utils.BankFormScreenStateFactory
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
-import org.junit.Before
 import org.junit.Rule
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -108,11 +106,6 @@ class USBankAccountFormViewModelTest {
     @get:Rule
     val viewModelStoreRule = ViewModelStoreTestRule()
 
-    @Before
-    fun setup() {
-        PaymentConfiguration.init(ApplicationProvider.getApplicationContext(), "pk_test_123")
-    }
-
     @Test
     fun `when email and name is valid then required fields are filled`() =
         runTest(UnconfinedTestDispatcher()) {
@@ -162,10 +155,21 @@ class USBankAccountFormViewModelTest {
     @Test
     fun `collect bank account is callable with initial screen state`() =
         runTest(UnconfinedTestDispatcher()) {
-            val viewModel = createViewModel()
+            val apiConfiguration = DEFAULT_API_CONFIG.copy(
+                publishableKey = "pk_test_view_model_args",
+                stripeAccountId = "acct_view_model_args",
+            )
+            val viewModel = createViewModel(
+                args = defaultArgs.copy(apiConfiguration = apiConfiguration),
+            )
             viewModel.collectBankAccountLauncher = mockCollectBankAccountLauncher
             viewModel.handlePrimaryButtonClick()
-            verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(any(), anyOrNull(), any(), any())
+            verify(mockCollectBankAccountLauncher).presentWithPaymentIntent(
+                eq(apiConfiguration.publishableKey),
+                eq(apiConfiguration.stripeAccountId),
+                any(),
+                any(),
+            )
         }
 
     @Test


### PR DESCRIPTION
# Summary

Pass the loaded PaymentSheet API credentials through US bank-account form arguments and remove the ACH view model dependency on `PaymentConfiguration`.

Changed classes and entry points:

- `USBankAccountFormArguments`: Add `ApiConfiguration.State` 
- `USBankAccountFormArgumentsFactory`: Source `ApiConfiguration.State` from `PaymentMethodMetadata` .
- `USBankAccountForm`: Passes `ApiConfiguration.State` into the view-model arguments.
- `USBankAccountFormViewModel`: Uses argument credentials for PaymentIntent, SetupIntent, and deferred bank-account collection.
- `USBankAccountFormViewModelModule`: Removes `PaymentConfigurationModule`.
- `CustomerSheetViewModel`: Builds US bank-account arguments from `PaymentMethodMetadata.apiConfiguration`.
- `USBankAccountFormViewModelTest` and `CustomerSheetScreenshotTest`: Update test configuration setup.

Committed and created by Codex.

# Motivation

ACH collection can outlive its originating PaymentSheet load and must use the immutable credential snapshot associated with that instance rather than process-wide configuration.

# Testing

- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

# Screenshots

Not applicable — internal configuration plumbing only.

# Changelog

Not applicable — no public or intended user-visible behavior change.