### PR TITLE
Fix Checkout state consistency

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -24,6 +24,7 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
 ) {
     fun confirm() {
         val state = stateHolder.state ?: return
+        if (!state.isOpen) return
         val paymentSelection = state.paymentSelection ?: return
         val arguments = operationCoordinator.tryBeginConfirmation {
           confirmationArgs(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -267,6 +267,11 @@ class CheckoutController @Inject internal constructor(
             ?: return kotlin.Result.failure(
                 IllegalStateException("Cannot mutate checkout session before it is configured.")
             )
+        if (stateHolder.state?.isOpen != true) {
+            return kotlin.Result.failure(
+                IllegalStateException("Cannot mutate a completed or expired checkout session.")
+            )
+        }
         if (sheetStateHolder.sheetIsOpen) {
             return kotlin.Result.failure(
                 IllegalStateException("Cannot mutate checkout session while a payment flow is presented.")
@@ -277,6 +282,7 @@ class CheckoutController @Inject internal constructor(
                 // Re-read the latest committed state inside the lock so serialized mutations
                 // build on each other's results rather than a stale snapshot.
                 val state = requireNotNull(stateHolder.state)
+                check(state.isOpen) { "Cannot mutate a completed or expired checkout session." }
                 val response = state.block(state.checkoutSessionResponse.id).getOrThrow()
                 val newState = state
                     .copy(checkoutSessionResponse = response)

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerState.kt
@@ -27,6 +27,9 @@ internal data class CheckoutControllerState(
     val previousNewSelections: Bundle,
     val linkEagerPresentationSuppressed: Boolean,
 ) : Parcelable {
+    val isOpen: Boolean
+        get() = checkoutSessionResponse.status == CheckoutSessionResponse.Status.OPEN
+
     fun asCheckoutSession(
         paymentOptionFactory: CheckoutPaymentOptionDisplayDataFactory,
         availableExpressButtonTypesFactory: AvailableExpressButtonTypesFactory,

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutControllerStateHolder.kt
@@ -59,6 +59,7 @@ internal class CheckoutControllerStateHolder @Inject constructor(
 
     override fun setSelection(updatedSelection: PaymentSelection?) {
         val current = requireState(operation = "setSelection") ?: return
+        if (!current.isOpen) return
         val previousNewSelections = Bundle(current.previousNewSelections).apply {
             stashNewSelection(updatedSelection)
         }
@@ -70,11 +71,13 @@ internal class CheckoutControllerStateHolder @Inject constructor(
 
     override fun setTemporarySelection(code: PaymentMethodCode?) {
         val current = requireState(operation = "setTemporarySelection") ?: return
+        if (!current.isOpen) return
         state = current.copy(temporarySelection = code)
     }
 
     override fun setPreviousNewSelections(bundle: Bundle) {
         val current = requireState(operation = "setPreviousNewSelections") ?: return
+        if (!current.isOpen) return
         val previousNewSelections = Bundle(current.previousNewSelections).apply {
             putAll(bundle)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenter.kt
@@ -51,9 +51,9 @@ internal class CheckoutLinkPaymentOptionsPresenter @Inject constructor(
         if (sheetStateHolder.sheetIsOpen) return
         val state = stateHolder.state
         if (state == null) {
-            defaultPresenter.present()
             return
         }
+        if (!state.isOpen) return
 
         sheetStateHolder.sheetIsOpen = true
         val didLaunch = selectionLauncher.launchIfEligible(

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -20,6 +20,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private val confirmationHandler: ConfirmationHandler,
     private val sheetStateHolder: SheetStateHolder,
     private val sessionRefresher: CheckoutSessionRefresher,
+    private val stateHolder: CheckoutControllerStateHolder,
     private val logger: Logger,
     private val resultCallback: CheckoutController.ResultCallback,
 ) {
@@ -113,7 +114,12 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
 
         try {
-            mapResult(wasRestored)?.let(resultCallback::onResult)
+            mapResult(wasRestored)?.let { result ->
+                if (result is CheckoutController.Result.Completed) {
+                    stateHolder.state = null
+                }
+                resultCallback.onResult(result)
+            }
         } finally {
             synchronized(admissionLock) {
                 confirmationInFlight = false

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionRefresher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSessionRefresher.kt
@@ -1,6 +1,9 @@
 package com.stripe.android.checkout
 
+import android.os.Bundle
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.stashNewSelection
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import javax.inject.Inject
@@ -13,6 +16,12 @@ internal interface CheckoutSessionRefresher {
     suspend fun refresh()
 
     suspend fun refresh(response: CheckoutSessionResponse)
+
+    suspend fun refresh(
+        response: CheckoutSessionResponse,
+        paymentSelection: PaymentSelection?,
+        previousNewSelections: Bundle,
+    )
 }
 
 @OptIn(CheckoutSessionPreview::class)
@@ -46,5 +55,24 @@ internal class DefaultCheckoutSessionRefresher internal constructor(
     override suspend fun refresh(response: CheckoutSessionResponse) {
         val state = stateHolder.state ?: return
         reloadState(state.copy(checkoutSessionResponse = response))
+    }
+
+    override suspend fun refresh(
+        response: CheckoutSessionResponse,
+        paymentSelection: PaymentSelection?,
+        previousNewSelections: Bundle,
+    ) {
+        val state = stateHolder.state ?: return
+        val mergedPreviousNewSelections = Bundle(state.previousNewSelections).apply {
+            putAll(previousNewSelections)
+            stashNewSelection(paymentSelection)
+        }
+        reloadState(
+            state.copy(
+                checkoutSessionResponse = response,
+                paymentSelection = paymentSelection,
+                previousNewSelections = mergedPreviousNewSelections,
+            )
+        )
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -28,7 +28,6 @@ import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.CustomerStateHolder
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.model.paymentMethodType
-import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
@@ -59,6 +58,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     activityResultCaller: ActivityResultCaller,
     private val lifecycleOwner: LifecycleOwner,
     private val selectionHolder: EmbeddedSelectionHolder,
+    private val checkoutStateHolder: CheckoutControllerStateHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val sheetStateHolder: SheetStateHolder,
     private val errorReporter: ErrorReporter,
@@ -106,11 +106,11 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private fun handleFormResult(result: EmbeddedActivityResult) {
         when (result) {
             is EmbeddedActivityResult.Complete -> {
-                applyCompleteResult(result)
-                if (!result.hasBeenConfirmed) {
-                    result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
+                applyCompleteResult(result) {
+                    if (!result.hasBeenConfirmed) {
+                        result.selection?.let { rowSelectionImmediateActionHandler.invoke() }
+                    }
                 }
-                refreshCheckoutSession(result.checkoutSessionResponse)
             }
             is EmbeddedActivityResult.Cancelled -> applyCustomerState(result.customerState)
             is EmbeddedActivityResult.Error -> Unit
@@ -120,7 +120,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private fun handleManageResult(result: EmbeddedActivityResult) {
         when (result) {
             is EmbeddedActivityResult.Complete -> {
-                applyCompleteResult(result)
+                applyCompleteResultImmediately(result)
                 if (result.shouldInvokeSelectionCallback && result.selection is PaymentSelection.Saved) {
                     rowSelectionImmediateActionHandler.invoke()
                 }
@@ -133,8 +133,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
     private fun handlePaymentOptionsResult(result: EmbeddedActivityResult) {
         when (result) {
             is EmbeddedActivityResult.Complete -> {
-                applyCompleteResult(result)
-                refreshCheckoutSession(result.checkoutSessionResponse)
+                applyCompleteResult(result, onSelectionCommitted = {})
             }
             is EmbeddedActivityResult.Cancelled -> {
                 applyCustomerState(result.customerState)
@@ -144,21 +143,42 @@ internal class CheckoutSheetLauncher @Inject constructor(
         }
     }
 
-    private fun applyCompleteResult(result: EmbeddedActivityResult.Complete) {
+    private fun applyCompleteResult(
+        result: EmbeddedActivityResult.Complete,
+        onSelectionCommitted: () -> Unit,
+    ) {
         applyCustomerState(result.customerState)
-        selectionHolder.setPreviousNewSelections(result.previousNewSelections)
-        selectionHolder.setSelection(result.selection)
-    }
-
-    private fun refreshCheckoutSession(response: CheckoutSessionResponse?) {
-        response ?: return
+        val response = result.checkoutSessionResponse
+        if (response == null) {
+            applySelection(result)
+            onSelectionCommitted()
+            return
+        }
         coroutineScope.launch {
             operationCoordinator.runMutation {
-                runCatching { sessionRefresher.refresh(response) }
+                runCatching {
+                    sessionRefresher.refresh(
+                        response = response,
+                        paymentSelection = result.selection,
+                        previousNewSelections = result.previousNewSelections,
+                    )
+                }
+            }.onSuccess {
+                onSelectionCommitted()
             }.onFailure {
                 logger.error("Failed to refresh the checkout session after the sheet closed.", it)
             }
         }
+    }
+
+    private fun applyCompleteResultImmediately(result: EmbeddedActivityResult.Complete) {
+        applyCustomerState(result.customerState)
+        applySelection(result)
+    }
+
+    private fun applySelection(result: EmbeddedActivityResult.Complete) {
+        selectionHolder.setPreviousNewSelections(result.previousNewSelections)
+        selectionHolder.setSelection(result.selection)
     }
 
     private fun applyCustomerState(customerState: CustomerState?) {
@@ -189,7 +209,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             )
             return
         }
-        if (sheetStateHolder.sheetIsOpen) return
+        if (!checkoutStateHolder.state.isOpen() || sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
         selectionHolder.setTemporarySelection(code)
         val currentSelection = (selectionHolder.selection.value as? PaymentSelection.New?)
@@ -225,7 +245,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             )
             return
         }
-        if (sheetStateHolder.sheetIsOpen) return
+        if (!checkoutStateHolder.state.isOpen() || sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
         val args = EmbeddedActivityArgs(
             paymentMethodMetadata = paymentMethodMetadata,
@@ -255,7 +275,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
             )
             return
         }
-        if (sheetStateHolder.sheetIsOpen) return
+        if (!checkoutStateHolder.state.isOpen() || sheetStateHolder.sheetIsOpen) return
         sheetStateHolder.sheetIsOpen = true
         val initialArgs = createPaymentOptionsArgs(
             paymentMethodMetadata = paymentMethodMetadata,
@@ -280,7 +300,7 @@ internal class CheckoutSheetLauncher @Inject constructor(
 
         lifecycleOwner.lifecycleScope.launch {
             operationCoordinator.isUpdating.first { isUpdating -> !isUpdating }
-            if (!sheetStateHolder.sheetIsOpen) {
+            if (!checkoutStateHolder.state.isOpen() || !sheetStateHolder.sheetIsOpen) {
                 launcherState.isAwaitingPaymentOptionsReady = false
                 return@launch
             }
@@ -327,3 +347,5 @@ internal class CheckoutSheetLauncher @Inject constructor(
         )
     }
 }
+
+private fun CheckoutControllerState?.isOpen(): Boolean = this?.isOpen == true

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentelement.confirmation.link.LinkConfirmationOptio
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
@@ -37,6 +38,17 @@ internal class CheckoutConfirmationPerformerTest {
     @Test
     fun `confirm does nothing when there is no selection`() = runScenario(
         state = CheckoutControllerStateFactory.create(paymentSelection = null),
+    ) {
+        performer.confirm()
+    }
+
+    @Test
+    fun `confirm does nothing when checkout session is expired`() = runScenario(
+        state = googlePayState(paymentSelection = PaymentSelection.GooglePay).copy(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                status = CheckoutSessionResponse.Status.EXPIRED,
+            )
+        ),
     ) {
         performer.confirm()
     }
@@ -125,6 +137,7 @@ internal class CheckoutConfirmationPerformerTest {
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             sessionRefresher = sessionRefresher,
+            stateHolder = stateHolder,
             logger = Logger.noop(),
             resultCallback = {},
         )

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerStateHolderTest.kt
@@ -15,6 +15,7 @@ import com.stripe.android.paymentelement.EmbeddedPaymentElement
 import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.FakeErrorReporter
 import kotlinx.coroutines.test.runTest
@@ -172,6 +173,20 @@ internal class CheckoutControllerStateHolderTest {
     }
 
     @Test
+    fun `selection setters no-op after the checkout session expires`() = testScenario {
+        val expiredState = committedState(status = CheckoutSessionResponse.Status.EXPIRED)
+        stateHolder.state = expiredState
+
+        stateHolder.setSelection(PaymentSelection.GooglePay)
+        stateHolder.setTemporarySelection("card")
+        stateHolder.setPreviousNewSelections(
+            Bundle().apply { putParcelable("cashapp", PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION) },
+        )
+
+        assertThat(stateHolder.state).isEqualTo(expiredState)
+    }
+
+    @Test
     fun `projects selection, temporarySelection and previousNewSelections from a restored state`() = runTest {
         // Simulates process-death restore: a committed state is read back from SavedStateHandle by a
         // freshly constructed holder, and every selection projection must reflect it.
@@ -202,10 +217,12 @@ internal class CheckoutControllerStateHolderTest {
         paymentMethodMetadata: PaymentMethodMetadata = PaymentMethodMetadataFactory.create(),
         expressCheckoutElementPaymentMethodMetadata: PaymentMethodMetadata? = PaymentMethodMetadataFactory.create(),
         requiresShippingAddress: Boolean = false,
+        status: CheckoutSessionResponse.Status = CheckoutSessionResponse.Status.OPEN,
     ) = CheckoutControllerState(
         configuration = CheckoutController.Configuration().build(),
         checkoutSessionResponse = CheckoutSessionResponseFactory.create(
             requiresShippingAddress = requiresShippingAddress,
+            status = status,
         ),
         flagImages = null,
         collectedDetails = CheckoutCollectedDetails(email = null),

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -759,6 +759,14 @@ internal class CheckoutControllerTest {
         assertThat(result.isSuccess).isTrue()
         assertThat(controller.session.value?.status)
             .isInstanceOf(CheckoutController.Session.Status.Complete::class.java)
+
+        val mutation = controller.updateEmail("after-completion@example.com")
+
+        assertThat(mutation.isFailure).isTrue()
+        assertThat(mutation.exceptionOrNull()).hasMessageThat()
+            .isEqualTo("Cannot mutate a completed or expired checkout session.")
+        assertThat(controller.session.value?.status)
+            .isInstanceOf(CheckoutController.Session.Status.Complete::class.java)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutLinkPaymentOptionsPresenterTest.kt
@@ -64,6 +64,16 @@ internal class CheckoutLinkPaymentOptionsPresenterTest {
     }
 
     @Test
+    fun `payment options are not presented after checkout state is cleared`() = runScenario {
+        stateHolder.state = null
+
+        presenter.present()
+
+        verify(defaultPresenter, never()).present()
+        verifyLinkWasNotPresented()
+    }
+
+    @Test
     fun `eligible Link launches with exact arguments and keeps sheet open`() = runScenario {
         presenter.present()
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -269,6 +269,7 @@ internal class CheckoutOperationCoordinatorTest {
         )
         assertThat(refreshCalls.awaitItem()).isEqualTo(FakeCheckoutSessionRefresher.Call.Fetch)
         assertThat(resultTurbine.awaitItem()).isInstanceOf<CheckoutController.Result.Completed>()
+        assertThat(stateHolder.state).isNull()
     }
 
     @Test
@@ -751,10 +752,14 @@ internal class CheckoutOperationCoordinatorTest {
         }
         val resultTurbine = Turbine<CheckoutController.Result>()
         val sessionRefresher = FakeCheckoutSessionRefresher()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(SavedStateHandle()).apply {
+            state = CheckoutControllerStateFactory.create()
+        }
         val coordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
             sessionRefresher = sessionRefresher,
+            stateHolder = stateHolder,
             logger = logger,
             resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
         )
@@ -769,6 +774,7 @@ internal class CheckoutOperationCoordinatorTest {
             resultTurbine = resultTurbine,
             refreshCalls = sessionRefresher.calls,
             sessionRefresher = sessionRefresher,
+            stateHolder = stateHolder,
             observerJob = observerJob,
             testScope = this,
         ).block()
@@ -784,6 +790,7 @@ internal class CheckoutOperationCoordinatorTest {
         val resultTurbine: Turbine<CheckoutController.Result>,
         val refreshCalls: Turbine<FakeCheckoutSessionRefresher.Call>,
         private val sessionRefresher: FakeCheckoutSessionRefresher,
+        val stateHolder: CheckoutControllerStateHolder,
         val observerJob: Job,
         private val testScope: TestScope,
     ) : CoroutineScope by testScope {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.DefaultCustomerStateHolder
 import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
+import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.DummyActivityResultCaller.RegisterCall
@@ -195,6 +196,25 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
+    fun `launchForm is not launched when checkout session is expired`() = testScenario {
+        checkoutStateHolder.state = CheckoutControllerStateFactory.create(
+            checkoutSessionResponse = CheckoutSessionResponseFactory.create(
+                status = CheckoutSessionResponse.Status.EXPIRED,
+            )
+        )
+
+        sheetLauncher.launchForm(
+            code = "card",
+            paymentMethodMetadata = PaymentMethodMetadataFactory.create(),
+            configuration = EmbeddedConfigurationFactory.create(),
+            customerState = null,
+            promotion = null,
+        )
+
+        assertThat(sheetStateHolder.sheetIsOpen).isFalse()
+    }
+
+    @Test
     fun `formActivityLauncher sets selection and customer state on complete result`() = testScenario {
         selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         launchForm("cashapp")
@@ -259,6 +279,7 @@ internal class CheckoutSheetLauncherTest {
     @Test
     fun `formActivityLauncher refreshes checkout session from complete result`() = testScenario {
         val response = CheckoutSessionResponseFactory.create()
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         sessionRefresher.enqueueRefreshAction {}
         val result = EmbeddedActivityResult.Complete(
             previousNewSelections = Bundle(),
@@ -274,11 +295,17 @@ internal class CheckoutSheetLauncherTest {
         val callback = registerCall.callback.asCallbackFor<EmbeddedActivityResult>()
 
         callback.onActivityResult(result)
-        assertThat(selectionHolder.selection.value).isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        assertThat(selectionHolder.selection.value).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         assertThat(sheetStateHolder.sheetIsOpen).isFalse()
         runCurrent()
 
-        assertThat(awaitRefreshCall()).isEqualTo(FakeCheckoutSessionRefresher.Call.Commit(response))
+        assertThat(awaitRefreshCall()).isEqualTo(
+            FakeCheckoutSessionRefresher.Call.CommitWithSelection(
+                response = response,
+                paymentSelection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+                previousNewSelections = result.previousNewSelections,
+            )
+        )
     }
 
     @Test
@@ -788,9 +815,10 @@ internal class CheckoutSheetLauncherTest {
     }
 
     @Test
-    fun `paymentOptionsResult contains checkout session refresh failure`() = testScenario {
+    fun `paymentOptionsResult keeps previous selection when checkout session refresh fails`() = testScenario {
         val response = CheckoutSessionResponseFactory.create()
         val expectedError = IllegalStateException("Refresh failed")
+        selectionHolder.setSelection(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         sessionRefresher.enqueueRefreshAction { throw expectedError }
         val result = EmbeddedActivityResult.Complete(
             previousNewSelections = Bundle(),
@@ -806,8 +834,14 @@ internal class CheckoutSheetLauncherTest {
         callback.onActivityResult(result)
         runCurrent()
 
-        assertThat(awaitRefreshCall()).isEqualTo(FakeCheckoutSessionRefresher.Call.Commit(response))
-        assertThat(selectionHolder.selection.value).isEqualTo(PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION)
+        assertThat(awaitRefreshCall()).isEqualTo(
+            FakeCheckoutSessionRefresher.Call.CommitWithSelection(
+                response = response,
+                paymentSelection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION,
+                previousNewSelections = result.previousNewSelections,
+            )
+        )
+        assertThat(selectionHolder.selection.value).isEqualTo(PaymentMethodFixtures.CARD_PAYMENT_SELECTION)
         assertThat(logger.errorLogs).containsExactly(
             "Failed to refresh the checkout session after the sheet closed." to expectedError
         )
@@ -912,12 +946,16 @@ internal class CheckoutSheetLauncherTest {
         val sheetStateHolder = SheetStateHolder(savedStateHandle)
         val errorReporter = FakeErrorReporter()
         val sessionRefresher = FakeCheckoutSessionRefresher()
+        val checkoutStateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle).apply {
+            state = CheckoutControllerStateFactory.create()
+        }
         val logger = FakeLogger()
         val confirmationHandler = FakeConfirmationHandler()
         val operationCoordinator = CheckoutOperationCoordinator(
             confirmationHandler = confirmationHandler,
             sheetStateHolder = sheetStateHolder,
             sessionRefresher = sessionRefresher,
+            stateHolder = checkoutStateHolder,
             logger = logger,
             resultCallback = CheckoutController.ResultCallback {},
         )
@@ -939,6 +977,7 @@ internal class CheckoutSheetLauncherTest {
                     activityResultCaller = activityResultCaller,
                     lifecycleOwner = owner,
                     selectionHolder = selectionHolder,
+                    checkoutStateHolder = checkoutStateHolder,
                     customerStateHolder = customerStateHolder,
                     sheetStateHolder = sheetStateHolder,
                     errorReporter = errorReporter,
@@ -964,6 +1003,7 @@ internal class CheckoutSheetLauncherTest {
 
             Scenario(
                 selectionHolder = selectionHolder,
+                checkoutStateHolder = checkoutStateHolder,
                 lifecycleOwner = lifecycleOwner,
                 customerStateHolder = customerStateHolder,
                 dummyActivityResultCallerScenario = this,
@@ -991,6 +1031,7 @@ internal class CheckoutSheetLauncherTest {
 
     private class Scenario(
         val selectionHolder: EmbeddedSelectionHolder,
+        val checkoutStateHolder: CheckoutControllerStateHolder,
         val lifecycleOwner: TestLifecycleOwner,
         val customerStateHolder: CustomerStateHolder,
         val dummyActivityResultCallerScenario: DummyActivityResultCaller.Scenario,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutSessionRefresherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutSessionRefresherTest.kt
@@ -2,7 +2,9 @@ package com.stripe.android.checkout
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.model.PaymentMethodFixtures
 import com.stripe.android.paymentelement.CheckoutSessionPreview
+import com.stripe.android.paymentelement.embedded.previousNewSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -21,6 +23,24 @@ internal class DefaultCheckoutSessionRefresherTest {
 
         assertThat(refreshActions.reloadCalls.awaitItem())
             .isEqualTo(initialState.copy(checkoutSessionResponse = response))
+    }
+
+    @Test
+    fun `refresh with selection commits response and selection together`() = runScenario {
+        val response = CheckoutSessionResponseFactory.create(id = "cs_updated")
+        val selection = PaymentMethodFixtures.CASHAPP_PAYMENT_SELECTION
+
+        refresher.refresh(
+            response = response,
+            paymentSelection = selection,
+            previousNewSelections = android.os.Bundle(),
+        )
+
+        val committedState = refreshActions.reloadCalls.awaitItem()
+        assertThat(committedState.checkoutSessionResponse).isEqualTo(response)
+        assertThat(committedState.paymentSelection).isEqualTo(selection)
+        assertThat(committedState.previousNewSelections.previousNewSelection("cashapp"))
+            .isEqualTo(selection)
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSessionRefresher.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/FakeCheckoutSessionRefresher.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.checkout
 
+import android.os.Bundle
 import app.cash.turbine.Turbine
+import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 
 internal class FakeCheckoutSessionRefresher : CheckoutSessionRefresher {
@@ -19,6 +21,14 @@ internal class FakeCheckoutSessionRefresher : CheckoutSessionRefresher {
         record(Call.Commit(response))
     }
 
+    override suspend fun refresh(
+        response: CheckoutSessionResponse,
+        paymentSelection: PaymentSelection?,
+        previousNewSelections: Bundle,
+    ) {
+        record(Call.CommitWithSelection(response, paymentSelection, previousNewSelections))
+    }
+
     fun ensureAllEventsConsumed() {
         calls.ensureAllEventsConsumed()
         refreshActions.ensureAllEventsConsumed()
@@ -32,5 +42,10 @@ internal class FakeCheckoutSessionRefresher : CheckoutSessionRefresher {
     sealed interface Call {
         data object Fetch : Call
         data class Commit(val response: CheckoutSessionResponse) : Call
+        data class CommitWithSelection(
+            val response: CheckoutSessionResponse,
+            val paymentSelection: PaymentSelection?,
+            val previousNewSelections: Bundle,
+        ) : Call
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -245,6 +245,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             confirmationHandler = confirmationHandler,
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             sessionRefresher = sessionRefresher,
+            stateHolder = stateHolder,
             logger = Logger.noop(),
             resultCallback = {},
         )


### PR DESCRIPTION
# Summary

- Prevent Checkout presentation, confirmation, and local mutations after a Checkout Session completes or expires.
- Clear loaded Checkout state before delivering a successful confirmation result.
- Commit automatic-tax session totals and the associated payment selection atomically, preserving the prior state if refresh fails.

# Motivation

Checkout retained actionable local state after terminal session states, unlike FlowController's successful-completion cleanup. Automatic-tax selection also exposed a transient state where the new payment option was visible with old totals, and retained that selection if the totals refresh failed.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Validated with focused `:paymentsheet:testDebugUnitTest` coverage for Checkout controller, state holder, confirmation, operation coordination, session refresh, sheet launch, Link presentation, and express checkout confirmation. Also ran `./gradlew detekt`.

# Screenshots

Not applicable; this changes state coordination without visual UI changes.

# Changelog

Not applicable; Checkout Session support is currently a restricted preview API.

Committed and created by Codex.
