### PR TITLE
Use typed state for embedded sheet activities

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -2,7 +2,6 @@ package com.stripe.android.checkout
 
 import android.app.Application
 import android.graphics.drawable.Drawable
-import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.ComponentActivity
 import androidx.annotation.RestrictTo
@@ -23,6 +22,7 @@ import com.stripe.android.elements.ShippingAddressElement
 import com.stripe.android.elements.ece.ExpressButtonType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -340,7 +340,7 @@ class CheckoutController @Inject internal constructor(
                 copy(
                     paymentSelection = null,
                     temporarySelection = null,
-                    previousNewSelections = Bundle(),
+                    previousNewSelections = PreviousNewSelections.empty,
                 )
             },
         ) {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -1,19 +1,22 @@
 package com.stripe.android.checkout
 
 import android.graphics.Bitmap
-import android.os.Bundle
 import android.os.Parcelable
 import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.elements.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
+import com.stripe.android.paymentelement.embedded.PreviousNewSelectionsParceler
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 
 @OptIn(CheckoutSessionPreview::class)
 @Parcelize
+@TypeParceler<PreviousNewSelections, PreviousNewSelectionsParceler>()
 internal data class CheckoutControllerState(
     val configuration: CheckoutController.Configuration.State,
     val checkoutSessionResponse: CheckoutSessionResponse,
@@ -24,7 +27,7 @@ internal data class CheckoutControllerState(
     val embeddedConfiguration: EmbeddedPaymentElement.Configuration,
     val paymentSelection: PaymentSelection?,
     val temporarySelection: String?,
-    val previousNewSelections: Bundle,
+    val previousNewSelections: PreviousNewSelections,
     val linkEagerPresentationSuppressed: Boolean,
 ) : Parcelable {
     fun asCheckoutSession(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -1,14 +1,12 @@
 package com.stripe.android.checkout
 
-import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.checkout.CheckoutController.Session
 import com.stripe.android.elements.ece.AvailableExpressButtonTypesFactory
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.previousNewSelection
-import com.stripe.android.paymentelement.embedded.stashNewSelection
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.uicore.utils.mapAsStateFlow
@@ -54,17 +52,14 @@ internal class CheckoutControllerStateHolder @Inject constructor(
     override val temporarySelection: StateFlow<String?> =
         stateFlow.mapAsStateFlow { it?.temporarySelection }
 
-    override val previousNewSelections: Bundle
-        get() = state?.previousNewSelections ?: Bundle()
+    override val previousNewSelections: PreviousNewSelections
+        get() = state?.previousNewSelections ?: PreviousNewSelections.empty
 
     override fun setSelection(updatedSelection: PaymentSelection?) {
         val current = requireState(operation = "setSelection") ?: return
-        val previousNewSelections = Bundle(current.previousNewSelections).apply {
-            stashNewSelection(updatedSelection)
-        }
         state = current.copy(
             paymentSelection = updatedSelection,
-            previousNewSelections = previousNewSelections,
+            previousNewSelections = current.previousNewSelections.updatedWith(updatedSelection),
         )
     }
 
@@ -73,16 +68,20 @@ internal class CheckoutControllerStateHolder @Inject constructor(
         state = current.copy(temporarySelection = code)
     }
 
-    override fun setPreviousNewSelections(bundle: Bundle) {
+    override fun setPreviousNewSelections(selections: PreviousNewSelections) {
         val current = requireState(operation = "setPreviousNewSelections") ?: return
-        val previousNewSelections = Bundle(current.previousNewSelections).apply {
-            putAll(bundle)
-        }
-        state = current.copy(previousNewSelections = previousNewSelections)
+        state = current.copy(
+            previousNewSelections = current.previousNewSelections.mergedWith(selections),
+        )
+    }
+
+    override fun clearPreviousNewSelections() {
+        val current = requireState(operation = "clearPreviousNewSelections") ?: return
+        state = current.copy(previousNewSelections = PreviousNewSelections.empty)
     }
 
     override fun getPreviousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
-        return previousNewSelections.previousNewSelection(code)
+        return previousNewSelections[code]
     }
 
     /**

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -13,8 +13,8 @@ import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
@@ -85,7 +85,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         )
     }
 
-    private val activityLauncher: ActivityResultLauncher<EmbeddedActivityArgs> =
+    private val activityLauncher: ActivityResultLauncher<EmbeddedActivityState> =
         activityResultCaller.registerForActivityResult(EmbeddedSheetContract) { result ->
             launcherState.isAwaitingPaymentOptionsReady = false
             sheetStateHolder.sheetIsOpen = false
@@ -195,20 +195,13 @@ internal class CheckoutSheetLauncher @Inject constructor(
         val currentSelection = (selectionHolder.selection.value as? PaymentSelection.New?)
             .takeIf { it?.paymentMethodType == code }
             ?: selectionHolder.getPreviousNewSelection(code)
-        val args = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = configuration,
-            productUsage = productUsage,
-            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
-            statusBarColor = statusBarColor,
-            selection = currentSelection,
+        val args = EmbeddedActivityState.Ready.Form(
+            context = createContext(paymentMethodMetadata, configuration),
+            selectedPaymentMethodCode = code,
+            initialSelection = currentSelection,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = listOfNotNull(promotion),
-            launchMode = EmbeddedLaunchMode.Form(
-                selectedPaymentMethodCode = code,
-            ),
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            promotion = promotion,
         )
         activityLauncher.launch(args)
     }
@@ -227,18 +220,11 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
-        val args = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = configuration,
-            productUsage = productUsage,
-            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
-            statusBarColor = statusBarColor,
-            selection = selection,
+        val args = EmbeddedActivityState.Ready.Manage(
+            context = createContext(paymentMethodMetadata, configuration),
+            initialSelection = selection,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.Manage,
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -257,19 +243,17 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
-        val initialArgs = createPaymentOptionsArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = configuration,
-            selection = selection,
-            customerState = customerState,
-            presentationState = if (operationCoordinator.isUpdating.value) {
-                EmbeddedActivityArgs.PresentationState.Loading
-            } else {
-                EmbeddedActivityArgs.PresentationState.Ready
-            },
-        )
-        launcherState.isAwaitingPaymentOptionsReady =
-            initialArgs.presentationState == EmbeddedActivityArgs.PresentationState.Loading
+        val initialArgs = if (operationCoordinator.isUpdating.value) {
+            EmbeddedActivityState.LoadingPaymentOptions(
+                context = createContext(paymentMethodMetadata, configuration),
+                initialSelection = selection,
+                previousNewSelections = selectionHolder.previousNewSelections,
+                customerState = customerState,
+            )
+        } else {
+            createPaymentOptionsArgs(paymentMethodMetadata, customerState, selection, configuration)
+        }
+        launcherState.isAwaitingPaymentOptionsReady = initialArgs is EmbeddedActivityState.LoadingPaymentOptions
         activityLauncher.launch(initialArgs)
 
         resumePendingReadyLaunch()
@@ -298,7 +282,6 @@ internal class CheckoutSheetLauncher @Inject constructor(
                     configuration = refreshedState.configuration,
                     selection = selectionHolder.selection.value,
                     customerState = customerStateHolder.customer.value,
-                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
                 )
             )
             launcherState.isAwaitingPaymentOptionsReady = false
@@ -310,20 +293,25 @@ internal class CheckoutSheetLauncher @Inject constructor(
         customerState: CustomerState?,
         selection: PaymentSelection?,
         configuration: EmbeddedPaymentElement.Configuration,
-        presentationState: EmbeddedActivityArgs.PresentationState,
-    ): EmbeddedActivityArgs {
-        return EmbeddedActivityArgs(
+    ): EmbeddedActivityState.Ready.PaymentOptions {
+        return EmbeddedActivityState.Ready.PaymentOptions(
+            context = createContext(paymentMethodMetadata, configuration),
+            initialSelection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
+            customerState = customerState,
+        )
+    }
+
+    private fun createContext(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        configuration: EmbeddedPaymentElement.Configuration,
+    ): EmbeddedActivityState.Context {
+        return EmbeddedActivityState.Context(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
             productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
-            selection = selection,
-            previousNewSelections = selectionHolder.previousNewSelections,
-            customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.PaymentOptions,
-            presentationState = presentationState,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -1,12 +1,12 @@
 package com.stripe.android.checkout
 
 import android.graphics.Bitmap
-import android.os.Bundle
 import com.stripe.android.common.model.CommonConfiguration
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -181,7 +181,7 @@ internal class CheckoutStateLoader @Inject constructor(
         val cachedFlagImages: Map<String, Bitmap>?,
         val previousSelection: PaymentSelection?,
         val temporarySelection: String?,
-        val previousNewSelections: Bundle,
+        val previousNewSelections: PreviousNewSelections,
         val linkEagerPresentationSuppressed: Boolean,
     ) {
         companion object {
@@ -189,7 +189,7 @@ internal class CheckoutStateLoader @Inject constructor(
                 cachedFlagImages = null,
                 previousSelection = null,
                 temporarySelection = null,
-                previousNewSelections = Bundle(),
+                previousNewSelections = PreviousNewSelections.empty,
                 linkEagerPresentationSuppressed = false,
             )
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/EmbeddedPaymentElement.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement
 
 import android.app.Activity
 import android.graphics.drawable.Drawable
-import android.os.Bundle
 import android.os.Parcelable
 import androidx.activity.result.ActivityResultCaller
 import androidx.annotation.RestrictTo
@@ -23,6 +22,8 @@ import com.stripe.android.model.PaymentIntent
 import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.SetupIntent
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
+import com.stripe.android.paymentelement.embedded.PreviousNewSelectionsParceler
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationCoordinator
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfirmationStateHolder
@@ -45,6 +46,7 @@ import com.stripe.android.uicore.utils.collectAsState
 import dev.drewhamilton.poko.Poko
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 import javax.inject.Inject
 
 @EmbeddedPaymentElementScope
@@ -766,10 +768,11 @@ class EmbeddedPaymentElement @Inject internal constructor(
      */
     @Poko
     @Parcelize
+    @TypeParceler<PreviousNewSelections, PreviousNewSelectionsParceler>()
     class State internal constructor(
         internal val confirmationState: EmbeddedConfirmationStateHolder.State,
         internal val customer: CustomerState?,
-        internal val previousNewSelections: Bundle,
+        internal val previousNewSelections: PreviousNewSelections,
     ) : Parcelable
 
     internal companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolder.kt
@@ -12,32 +12,48 @@ import javax.inject.Singleton
 internal class DefaultEmbeddedSelectionHolder @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) : EmbeddedSelectionHolder {
+    init {
+        persistPreviousNewSelections(readPreviousNewSelections())
+    }
+
     override val selection: StateFlow<PaymentSelection?> =
         savedStateHandle.getStateFlow(EMBEDDED_SELECTION_KEY, null)
     override val temporarySelection: StateFlow<String?> =
         savedStateHandle.getStateFlow(EMBEDDED_TEMPORARY_SELECTION_KEY, null)
-    override val previousNewSelections: Bundle = savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY]
-        ?: Bundle().also {
-            savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = it
-        }
+    override val previousNewSelections: PreviousNewSelections
+        get() = readPreviousNewSelections()
 
     override fun setSelection(updatedSelection: PaymentSelection?) {
         savedStateHandle[EMBEDDED_SELECTION_KEY] = updatedSelection
-        previousNewSelections.stashNewSelection(updatedSelection)
-        savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = previousNewSelections
+        persistPreviousNewSelections(previousNewSelections.updatedWith(updatedSelection))
     }
 
     override fun setTemporarySelection(code: PaymentMethodCode?) {
         savedStateHandle[EMBEDDED_TEMPORARY_SELECTION_KEY] = code
     }
 
-    override fun setPreviousNewSelections(bundle: Bundle) {
-        this.previousNewSelections.putAll(bundle)
-        savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = previousNewSelections
+    override fun setPreviousNewSelections(selections: PreviousNewSelections) {
+        persistPreviousNewSelections(previousNewSelections.mergedWith(selections))
+    }
+
+    override fun clearPreviousNewSelections() {
+        persistPreviousNewSelections(PreviousNewSelections.empty)
     }
 
     override fun getPreviousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
-        return previousNewSelections.previousNewSelection(code)
+        return previousNewSelections[code]
+    }
+
+    private fun readPreviousNewSelections(): PreviousNewSelections {
+        return when (val savedSelections = savedStateHandle.get<Any?>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)) {
+            is Bundle -> PreviousNewSelections.fromBundle(savedSelections)
+            is PreviousNewSelections -> savedSelections
+            else -> PreviousNewSelections.empty
+        }
+    }
+
+    private fun persistPreviousNewSelections(selections: PreviousNewSelections) {
+        savedStateHandle[EMBEDDED_PREVIOUS_SELECTIONS_KEY] = selections.toBundle()
     }
 
     companion object {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgs.kt
@@ -7,10 +7,12 @@ import androidx.core.os.BundleCompat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
 import kotlinx.parcelize.Parcelize
 
+/** Stable Parcelable carrier used by the activity contract and saved instance state. */
 @Parcelize
 internal data class EmbeddedActivityArgs(
     val paymentMethodMetadata: PaymentMethodMetadata,
@@ -36,6 +38,198 @@ internal data class EmbeddedActivityArgs(
         fun fromIntent(intent: Intent): EmbeddedActivityArgs? {
             return intent.extras?.let { bundle ->
                 BundleCompat.getParcelable(bundle, EXTRA_ARGS, EmbeddedActivityArgs::class.java)
+            }
+        }
+    }
+}
+
+internal sealed interface EmbeddedActivityState {
+    val appearance: PaymentSheet.Appearance
+
+    data class LoadingPaymentOptions(
+        val context: Context,
+        val initialSelection: PaymentSelection?,
+        val previousNewSelections: PreviousNewSelections,
+        val customerState: CustomerState?,
+    ) : EmbeddedActivityState {
+        override val appearance: PaymentSheet.Appearance
+            get() = context.configuration.appearance
+    }
+
+    sealed interface Ready : EmbeddedActivityState {
+        val context: Context
+        val initialSelection: PaymentSelection?
+        val previousNewSelections: PreviousNewSelections
+        val customerState: CustomerState?
+
+        override val appearance: PaymentSheet.Appearance
+            get() = context.configuration.appearance
+
+        val launchMode: EmbeddedLaunchMode
+            get() = when (this) {
+                is Form -> EmbeddedLaunchMode.Form(selectedPaymentMethodCode)
+                is Manage -> EmbeddedLaunchMode.Manage
+                is PaymentOptions -> EmbeddedLaunchMode.PaymentOptions
+            }
+
+        val promotions: List<PaymentMethodMessagePromotion>
+            get() = when (this) {
+                is Form -> listOfNotNull(promotion)
+                is Manage, is PaymentOptions -> emptyList()
+            }
+
+        data class Form(
+            override val context: Context,
+            val selectedPaymentMethodCode: String,
+            override val initialSelection: PaymentSelection.New?,
+            override val previousNewSelections: PreviousNewSelections,
+            override val customerState: CustomerState?,
+            val promotion: PaymentMethodMessagePromotion?,
+        ) : Ready
+
+        data class Manage(
+            override val context: Context,
+            override val initialSelection: PaymentSelection?,
+            override val previousNewSelections: PreviousNewSelections,
+            override val customerState: CustomerState,
+        ) : Ready
+
+        data class PaymentOptions(
+            override val context: Context,
+            override val initialSelection: PaymentSelection?,
+            override val previousNewSelections: PreviousNewSelections,
+            override val customerState: CustomerState?,
+        ) : Ready
+    }
+
+    data class Context(
+        val paymentMethodMetadata: PaymentMethodMetadata,
+        val configuration: EmbeddedPaymentElement.Configuration,
+        val productUsage: Set<String>,
+        val paymentElementCallbackIdentifier: String,
+        val statusBarColor: Int?,
+    )
+}
+
+internal fun EmbeddedActivityState.toArgs(): EmbeddedActivityArgs {
+    val context: EmbeddedActivityState.Context
+    val selection: PaymentSelection?
+    val previousNewSelections: PreviousNewSelections
+    val customerState: CustomerState?
+    val promotions: List<PaymentMethodMessagePromotion>
+    val launchMode: EmbeddedLaunchMode
+    val presentationState: EmbeddedActivityArgs.PresentationState
+
+    when (this) {
+        is EmbeddedActivityState.LoadingPaymentOptions -> {
+            context = this.context
+            selection = initialSelection
+            previousNewSelections = this.previousNewSelections
+            customerState = this.customerState
+            promotions = emptyList()
+            launchMode = EmbeddedLaunchMode.PaymentOptions
+            presentationState = EmbeddedActivityArgs.PresentationState.Loading
+        }
+        is EmbeddedActivityState.Ready -> {
+            context = this.context
+            selection = initialSelection
+            previousNewSelections = this.previousNewSelections
+            customerState = this.customerState
+            promotions = this.promotions
+            launchMode = this.launchMode
+            presentationState = EmbeddedActivityArgs.PresentationState.Ready
+        }
+    }
+
+    return EmbeddedActivityArgs(
+        paymentMethodMetadata = context.paymentMethodMetadata,
+        configuration = context.configuration,
+        productUsage = context.productUsage,
+        paymentElementCallbackIdentifier = context.paymentElementCallbackIdentifier,
+        statusBarColor = context.statusBarColor,
+        selection = selection,
+        previousNewSelections = previousNewSelections.toBundle(),
+        customerState = customerState,
+        promotions = promotions,
+        launchMode = launchMode,
+        presentationState = presentationState,
+    )
+}
+
+internal fun EmbeddedActivityArgs.toState(): EmbeddedActivityState? {
+    val context = EmbeddedActivityState.Context(
+        paymentMethodMetadata = paymentMethodMetadata,
+        configuration = configuration,
+        productUsage = productUsage,
+        paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
+        statusBarColor = statusBarColor,
+    )
+    val previousNewSelections = PreviousNewSelections.fromBundle(previousNewSelections)
+
+    return when (presentationState) {
+        EmbeddedActivityArgs.PresentationState.Loading -> toLoadingState(context, previousNewSelections)
+        EmbeddedActivityArgs.PresentationState.Ready -> toReadyState(context, previousNewSelections)
+    }
+}
+
+private fun EmbeddedActivityArgs.toLoadingState(
+    context: EmbeddedActivityState.Context,
+    previousNewSelections: PreviousNewSelections,
+): EmbeddedActivityState.LoadingPaymentOptions? {
+    return if (launchMode is EmbeddedLaunchMode.PaymentOptions && promotions.isEmpty()) {
+        EmbeddedActivityState.LoadingPaymentOptions(
+            context = context,
+            initialSelection = selection,
+            previousNewSelections = previousNewSelections,
+            customerState = customerState,
+        )
+    } else {
+        null
+    }
+}
+
+private fun EmbeddedActivityArgs.toReadyState(
+    context: EmbeddedActivityState.Context,
+    previousNewSelections: PreviousNewSelections,
+): EmbeddedActivityState.Ready? {
+    return when (val launchMode = launchMode) {
+        is EmbeddedLaunchMode.Form -> {
+            val initialSelection = selection as? PaymentSelection.New
+            if ((selection != null && initialSelection == null) || promotions.size > 1) {
+                null
+            } else {
+                EmbeddedActivityState.Ready.Form(
+                    context = context,
+                    selectedPaymentMethodCode = launchMode.selectedPaymentMethodCode,
+                    initialSelection = initialSelection,
+                    previousNewSelections = previousNewSelections,
+                    customerState = customerState,
+                    promotion = promotions.singleOrNull(),
+                )
+            }
+        }
+        is EmbeddedLaunchMode.Manage -> {
+            if (customerState == null || promotions.isNotEmpty()) {
+                null
+            } else {
+                EmbeddedActivityState.Ready.Manage(
+                    context = context,
+                    initialSelection = selection,
+                    previousNewSelections = previousNewSelections,
+                    customerState = customerState,
+                )
+            }
+        }
+        is EmbeddedLaunchMode.PaymentOptions -> {
+            if (promotions.isNotEmpty()) {
+                null
+            } else {
+                EmbeddedActivityState.Ready.PaymentOptions(
+                    context = context,
+                    initialSelection = selection,
+                    previousNewSelections = previousNewSelections,
+                    customerState = customerState,
+                )
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityResult.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityResult.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentelement.embedded
 
 import android.content.Intent
-import android.os.Bundle
 import android.os.Parcelable
 import androidx.core.os.BundleCompat
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -9,15 +8,17 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.view.ActivityStarter
 import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 
 internal sealed interface EmbeddedActivityResult : Parcelable {
 
     val launchMode: EmbeddedLaunchMode
 
     @Parcelize
+    @TypeParceler<PreviousNewSelections, PreviousNewSelectionsParceler>()
     data class Complete(
         val selection: PaymentSelection?,
-        val previousNewSelections: Bundle,
+        val previousNewSelections: PreviousNewSelections,
         val hasBeenConfirmed: Boolean,
         val customerState: CustomerState?,
         val checkoutSessionResponse: CheckoutSessionResponse?,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/EmbeddedSelectionHolder.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.embedded
 
-import android.os.Bundle
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.flow.StateFlow
@@ -8,13 +7,15 @@ import kotlinx.coroutines.flow.StateFlow
 internal interface EmbeddedSelectionHolder {
     val selection: StateFlow<PaymentSelection?>
     val temporarySelection: StateFlow<String?>
-    val previousNewSelections: Bundle
+    val previousNewSelections: PreviousNewSelections
 
     fun setSelection(updatedSelection: PaymentSelection?)
 
     fun setTemporarySelection(code: PaymentMethodCode?)
 
-    fun setPreviousNewSelections(bundle: Bundle)
+    fun setPreviousNewSelections(selections: PreviousNewSelections)
+
+    fun clearPreviousNewSelections()
 
     fun getPreviousNewSelection(code: PaymentMethodCode): PaymentSelection.New?
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/PreviousNewSelections.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/PreviousNewSelections.kt
@@ -1,17 +1,64 @@
 package com.stripe.android.paymentelement.embedded
 
 import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
 
-internal fun Bundle.stashNewSelection(selection: PaymentSelection?) {
-    if (selection is PaymentSelection.New) {
-        putParcelable(selection.paymentMethodType, selection)
+@Parcelize
+internal data class PreviousNewSelections private constructor(
+    private val selections: Map<PaymentMethodCode, PaymentSelection.New>,
+) : Parcelable {
+    operator fun get(code: PaymentMethodCode): PaymentSelection.New? = selections[code]
+
+    fun updatedWith(selection: PaymentSelection?): PreviousNewSelections {
+        return if (selection is PaymentSelection.New) {
+            PreviousNewSelections(selections + (selection.paymentMethodType to selection))
+        } else {
+            this
+        }
+    }
+
+    fun mergedWith(other: PreviousNewSelections): PreviousNewSelections {
+        return PreviousNewSelections(selections + other.selections)
+    }
+
+    val isEmpty: Boolean
+        get() = selections.isEmpty()
+
+    fun toBundle(): Bundle = Bundle().apply {
+        selections.forEach { (code, selection) ->
+            putParcelable(code, selection)
+        }
+    }
+
+    companion object {
+        val empty: PreviousNewSelections = PreviousNewSelections(emptyMap())
+
+        fun fromBundle(bundle: Bundle): PreviousNewSelections {
+            @Suppress("DEPRECATION")
+            val selections = bundle.keySet().mapNotNull { code ->
+                (bundle.getParcelable(code) as? PaymentSelection.New)?.let { selection ->
+                    code to selection
+                }
+            }.toMap()
+            return PreviousNewSelections(selections)
+        }
     }
 }
 
-internal fun Bundle.previousNewSelection(code: PaymentMethodCode): PaymentSelection.New? {
-    @Suppress("DEPRECATION")
-    return getParcelable(code) as PaymentSelection.New?
+/** Preserves the Bundle encoding used before [PreviousNewSelections] became a typed value. */
+internal object PreviousNewSelectionsParceler : Parceler<PreviousNewSelections> {
+    override fun create(parcel: Parcel): PreviousNewSelections {
+        val bundle = parcel.readBundle(PreviousNewSelections::class.java.classLoader) ?: Bundle()
+        return PreviousNewSelections.fromBundle(bundle)
+    }
+
+    override fun PreviousNewSelections.write(parcel: Parcel, flags: Int) {
+        parcel.writeBundle(toBundle())
+    }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -8,8 +8,8 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
 import com.stripe.android.paymentelement.embedded.EmbeddedRowSelectionImmediateActionHandler
@@ -75,7 +75,7 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         )
     }
 
-    private val activityLauncher: ActivityResultLauncher<EmbeddedActivityArgs> =
+    private val activityLauncher: ActivityResultLauncher<EmbeddedActivityState> =
         activityResultCaller.registerForActivityResult(EmbeddedSheetContract) { result ->
             sheetStateHolder.sheetIsOpen = false
             when (result.launchMode) {
@@ -181,20 +181,13 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         val currentSelection = (selectionHolder.selection.value as? PaymentSelection.New?)
             .takeIf { it?.paymentMethodType == code }
             ?: selectionHolder.getPreviousNewSelection(code)
-        val args = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = configuration,
-            productUsage = productUsage,
-            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
-            statusBarColor = statusBarColor,
-            selection = currentSelection,
+        val args = EmbeddedActivityState.Ready.Form(
+            context = createContext(paymentMethodMetadata, configuration),
+            selectedPaymentMethodCode = code,
+            initialSelection = currentSelection,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = listOfNotNull(promotion),
-            launchMode = EmbeddedLaunchMode.Form(
-                selectedPaymentMethodCode = code,
-            ),
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            promotion = promotion,
         )
         activityLauncher.launch(args)
     }
@@ -213,18 +206,11 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
-        val args = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = configuration,
-            productUsage = productUsage,
-            paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
-            statusBarColor = statusBarColor,
-            selection = selection,
+        val args = EmbeddedActivityState.Ready.Manage(
+            context = createContext(paymentMethodMetadata, configuration),
+            initialSelection = selection,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.Manage,
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
         activityLauncher.launch(args)
     }
@@ -243,19 +229,25 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
         }
         if (sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
-        val args = EmbeddedActivityArgs(
+        val args = EmbeddedActivityState.Ready.PaymentOptions(
+            context = createContext(paymentMethodMetadata, configuration),
+            initialSelection = selection,
+            previousNewSelections = selectionHolder.previousNewSelections,
+            customerState = customerState,
+        )
+        activityLauncher.launch(args)
+    }
+
+    private fun createContext(
+        paymentMethodMetadata: PaymentMethodMetadata,
+        configuration: EmbeddedPaymentElement.Configuration,
+    ): EmbeddedActivityState.Context {
+        return EmbeddedActivityState.Context(
             paymentMethodMetadata = paymentMethodMetadata,
             configuration = configuration,
             productUsage = productUsage,
             paymentElementCallbackIdentifier = paymentElementCallbackIdentifier,
             statusBarColor = statusBarColor,
-            selection = selection,
-            previousNewSelections = selectionHolder.previousNewSelections,
-            customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.PaymentOptions,
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
-        activityLauncher.launch(args)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedConfigurationCoordinator.kt
@@ -1,11 +1,11 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import android.os.Bundle
 import com.stripe.android.common.model.asCommonConfiguration
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.EmbeddedPaymentElement.ConfigureResult
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.CoroutineScope
@@ -75,7 +75,7 @@ internal class DefaultEmbeddedConfigurationCoordinator @Inject constructor(
                 statusBarColor = statusBarColor,
             ),
             customer = state.customer,
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
         )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedStateHelper.kt
@@ -81,7 +81,7 @@ internal class DefaultEmbeddedStateHelper @Inject constructor(
         contentStateHolder.clearEmbeddedContent()
         confirmationStateHolder.state = null
         selectionHolder.setSelection(null)
-        selectionHolder.previousNewSelections.clear()
+        selectionHolder.clearPreviousNewSelections()
         customerStateHolder.setCustomerState(null)
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -8,6 +8,8 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.core.os.BundleCompat
 import com.stripe.android.common.ui.ElementsBottomSheetLayout
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.toArgs
+import com.stripe.android.paymentelement.embedded.toState
 import com.stripe.android.paymentsheet.ui.PaymentElementTheme
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
@@ -22,7 +24,9 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
 
         val activityArgs = savedInstanceState?.let {
             BundleCompat.getParcelable(it, STATE_ACTIVITY_ARGS, EmbeddedActivityArgs::class.java)
-        } ?: EmbeddedActivityArgs.fromIntent(intent) ?: run {
+        } ?: EmbeddedActivityArgs.fromIntent(intent)
+        val activityState = activityArgs?.toState()
+        if (activityState == null) {
             finish()
             return
         }
@@ -30,13 +34,13 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
         renderEdgeToEdge()
         val coordinator = EmbeddedSheetActivityCoordinator(
             activity = this,
-            initialArgs = activityArgs,
+            initialState = activityState,
             presentationFactory = EmbeddedSheetPresentation,
         )
         this.coordinator = coordinator
         coordinator.register()
         setContent {
-            PaymentElementTheme(appearance = activityArgs.configuration.appearance) {
+            PaymentElementTheme(appearance = coordinator.currentState.appearance) {
                 val bottomSheetState = rememberStripeBottomSheetState(
                     confirmValueChange = { coordinator.canDismiss() },
                 )
@@ -65,9 +69,7 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        EmbeddedActivityArgs.fromIntent(intent)?.let {
-            outState.putParcelable(STATE_ACTIVITY_ARGS, it)
-        }
+        coordinator?.currentState?.let { outState.putParcelable(STATE_ACTIVITY_ARGS, it.toArgs()) }
         super.onSaveInstanceState(outState)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinator.kt
@@ -7,23 +7,27 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import com.stripe.android.common.ui.PaymentElementActivityResultCaller
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
-import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
+import com.stripe.android.paymentelement.embedded.toState
 
 internal class EmbeddedSheetActivityCoordinator(
     private val activity: EmbeddedSheetActivity,
-    initialArgs: EmbeddedActivityArgs,
+    initialState: EmbeddedActivityState,
     private val presentationFactory: EmbeddedSheetPresentationFactory,
 ) {
     private var state by mutableStateOf(
         State(
-            args = initialArgs,
+            state = initialState,
             presentation = presentationFactory.create(
                 activity = activity,
-                args = initialArgs,
+                state = initialState,
                 activityResultCaller = activity,
             ),
         ),
     )
+
+    val currentState: EmbeddedActivityState
+        get() = state.state
 
     fun register() {
         state.presentation.register()
@@ -43,24 +47,21 @@ internal class EmbeddedSheetActivityCoordinator(
     }
 
     fun handleNewIntent(intent: Intent) {
-        val updatedArgs = EmbeddedActivityArgs.fromIntent(intent) ?: return
-        val isValidTransition =
-            !activity.isFinishing &&
-                state.args.presentationState == EmbeddedActivityArgs.PresentationState.Loading &&
-                state.args.launchMode is EmbeddedLaunchMode.PaymentOptions &&
-                updatedArgs.presentationState == EmbeddedActivityArgs.PresentationState.Ready &&
-                updatedArgs.launchMode is EmbeddedLaunchMode.PaymentOptions
+        val updatedState = EmbeddedActivityArgs.fromIntent(intent)?.toState() ?: return
+        val isValidTransition = !activity.isFinishing &&
+            state.state is EmbeddedActivityState.LoadingPaymentOptions &&
+            updatedState is EmbeddedActivityState.Ready.PaymentOptions
         if (!isValidTransition) return
 
         activity.intent = intent
         state.presentation.onDestroy()
         state = State(
-            args = updatedArgs,
+            state = updatedState,
             presentation = presentationFactory.create(
                 activity = activity,
-                args = updatedArgs,
+                state = updatedState,
                 activityResultCaller = PaymentElementActivityResultCaller(
-                    key = "EmbeddedSheetActivity_${updatedArgs.paymentElementCallbackIdentifier}",
+                    key = "EmbeddedSheetActivity_${updatedState.context.paymentElementCallbackIdentifier}",
                     registryOwner = activity,
                 ),
             ),
@@ -73,7 +74,7 @@ internal class EmbeddedSheetActivityCoordinator(
     }
 
     private data class State(
-        val args: EmbeddedActivityArgs,
+        val state: EmbeddedActivityState,
         val presentation: EmbeddedSheetPresentation,
     )
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetContract.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetContract.kt
@@ -5,12 +5,14 @@ import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
+import com.stripe.android.paymentelement.embedded.toArgs
 
-internal object EmbeddedSheetContract : ActivityResultContract<EmbeddedActivityArgs, EmbeddedActivityResult>() {
-    override fun createIntent(context: Context, input: EmbeddedActivityArgs): Intent {
+internal object EmbeddedSheetContract : ActivityResultContract<EmbeddedActivityState, EmbeddedActivityResult>() {
+    override fun createIntent(context: Context, input: EmbeddedActivityState): Intent {
         return Intent(context, EmbeddedSheetActivity::class.java)
             .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
-            .putExtra(EmbeddedActivityArgs.EXTRA_ARGS, input)
+            .putExtra(EmbeddedActivityArgs.EXTRA_ARGS, input.toArgs())
     }
 
     override fun parseResult(resultCode: Int, intent: Intent?): EmbeddedActivityResult {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetPresentation.kt
@@ -3,8 +3,8 @@ package com.stripe.android.paymentelement.embedded.sheet
 import android.app.Activity
 import androidx.activity.result.ActivityResultCaller
 import androidx.compose.runtime.Composable
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 
 internal interface EmbeddedSheetPresentation {
     fun register()
@@ -18,30 +18,21 @@ internal interface EmbeddedSheetPresentation {
 
     fun onDestroy()
 
-    interface Factory {
-        fun create(
-            activity: EmbeddedSheetActivity,
-            args: EmbeddedActivityArgs,
-            activityResultCaller: ActivityResultCaller,
-        ): EmbeddedSheetPresentation
-    }
-
     companion object : EmbeddedSheetPresentationFactory {
         override fun create(
             activity: EmbeddedSheetActivity,
-            args: EmbeddedActivityArgs,
+            state: EmbeddedActivityState,
             activityResultCaller: ActivityResultCaller,
         ): EmbeddedSheetPresentation {
-            return when (args.presentationState) {
-                EmbeddedActivityArgs.PresentationState.Loading -> LoadingEmbeddedSheetPresentation.Factory.create(
+            return when (state) {
+                is EmbeddedActivityState.LoadingPaymentOptions -> LoadingEmbeddedSheetPresentation.Factory.create(
                     activity = activity,
-                    args = args,
-                    activityResultCaller = activityResultCaller,
+                    state = state,
                 )
-                EmbeddedActivityArgs.PresentationState.Ready ->
-                    EmbeddedSheetViewModel.Factory { args }.createReadyPresentation(
+                is EmbeddedActivityState.Ready ->
+                    EmbeddedSheetViewModel.Factory { state }.createReadyPresentation(
                         activity = activity,
-                        args = args,
+                        state = state,
                         activityResultCaller = activityResultCaller,
                     )
             }
@@ -52,7 +43,7 @@ internal interface EmbeddedSheetPresentation {
 internal interface EmbeddedSheetPresentationFactory {
     fun create(
         activity: EmbeddedSheetActivity,
-        args: EmbeddedActivityArgs,
+        state: EmbeddedActivityState,
         activityResultCaller: ActivityResultCaller,
     ): EmbeddedSheetPresentation
 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.createSavedStateHandle
 import androidx.lifecycle.viewmodel.CreationExtras
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.utils.requireApplication
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -23,41 +23,42 @@ internal class EmbeddedSheetViewModel @Inject constructor(
     }
 
     class Factory(
-        private val argsSupplier: () -> EmbeddedActivityArgs,
+        private val stateSupplier: () -> EmbeddedActivityState.Ready,
     ) : ViewModelProvider.Factory {
         fun createReadyPresentation(
             activity: EmbeddedSheetActivity,
-            args: EmbeddedActivityArgs,
+            state: EmbeddedActivityState.Ready,
             activityResultCaller: ActivityResultCaller,
         ): EmbeddedSheetPresentation {
             val viewModel = ViewModelProvider(activity, this)[EmbeddedSheetViewModel::class.java]
             return viewModel.embeddedSheetPresentationFactory.create(
                 activity = activity,
-                args = args,
+                state = state,
                 activityResultCaller = activityResultCaller,
             )
         }
 
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
-            val args = argsSupplier()
+            val state = stateSupplier()
+            val context = state.context
             val customViewModelScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
             val component = DaggerEmbeddedSheetComponent.factory().build(
-                paymentMethodMetadata = args.paymentMethodMetadata,
-                statusBarColor = args.statusBarColor,
-                configuration = args.configuration,
-                productUsage = args.productUsage,
-                paymentElementCallbackIdentifier = args.paymentElementCallbackIdentifier,
+                paymentMethodMetadata = context.paymentMethodMetadata,
+                statusBarColor = context.statusBarColor,
+                configuration = context.configuration,
+                productUsage = context.productUsage,
+                paymentElementCallbackIdentifier = context.paymentElementCallbackIdentifier,
                 application = extras.requireApplication(),
                 savedStateHandle = extras.createSavedStateHandle(),
-                promotions = args.promotions,
-                launchMode = args.launchMode,
+                promotions = state.promotions,
+                launchMode = state.launchMode,
                 viewModelScope = customViewModelScope,
             )
 
-            component.customerStateHolder.setCustomerState(args.customerState)
-            component.selectionHolder.setPreviousNewSelections(args.previousNewSelections)
-            component.selectionHolder.setSelection(args.selection)
+            component.customerStateHolder.setCustomerState(state.customerState)
+            component.selectionHolder.setPreviousNewSelections(state.previousNewSelections)
+            component.selectionHolder.setSelection(state.initialSelection)
 
             return component.viewModel as T
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/LoadingEmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/LoadingEmbeddedSheetPresentation.kt
@@ -2,18 +2,17 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.addCallback
-import androidx.activity.result.ActivityResultCaller
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import com.stripe.android.common.ui.BottomSheetLoadingIndicator
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 
 internal class LoadingEmbeddedSheetPresentation(
     private val activity: EmbeddedSheetActivity,
-    private val args: EmbeddedActivityArgs,
+    private val state: EmbeddedActivityState.LoadingPaymentOptions,
 ) : EmbeddedSheetPresentation {
     private var backCallback: OnBackPressedCallback? = null
 
@@ -44,20 +43,19 @@ internal class LoadingEmbeddedSheetPresentation(
 
     private fun createCancellationResult(): EmbeddedActivityResult {
         return EmbeddedActivityResult.Cancelled(
-            customerState = args.customerState,
+            customerState = state.customerState,
             launchMode = EmbeddedLaunchMode.PaymentOptions,
         )
     }
 
-    object Factory : EmbeddedSheetPresentation.Factory {
-        override fun create(
+    object Factory {
+        fun create(
             activity: EmbeddedSheetActivity,
-            args: EmbeddedActivityArgs,
-            activityResultCaller: ActivityResultCaller,
+            state: EmbeddedActivityState.LoadingPaymentOptions,
         ): LoadingEmbeddedSheetPresentation {
             return LoadingEmbeddedSheetPresentation(
                 activity = activity,
-                args = args,
+                state = state,
             )
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/ReadyEmbeddedSheetPresentation.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/ReadyEmbeddedSheetPresentation.kt
@@ -20,8 +20,8 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.lifecycleScope
 import com.stripe.android.common.ui.BottomSheetScaffold
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -40,7 +40,7 @@ import kotlinx.coroutines.launch
 
 internal class ReadyEmbeddedSheetPresentation @AssistedInject constructor(
     @Assisted private val activity: EmbeddedSheetActivity,
-    @Assisted private val args: EmbeddedActivityArgs,
+    @Assisted private val state: EmbeddedActivityState.Ready,
     @Assisted private val activityResultCaller: ActivityResultCaller,
     private val eventReporter: EventReporter,
     private val customerStateHolder: CustomerStateHolder,
@@ -93,33 +93,30 @@ internal class ReadyEmbeddedSheetPresentation @AssistedInject constructor(
     }
 
     private fun createDismissalResult(): EmbeddedActivityResult {
-        return when (val launchMode = args.launchMode) {
-            is EmbeddedLaunchMode.Form -> EmbeddedActivityResult.Cancelled(
+        return when (state) {
+            is EmbeddedActivityState.Ready.Form -> EmbeddedActivityResult.Cancelled(
                 customerState = customerStateHolder.customer.value,
-                launchMode = launchMode,
+                launchMode = state.launchMode,
             )
-            is EmbeddedLaunchMode.Manage -> createManageResult(
+            is EmbeddedActivityState.Ready.Manage -> createManageResult(
                 shouldInvokeSelectionCallback = false,
-                launchMode = launchMode,
             )
-            is EmbeddedLaunchMode.PaymentOptions -> createPaymentOptionsCancellationResult()
+            is EmbeddedActivityState.Ready.PaymentOptions -> createPaymentOptionsCancellationResult()
         }
     }
 
     private fun createNavigatorResult(result: Boolean?): EmbeddedActivityResult {
-        return when (val launchMode = args.launchMode) {
-            is EmbeddedLaunchMode.Form -> createDismissalResult()
-            is EmbeddedLaunchMode.Manage -> createManageResult(
+        return when (state) {
+            is EmbeddedActivityState.Ready.Form -> createDismissalResult()
+            is EmbeddedActivityState.Ready.Manage -> createManageResult(
                 shouldInvokeSelectionCallback = result == true,
-                launchMode = launchMode,
             )
-            is EmbeddedLaunchMode.PaymentOptions -> createPaymentOptionsCancellationResult()
+            is EmbeddedActivityState.Ready.PaymentOptions -> createPaymentOptionsCancellationResult()
         }
     }
 
     private fun createManageResult(
         shouldInvokeSelectionCallback: Boolean,
-        launchMode: EmbeddedLaunchMode.Manage,
     ): EmbeddedActivityResult {
         return EmbeddedActivityResult.Complete(
             selection = selectionHolder.selection.value,
@@ -128,7 +125,7 @@ internal class ReadyEmbeddedSheetPresentation @AssistedInject constructor(
             customerState = customerStateHolder.customer.value,
             checkoutSessionResponse = null,
             shouldInvokeSelectionCallback = shouldInvokeSelectionCallback,
-            launchMode = launchMode,
+            launchMode = EmbeddedLaunchMode.Manage,
         )
     }
 
@@ -160,10 +157,10 @@ internal class ReadyEmbeddedSheetPresentation @AssistedInject constructor(
     }
 
     @AssistedFactory
-    interface Factory : EmbeddedSheetPresentation.Factory {
-        override fun create(
+    interface Factory {
+        fun create(
             activity: EmbeddedSheetActivity,
-            args: EmbeddedActivityArgs,
+            state: EmbeddedActivityState.Ready,
             activityResultCaller: ActivityResultCaller,
         ): ReadyEmbeddedSheetPresentation
     }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateFactory.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.checkout
 
 import android.graphics.Bitmap
-import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import com.stripe.android.elements.ExpressCheckoutElement
 import com.stripe.android.elements.ece.AvailableExpressButtonTypesFactory
@@ -10,6 +9,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -31,7 +31,7 @@ internal object CheckoutControllerStateFactory {
             EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
-        previousNewSelections: Bundle = Bundle(),
+        previousNewSelections: PreviousNewSelections = PreviousNewSelections.empty,
         linkEagerPresentationSuppressed: Boolean = false,
     ): CheckoutControllerState {
         return CheckoutControllerState(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.checkout
 
-import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
@@ -12,7 +11,7 @@ import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFact
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.embedded.previousNewSelection
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -100,7 +99,7 @@ internal class CheckoutControllerStateHolderTest {
 
     @Test
     fun `setSelection with a new selection emits and stashes it into previousNewSelections`() = testScenario {
-        val originalPreviousNewSelections = Bundle()
+        val originalPreviousNewSelections = PreviousNewSelections.empty
         stateHolder.state = committedState(previousNewSelections = originalPreviousNewSelections)
 
         stateHolder.selection.test {
@@ -132,16 +131,14 @@ internal class CheckoutControllerStateHolderTest {
     @Test
     fun `setPreviousNewSelections merges into the existing previousNewSelections rather than replacing`() =
         testScenario {
-            val originalPreviousNewSelections = Bundle().apply {
-                putParcelable("card", PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
-            }
+            val originalPreviousNewSelections = PreviousNewSelections.empty
+                .updatedWith(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
             stateHolder.state = committedState(
                 previousNewSelections = originalPreviousNewSelections,
             )
 
-            val bundle = Bundle().apply {
-                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-            }
+            val bundle = PreviousNewSelections.empty
+                .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
             stateHolder.setPreviousNewSelections(bundle)
 
             assertThat(stateHolder.state?.previousNewSelections).isNotSameInstanceAs(originalPreviousNewSelections)
@@ -149,7 +146,7 @@ internal class CheckoutControllerStateHolderTest {
                 .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
             assertThat(stateHolder.getPreviousNewSelection("cashapp"))
                 .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-            assertThat(originalPreviousNewSelections.previousNewSelection("cashapp")).isNull()
+            assertThat(originalPreviousNewSelections["cashapp"]).isNull()
         }
 
     @Test
@@ -161,7 +158,7 @@ internal class CheckoutControllerStateHolderTest {
         assertSetBeforeLoadError(operation = "setTemporarySelection")
 
         stateHolder.setPreviousNewSelections(
-            Bundle().apply { putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION) },
+            PreviousNewSelections.empty.updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION),
         )
         assertSetBeforeLoadError(operation = "setPreviousNewSelections")
 
@@ -178,9 +175,8 @@ internal class CheckoutControllerStateHolderTest {
         val restored = committedState(
             paymentSelection = PaymentSelection.GooglePay,
             temporarySelection = "card",
-            previousNewSelections = Bundle().apply {
-                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-            },
+            previousNewSelections = PreviousNewSelections.empty
+                .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION),
         )
         val stateHolder = CheckoutControllerStateHolder(
             savedStateHandle = SavedStateHandle(mapOf(CheckoutControllerStateHolder.STATE_KEY to restored)),
@@ -198,7 +194,7 @@ internal class CheckoutControllerStateHolderTest {
     private fun committedState(
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
-        previousNewSelections: Bundle = Bundle(),
+        previousNewSelections: PreviousNewSelections = PreviousNewSelections.empty,
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata? = PaymentMethodMetadataFactory.create(),
         requiresShippingAddress: Boolean = false,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.checkout
 
 import android.app.Application
-import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.ReceiveTurbine
@@ -26,6 +25,7 @@ import com.stripe.android.networktesting.testBodyFromFile
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbacks
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -399,9 +399,8 @@ internal class CheckoutControllerTest {
     fun `clearPaymentOption clears payment option state`() = runMutationScenario(
         paymentSelection = PaymentSelection.GooglePay,
         temporarySelection = "card",
-        previousNewSelections = Bundle().apply {
-            putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-        },
+        previousNewSelections = PreviousNewSelections.empty
+            .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION),
     ) {
         controller.session.test {
             assertThat(awaitItem()?.paymentOption).isNotNull()
@@ -1186,7 +1185,7 @@ internal class CheckoutControllerTest {
         initModifier: (JSONObject) -> Unit = {},
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
-        previousNewSelections: Bundle = Bundle(),
+        previousNewSelections: PreviousNewSelections = PreviousNewSelections.empty,
         sheetIsOpen: Boolean = false,
         assertLoadingConsumed: Boolean = false,
         block: suspend MutationScenario.() -> Unit,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.checkout
 
 import android.app.Application
-import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
@@ -9,6 +8,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
@@ -16,17 +16,16 @@ import com.stripe.android.model.PaymentMethodMessagePromotion
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentelement.embedded.content.EmbeddedConfigurationFactory
 import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelperStateHolder
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
-import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
-import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -73,20 +72,13 @@ internal class CheckoutSheetLauncherTest {
                 url = "https://www.test.com",
             ),
         )
-        val expectedArgs = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = EmbeddedConfigurationFactory.create(),
-            productUsage = setOf("Checkout"),
-            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
-            statusBarColor = null,
-            selection = null,
+        val expectedArgs = EmbeddedActivityState.Ready.Form(
+            context = readyContext(paymentMethodMetadata),
+            selectedPaymentMethodCode = code,
+            initialSelection = null,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = listOf(promotion),
-            launchMode = EmbeddedLaunchMode.Form(
-                selectedPaymentMethodCode = code,
-            ),
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            promotion = promotion,
         )
 
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
@@ -115,8 +107,8 @@ internal class CheckoutSheetLauncherTest {
             customerState = createCustomerState(),
             promotion = null,
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.selection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityState.Ready.Form
+        assertThat(launchCall.initialSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
     }
 
     @Test
@@ -131,8 +123,8 @@ internal class CheckoutSheetLauncherTest {
             customerState = createCustomerState(),
             promotion = null,
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.selection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityState.Ready.Form
+        assertThat(launchCall.initialSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
     }
 
     @Test
@@ -146,8 +138,8 @@ internal class CheckoutSheetLauncherTest {
             customerState = createCustomerState(),
             promotion = null,
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.selection).isNull()
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityState.Ready.Form
+        assertThat(launchCall.initialSelection).isNull()
     }
 
     @Test
@@ -161,8 +153,8 @@ internal class CheckoutSheetLauncherTest {
             customerState = createCustomerState(),
             promotion = null,
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.selection).isNull()
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityState.Ready.Form
+        assertThat(launchCall.initialSelection).isNull()
     }
 
     @Test
@@ -201,7 +193,7 @@ internal class CheckoutSheetLauncherTest {
 
         val customerState = createCustomerState()
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = customerState,
@@ -224,7 +216,7 @@ internal class CheckoutSheetLauncherTest {
     fun `formActivityLauncher invokes immediate action when complete result has selection`() = testScenario {
         launchForm("cashapp")
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = null,
@@ -242,7 +234,7 @@ internal class CheckoutSheetLauncherTest {
     fun `formActivityLauncher does not invoke immediate action when the result is confirmed`() = testScenario {
         launchForm("cashapp")
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = true,
             customerState = null,
@@ -261,7 +253,7 @@ internal class CheckoutSheetLauncherTest {
         val response = CheckoutSessionResponseFactory.create()
         sessionRefresher.enqueueRefreshAction {}
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = null,
@@ -284,7 +276,7 @@ internal class CheckoutSheetLauncherTest {
     @Test
     fun `formActivityLauncher does not refresh checkout session when complete result has no response`() = testScenario {
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = null,
@@ -344,7 +336,7 @@ internal class CheckoutSheetLauncherTest {
     @Test
     fun `form result handled correctly without prior launchForm call (simulates host recreation)`() = testScenario {
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
             hasBeenConfirmed = true,
             customerState = null,
@@ -367,18 +359,11 @@ internal class CheckoutSheetLauncherTest {
     fun `launchManage launches activity with correct parameters`() = testScenario {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
-        val expectedArgs = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = EmbeddedConfigurationFactory.create(),
-            productUsage = setOf("Checkout"),
-            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
-            statusBarColor = null,
-            selection = PaymentSelection.GooglePay,
+        val expectedArgs = EmbeddedActivityState.Ready.Manage(
+            context = readyContext(paymentMethodMetadata),
+            initialSelection = PaymentSelection.GooglePay,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.Manage,
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchManage(
@@ -425,7 +410,7 @@ internal class CheckoutSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
@@ -446,7 +431,7 @@ internal class CheckoutSheetLauncherTest {
     @Test
     fun `manageSheetLauncher invokes immediate action for saved selection when flagged`() = testScenario {
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             customerState = null,
             selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD),
             hasBeenConfirmed = false,
@@ -496,18 +481,11 @@ internal class CheckoutSheetLauncherTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.GooglePay
-        val expectedArgs = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = EmbeddedConfigurationFactory.create(),
-            productUsage = setOf("Checkout"),
-            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
-            statusBarColor = null,
-            selection = selection,
+        val expectedArgs = EmbeddedActivityState.Ready.PaymentOptions(
+            context = readyContext(paymentMethodMetadata),
+            initialSelection = selection,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.PaymentOptions,
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchPaymentOptions(
@@ -534,15 +512,16 @@ internal class CheckoutSheetLauncherTest {
         runCurrent()
 
         val initialState = requireNotNull(embeddedContentState.value)
+        val initialCustomer = createCustomerState()
         sheetLauncher.launchPaymentOptions(
             paymentMethodMetadata = initialState.paymentMethodMetadata,
-            customerState = null,
+            customerState = initialCustomer,
             selection = null,
             configuration = initialState.configuration,
         )
-        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(loadingArgs.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
-        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+        val loadingState = dummyActivityResultCallerScenario.awaitLaunchCall()
+            as EmbeddedActivityState.LoadingPaymentOptions
+        assertThat(loadingState.customerState).isEqualTo(initialCustomer)
 
         val refreshedMetadata = PaymentMethodMetadataFactory.create()
         val refreshedConfiguration = EmbeddedConfigurationFactory.create(merchantDisplayName = "Refreshed merchant")
@@ -557,13 +536,12 @@ internal class CheckoutSheetLauncherTest {
         mutationGate.complete(Unit)
         runCurrent()
 
-        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(readyArgs.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
-        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
-        assertThat(readyArgs.paymentMethodMetadata).isEqualTo(refreshedMetadata)
-        assertThat(readyArgs.configuration).isEqualTo(refreshedConfiguration)
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall()
+            as EmbeddedActivityState.Ready.PaymentOptions
+        assertThat(readyArgs.context.paymentMethodMetadata).isEqualTo(refreshedMetadata)
+        assertThat(readyArgs.context.configuration).isEqualTo(refreshedConfiguration)
         assertThat(readyArgs.customerState).isEqualTo(refreshedCustomer)
-        assertThat(readyArgs.selection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        assertThat(readyArgs.initialSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
     }
 
     @Test
@@ -584,8 +562,8 @@ internal class CheckoutSheetLauncherTest {
             selection = null,
             configuration = initialState.configuration,
         )
-        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall()
+        assertThat(loadingArgs).isInstanceOf<EmbeddedActivityState.LoadingPaymentOptions>()
         assertThat(launcherState.isAwaitingPaymentOptionsReady).isTrue()
 
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
@@ -597,8 +575,8 @@ internal class CheckoutSheetLauncherTest {
         recreateSheetLauncher(TestLifecycleOwner(), recreatedLauncherState)
         runCurrent()
 
-        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall()
+        assertThat(readyArgs).isInstanceOf<EmbeddedActivityState.Ready.PaymentOptions>()
         assertThat(recreatedLauncherState.isAwaitingPaymentOptionsReady).isFalse()
     }
 
@@ -620,16 +598,16 @@ internal class CheckoutSheetLauncherTest {
             selection = selectionHolder.selection.value,
             configuration = retainedState.configuration,
         )
-        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall()
+        assertThat(loadingArgs).isInstanceOf<EmbeddedActivityState.LoadingPaymentOptions>()
 
         mutationGate.complete(Unit)
         runCurrent()
 
-        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(readyArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Ready)
-        assertThat(readyArgs.paymentMethodMetadata).isEqualTo(retainedState.paymentMethodMetadata)
-        assertThat(readyArgs.configuration).isEqualTo(retainedState.configuration)
+        val readyArgs = dummyActivityResultCallerScenario.awaitLaunchCall()
+            as EmbeddedActivityState.Ready.PaymentOptions
+        assertThat(readyArgs.context.paymentMethodMetadata).isEqualTo(retainedState.paymentMethodMetadata)
+        assertThat(readyArgs.context.configuration).isEqualTo(retainedState.configuration)
     }
 
     @Test
@@ -650,8 +628,8 @@ internal class CheckoutSheetLauncherTest {
             selection = null,
             configuration = initialState.configuration,
         )
-        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(loadingArgs.presentationState).isEqualTo(EmbeddedActivityArgs.PresentationState.Loading)
+        val loadingArgs = dummyActivityResultCallerScenario.awaitLaunchCall()
+        assertThat(loadingArgs).isInstanceOf<EmbeddedActivityState.LoadingPaymentOptions>()
 
         embeddedContentState.value = null
         mutationGate.complete(Unit)
@@ -707,11 +685,12 @@ internal class CheckoutSheetLauncherTest {
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             configuration = EmbeddedConfigurationFactory.create(),
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall()
+            as EmbeddedActivityState.Ready.PaymentOptions
 
-        assertThat(launchCall.previousNewSelections.previousNewSelection("card"))
+        assertThat(launchCall.previousNewSelections["card"])
             .isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
-        assertThat(launchCall.previousNewSelections.previousNewSelection("cashapp"))
+        assertThat(launchCall.previousNewSelections["cashapp"])
             .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }
 
@@ -744,9 +723,8 @@ internal class CheckoutSheetLauncherTest {
     @Test
     fun `paymentOptionsResult merges returned previous new selections into selection holder`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
-        val returnedSelections = Bundle().apply {
-            stashNewSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-        }
+        val returnedSelections = PreviousNewSelections.empty
+            .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
         val result = EmbeddedActivityResult.Complete(
             previousNewSelections = returnedSelections,
             customerState = null,
@@ -770,7 +748,7 @@ internal class CheckoutSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
@@ -793,7 +771,7 @@ internal class CheckoutSheetLauncherTest {
         val expectedError = IllegalStateException("Refresh failed")
         sessionRefresher.enqueueRefreshAction { throw expectedError }
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             customerState = null,
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
@@ -1044,6 +1022,18 @@ internal class CheckoutSheetLauncherTest {
             )
             dummyActivityResultCallerScenario.awaitLaunchCall()
         }
+    }
+
+    private fun readyContext(
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): EmbeddedActivityState.Context {
+        return EmbeddedActivityState.Context(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = EmbeddedConfigurationFactory.create(),
+            productUsage = setOf("Checkout"),
+            paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+            statusBarColor = null,
+        )
     }
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.checkout
 
 import android.app.Application
 import android.graphics.Bitmap
-import android.os.Bundle
 import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
@@ -20,6 +19,7 @@ import com.stripe.android.paymentelement.CardFundingFilteringPrivatePreview
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedFormHelperFactory
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentelement.embedded.content.DefaultEmbeddedSelectionChooser
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSelectionChooser
 import com.stripe.android.paymentsheet.CustomerStateHolder
@@ -309,9 +309,8 @@ internal class CheckoutStateLoaderTest {
     fun `reload carries the temporary selection and previous new selections forward`() = runScenario {
         val seeded = committedState(
             temporarySelection = "card",
-            previousNewSelections = Bundle().apply {
-                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-            },
+            previousNewSelections = PreviousNewSelections.empty
+                .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION),
         )
 
         loader.reload(seeded)
@@ -334,9 +333,8 @@ internal class CheckoutStateLoaderTest {
         // configuration load must start from a clean slate rather than carrying them forward.
         stateHolder.state = committedState(
             temporarySelection = "card",
-            previousNewSelections = Bundle().apply {
-                putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-            },
+            previousNewSelections = PreviousNewSelections.empty
+                .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION),
         )
 
         loader.loadInitial(configuration = defaultConfiguration(), checkoutSessionResponse = response())
@@ -370,7 +368,7 @@ internal class CheckoutStateLoaderTest {
     private fun committedState(
         paymentSelection: PaymentSelection? = null,
         temporarySelection: String? = null,
-        previousNewSelections: Bundle = Bundle(),
+        previousNewSelections: PreviousNewSelections = PreviousNewSelections.empty,
         checkoutSessionResponse: CheckoutSessionResponse = CheckoutSessionResponseFactory.create(),
         linkEagerPresentationSuppressed: Boolean = false,
     ) = CheckoutControllerState(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/DefaultEmbeddedSelectionHolderTest.kt
@@ -38,23 +38,24 @@ internal class DefaultEmbeddedSelectionHolderTest {
         assertThat(selectionHolder.previousNewSelections.isEmpty).isTrue()
         selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
         assertThat(selectionHolder.previousNewSelections.isEmpty).isFalse()
-        assertThat(selectionHolder.previousNewSelections.size()).isEqualTo(1)
+        assertThat(selectionHolder.previousNewSelections["cashapp"])
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }
 
     @Test
-    fun `initializing with empty savedStateHandle stores previousNewSelections bundle`() = testScenario {
-        val savedBundle = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
+    fun `initializing with empty savedStateHandle stores previousNewSelections`() = testScenario {
+        val savedSelections = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
 
-        assertThat(savedBundle).isNotNull()
-        assertThat(savedBundle?.isEmpty).isTrue()
+        assertThat(savedSelections).isNotNull()
+        assertThat(savedSelections?.isEmpty).isTrue()
     }
 
     @Test
     fun `setting new selection persists previousNewSelections in savedStateHandle`() = testScenario {
         selectionHolder.setSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
 
-        val savedBundle = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
-        assertThat(savedBundle?.previousNewSelection("cashapp"))
+        val savedSelections = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
+        assertThat(savedSelections?.let(PreviousNewSelections::fromBundle)?.get("cashapp"))
             .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
 
         val restoredHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
@@ -80,9 +81,9 @@ internal class DefaultEmbeddedSelectionHolderTest {
         setup = {
             set(
                 EMBEDDED_PREVIOUS_SELECTIONS_KEY,
-                Bundle().apply {
-                    putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-                }
+                PreviousNewSelections.empty
+                    .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+                    .toBundle()
             )
         },
     ) {
@@ -124,24 +125,23 @@ internal class DefaultEmbeddedSelectionHolderTest {
     @Test
     fun `setting previousNewSelections updates previousNewSelections`() = testScenario {
         assertThat(selectionHolder.previousNewSelections.isEmpty).isTrue()
-        val previousNewSelections = Bundle().apply {
-            putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-        }
+        val previousNewSelections = PreviousNewSelections.empty
+            .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
         selectionHolder.setPreviousNewSelections(previousNewSelections)
         assertThat(selectionHolder.previousNewSelections.isEmpty).isFalse()
-        assertThat(selectionHolder.previousNewSelections.size()).isEqualTo(1)
+        assertThat(selectionHolder.previousNewSelections["cashapp"])
+            .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }
 
     @Test
-    fun `setting previousNewSelections persists bundle in savedStateHandle`() = testScenario {
-        val previousNewSelections = Bundle().apply {
-            putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-        }
+    fun `setting previousNewSelections persists in savedStateHandle`() = testScenario {
+        val previousNewSelections = PreviousNewSelections.empty
+            .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
 
         selectionHolder.setPreviousNewSelections(previousNewSelections)
 
-        val savedBundle = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
-        assertThat(savedBundle?.previousNewSelection("cashapp"))
+        val savedSelections = savedStateHandle.get<Bundle>(EMBEDDED_PREVIOUS_SELECTIONS_KEY)
+        assertThat(savedSelections?.let(PreviousNewSelections::fromBundle)?.get("cashapp"))
             .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgsTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/EmbeddedActivityArgsTest.kt
@@ -1,0 +1,165 @@
+package com.stripe.android.paymentelement.embedded
+
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.core.os.bundleOf
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
+import com.stripe.android.model.PaymentMethodFixtures
+import com.stripe.android.model.PaymentMethodMessageLearnMore
+import com.stripe.android.model.PaymentMethodMessagePromotion
+import com.stripe.android.paymentelement.EmbeddedPaymentElement
+import com.stripe.android.paymentsheet.PaymentSheetFixtures
+import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.model.paymentMethodType
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class EmbeddedActivityArgsTest {
+    @Test
+    fun `legacy loading args restore loading state including customer state`() {
+        val state = EmbeddedActivityState.LoadingPaymentOptions(
+            context = context,
+            initialSelection = PaymentSelection.GooglePay,
+            previousNewSelections = previousNewSelections,
+            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+        )
+
+        val restored = parcelRoundTrip(state.toArgs()).toState()
+
+        assertThat(restored).isEqualTo(state)
+    }
+
+    @Test
+    fun `legacy ready form args restore ready form state`() {
+        val state = EmbeddedActivityState.Ready.Form(
+            context = context,
+            selectedPaymentMethodCode = "cashapp",
+            initialSelection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+            previousNewSelections = previousNewSelections,
+            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            promotion = PaymentMethodMessagePromotion(
+                paymentMethodType = "cashapp",
+                message = "Promotion",
+                learnMore = PaymentMethodMessageLearnMore("Learn more", "https://stripe.com"),
+            ),
+        )
+
+        val restored = parcelRoundTrip(state.toArgs()).toState() as EmbeddedActivityState.Ready.Form
+
+        assertThat(restored.context).isEqualTo(state.context)
+        assertThat(restored.selectedPaymentMethodCode).isEqualTo("cashapp")
+        assertThat(restored.initialSelection?.paymentMethodType).isEqualTo("cashapp")
+        assertThat(restored.previousNewSelections["card"]?.paymentMethodType).isEqualTo("card")
+        assertThat(restored.customerState).isEqualTo(state.customerState)
+        assertThat(restored.promotion).isEqualTo(state.promotion)
+    }
+
+    @Test
+    fun `legacy ready manage args restore ready manage state`() {
+        val state = EmbeddedActivityState.Ready.Manage(
+            context = context,
+            initialSelection = PaymentSelection.GooglePay,
+            previousNewSelections = previousNewSelections,
+            customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+        )
+
+        assertThat(parcelRoundTrip(state.toArgs()).toState()).isEqualTo(state)
+    }
+
+    @Test
+    fun `legacy ready payment options args restore ready payment options state`() {
+        val state = EmbeddedActivityState.Ready.PaymentOptions(
+            context = context,
+            initialSelection = PaymentSelection.GooglePay,
+            previousNewSelections = previousNewSelections,
+            customerState = null,
+        )
+
+        assertThat(parcelRoundTrip(state.toArgs()).toState()).isEqualTo(state)
+    }
+
+    @Test
+    fun `invalid legacy loading mode is rejected`() {
+        val state = EmbeddedActivityState.LoadingPaymentOptions(
+            context = context,
+            initialSelection = null,
+            previousNewSelections = PreviousNewSelections.empty,
+            customerState = null,
+        )
+        val invalidArgs = state.toArgs().copy(launchMode = EmbeddedLaunchMode.Manage)
+
+        assertThat(invalidArgs.toState()).isNull()
+    }
+
+    @Test
+    fun `previous new selections updates and merges immutably`() {
+        val cardSelections = PreviousNewSelections.empty
+            .updatedWith(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        val cashAppSelections = PreviousNewSelections.empty
+            .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        val merged = cardSelections.mergedWith(cashAppSelections)
+
+        assertThat(cardSelections["cashapp"]).isNull()
+        assertThat(merged["card"]).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        assertThat(merged["cashapp"]).isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+    }
+
+    @Test
+    fun `previous new selections reads legacy Bundle parcel encoding`() {
+        val legacyBundle = previousNewSelections.toBundle()
+        val parcel = Parcel.obtain()
+        parcel.writeBundle(legacyBundle)
+        parcel.setDataPosition(0)
+
+        val restored = PreviousNewSelectionsParceler.create(parcel)
+
+        parcel.recycle()
+        assertThat(restored).isEqualTo(previousNewSelections)
+    }
+
+    @Test
+    fun `previous new selections writes legacy Bundle parcel encoding`() {
+        val parcel = Parcel.obtain()
+        with(PreviousNewSelectionsParceler) {
+            previousNewSelections.write(parcel, 0)
+        }
+        parcel.setDataPosition(0)
+
+        val restoredBundle = requireNotNull(parcel.readBundle(javaClass.classLoader))
+
+        parcel.recycle()
+        assertThat(PreviousNewSelections.fromBundle(restoredBundle)).isEqualTo(previousNewSelections)
+    }
+
+    private val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
+    private val context = EmbeddedActivityState.Context(
+        paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+        configuration = configuration,
+        productUsage = setOf("EmbeddedPaymentElement"),
+        paymentElementCallbackIdentifier = "callback_identifier",
+        statusBarColor = null,
+    )
+    private val previousNewSelections = PreviousNewSelections.empty
+        .updatedWith(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+
+    private inline fun <reified T : Parcelable> parcelRoundTrip(source: T): T {
+        val bundle = bundleOf(PARCELABLE_KEY to source)
+        val parcel = Parcel.obtain()
+        bundle.writeToParcel(parcel, 0)
+        parcel.setDataPosition(0)
+        val restoredBundle = Bundle.CREATOR.createFromParcel(parcel).apply {
+            classLoader = T::class.java.classLoader
+        }
+        parcel.recycle()
+        @Suppress("DEPRECATION")
+        return requireNotNull(restoredBundle.getParcelable(PARCELABLE_KEY))
+    }
+
+    private companion object {
+        const val PARCELABLE_KEY = "parcelable"
+    }
+}

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedConfirmationHelperTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import com.google.common.truth.Truth.assertThat
@@ -15,6 +14,7 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.gpay.GooglePayConfirmationOption
 import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOption
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -148,7 +148,11 @@ internal class DefaultEmbeddedConfirmationHelperTest {
         )
         confirmationStateHolder.state = loadedState
         val stateHelper = FakeEmbeddedStateHelper()
-        stateHelper.state = if (loadedState != null) EmbeddedPaymentElement.State(loadedState, null, Bundle()) else null
+        stateHelper.state = if (loadedState != null) {
+            EmbeddedPaymentElement.State(loadedState, null, PreviousNewSelections.empty)
+        } else {
+            null
+        }
         val callbackHelper = FakeEmbeddedResultCallbackHelper(
             stateHelper = stateHelper
         )

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedResultCallbackHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedResultCallbackHelperTest.kt
@@ -1,6 +1,5 @@
 package com.stripe.android.paymentelement.embedded.content
 
-import android.os.Bundle
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
@@ -8,6 +7,7 @@ import com.stripe.android.isInstanceOf
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedResultCallbackHelper
 import com.stripe.android.paymentelement.embedded.EmbeddedResultCallbackHelper
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -38,7 +38,7 @@ internal class DefaultEmbeddedResultCallbackHelperTest {
         stateHelper.state = EmbeddedPaymentElement.State(
             confirmationState = EmbeddedConfirmationStateFixtures.defaultState(),
             customer = null,
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
         )
         val resultCallbackTurbine = Turbine<EmbeddedPaymentElement.Result>()
         val helper = DefaultEmbeddedResultCallbackHelper(

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncherTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentelement.embedded.content
 
 import android.app.Application
-import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
@@ -9,6 +8,7 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
+import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.model.PaymentMethodMessageLearnMore
@@ -17,13 +17,12 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.confirmation.asCallbackFor
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedRowSelectionImmediateActionHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
-import com.stripe.android.paymentelement.embedded.previousNewSelection
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
-import com.stripe.android.paymentelement.embedded.stashNewSelection
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
@@ -71,20 +70,13 @@ internal class DefaultEmbeddedSheetLauncherTest {
                 url = "https://www.test.com",
             ),
         )
-        val expectedArgs = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = EmbeddedConfigurationFactory.create(),
-            productUsage = setOf("EmbeddedPaymentElement"),
-            paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
-            statusBarColor = null,
-            selection = null,
+        val expectedArgs = EmbeddedActivityState.Ready.Form(
+            context = readyContext(paymentMethodMetadata),
+            selectedPaymentMethodCode = code,
+            initialSelection = null,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = listOf(promotion),
-            launchMode = EmbeddedLaunchMode.Form(
-                selectedPaymentMethodCode = code,
-            ),
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+            promotion = promotion,
         )
 
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
@@ -114,8 +106,8 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = createCustomerState(),
             promotion = null,
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.selection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityState.Ready.Form
+        assertThat(launchCall.initialSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
     }
 
     @Test
@@ -131,8 +123,8 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = createCustomerState(),
             promotion = null,
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.selection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityState.Ready.Form
+        assertThat(launchCall.initialSelection).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
     }
 
     @Test
@@ -147,8 +139,8 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = createCustomerState(),
             promotion = null,
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.selection).isNull()
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityState.Ready.Form
+        assertThat(launchCall.initialSelection).isNull()
     }
 
     @Test
@@ -163,8 +155,8 @@ internal class DefaultEmbeddedSheetLauncherTest {
             customerState = createCustomerState(),
             promotion = null,
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
-        assertThat(launchCall.selection).isNull()
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityState.Ready.Form
+        assertThat(launchCall.initialSelection).isNull()
     }
 
     @Test
@@ -208,7 +200,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         launchForm("test_code")
 
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = null,
             hasBeenConfirmed = true,
             customerState = null,
@@ -236,7 +228,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         launchForm("cashapp")
 
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
             hasBeenConfirmed = false,
             customerState = null,
@@ -266,7 +258,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             launchForm("cashapp")
 
             val result = EmbeddedActivityResult.Complete(
-                previousNewSelections = Bundle(),
+                previousNewSelections = PreviousNewSelections.empty,
                 selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
                 hasBeenConfirmed = false,
                 customerState = null,
@@ -292,7 +284,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             launchForm("cashapp")
 
             val result = EmbeddedActivityResult.Complete(
-                previousNewSelections = Bundle(),
+                previousNewSelections = PreviousNewSelections.empty,
                 selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
                 hasBeenConfirmed = true,
                 customerState = null,
@@ -359,7 +351,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
 
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             customerState = createCustomerState(),
             selection = null,
             hasBeenConfirmed = false,
@@ -398,18 +390,11 @@ internal class DefaultEmbeddedSheetLauncherTest {
     fun `launchManage launches activity with correct parameters`() = testScenario {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
-        val expectedArgs = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = EmbeddedConfigurationFactory.create(),
-            productUsage = setOf("EmbeddedPaymentElement"),
-            paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
-            statusBarColor = null,
-            selection = PaymentSelection.GooglePay,
+        val expectedArgs = EmbeddedActivityState.Ready.Manage(
+            context = readyContext(paymentMethodMetadata),
+            initialSelection = PaymentSelection.GooglePay,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.Manage,
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchManage(
@@ -443,7 +428,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
@@ -469,7 +454,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
             val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             val result = EmbeddedActivityResult.Complete(
-                previousNewSelections = Bundle(),
+                previousNewSelections = PreviousNewSelections.empty,
                 customerState = customerState,
                 selection = selection,
                 hasBeenConfirmed = false,
@@ -492,7 +477,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
             val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
             val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
             val result = EmbeddedActivityResult.Complete(
-                previousNewSelections = Bundle(),
+                previousNewSelections = PreviousNewSelections.empty,
                 customerState = customerState,
                 selection = selection,
                 hasBeenConfirmed = false,
@@ -537,7 +522,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
     @Test
     fun `form result handled correctly without prior launchForm call (simulates host recreation)`() = testScenario {
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             selection = PaymentMethodFixtures.CARD_PAYMENT_SELECTION,
             hasBeenConfirmed = true,
             customerState = null,
@@ -579,18 +564,11 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.GooglePay
-        val expectedArgs = EmbeddedActivityArgs(
-            paymentMethodMetadata = paymentMethodMetadata,
-            configuration = EmbeddedConfigurationFactory.create(),
-            productUsage = setOf("EmbeddedPaymentElement"),
-            paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
-            statusBarColor = null,
-            selection = selection,
+        val expectedArgs = EmbeddedActivityState.Ready.PaymentOptions(
+            context = readyContext(paymentMethodMetadata),
+            initialSelection = selection,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.PaymentOptions,
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
 
         sheetLauncher.launchPaymentOptions(
@@ -644,18 +622,18 @@ internal class DefaultEmbeddedSheetLauncherTest {
             selection = PaymentSelection.GooglePay,
             configuration = EmbeddedConfigurationFactory.create(),
         )
-        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall() as EmbeddedActivityArgs
+        val launchCall = dummyActivityResultCallerScenario.awaitLaunchCall()
+            as EmbeddedActivityState.Ready.PaymentOptions
 
-        assertThat(launchCall.previousNewSelections.previousNewSelection("cashapp"))
+        assertThat(launchCall.previousNewSelections["cashapp"])
             .isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
     }
 
     @Test
     fun `paymentOptionsResult merges returned previous new selections into selection holder`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
-        val returnedSelections = Bundle().apply {
-            stashNewSelection(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
-        }
+        val returnedSelections = PreviousNewSelections.empty
+            .updatedWith(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
         val result = EmbeddedActivityResult.Complete(
             previousNewSelections = returnedSelections,
             customerState = null,
@@ -679,7 +657,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.Saved(PaymentMethodFixtures.CARD_PAYMENT_METHOD)
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             customerState = customerState,
             selection = selection,
             hasBeenConfirmed = false,
@@ -700,7 +678,7 @@ internal class DefaultEmbeddedSheetLauncherTest {
     fun `paymentOptionsResult callback invokes completion callback on confirmed result`() = testScenario {
         sheetStateHolder.sheetIsOpen = true
         val result = EmbeddedActivityResult.Complete(
-            previousNewSelections = Bundle(),
+            previousNewSelections = PreviousNewSelections.empty,
             customerState = null,
             selection = null,
             hasBeenConfirmed = true,
@@ -868,5 +846,17 @@ internal class DefaultEmbeddedSheetLauncherTest {
             )
             dummyActivityResultCallerScenario.awaitLaunchCall()
         }
+    }
+
+    private fun readyContext(
+        paymentMethodMetadata: PaymentMethodMetadata,
+    ): EmbeddedActivityState.Context {
+        return EmbeddedActivityState.Context(
+            paymentMethodMetadata = paymentMethodMetadata,
+            configuration = EmbeddedConfigurationFactory.create(),
+            productUsage = setOf("EmbeddedPaymentElement"),
+            paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
+            statusBarColor = null,
+        )
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedStateHelperTest.kt
@@ -1,7 +1,6 @@
 
 package com.stripe.android.paymentelement.embedded.content
 
-import android.os.Bundle
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
@@ -14,6 +13,7 @@ import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.DefaultEmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.EmbeddedSelectionHolder
 import com.stripe.android.paymentelement.embedded.InternalRowSelectionCallback
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -85,7 +85,9 @@ internal class DefaultEmbeddedStateHelperTest {
             selection = PaymentSelection.GooglePay,
             customer = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
         )
-        selectionHolder.previousNewSelections.putParcelable("card", PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        selectionHolder.setPreviousNewSelections(
+            PreviousNewSelections.empty.updatedWith(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
+        )
 
         confirmationHandler.bootstrapTurbine.awaitItem()
         assertThat(stateHelper.state).isNotNull()
@@ -271,7 +273,7 @@ internal class DefaultEmbeddedStateHelperTest {
                     statusBarColor = null,
                 ),
                 customer = customer,
-                previousNewSelections = Bundle(),
+                previousNewSelections = PreviousNewSelections.empty,
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/form/EmbeddedSheetActivityTest.kt
@@ -30,9 +30,10 @@ import com.stripe.android.model.PaymentIntentFixtures
 import com.stripe.android.model.PaymentMethodCode
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetActivity
 import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetContract
 import com.stripe.android.paymentsheet.createCustomerState
@@ -252,20 +253,19 @@ internal class EmbeddedSheetActivityTest {
         ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
             EmbeddedSheetContract.createIntent(
                 context = applicationContext,
-                input = EmbeddedActivityArgs(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    configuration = configuration,
-                    productUsage = setOf("EmbeddedPaymentElement"),
-                    statusBarColor = null,
-                    paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
-                    selection = null,
-                    previousNewSelections = Bundle(),
-                    customerState = createCustomerState(paymentMethods = emptyList()),
-                    promotions = emptyList(),
-                    launchMode = EmbeddedLaunchMode.Form(
-                        selectedPaymentMethodCode = selectedPaymentMethodCode,
+                input = EmbeddedActivityState.Ready.Form(
+                    context = EmbeddedActivityState.Context(
+                        paymentMethodMetadata = paymentMethodMetadata,
+                        configuration = configuration,
+                        productUsage = setOf("EmbeddedPaymentElement"),
+                        statusBarColor = null,
+                        paymentElementCallbackIdentifier = "EmbeddedFormTestIdentifier",
                     ),
-                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+                    selectedPaymentMethodCode = selectedPaymentMethodCode,
+                    initialSelection = null,
+                    previousNewSelections = PreviousNewSelections.empty,
+                    customerState = createCustomerState(paymentMethods = emptyList()),
+                    promotion = null,
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityCoordinatorTest.kt
@@ -1,7 +1,6 @@
 package com.stripe.android.paymentelement.embedded.sheet
 
 import android.content.Intent
-import android.os.Bundle
 import androidx.activity.result.ActivityResultCaller
 import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
@@ -14,7 +13,9 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
-import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
+import com.stripe.android.paymentelement.embedded.toArgs
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.createComposeCleanupRule
@@ -40,7 +41,7 @@ internal class EmbeddedSheetActivityCoordinatorTest {
     @Test
     fun `construction creates the presentation`() = runScenario {
         assertThat(createCall.activity).isSameInstanceAs(activity)
-        assertThat(createCall.args).isEqualTo(args)
+        assertThat(createCall.state).isEqualTo(state)
         assertThat(createCall.activityResultCaller).isSameInstanceAs(activity)
     }
 
@@ -84,18 +85,17 @@ internal class EmbeddedSheetActivityCoordinatorTest {
 
     @Test
     fun `valid loading to ready transition replaces and registers presentation`() = runScenario {
-        val readyArgs = createArgs(
-            presentationState = EmbeddedActivityArgs.PresentationState.Ready,
+        val readyState = createReadyState(
             callbackIdentifier = "updated_callback_identifier",
         )
-        val readyIntent = createIntent(readyArgs)
+        val readyIntent = createIntent(readyState)
 
         coordinator.handleNewIntent(readyIntent)
 
         assertThat(initialPresentation.onDestroyCalls.awaitItem()).isEqualTo(Unit)
         val createCall = presentationFactory.createCalls.awaitItem()
         assertThat(createCall.activity).isSameInstanceAs(activity)
-        assertThat(createCall.args).isEqualTo(readyArgs)
+        assertThat(createCall.state).isEqualTo(readyState)
         assertThat(createCall.activityResultCaller).isNotSameInstanceAs(activity)
         assertThat(readyPresentation.registerCalls.awaitItem()).isEqualTo(Unit)
         assertThat(activity.intent).isSameInstanceAs(readyIntent)
@@ -112,7 +112,7 @@ internal class EmbeddedSheetActivityCoordinatorTest {
     @Test
     fun `loading intent is ignored`() = runScenario {
         assertTransitionIgnored(
-            createIntent(createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Loading))
+            createIntent(createLoadingState())
         )
     }
 
@@ -120,20 +120,17 @@ internal class EmbeddedSheetActivityCoordinatorTest {
     fun `ready manage intent is ignored`() = runScenario {
         assertTransitionIgnored(
             createIntent(
-                createArgs(
-                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
-                    launchMode = EmbeddedLaunchMode.Manage,
-                )
+                createManageState()
             )
         )
     }
 
     @Test
     fun `ready coordinator ignores later ready intent`() = runScenario(
-        initialArgs = createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready),
+        initialState = createReadyState(),
     ) {
         assertTransitionIgnored(
-            createIntent(createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready))
+            createIntent(createReadyState())
         )
     }
 
@@ -142,14 +139,12 @@ internal class EmbeddedSheetActivityCoordinatorTest {
         activity.finish()
 
         assertTransitionIgnored(
-            createIntent(createArgs(presentationState = EmbeddedActivityArgs.PresentationState.Ready))
+            createIntent(createReadyState())
         )
     }
 
     private fun runScenario(
-        initialArgs: EmbeddedActivityArgs = createArgs(
-            presentationState = EmbeddedActivityArgs.PresentationState.Loading,
-        ),
+        initialState: EmbeddedActivityState = createLoadingState(),
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val activity = Robolectric.buildActivity(EmbeddedSheetActivity::class.java).get()
@@ -161,14 +156,14 @@ internal class EmbeddedSheetActivityCoordinatorTest {
         )
         val coordinator = EmbeddedSheetActivityCoordinator(
             activity = activity,
-            initialArgs = initialArgs,
+            initialState = initialState,
             presentationFactory = presentationFactory,
         )
         val createCall = presentationFactory.createCalls.awaitItem()
 
         Scenario(
             activity = activity,
-            args = initialArgs,
+            state = initialState,
             coordinator = coordinator,
             initialPresentation = initialPresentation,
             readyPresentation = readyPresentation,
@@ -183,7 +178,7 @@ internal class EmbeddedSheetActivityCoordinatorTest {
 
     private data class Scenario(
         val activity: EmbeddedSheetActivity,
-        val args: EmbeddedActivityArgs,
+        val state: EmbeddedActivityState,
         val coordinator: EmbeddedSheetActivityCoordinator,
         val initialPresentation: FakeEmbeddedSheetPresentation,
         val readyPresentation: FakeEmbeddedSheetPresentation,
@@ -212,13 +207,13 @@ internal class EmbeddedSheetActivityCoordinatorTest {
 
         override fun create(
             activity: EmbeddedSheetActivity,
-            args: EmbeddedActivityArgs,
+            state: EmbeddedActivityState,
             activityResultCaller: ActivityResultCaller,
         ): EmbeddedSheetPresentation {
-            createCalls.add(CreateCall(activity, args, activityResultCaller))
-            return when (args.presentationState) {
-                EmbeddedActivityArgs.PresentationState.Loading -> initialPresentation
-                EmbeddedActivityArgs.PresentationState.Ready -> readyPresentation
+            createCalls.add(CreateCall(activity, state, activityResultCaller))
+            return when (state) {
+                is EmbeddedActivityState.LoadingPaymentOptions -> initialPresentation
+                is EmbeddedActivityState.Ready -> readyPresentation
             }
         }
 
@@ -228,7 +223,7 @@ internal class EmbeddedSheetActivityCoordinatorTest {
 
         data class CreateCall(
             val activity: EmbeddedSheetActivity,
-            val args: EmbeddedActivityArgs,
+            val state: EmbeddedActivityState,
             val activityResultCaller: ActivityResultCaller,
         )
     }
@@ -274,28 +269,47 @@ internal class EmbeddedSheetActivityCoordinatorTest {
     private companion object {
         const val CONTENT_TEST_TAG = "coordinator_content"
 
-        fun createArgs(
-            presentationState: EmbeddedActivityArgs.PresentationState,
-            launchMode: EmbeddedLaunchMode = EmbeddedLaunchMode.PaymentOptions,
+        fun createReadyState(
             callbackIdentifier: String = "callback_identifier",
-        ): EmbeddedActivityArgs {
-            return EmbeddedActivityArgs(
+        ): EmbeddedActivityState.Ready.PaymentOptions {
+            return EmbeddedActivityState.Ready.PaymentOptions(
+                context = createContext(callbackIdentifier),
+                initialSelection = null,
+                previousNewSelections = PreviousNewSelections.empty,
+                customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            )
+        }
+
+        fun createManageState(): EmbeddedActivityState.Ready.Manage {
+            return EmbeddedActivityState.Ready.Manage(
+                context = createContext("callback_identifier"),
+                initialSelection = null,
+                previousNewSelections = PreviousNewSelections.empty,
+                customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            )
+        }
+
+        fun createLoadingState(): EmbeddedActivityState.LoadingPaymentOptions {
+            return EmbeddedActivityState.LoadingPaymentOptions(
+                context = createContext("callback_identifier"),
+                initialSelection = null,
+                previousNewSelections = PreviousNewSelections.empty,
+                customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
+            )
+        }
+
+        private fun createContext(callbackIdentifier: String): EmbeddedActivityState.Context {
+            return EmbeddedActivityState.Context(
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
                 configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
                 productUsage = setOf("EmbeddedPaymentElement"),
                 paymentElementCallbackIdentifier = callbackIdentifier,
                 statusBarColor = null,
-                selection = null,
-                previousNewSelections = Bundle(),
-                customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
-                promotions = emptyList(),
-                launchMode = launchMode,
-                presentationState = presentationState,
             )
         }
 
-        fun createIntent(args: EmbeddedActivityArgs): Intent {
-            return Intent().putExtra(EmbeddedActivityArgs.EXTRA_ARGS, args)
+        fun createIntent(state: EmbeddedActivityState): Intent {
+            return Intent().putExtra(EmbeddedActivityArgs.EXTRA_ARGS, state.toArgs())
         }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivityTest.kt
@@ -23,9 +23,9 @@ import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.networktesting.TestApiKeys
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
-import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
 import com.stripe.android.paymentsheet.model.PaymentSelection
@@ -262,21 +262,19 @@ internal class EmbeddedSheetActivityTest {
         ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
             EmbeddedSheetContract.createIntent(
                 context = applicationContext,
-                input = EmbeddedActivityArgs(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.")
-                        .build(),
-                    productUsage = setOf("EmbeddedPaymentElement"),
-                    paymentElementCallbackIdentifier = "EmbeddedSheetActivityTestCallbackIdentifier",
-                    statusBarColor = null,
-                    selection = selection,
-                    previousNewSelections = Bundle(),
+                input = EmbeddedActivityState.Ready.Manage(
+                    context = EmbeddedActivityState.Context(
+                        paymentMethodMetadata = paymentMethodMetadata,
+                        configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+                        productUsage = setOf("EmbeddedPaymentElement"),
+                        paymentElementCallbackIdentifier = "EmbeddedSheetActivityTestCallbackIdentifier",
+                        statusBarColor = null,
+                    ),
+                    initialSelection = selection,
+                    previousNewSelections = PreviousNewSelections.empty,
                     customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE.copy(
                         paymentMethods = paymentMethods,
                     ),
-                    promotions = emptyList(),
-                    launchMode = EmbeddedLaunchMode.Manage,
-                    presentationState = EmbeddedActivityArgs.PresentationState.Ready,
                 ),
             )
         ).use { scenario ->

--- a/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentelement/embedded/sheet/PaymentOptionsEmbeddedSheetActivityTest.kt
@@ -2,7 +2,6 @@ package com.stripe.android.paymentelement.embedded.sheet
 
 import android.app.Activity
 import android.app.Application
-import android.os.Bundle
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
@@ -27,11 +26,10 @@ import com.stripe.android.model.PaymentMethod
 import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.networktesting.NetworkRule
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
-import com.stripe.android.paymentelement.embedded.EmbeddedActivityArgs
 import com.stripe.android.paymentelement.embedded.EmbeddedActivityResult
+import com.stripe.android.paymentelement.embedded.EmbeddedActivityState
 import com.stripe.android.paymentelement.embedded.EmbeddedLaunchMode
-import com.stripe.android.paymentelement.embedded.previousNewSelection
-import com.stripe.android.paymentelement.embedded.stashNewSelection
+import com.stripe.android.paymentelement.embedded.PreviousNewSelections
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.R
@@ -71,7 +69,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
     @Test
     fun `loading renders and cancellation returns PaymentOptions`() = launch(
-        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+        loading = true,
     ) { scenario ->
         composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
 
@@ -88,7 +86,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
     @Test
     fun `recreated loading activity remains loading`() = launch(
-        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+        loading = true,
     ) { scenario ->
         composeTestRule.onNodeWithTag(EMBEDDED_SHEET_LOADING_TEST_TAG).assertIsDisplayed()
 
@@ -103,7 +101,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
     @Test
     fun `ready intent updates loading content without replacing composition and survives recreation`() = launch(
-        presentationState = EmbeddedActivityArgs.PresentationState.Loading,
+        loading = true,
     ) { scenario ->
         val readyIntent = EmbeddedSheetContract.createIntent(
             applicationContext,
@@ -111,7 +109,6 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                 paymentMethodMetadata = PaymentMethodMetadataFactory.create(
                     paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Horizontal,
                 ),
-                presentationState = EmbeddedActivityArgs.PresentationState.Ready,
             ),
         )
 
@@ -165,9 +162,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
         launch(
             selection = selection,
-            previousNewSelections = Bundle().apply {
-                stashNewSelection(previousNewSelection)
-            },
+            previousNewSelections = PreviousNewSelections.empty.updatedWith(previousNewSelection),
         ) { scenario ->
             composeTestRule.onNodeWithTag(PRIMARY_BUTTON_TEST_TAG)
                 .performScrollTo()
@@ -180,7 +175,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                 scenario.result.resultData,
             ) as EmbeddedActivityResult.Complete
             assertThat(result.selection).isEqualTo(selection)
-            assertThat(result.previousNewSelections.previousNewSelection("cashapp"))
+            assertThat(result.previousNewSelections["cashapp"])
                 .isEqualTo(previousNewSelection)
             assertThat(result.launchMode).isEqualTo(EmbeddedLaunchMode.PaymentOptions)
         }
@@ -312,11 +307,11 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
     private fun launch(
         selection: PaymentSelection? = null,
-        previousNewSelections: Bundle = Bundle(),
+        previousNewSelections: PreviousNewSelections = PreviousNewSelections.empty,
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         ),
-        presentationState: EmbeddedActivityArgs.PresentationState = EmbeddedActivityArgs.PresentationState.Ready,
+        loading: Boolean = false,
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) = launch(
         selection = selection,
@@ -327,7 +322,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                 listOf(it.paymentMethod)
             }.orEmpty(),
         ),
-        presentationState = presentationState,
+        loading = loading,
         block = block,
     )
 
@@ -336,7 +331,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) = launch(
         selection = null,
-        previousNewSelections = Bundle(),
+        previousNewSelections = PreviousNewSelections.empty,
         paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         ),
@@ -346,10 +341,10 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
     private fun launch(
         selection: PaymentSelection?,
-        previousNewSelections: Bundle,
+        previousNewSelections: PreviousNewSelections,
         paymentMethodMetadata: PaymentMethodMetadata,
         customerState: CustomerState,
-        presentationState: EmbeddedActivityArgs.PresentationState = EmbeddedActivityArgs.PresentationState.Ready,
+        loading: Boolean = false,
         block: (ActivityScenario<EmbeddedSheetActivity>) -> Unit,
     ) {
         ActivityScenario.launchActivityForResult<EmbeddedSheetActivity>(
@@ -360,7 +355,7 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
                     previousNewSelections = previousNewSelections,
                     paymentMethodMetadata = paymentMethodMetadata,
                     customerState = customerState,
-                    presentationState = presentationState,
+                    loading = loading,
                 ),
             )
         ).use { scenario ->
@@ -370,26 +365,36 @@ internal class PaymentOptionsEmbeddedSheetActivityTest {
 
     private fun createArgs(
         selection: PaymentSelection? = null,
-        previousNewSelections: Bundle = Bundle(),
+        previousNewSelections: PreviousNewSelections = PreviousNewSelections.empty,
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(
             paymentMethodLayout = PaymentSheet.PaymentMethodLayout.Vertical,
         ),
         customerState: CustomerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE,
-        presentationState: EmbeddedActivityArgs.PresentationState,
-    ): EmbeddedActivityArgs {
-        return EmbeddedActivityArgs(
+        loading: Boolean = false,
+    ): EmbeddedActivityState {
+        val configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build()
+        val context = EmbeddedActivityState.Context(
             paymentMethodMetadata = paymentMethodMetadata,
-            configuration = EmbeddedPaymentElement.Configuration.Builder("Example, Inc.").build(),
+            configuration = configuration,
             productUsage = setOf("EmbeddedPaymentElement"),
             statusBarColor = null,
             paymentElementCallbackIdentifier = "PaymentOptionsTestIdentifier",
-            selection = selection,
-            previousNewSelections = previousNewSelections,
-            customerState = customerState,
-            promotions = emptyList(),
-            launchMode = EmbeddedLaunchMode.PaymentOptions,
-            presentationState = presentationState,
         )
+        return if (loading) {
+            EmbeddedActivityState.LoadingPaymentOptions(
+                context = context,
+                initialSelection = selection,
+                previousNewSelections = previousNewSelections,
+                customerState = customerState,
+            )
+        } else {
+            EmbeddedActivityState.Ready.PaymentOptions(
+                context = context,
+                initialSelection = selection,
+                previousNewSelections = previousNewSelections,
+                customerState = customerState,
+            )
+        }
     }
 
     private fun checkoutPaymentMethodMetadata(): PaymentMethodMetadata {


### PR DESCRIPTION
# Summary

- Model embedded sheet launches with typed loading, form, manage, and payment-options states.
- Keep the existing Parcelable activity boundary while validating conversions to and from the typed state.
- Replace mutable selection Bundles with an immutable `PreviousNewSelections` value that preserves the legacy parcel encoding.

# Motivation

The embedded sheet previously represented presentation state, launch mode, promotions, customer state, and selections as independent fields. That allowed invalid combinations to reach the activity. Typed states make those combinations unrepresentable in the launchers and constrain loading-to-ready transitions while retaining saved-state and parcel compatibility.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Validated with:

- `./gradlew detekt :paymentsheet:testDebugUnitTest`

No tests were newly ignored.

# Screenshots

Not applicable: this is an internal state-modeling refactor with no visual changes.

# Changelog

Not applicable: this internal refactor does not change the public API or user-visible behavior.

Committed and created by Codex.
