### PR TITLE
Handle destroyed host launch failures

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
@@ -4,6 +4,7 @@ package com.stripe.android.checkout
 
 import androidx.activity.result.ActivityResultRegistry
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import com.stripe.android.checkout.injection.CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER
 import com.stripe.android.link.LinkActivityResult
@@ -30,6 +31,7 @@ internal class CheckoutLinkPaymentOptionsPresenter @Inject constructor(
     private val customerStateHolder: CustomerStateHolder,
     private val linkAccountHolder: LinkAccountHolder,
     private val sheetStateHolder: SheetStateHolder,
+    private val resultCallback: CheckoutController.ResultCallback,
 ) : EmbeddedPaymentOptionsPresenter {
     init {
         linkPaymentLauncher.register(
@@ -49,6 +51,12 @@ internal class CheckoutLinkPaymentOptionsPresenter @Inject constructor(
 
     override fun present() {
         if (sheetStateHolder.sheetIsOpen) return
+        if (lifecycleOwner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+            resultCallback.onResult(
+                CheckoutController.Result.Failed(invalidHostStateError(lifecycleOwner))
+            )
+            return
+        }
         val state = stateHolder.state
         if (state == null) {
             defaultPresenter.present()
@@ -56,12 +64,20 @@ internal class CheckoutLinkPaymentOptionsPresenter @Inject constructor(
         }
 
         sheetStateHolder.sheetIsOpen = true
-        val didLaunch = selectionLauncher.launchIfEligible(
-            selection = state.paymentSelection,
-            configuration = state.paymentMethodMetadata.linkState?.configuration,
-            paymentMethodMetadata = state.paymentMethodMetadata,
-            hasUserDeclinedVerification = state.linkEagerPresentationSuppressed,
-        )
+        val didLaunch = try {
+            selectionLauncher.launchIfEligible(
+                selection = state.paymentSelection,
+                configuration = state.paymentMethodMetadata.linkState?.configuration,
+                paymentMethodMetadata = state.paymentMethodMetadata,
+                hasUserDeclinedVerification = state.linkEagerPresentationSuppressed,
+            )
+        } catch (error: IllegalStateException) {
+            sheetStateHolder.sheetIsOpen = false
+            resultCallback.onResult(
+                CheckoutController.Result.Failed(invalidHostStateError(lifecycleOwner, error))
+            )
+            return
+        }
         if (!didLaunch) {
             presentDefault()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout
 import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.lifecycleScope
@@ -64,6 +65,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private val errorReporter: ErrorReporter,
     private val sessionRefresher: CheckoutSessionRefresher,
     private val operationCoordinator: CheckoutOperationCoordinator,
+    private val resultCallback: CheckoutController.ResultCallback,
     private val launcherState: CheckoutSheetLauncherState,
     private val embeddedContentState: StateFlow<EmbeddedContentHelperStateHolder.State?>,
     private val logger: Logger,
@@ -210,7 +212,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             ),
             presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
-        activityLauncher.launch(args)
+        launch(args)
     }
 
     override fun launchManage(
@@ -240,7 +242,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             launchMode = EmbeddedLaunchMode.Manage,
             presentationState = EmbeddedActivityArgs.PresentationState.Ready,
         )
-        activityLauncher.launch(args)
+        launch(args)
     }
 
     override fun launchPaymentOptions(
@@ -270,7 +272,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
         )
         launcherState.isAwaitingPaymentOptionsReady =
             initialArgs.presentationState == EmbeddedActivityArgs.PresentationState.Loading
-        activityLauncher.launch(initialArgs)
+        if (!launch(initialArgs)) return
 
         resumePendingReadyLaunch()
     }
@@ -290,9 +292,10 @@ internal class CheckoutSheetLauncher @Inject constructor(
                 errorReporter.report(
                     ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
                 )
+                resetLaunchState()
                 return@launch
             }
-            activityLauncher.launch(
+            launch(
                 createPaymentOptionsArgs(
                     paymentMethodMetadata = refreshedState.paymentMethodMetadata,
                     configuration = refreshedState.configuration,
@@ -303,6 +306,32 @@ internal class CheckoutSheetLauncher @Inject constructor(
             )
             launcherState.isAwaitingPaymentOptionsReady = false
         }
+    }
+
+    private fun launch(args: EmbeddedActivityArgs): Boolean {
+        if (lifecycleOwner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+            resetLaunchState()
+            resultCallback.onResult(
+                CheckoutController.Result.Failed(invalidHostStateError(lifecycleOwner))
+            )
+            return false
+        }
+        return try {
+            activityLauncher.launch(args)
+            true
+        } catch (error: IllegalStateException) {
+            resetLaunchState()
+            resultCallback.onResult(
+                CheckoutController.Result.Failed(invalidHostStateError(lifecycleOwner, error))
+            )
+            false
+        }
+    }
+
+    private fun resetLaunchState() {
+        launcherState.isAwaitingPaymentOptionsReady = false
+        sheetStateHolder.sheetIsOpen = false
+        selectionHolder.setTemporarySelection(null)
     }
 
     private fun createPaymentOptionsArgs(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/InvalidHostStateError.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/InvalidHostStateError.kt
@@ -1,0 +1,11 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.LifecycleOwner
+
+internal fun invalidHostStateError(
+    lifecycleOwner: LifecycleOwner,
+    cause: IllegalStateException? = null,
+): IllegalStateException {
+    val message = "The host activity is not in a valid state (${lifecycleOwner.lifecycle.currentState})."
+    return IllegalStateException(message, cause)
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowController.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.core.app.ActivityOptionsCompat
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.ViewModelStoreOwner
@@ -292,15 +293,24 @@ internal class DefaultFlowController @Inject internal constructor(
 
     override fun presentPaymentOptions() {
         withCurrentState { state ->
+            if (lifecycleOwner.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+                reportInvalidHostState()
+                return@withCurrentState
+            }
             val linkConfiguration = state.paymentSheetState.linkConfiguration
             val paymentSelection = viewModel.paymentSelection
 
-            val didPresentLink = linkPaymentMethodSelectionLauncher.launchIfEligible(
-                selection = paymentSelection,
-                configuration = linkConfiguration,
-                paymentMethodMetadata = state.paymentSheetState.paymentMethodMetadata,
-                hasUserDeclinedVerification = viewModel.state?.declinedLink2FA == true,
-            )
+            val didPresentLink = try {
+                linkPaymentMethodSelectionLauncher.launchIfEligible(
+                    selection = paymentSelection,
+                    configuration = linkConfiguration,
+                    paymentMethodMetadata = state.paymentSheetState.paymentMethodMetadata,
+                    hasUserDeclinedVerification = viewModel.state?.declinedLink2FA == true,
+                )
+            } catch (error: IllegalStateException) {
+                reportInvalidHostState(error)
+                return@withCurrentState
+            }
 
             if (!didPresentLink) {
                 showPaymentOptionList(state, paymentSelection)
@@ -332,9 +342,15 @@ internal class DefaultFlowController @Inject internal constructor(
         try {
             paymentOptionActivityLauncher.launch(args, options)
         } catch (e: IllegalStateException) {
-            val message = "The host activity is not in a valid state (${lifecycleOwner.lifecycle.currentState})."
-            paymentResultCallback.onPaymentSheetResult(PaymentSheetResult.Failed(IllegalStateException(message, e)))
+            reportInvalidHostState(e)
         }
+    }
+
+    private fun reportInvalidHostState(cause: IllegalStateException? = null) {
+        val message = "The host activity is not in a valid state (${lifecycleOwner.lifecycle.currentState})."
+        paymentResultCallback.onPaymentSheetResult(
+            PaymentSheetResult.Failed(IllegalStateException(message, cause))
+        )
     }
 
     fun onLinkResultFromFlowController(result: LinkActivityResult) {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultRegistry
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkout.injection.CHECKOUT_LINK_PAYMENT_METHOD_SELECTION_LAUNCHER
 import com.stripe.android.link.LinkAccountUpdate
@@ -32,16 +33,19 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.state.CustomerState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 internal class CheckoutLinkPaymentOptionsPresenterTest {
     @Test
@@ -210,12 +214,43 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
     }
 
+    @Test
+    fun `present after host is destroyed reports failure without leaving sheet open`() = runScenario {
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+        presenter.present()
+
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error).hasMessageThat().contains("The host activity is not in a valid state (DESTROYED).")
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        verifyLinkWasNotPresented()
+    }
+
+    @Test
+    fun `Link launcher failure reports failure without leaving sheet open`() = runScenario {
+        val launchError = IllegalStateException("Host cannot launch")
+        doThrow(launchError).whenever(linkPaymentLauncher).present(
+            configuration = any(),
+            paymentMethodMetadata = any(),
+            linkAccountInfo = any(),
+            launchMode = any(),
+            linkExpressMode = any(),
+            statusBarColor = anyOrNull(),
+        )
+
+        presenter.present()
+
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error.cause).isSameInstanceAs(launchError)
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+    }
+
     @Suppress("LongMethod")
     private fun runScenario(
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
         selection: PaymentSelection? = linkSelection,
-        block: Scenario.() -> Unit,
-    ) {
+        block: suspend Scenario.() -> Unit,
+    ) = runTest {
         val paymentMethodMetadata = PaymentMethodMetadataFactory.create(
             linkState = com.stripe.android.paymentsheet.state.LinkState(
                 configuration = TestFactory.LINK_CONFIGURATION,
@@ -242,6 +277,7 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
         val linkPaymentLauncher = mock<LinkPaymentLauncher>()
         val activityResultRegistry = mock<ActivityResultRegistry>()
         val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = Dispatchers.Unconfined)
+        val resultTurbine = Turbine<CheckoutController.Result>()
         val presenter = CheckoutLinkPaymentOptionsPresenter(
             defaultPresenter = defaultPresenter,
             selectionLauncher = LinkPaymentMethodSelectionLauncher(
@@ -257,6 +293,7 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
             customerStateHolder = customerStateHolder,
             linkAccountHolder = linkAccountHolder,
             sheetStateHolder = sheetStateHolder,
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
         )
         val callbackCaptor = argumentCaptor<(LinkActivityResult) -> Unit>()
         verify(linkPaymentLauncher).register(
@@ -278,7 +315,9 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
             linkAccountInfo = linkAccountInfo,
             paymentMethodMetadata = paymentMethodMetadata,
             resultCallback = callbackCaptor.firstValue,
+            resultTurbine = resultTurbine,
         ).block()
+        resultTurbine.ensureAllEventsConsumed()
     }
 
     private data class Scenario(
@@ -294,6 +333,7 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
         val linkAccountInfo: LinkAccountUpdate.Value,
         val paymentMethodMetadata: com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata,
         val resultCallback: (LinkActivityResult) -> Unit,
+        val resultTurbine: Turbine<CheckoutController.Result>,
     ) {
         val linkConfiguration: LinkConfiguration
             get() = requireNotNull(paymentMethodMetadata.linkState?.configuration)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.Turbine
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFactory
@@ -633,7 +634,7 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
-    fun `missing refreshed state does not crash when mutation finishes`() = testScenario {
+    fun `missing refreshed state resets launch state when mutation finishes`() = testScenario {
         val mutationGate = CompletableDeferred<Unit>()
         coroutineScope.launch {
             operationCoordinator.runMutation {
@@ -660,7 +661,8 @@ internal class CheckoutSheetLauncherTest {
         assertThat(errorReporter.getLoggedErrors()).containsExactly(
             "unexpected_error.embedded.embedded_sheet_launcher.embedded_state_is_null"
         )
-        assertThat(launcherState.isAwaitingPaymentOptionsReady).isTrue()
+        assertThat(launcherState.isAwaitingPaymentOptionsReady).isFalse()
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
     }
 
     @Test
@@ -893,6 +895,25 @@ internal class CheckoutSheetLauncherTest {
         assertThat(sheetStateHolder.sheetIsOpen).isTrue()
     }
 
+    @Test
+    fun `launchForm after host is destroyed reports failure and resets launch state`() = testScenario {
+        lifecycleOwner.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        dummyActivityResultCallerScenario.awaitNextUnregisteredLauncher()
+
+        sheetLauncher.launchForm(
+            code = "card",
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            configuration = EmbeddedConfigurationFactory.create(),
+            customerState = null,
+            promotion = null,
+        )
+
+        val result = resultTurbine.awaitItem() as CheckoutController.Result.Failed
+        assertThat(result.error).hasMessageThat().contains("The host activity is not in a valid state (DESTROYED).")
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+        assertThat(selectionHolder.temporarySelection.value).isNull()
+    }
+
     @Suppress("LongMethod")
     private fun testScenario(
         block: suspend Scenario.() -> Unit
@@ -914,12 +935,13 @@ internal class CheckoutSheetLauncherTest {
         val sessionRefresher = FakeCheckoutSessionRefresher()
         val logger = FakeLogger()
         val confirmationHandler = FakeConfirmationHandler()
+        val resultTurbine = Turbine<CheckoutController.Result>()
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
             sessionRefresher = sessionRefresher,
             logger = logger,
-            resultCallback = CheckoutController.ResultCallback {},
+            resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
         )
         val launcherState = CheckoutSheetLauncherState(savedStateHandle)
         val embeddedContentState = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(
@@ -944,6 +966,7 @@ internal class CheckoutSheetLauncherTest {
                     errorReporter = errorReporter,
                     sessionRefresher = sessionRefresher,
                     operationCoordinator = operationCoordinator,
+                    resultCallback = CheckoutController.ResultCallback(resultTurbine::add),
                     launcherState = state,
                     embeddedContentState = embeddedContentState,
                     logger = logger,
@@ -976,6 +999,7 @@ internal class CheckoutSheetLauncherTest {
                 sessionRefresher = sessionRefresher,
                 logger = logger,
                 operationCoordinator = operationCoordinator,
+                resultTurbine = resultTurbine,
                 launcherState = launcherState,
                 savedStateHandle = savedStateHandle,
                 embeddedContentState = embeddedContentState,
@@ -983,6 +1007,7 @@ internal class CheckoutSheetLauncherTest {
                 createSheetLauncher = ::createSheetLauncher,
                 runCurrent = testScheduler::runCurrent,
             ).block()
+            resultTurbine.ensureAllEventsConsumed()
         }
 
         confirmationHandler.validate()
@@ -1003,6 +1028,7 @@ internal class CheckoutSheetLauncherTest {
         val sessionRefresher: FakeCheckoutSessionRefresher,
         val logger: FakeLogger,
         val operationCoordinator: CheckoutOperationCoordinator,
+        val resultTurbine: Turbine<CheckoutController.Result>,
         val launcherState: CheckoutSheetLauncherState,
         val savedStateHandle: SavedStateHandle,
         val embeddedContentState: MutableStateFlow<EmbeddedContentHelperStateHolder.State?>,

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/flowcontroller/DefaultFlowControllerTest.kt
@@ -574,6 +574,35 @@ internal class DefaultFlowControllerTest {
     }
 
     @Test
+    fun `presentPaymentOptions() with eligible Link and activity destroyed should fail`() = runTest {
+        linkGate.setShowRuxInFlowController(true)
+        val flowController = createFlowController(
+            paymentSelection = PaymentSelection.Link(
+                brand = LinkBrand.Link,
+                selectedPayment = null,
+            )
+        )
+        linkAccountHolder.set(LinkAccountUpdate.Value(TestFactory.LINK_ACCOUNT))
+        flowController.configureExpectingSuccess()
+        lifecycleOwner.currentState = Lifecycle.State.DESTROYED
+
+        flowController.presentPaymentOptions()
+
+        val resultCaptor = argumentCaptor<PaymentSheetResult.Failed>()
+        verify(paymentResultCallback).onPaymentSheetResult(resultCaptor.capture())
+        assertThat(resultCaptor.firstValue.error).hasMessageThat()
+            .isEqualTo("The host activity is not in a valid state (DESTROYED).")
+        verify(flowControllerLinkPaymentLauncher, never()).present(
+            configuration = any(),
+            paymentMethodMetadata = any(),
+            linkAccountInfo = any(),
+            launchMode = any(),
+            linkExpressMode = any(),
+            statusBarColor = anyOrNull(),
+        )
+    }
+
+    @Test
     fun `presentPaymentOptions shows Link picker when a Link payment method is already selected`() = runTest {
         linkGate.setShowRuxInFlowController(true)
 


### PR DESCRIPTION
# Summary

- Report destroyed-host and `ActivityResultLauncher` failures through the Checkout and FlowController result callbacks.
- Reset Checkout sheet launch state when presentation fails, including eager Link and deferred-ready paths.
- Add regression coverage for ordinary and eager-Link presentation after host destruction.

# Motivation

Launching payment options from a destroyed host was inconsistent. FlowController reported failures for its ordinary launcher, Checkout could throw, and eager-Link paths could silently no-op or leave `sheetIsOpen` stuck. This makes all of those paths terminate with a failure result and reusable state.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated checks:

- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutSheetLauncherTest' --tests 'com.stripe.android.checkout.CheckoutLinkPaymentOptionsPresenterTest' --tests 'com.stripe.android.paymentsheet.flowcontroller.DefaultFlowControllerTest'`
- `./gradlew detekt`

No tests were ignored.

# Screenshots

| Before | After |
| --- | --- |
| Not applicable: lifecycle error handling has no visual change. | Not applicable: lifecycle error handling has no visual change. |

# Changelog

Not applicable: this corrects internal launcher lifecycle handling without changing the public API.

Committed and created by Codex.
