### PR TITLE
Preserve Checkout presentation lock across host recreation

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
@@ -41,7 +41,6 @@ internal class CheckoutLinkPaymentOptionsPresenter @Inject constructor(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     linkPaymentLauncher.unregister()
-                    sheetStateHolder.sheetIsOpen = false
                 }
             }
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
@@ -201,13 +201,13 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
     }
 
     @Test
-    fun `destroy unregisters direct Link and clears open state`() = runScenario {
+    fun `destroy unregisters direct Link and preserves open state`() = runScenario {
         presenter.present()
 
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
         verify(linkPaymentLauncher).unregister()
-        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(sheetStateHolder.sheetIsOpen).isTrue()
     }
 
     @Suppress("LongMethod")

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 
 @OptIn(CheckoutSessionPreview::class)
@@ -568,6 +569,7 @@ internal class CheckoutSheetLauncherTest {
 
     @Test
     fun `recreated launcher sends ready arguments when mutation finishes`() = testScenario {
+        createLinkPaymentOptionsPresenter()
         val mutationGate = CompletableDeferred<Unit>()
         coroutineScope.launch {
             operationCoordinator.runMutation {
@@ -1015,6 +1017,20 @@ internal class CheckoutSheetLauncherTest {
     ) {
         fun runCurrent() {
             runCurrent.invoke()
+        }
+
+        fun createLinkPaymentOptionsPresenter() {
+            CheckoutLinkPaymentOptionsPresenter(
+                defaultPresenter = mock(),
+                selectionLauncher = mock(),
+                linkPaymentLauncher = mock(),
+                activityResultRegistry = mock(),
+                lifecycleOwner = lifecycleOwner,
+                stateHolder = mock(),
+                customerStateHolder = customerStateHolder,
+                linkAccountHolder = mock(),
+                sheetStateHolder = sheetStateHolder,
+            )
         }
 
         suspend fun recreateSheetLauncher(


### PR DESCRIPTION
# Summary
Preserve Checkout's saved presentation lock when the host lifecycle is destroyed, while still unregistering the Link launcher.

Extend host-recreation coverage so the pending loading-to-ready transition runs with the Link-aware payment options presenter attached to the same lifecycle.

# Motivation
During an Activity configuration change, `CheckoutLinkPaymentOptionsPresenter` cleared the shared `sheetIsOpen` flag. A recreated `CheckoutSheetLauncher` could then treat its pending sheet as closed, suppress the ready relaunch, and leave the embedded activity loading. Clearing the lock also allowed mutations, confirmation, or a second presentation while an existing flow remained visible.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutLinkPaymentOptionsPresenterTest' --tests 'com.stripe.android.checkout.CheckoutSheetLauncherTest'`
- `./gradlew :paymentsheet:detekt`
- `./gradlew detekt`

No tests were ignored.

# Screenshots
Not applicable; this changes lifecycle state handling without a visual UI change.

# Changelog
Not applicable; this fixes preview Checkout internals and does not require a public changelog entry.

Committed and created by Codex.
