### PR TITLE
StripeCryptoOnramp: Callback Registration Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ NEXT_VERSION_BUMP: PATCH
 ### PaymentSheet
 * [FIXED][14436](https://github.com/stripe/stripe-android/pull/14436) Fixed a rare race condition which could result in the payment sheet being half-visible on screen.
 
+### CryptoOnramp
+* [FIXED] Fixed missing callbacks when reusing an `OnrampCoordinator` to create a new presenter after its previous host activity finishes.
+
 ## 23.18.0 - 2026-09-08
 
 ### PaymentSheet

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCallbackStore.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCallbackStore.kt
@@ -1,0 +1,25 @@
+package com.stripe.android.crypto.onramp
+
+import com.stripe.android.crypto.onramp.model.OnrampCallbacks
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Coordinators share the cached component's interactor and callback key. Keep the latest
+ * builder-supplied callbacks here so an older coordinator cannot restore stale callbacks.
+ */
+@Singleton
+internal class OnrampCallbackStore @Inject constructor(
+    private val onrampCallbackIdentifier: String,
+) {
+    private lateinit var callbacks: OnrampCallbacks.State
+
+    fun update(callbacks: OnrampCallbacks.State) {
+        this.callbacks = callbacks
+        restore()
+    }
+
+    fun restore() {
+        OnrampCallbackReferences[onrampCallbackIdentifier] = callbacks
+    }
+}

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
@@ -41,7 +41,9 @@ import javax.inject.Inject
 class OnrampCoordinator @Inject internal constructor(
     private val interactor: OnrampInteractor,
     private val presenterComponentFactory: OnrampPresenterComponent.Factory,
+    private val onrampCallbackIdentifier: String,
 ) {
+    private lateinit var callbacks: OnrampCallbacks.State
 
     /**
      * Initialize the coordinator with the provided configuration.
@@ -207,6 +209,9 @@ class OnrampCoordinator @Inject internal constructor(
     fun createPresenter(
         activity: ComponentActivity
     ): Presenter {
+        // A finished host removes the global registration. Restore it before
+        // constructing launchers, which can synchronously deliver pending results.
+        OnrampCallbackReferences[onrampCallbackIdentifier] = callbacks
         return presenterComponentFactory
             .build(
                 activity = activity,
@@ -306,10 +311,12 @@ class OnrampCoordinator @Inject internal constructor(
 
             // Register callbacks eagerly so they're available for activity result
             // redelivery at onStart(), before Compose's first frame.
-            OnrampCallbackReferences[onrampComponent.onrampCallbackIdentifier] =
-                onrampCallbacks.build()
+            val callbacks = onrampCallbacks.build()
+            OnrampCallbackReferences[onrampComponent.onrampCallbackIdentifier] = callbacks
 
-            return onrampComponent.onrampCoordinator
+            return onrampComponent.onrampCoordinator.also {
+                it.callbacks = callbacks
+            }
         }
     }
 }

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampCoordinator.kt
@@ -41,9 +41,8 @@ import javax.inject.Inject
 class OnrampCoordinator @Inject internal constructor(
     private val interactor: OnrampInteractor,
     private val presenterComponentFactory: OnrampPresenterComponent.Factory,
-    private val onrampCallbackIdentifier: String,
+    private val callbackStore: OnrampCallbackStore,
 ) {
-    private lateinit var callbacks: OnrampCallbacks.State
 
     /**
      * Initialize the coordinator with the provided configuration.
@@ -211,7 +210,7 @@ class OnrampCoordinator @Inject internal constructor(
     ): Presenter {
         // A finished host removes the global registration. Restore it before
         // constructing launchers, which can synchronously deliver pending results.
-        OnrampCallbackReferences[onrampCallbackIdentifier] = callbacks
+        callbackStore.restore()
         return presenterComponentFactory
             .build(
                 activity = activity,
@@ -312,10 +311,8 @@ class OnrampCoordinator @Inject internal constructor(
             // Register callbacks eagerly so they're available for activity result
             // redelivery at onStart(), before Compose's first frame.
             val callbacks = onrampCallbacks.build()
-            OnrampCallbackReferences[onrampComponent.onrampCallbackIdentifier] = callbacks
-
             return onrampComponent.onrampCoordinator.also {
-                it.callbacks = callbacks
+                it.callbackStore.update(callbacks)
             }
         }
     }

--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampComponentHolder.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/di/OnrampComponentHolder.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.crypto.onramp.di
 
 import android.app.Application
+import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
 
 /**
@@ -26,6 +27,13 @@ internal object OnrampComponentHolder {
                 application,
                 savedStateHandle,
             ).also { component = it }
+        }
+    }
+
+    @VisibleForTesting
+    fun reset() {
+        synchronized(this) {
+            component = null
         }
     }
 

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampCoordinatorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampCoordinatorTest.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
 import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.crypto.onramp.di.OnrampComponentHolder
 import com.stripe.android.crypto.onramp.model.OnrampAuthorizeResult
 import com.stripe.android.crypto.onramp.model.OnrampCallbacks
 import kotlinx.coroutines.Dispatchers
@@ -26,30 +27,23 @@ class OnrampCoordinatorTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
+        OnrampComponentHolder.reset()
+        OnrampCallbackReferences.remove(DEFAULT_ONRAMP_INSTANCE_KEY)
         Dispatchers.setMain(UnconfinedTestDispatcher())
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @After
     fun tearDown() {
+        OnrampCallbackReferences.remove(DEFAULT_ONRAMP_INSTANCE_KEY)
+        OnrampComponentHolder.reset()
         Dispatchers.resetMain()
     }
 
     @Test
     fun `retained coordinator restores callbacks after its host finishes`() = runTest {
         val results = Turbine<OnrampAuthorizeResult>()
-        val callbacks = OnrampCallbacks()
-            .verifyIdentityCallback { error("Unexpected identity result") }
-            .collectPaymentCallback { error("Unexpected payment result") }
-            .authorizeCallback { results.add(it) }
-            .checkoutCallback { error("Unexpected checkout result") }
-            .verifyKycCallback { error("Unexpected KYC result") }
-            .onrampSessionClientSecretProvider { error("Unexpected checkout request") }
-        val coordinator = OnrampCoordinator.Builder().build(
-            ApplicationProvider.getApplicationContext(),
-            SavedStateHandle(),
-            callbacks,
-        )
+        val coordinator = createCoordinator(results)
         val registered = OnrampCallbackReferences[DEFAULT_ONRAMP_INSTANCE_KEY]
         assertThat(registered).isNotNull()
         val first = Robolectric.buildActivity(ComponentActivity::class.java).setup()
@@ -76,5 +70,51 @@ class OnrampCoordinatorTest {
             OnrampCallbackReferences.remove(DEFAULT_ONRAMP_INSTANCE_KEY)
             results.ensureAllEventsConsumed()
         }
+    }
+
+    @Test
+    fun `older coordinator restores latest callbacks after host finishes`() = runTest {
+        val originalResults = Turbine<OnrampAuthorizeResult>()
+        val latestResults = Turbine<OnrampAuthorizeResult>()
+        val olderCoordinator = createCoordinator(originalResults)
+        val newerCoordinator = createCoordinator(latestResults)
+        assertThat(olderCoordinator).isNotSameInstanceAs(newerCoordinator)
+        val latestCallbacks = OnrampCallbackReferences[DEFAULT_ONRAMP_INSTANCE_KEY]
+        assertThat(latestCallbacks).isNotNull()
+
+        val first = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+        newerCoordinator.createPresenter(first.get())
+        first.get().finish()
+        first.pause().stop().destroy()
+        assertThat(OnrampCallbackReferences[DEFAULT_ONRAMP_INSTANCE_KEY]).isNull()
+
+        val second = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+        try {
+            val presenter = olderCoordinator.createPresenter(second.get())
+            assertThat(OnrampCallbackReferences[DEFAULT_ONRAMP_INSTANCE_KEY]).isSameInstanceAs(latestCallbacks)
+            presenter.authorize("lai_test")
+            assertThat(latestResults.awaitItem()).isInstanceOf(OnrampAuthorizeResult.Failed::class.java)
+            originalResults.expectNoEvents()
+        } finally {
+            second.get().finish()
+            second.pause().stop().destroy()
+            originalResults.ensureAllEventsConsumed()
+            latestResults.ensureAllEventsConsumed()
+        }
+    }
+
+    private fun createCoordinator(results: Turbine<OnrampAuthorizeResult>): OnrampCoordinator {
+        val callbacks = OnrampCallbacks()
+            .verifyIdentityCallback { error("Unexpected identity result") }
+            .collectPaymentCallback { error("Unexpected payment result") }
+            .authorizeCallback { results.add(it) }
+            .checkoutCallback { error("Unexpected checkout result") }
+            .verifyKycCallback { error("Unexpected KYC result") }
+            .onrampSessionClientSecretProvider { error("Unexpected checkout request") }
+        return OnrampCoordinator.Builder().build(
+            ApplicationProvider.getApplicationContext(),
+            SavedStateHandle(),
+            callbacks,
+        )
     }
 }

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampCoordinatorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampCoordinatorTest.kt
@@ -1,0 +1,80 @@
+package com.stripe.android.crypto.onramp
+
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.crypto.onramp.model.OnrampAuthorizeResult
+import com.stripe.android.crypto.onramp.model.OnrampCallbacks
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class OnrampCoordinatorTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `retained coordinator restores callbacks after its host finishes`() = runTest {
+        val results = Turbine<OnrampAuthorizeResult>()
+        val callbacks = OnrampCallbacks()
+            .verifyIdentityCallback { error("Unexpected identity result") }
+            .collectPaymentCallback { error("Unexpected payment result") }
+            .authorizeCallback { results.add(it) }
+            .checkoutCallback { error("Unexpected checkout result") }
+            .verifyKycCallback { error("Unexpected KYC result") }
+            .onrampSessionClientSecretProvider { error("Unexpected checkout request") }
+        val coordinator = OnrampCoordinator.Builder().build(
+            ApplicationProvider.getApplicationContext(),
+            SavedStateHandle(),
+            callbacks,
+        )
+        val registered = OnrampCallbackReferences[DEFAULT_ONRAMP_INSTANCE_KEY]
+        assertThat(registered).isNotNull()
+        val first = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+        try {
+            coordinator.createPresenter(first.get())
+            first.get().finish()
+            first.pause().stop().destroy()
+            assertThat(OnrampCallbackReferences[DEFAULT_ONRAMP_INSTANCE_KEY]).isNull()
+
+            val second = Robolectric.buildActivity(ComponentActivity::class.java).setup()
+            try {
+                val presenter = coordinator.createPresenter(second.get())
+                assertThat(OnrampCallbackReferences[DEFAULT_ONRAMP_INSTANCE_KEY]).isSameInstanceAs(registered)
+                // No backend configuration: the SDK must deliver its validation error
+                // through the original callback rather than throw for missing callbacks.
+                presenter.authorize("lai_test")
+                assertThat(results.awaitItem()).isInstanceOf(OnrampAuthorizeResult.Failed::class.java)
+                results.expectNoEvents()
+            } finally {
+                second.get().finish()
+                second.pause().stop().destroy()
+            }
+        } finally {
+            OnrampCallbackReferences.remove(DEFAULT_ONRAMP_INSTANCE_KEY)
+            results.ensureAllEventsConsumed()
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Retains callbacks on `OnrampCoordinator` and restores their registration before creating a new presenter, so they're available for immediate activity result redelivery.

# Motivation

Addresses an issue reported from React Native where the coordinator survives its host activity finishing, but its callbacks are removed during activity cleanup. Creating another presenter with the same coordinator previously left those callbacks unregistered, causing result delivery to throw before reaching the integration.

# Testing

- [x] Added tests
- [ ] Modified tests
- [ ] Manually verified

Added and passed a regression test that finishes the original activity, creates a presenter with the retained coordinator, and verifies that results reach the original callback.