### PR TITLE
Forward Checkout promotions to payment options

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -29,6 +29,7 @@ import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
+import com.stripe.android.paymentsheet.repositories.PaymentMethodMessagePromotionsHelper
 import com.stripe.android.paymentsheet.state.CustomerState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -72,6 +73,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     @Named(STATUS_BAR_COLOR) private val statusBarColor: Int?,
     @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
     private val rowSelectionImmediateActionHandler: EmbeddedRowSelectionImmediateActionHandler,
+    private val paymentMethodMessagePromotionsHelper: PaymentMethodMessagePromotionsHelper,
 ) : EmbeddedSheetLauncher {
 
     init {
@@ -321,7 +323,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             selection = selection,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = emptyList(),
+            promotions = paymentMethodMessagePromotionsHelper.getPromotions().orEmpty(),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
             presentationState = presentationState,
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -40,6 +40,7 @@ import com.stripe.android.testing.FakeLogger
 import com.stripe.android.testing.PaymentConfigurationTestRule
 import com.stripe.android.testing.asCallbackFor
 import com.stripe.android.uicore.utils.stateFlowOf
+import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -492,7 +493,9 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
-    fun `launchPaymentOptions launches activity with correct parameters`() = testScenario {
+    fun `launchPaymentOptions launches activity with correct parameters`() = testScenario(
+        promotions = listOf(FakePaymentMethodMessagePromotionsHelper.klarnaPromotion),
+    ) {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
         val customerState = PaymentSheetFixtures.EMPTY_CUSTOMER_STATE
         val selection = PaymentSelection.GooglePay
@@ -505,7 +508,7 @@ internal class CheckoutSheetLauncherTest {
             selection = selection,
             previousNewSelections = selectionHolder.previousNewSelections,
             customerState = customerState,
-            promotions = emptyList(),
+            promotions = listOf(FakePaymentMethodMessagePromotionsHelper.klarnaPromotion),
             launchMode = EmbeddedLaunchMode.PaymentOptions,
             presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
@@ -895,6 +898,7 @@ internal class CheckoutSheetLauncherTest {
 
     @Suppress("LongMethod")
     private fun testScenario(
+        promotions: List<PaymentMethodMessagePromotion>? = null,
         block: suspend Scenario.() -> Unit
     ) = runTest {
         var immediateActionInvoked = false
@@ -952,6 +956,7 @@ internal class CheckoutSheetLauncherTest {
                     statusBarColor = null,
                     paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
                     rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
+                    paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(promotions),
                 )
             }
 


### PR DESCRIPTION
# Summary

Forward fetched payment-method promotions when Checkout opens the full payment-options sheet. This keeps promotion and incentive messaging consistent between the inline payment element and the sheet.

# Motivation

`CheckoutSheetLauncher` previously constructed payment-options arguments with an empty promotions list. Promotions visible inline therefore disappeared when a customer opened the full payment-options sheet.

# Testing

- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Validated with:

- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.CheckoutSheetLauncherTest` (39 tests)
- `./gradlew detekt`

No tests were newly ignored.

# Screenshots

Not applicable; this changes data propagation and does not alter the static UI layout.

# Changelog

Not applicable; Checkout Session is a preview API and this fix does not require a public changelog entry.

Committed and created by Codex.
