### PR TITLE
Fix Checkout PaymentElement Google Pay configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutCommonConfigurationFactory.kt
@@ -23,7 +23,7 @@ internal class CheckoutCommonConfigurationFactory @Inject constructor(
         checkoutSessionResponse = checkoutSessionResponse,
         collectedDetails = collectedDetails,
         googlePayConfiguration =
-            configuration.toExpressCheckoutElementGooglePayConfiguration(checkoutSessionResponse),
+            configuration.toPaymentElementGooglePayConfiguration(checkoutSessionResponse),
         linkConfiguration = configuration.paymentElementConfiguration.linkConfiguration.asPaymentSheet(),
         billingDetailsCollectionConfiguration =
             checkoutSessionResponse.toBillingDetailsCollectionConfiguration(),

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfigurationMappers.kt
@@ -5,6 +5,7 @@ import com.stripe.android.paymentsheet.BuildConfig
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.addresselement.AddressDetails
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.elements.CheckoutGooglePayConfiguration.Display as GooglePayDisplay
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutSessionResponse.toBillingDetailsCollectionConfiguration():
@@ -41,13 +42,17 @@ internal fun CheckoutController.Configuration.State.toExpressCheckoutElementGoog
 internal fun CheckoutController.Configuration.State.toPaymentElementGooglePayConfiguration(
     checkoutSessionResponse: CheckoutSessionResponse,
 ): PaymentSheet.GooglePayConfiguration? =
-    checkoutSessionResponse.merchantCountry?.let { merchantCountry ->
-        paymentElementConfiguration.googlePayConfiguration.asPaymentSheet(
-            merchantCountry = merchantCountry,
-            liveMode = checkoutSessionResponse.livemode,
-            isDebugBuild = BuildConfig.DEBUG,
-        )
-    }
+    paymentElementConfiguration.googlePayConfiguration
+        .takeIf { it.display == GooglePayDisplay.Automatic }
+        ?.let { configuration ->
+            checkoutSessionResponse.merchantCountry?.let { merchantCountry ->
+                configuration.asPaymentSheet(
+                    merchantCountry = merchantCountry,
+                    liveMode = checkoutSessionResponse.livemode,
+                    isDebugBuild = BuildConfig.DEBUG,
+                )
+            }
+        }
 
 @OptIn(CheckoutSessionPreview::class)
 internal fun CheckoutController.Configuration.State.toBillingDetails(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactory.kt
@@ -31,7 +31,7 @@ internal class CheckoutEmbeddedConfigurationFactory @Inject constructor(
             )
             .termsDisplay(configuration.paymentElementConfiguration.termsDisplay.asPaymentSheet())
             .appearance(configuration.paymentElementConfiguration.appearance.asPaymentSheet())
-            .googlePay(configuration.toExpressCheckoutElementGooglePayConfiguration(checkoutSessionResponse))
+            .googlePay(configuration.toPaymentElementGooglePayConfiguration(checkoutSessionResponse))
             .link(configuration.paymentElementConfiguration.linkConfiguration.asPaymentSheet())
             .defaultBillingDetails(
                 configuration.toBillingDetails(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutEmbeddedConfigurationFactoryTest.kt
@@ -13,6 +13,7 @@ import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import org.junit.Test
+import com.stripe.android.elements.PaymentElement.Configuration.GooglePayConfiguration as PaymentElementGooglePayConfiguration
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Automatic as PSAutomatic
 import com.stripe.android.paymentsheet.PaymentSheet.BillingDetailsCollectionConfiguration.AddressCollectionMode.Full as PSFull
 
@@ -121,13 +122,24 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
-    fun `maps googlePayConfiguration using the checkout session country`() {
-        val configuration = controllerConfiguration(
-            googlePayConfiguration = GooglePayConfiguration()
-                .label("Total")
-                .buttonType(GooglePayConfiguration.ButtonType.Checkout)
-                .additionalEnabledNetworks(listOf("INTERAC")),
-        )
+    fun `maps payment element googlePayConfiguration using the checkout session country`() {
+        val configuration = CheckoutController.Configuration()
+            .paymentElement(
+                PaymentElement.Configuration().googlePayConfiguration(
+                    PaymentElementGooglePayConfiguration()
+                        .label("PE total")
+                        .buttonType(PaymentElementGooglePayConfiguration.ButtonType.Buy)
+                        .additionalEnabledNetworks(listOf("INTERAC"))
+                )
+            )
+            .expressCheckoutElement(
+                ExpressCheckoutElement.Configuration().googlePayConfiguration(
+                    GooglePayConfiguration()
+                        .label("ECE total")
+                        .buttonType(GooglePayConfiguration.ButtonType.Donate)
+                )
+            )
+            .build()
 
         val result = factory().create(
             configuration = configuration,
@@ -142,9 +154,9 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
         assertThat(googlePay.environment)
             .isEqualTo(PaymentSheet.GooglePayConfiguration.Environment.Test)
         assertThat(googlePay.countryCode).isEqualTo("GB")
-        assertThat(googlePay.label).isEqualTo("Total")
+        assertThat(googlePay.label).isEqualTo("PE total")
         assertThat(googlePay.buttonType)
-            .isEqualTo(PaymentSheet.GooglePayConfiguration.ButtonType.Checkout)
+            .isEqualTo(PaymentSheet.GooglePayConfiguration.ButtonType.Buy)
         assertThat(googlePay.additionalEnabledNetworks).containsExactly("INTERAC")
     }
 
@@ -220,17 +232,22 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     }
 
     @Test
-    fun `maps googlePay regardless of ECE display setting`() {
+    fun `leaves googlePay null when payment element display is Never`() {
         val result = factory().create(
-            configuration = controllerConfiguration(
-                googlePayConfiguration = GooglePayConfiguration()
-                    .display(GooglePayConfiguration.Display.Never),
-            ),
+            configuration = CheckoutController.Configuration()
+                .paymentElement(
+                    PaymentElement.Configuration().googlePayConfiguration(
+                        PaymentElementGooglePayConfiguration()
+                            .display(PaymentElementGooglePayConfiguration.Display.Never)
+                    )
+                )
+                .expressCheckoutElement(ExpressCheckoutElement.Configuration())
+                .build(),
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(merchantCountry = "US"),
             collectedDetails = collectedDetails(),
         )
 
-        assertThat(result.googlePay).isNotNull()
+        assertThat(result.googlePay).isNull()
     }
 
     @Test
@@ -365,20 +382,14 @@ internal class CheckoutEmbeddedConfigurationFactoryTest {
     private fun controllerConfiguration(
         embeddedViewDisplaysMandateText: Boolean = true,
         appearance: PaymentElement.Configuration.Appearance = PaymentElement.Configuration.Appearance(),
-        googlePayConfiguration: GooglePayConfiguration? = null,
     ): CheckoutController.Configuration.State {
-        val builder = CheckoutController.Configuration()
+        return CheckoutController.Configuration()
             .paymentElement(
                 PaymentElement.Configuration()
                     .embeddedViewDisplaysMandateText(embeddedViewDisplaysMandateText)
                     .appearance(appearance)
             )
-        if (googlePayConfiguration != null) {
-            builder.expressCheckoutElement(
-                ExpressCheckoutElement.Configuration().googlePayConfiguration(googlePayConfiguration)
-            )
-        }
-        return builder.build()
+            .build()
     }
 
     private fun collectedDetails(


### PR DESCRIPTION
# Summary

Use `PaymentElement.Configuration.googlePayConfiguration` when building Checkout's embedded PaymentElement sheet configuration. Honor `Display.Never` by omitting the sheet's Google Pay configuration.

Committed and created by Codex.

# Motivation

Checkout incorrectly sourced the embedded PaymentElement sheet's Google Pay settings from `ExpressCheckoutElement.Configuration`. As a result, PaymentElement-specific labels, button types, additional networks, and display preferences could be ignored, while Express Checkout settings could unexpectedly affect the PaymentElement sheet.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutEmbeddedConfigurationFactoryTest'`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

Not applicable. This fixes configuration wiring without changing a directly screenshot-testable UI state.

# Changelog

Not applicable. Checkout Session PaymentElement configuration is a preview API restricted to the library group.
