### PR TITLE
Preserve Link root flow across host recreation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
@@ -41,7 +41,6 @@ internal class CheckoutLinkPaymentOptionsPresenter @Inject constructor(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     linkPaymentLauncher.unregister()
-                    sheetStateHolder.sheetIsOpen = false
                 }
             }
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
@@ -207,7 +207,34 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
         verify(linkPaymentLauncher).unregister()
-        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+    }
+
+    @Test
+    fun `host recreation keeps direct Link root flow open until its result`() {
+        val savedStateHandle = SavedStateHandle()
+        runScenario(savedStateHandle = savedStateHandle) {
+            presenter.present()
+
+            lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+            verify(linkPaymentLauncher).unregister()
+            assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+        }
+
+        runScenario(savedStateHandle = savedStateHandle) {
+            assertThat(sheetStateHolder.sheetIsOpen).isTrue()
+
+            resultCallback(
+                LinkActivityResult.Canceled(
+                    reason = LinkActivityResult.Canceled.Reason.BackPressed,
+                    linkAccountUpdate = LinkAccountUpdate.None,
+                )
+            )
+
+            assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+            verify(defaultPresenter, never()).present()
+        }
     }
 
     @Suppress("LongMethod")

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
@@ -201,17 +201,7 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
     }
 
     @Test
-    fun `destroy unregisters direct Link and clears open state`() = runScenario {
-        presenter.present()
-
-        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
-
-        verify(linkPaymentLauncher).unregister()
-        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
-    }
-
-    @Test
-    fun `host recreation keeps direct Link root flow open until its result`() {
+    fun `host recreation unregisters old Link launcher and keeps root flow open until replacement result`() {
         val savedStateHandle = SavedStateHandle()
         runScenario(savedStateHandle = savedStateHandle) {
             presenter.present()


### PR DESCRIPTION
# Summary

Checkout Link remains the active sheet while its separate Link Activity is open, even if the merchant host is recreated.

## What changed

- `CheckoutLinkPaymentOptionsPresenter.onDestroy()` unregisters only its host-bound Link launcher callback.
- The controller-scoped `sheetIsOpen` gate remains set until a terminal Link result closes it, or until Link explicitly hands off to default PaymentOptions.

## What stays the same

- Link terminal outcomes still release the gate when the flow ends.
- The PaymentOptions handoff still releases the gate immediately before the default presenter takes ownership.
- No public API or Checkout Loading-to-Ready coordinator behavior changes.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Focused two-host coverage launches eligible Link, destroys the first host, registers a replacement presenter from the same saved state, and delivers a terminal Back result through the replacement callback. It verifies that the gate stays open while Link remains active and closes when Link ends.

The path-aware pre-push check passed the affected PaymentSheet static-analysis and API checks. CI is pending.

# Screenshots

Not applicable. This corrects lifecycle ownership without changing Link UI.

# Changelog

None. Checkout remains private preview, and this change does not affect public API.

Committed and created by Codex.
