### PR TITLE
Fix Checkout confirmation recovery

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -23,13 +23,26 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     fun confirm() {
-        val state = stateHolder.state ?: return
-        val paymentSelection = state.paymentSelection ?: return
+        val state = stateHolder.state ?: run {
+            operationCoordinator.reportConfirmationFailure(
+                IllegalStateException(
+                    "CheckoutPresenter.confirm() cannot be called before " +
+                        "CheckoutController.configure() has completed successfully."
+                )
+            )
+            return
+        }
+        val paymentSelection = state.paymentSelection ?: run {
+            operationCoordinator.reportConfirmationFailure(
+                IllegalStateException("Cannot confirm without a payment selection.")
+            )
+            return
+        }
         val arguments = operationCoordinator.tryBeginConfirmation {
-          confirmationArgs(
-              state = state,
-              paymentSelection = paymentSelection,
-          )
+            confirmationArgs(
+                state = state,
+                paymentSelection = paymentSelection,
+            )
         } ?: return
         analyticsPerformer.onPaymentElementConfirmationStarted(paymentSelection)
         viewModelScope.launch {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -57,19 +57,38 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     fun tryBeginConfirmation(
         arguments: () -> ConfirmationHandler.Args?,
     ): ConfirmationHandler.Args? {
-        return synchronized(admissionLock) {
-            if (sheetStateHolder.sheetIsOpen || pendingMutations > 0 || confirmationInFlight) {
-                return@synchronized null
+        val result = synchronized(admissionLock) {
+            val errorMessage = when {
+                sheetStateHolder.sheetIsOpen ->
+                    "Cannot confirm while a payment flow is presented."
+                pendingMutations > 0 ->
+                    "Cannot confirm while the checkout session is updating."
+                confirmationInFlight ->
+                    "Cannot confirm while another confirmation is in progress."
+                else -> null
             }
-            val confirmationArguments = arguments() ?: return@synchronized null
+            if (errorMessage != null) {
+                return@synchronized Result.failure(IllegalStateException(errorMessage))
+            }
+            val confirmationArguments = arguments() ?: return@synchronized Result.failure(
+                IllegalStateException(
+                    "Cannot create confirmation arguments for the current payment selection."
+                )
+            )
             check(mutex.tryLock()) {
                 "Checkout operation gate should be available after confirmation admission."
             }
             confirmationInFlight = true
             confirmationWasRestored = false
             updateIsUpdating()
-            confirmationArguments
+            Result.success(confirmationArguments)
         }
+        result.exceptionOrNull()?.let(::reportConfirmationFailure)
+        return result.getOrNull()
+    }
+
+    fun reportConfirmationFailure(error: Throwable) {
+        resultCallback.onResult(CheckoutController.Result.Failed(error))
     }
 
     suspend fun observeConfirmationResults() {
@@ -86,6 +105,9 @@ internal class CheckoutOperationCoordinator @Inject constructor(
                         } else {
                             sessionRefresher.refresh()
                         }
+                    }
+                    if (state.result.requestsPaymentDetailsModification()) {
+                        sheetStateHolder.embeddedContentHelper?.presentPaymentOptions()
                     }
                     state.result.asCheckoutResult(wasRestored)
                 }
@@ -142,6 +164,11 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private fun updateIsUpdating() {
         _isUpdating.value = confirmationInFlight || pendingMutations > 0
     }
+}
+
+private fun ConfirmationHandler.Result.requestsPaymentDetailsModification(): Boolean {
+    return this is ConfirmationHandler.Result.Canceled &&
+        action == ConfirmationHandler.Result.Canceled.Action.ModifyPaymentDetails
 }
 
 private fun ConfirmationHandler.Result.asCheckoutResult(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenterInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenterInitializer.kt
@@ -4,6 +4,7 @@ import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
+import com.stripe.android.paymentelement.embedded.content.EmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.parseAppearance
@@ -14,6 +15,7 @@ internal class CheckoutPresenterInitializer @Inject constructor(
     private val activityResultCaller: ActivityResultCaller,
     private val lifecycleOwner: LifecycleOwner,
     private val sheetLauncher: EmbeddedSheetLauncher,
+    private val embeddedContentHelper: EmbeddedContentHelper,
     private val sheetStateHolder: SheetStateHolder,
     private val stateHolder: CheckoutControllerStateHolder,
 ) {
@@ -21,12 +23,14 @@ internal class CheckoutPresenterInitializer @Inject constructor(
         confirmationHandler.register(activityResultCaller, lifecycleOwner)
 
         sheetStateHolder.sheetLauncher = sheetLauncher
+        sheetStateHolder.embeddedContentHelper = embeddedContentHelper
         stateHolder.state?.embeddedConfiguration?.appearance?.parseAppearance()
 
         lifecycleOwner.lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
                     sheetStateHolder.sheetLauncher = null
+                    sheetStateHolder.embeddedContentHelper = null
                 }
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/SheetStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/SheetStateHolder.kt
@@ -9,6 +9,7 @@ internal class SheetStateHolder @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
 ) {
     var sheetLauncher: EmbeddedSheetLauncher? = null
+    var embeddedContentHelper: EmbeddedContentHelper? = null
 
     var sheetIsOpen: Boolean
         get() = savedStateHandle.get<Boolean>(SHEET_IS_OPEN_KEY) == true

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import androidx.lifecycle.SavedStateHandle
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.Logger
 import com.stripe.android.isInstanceOf
@@ -30,25 +31,41 @@ import kotlin.test.Test
 internal class CheckoutConfirmationPerformerTest {
 
     @Test
-    fun `confirm does nothing when state is not loaded`() = runScenario(state = null) {
+    fun `confirm fails when state is not loaded`() = runScenario(state = null) {
         performer.confirm()
+
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error).hasMessageThat().isEqualTo(
+            "CheckoutPresenter.confirm() cannot be called before " +
+                "CheckoutController.configure() has completed successfully."
+        )
     }
 
     @Test
-    fun `confirm does nothing when there is no selection`() = runScenario(
+    fun `confirm fails when there is no selection`() = runScenario(
         state = CheckoutControllerStateFactory.create(paymentSelection = null),
     ) {
         performer.confirm()
+
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error).hasMessageThat().isEqualTo(
+            "Cannot confirm without a payment selection."
+        )
     }
 
     @Test
-    fun `confirm does nothing when the selection cannot be converted to a confirmation option`() = runScenario(
+    fun `confirm fails when the selection cannot be converted to a confirmation option`() = runScenario(
         state = CheckoutControllerStateFactory.create(
             checkoutSessionResponse = CheckoutSessionResponseFactory.create(merchantCountry = null),
             paymentSelection = PaymentSelection.GooglePay,
         ),
     ) {
         performer.confirm()
+
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error).hasMessageThat().isEqualTo(
+            "Cannot create confirmation arguments for the current payment selection."
+        )
     }
 
     @Test
@@ -121,12 +138,13 @@ internal class CheckoutConfirmationPerformerTest {
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
         stateHolder.state = state
         val sessionRefresher = FakeCheckoutSessionRefresher()
+        val resultTurbine = Turbine<CheckoutController.Result>()
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
-            resultCallback = {},
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
         )
         val eventReporter = FakeEventReporter()
         val analyticsPerformer = CheckoutAnalyticsPerformer(
@@ -152,11 +170,13 @@ internal class CheckoutConfirmationPerformerTest {
             confirmationHandler = confirmationHandler,
             eventReporter = eventReporter,
             stateHolder = stateHolder,
+            resultTurbine = resultTurbine,
         ).block()
 
         confirmationHandler.validate()
         sessionRefresher.ensureAllEventsConsumed()
         eventReporter.validate()
+        resultTurbine.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -164,6 +184,7 @@ internal class CheckoutConfirmationPerformerTest {
         val confirmationHandler: FakeConfirmationHandler,
         val eventReporter: FakeEventReporter,
         val stateHolder: CheckoutControllerStateHolder,
+        val resultTurbine: Turbine<CheckoutController.Result>,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.MutableConfirmationMetadata
 import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
+import com.stripe.android.paymentelement.embedded.content.FakeEmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
@@ -214,26 +215,33 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `confirmation does not start when arguments are unavailable`() = runScenario {
+    fun `confirmation fails when arguments are unavailable`() = runScenario {
         val arguments = coordinator.tryBeginConfirmation { null }
 
         assertThat(arguments).isNull()
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error).hasMessageThat().isEqualTo(
+            "Cannot create confirmation arguments for the current payment selection."
+        )
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
     @Test
-    fun `confirmation is ignored when a payment flow is presented`() = runScenario(
+    fun `confirmation fails when a payment flow is presented`() = runScenario(
         sheetIsOpen = true,
     ) {
         val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         assertThat(arguments).isNull()
-        resultTurbine.expectNoEvents()
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error).hasMessageThat().isEqualTo(
+            "Cannot confirm while a payment flow is presented."
+        )
         assertThat(coordinator.isUpdating.value).isFalse()
     }
 
     @Test
-    fun `confirmation is ignored while a mutation is in flight`() = runScenario {
+    fun `confirmation fails while a mutation is in flight`() = runScenario {
         val mutationStarted = CompletableDeferred<Unit>()
         val finishMutation = CompletableDeferred<Unit>()
         val mutation = async {
@@ -248,20 +256,26 @@ internal class CheckoutOperationCoordinatorTest {
         val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         assertThat(arguments).isNull()
-        resultTurbine.expectNoEvents()
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error).hasMessageThat().isEqualTo(
+            "Cannot confirm while the checkout session is updating."
+        )
 
         finishMutation.complete(Unit)
         mutation.await()
     }
 
     @Test
-    fun `second confirmation is ignored while confirmation is in flight`() = runScenario {
+    fun `second confirmation fails while confirmation is in flight`() = runScenario {
         assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNotNull()
 
         val arguments = coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
         assertThat(arguments).isNull()
-        resultTurbine.expectNoEvents()
+        val failure = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(failure.error).hasMessageThat().isEqualTo(
+            "Cannot confirm while another confirmation is in progress."
+        )
 
         enqueueRefreshAction {}
         confirmationState.value = ConfirmationHandler.State.Complete(
@@ -344,7 +358,7 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `canceled confirmation with modify payment details does not invoke callback and releases gate`() =
+    fun `canceled confirmation with modify payment details presents payment options and releases gate`() =
         runScenario {
             coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }
 
@@ -355,6 +369,7 @@ internal class CheckoutOperationCoordinatorTest {
                 )
             )
             assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
+            embeddedContentHelper.presentPaymentOptionsCalls.awaitItem()
             runCurrent()
 
             resultTurbine.expectNoEvents()
@@ -751,6 +766,8 @@ internal class CheckoutOperationCoordinatorTest {
         }
         val resultTurbine = Turbine<CheckoutController.Result>()
         val sessionRefresher = FakeCheckoutSessionRefresher()
+        val embeddedContentHelper = FakeEmbeddedContentHelper()
+        sheetStateHolder.embeddedContentHelper = embeddedContentHelper
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
@@ -770,12 +787,14 @@ internal class CheckoutOperationCoordinatorTest {
             refreshCalls = sessionRefresher.calls,
             sessionRefresher = sessionRefresher,
             observerJob = observerJob,
+            embeddedContentHelper = embeddedContentHelper,
             testScope = this,
         ).block()
 
         confirmationHandler.validate()
         resultTurbine.ensureAllEventsConsumed()
         sessionRefresher.ensureAllEventsConsumed()
+        embeddedContentHelper.presentPaymentOptionsCalls.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -785,6 +804,7 @@ internal class CheckoutOperationCoordinatorTest {
         val refreshCalls: Turbine<FakeCheckoutSessionRefresher.Call>,
         private val sessionRefresher: FakeCheckoutSessionRefresher,
         val observerJob: Job,
+        val embeddedContentHelper: FakeEmbeddedContentHelper,
         private val testScope: TestScope,
     ) : CoroutineScope by testScope {
         val response = CheckoutSessionResponseFactory.create(id = "cs_confirmed")

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterInitializerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterInitializerTest.kt
@@ -9,6 +9,7 @@ import com.google.common.truth.Truth.assertThat
 import com.stripe.android.paymentelement.confirmation.FakeConfirmationHandler
 import com.stripe.android.paymentelement.embedded.FakeEmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
+import com.stripe.android.paymentelement.embedded.content.FakeEmbeddedContentHelper
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.PaymentSheet
 import com.stripe.android.testing.CoroutineTestRule
@@ -37,12 +38,14 @@ internal class CheckoutPresenterInitializerTest {
     }
 
     @Test
-    fun `initialize registers the sheet launcher into the holder`() = runScenario {
+    fun `initialize registers payment presentation dependencies into the holder`() = runScenario {
         assertThat(sheetStateHolder.sheetLauncher).isNull()
+        assertThat(sheetStateHolder.embeddedContentHelper).isNull()
 
         initializer.initialize()
 
         assertThat(sheetStateHolder.sheetLauncher).isSameInstanceAs(sheetLauncher)
+        assertThat(sheetStateHolder.embeddedContentHelper).isSameInstanceAs(embeddedContentHelper)
         confirmationHandler.registerTurbine.awaitItem()
     }
 
@@ -54,6 +57,7 @@ internal class CheckoutPresenterInitializerTest {
         lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
 
         assertThat(sheetStateHolder.sheetLauncher).isNull()
+        assertThat(sheetStateHolder.embeddedContentHelper).isNull()
         confirmationHandler.registerTurbine.awaitItem()
     }
 
@@ -75,6 +79,7 @@ internal class CheckoutPresenterInitializerTest {
                 activityResultCaller = mock(),
                 lifecycleOwner = TestLifecycleOwner(),
                 sheetLauncher = FakeEmbeddedSheetLauncher(),
+                embeddedContentHelper = FakeEmbeddedContentHelper(),
                 sheetStateHolder = SheetStateHolder(SavedStateHandle()),
                 stateHolder = CheckoutControllerStateFactory.createStateHolder(
                     SavedStateHandle(mapOf(CheckoutControllerStateHolder.STATE_KEY to restoredState))
@@ -97,6 +102,7 @@ internal class CheckoutPresenterInitializerTest {
         val confirmationHandler = FakeConfirmationHandler()
         val activityResultCaller = mock<ActivityResultCaller>()
         val sheetLauncher = FakeEmbeddedSheetLauncher()
+        val embeddedContentHelper = FakeEmbeddedContentHelper()
         val sheetStateHolder = SheetStateHolder(SavedStateHandle())
         val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle())
         val initializer = CheckoutPresenterInitializer(
@@ -104,6 +110,7 @@ internal class CheckoutPresenterInitializerTest {
             activityResultCaller = activityResultCaller,
             lifecycleOwner = lifecycleOwner,
             sheetLauncher = sheetLauncher,
+            embeddedContentHelper = embeddedContentHelper,
             sheetStateHolder = sheetStateHolder,
             stateHolder = stateHolder,
         )
@@ -114,10 +121,12 @@ internal class CheckoutPresenterInitializerTest {
             activityResultCaller = activityResultCaller,
             lifecycleOwner = lifecycleOwner,
             sheetLauncher = sheetLauncher,
+            embeddedContentHelper = embeddedContentHelper,
             sheetStateHolder = sheetStateHolder,
         ).block()
 
         confirmationHandler.validate()
+        embeddedContentHelper.presentPaymentOptionsCalls.ensureAllEventsConsumed()
     }
 
     private class Scenario(
@@ -126,6 +135,7 @@ internal class CheckoutPresenterInitializerTest {
         val activityResultCaller: ActivityResultCaller,
         val lifecycleOwner: TestLifecycleOwner,
         val sheetLauncher: EmbeddedSheetLauncher,
+        val embeddedContentHelper: FakeEmbeddedContentHelper,
         val sheetStateHolder: SheetStateHolder,
     )
 }


### PR DESCRIPTION
# Summary

- Reopen Checkout payment options when confirmation requests modified payment details.
- Deliver `CheckoutController.Result.Failed` for invalid confirmation attempts instead of silently returning.
- Bind confirmation recovery to the active payment element presenter lifecycle.

# Motivation

Checkout handled confirmation recovery differently from FlowController. In particular, canceling a Bacs confirmation to change payment details did not reopen payment options, and confirmation calls made with invalid state, no selection, an open sheet, an active update, or another confirmation in progress produced no result.

This aligns Checkout's behavior with FlowController so integrators receive actionable failures and customers can revise their payment details.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutOperationCoordinatorTest' --tests 'com.stripe.android.checkout.CheckoutConfirmationPerformerTest' --tests 'com.stripe.android.checkout.CheckoutPresenterInitializerTest'`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

| Before | After |
| --- | --- |
| Not applicable — confirmation coordination has no standalone visual change. | Not applicable — recovery reuses the existing payment-options UI. |

# Changelog

Not applicable — Checkout is a preview API and this change aligns its confirmation behavior with the existing FlowController contract.

Committed and created by Codex.
