### PR TITLE
Fix CheckoutController presenter cleanup on destroy

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -23,6 +23,7 @@ import com.stripe.android.elements.ShippingAddressElement
 import com.stripe.android.elements.ece.ExpressButtonType
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackReferences
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionRepository
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
@@ -65,6 +66,7 @@ class CheckoutController @Inject internal constructor(
     @PaymentElementCallbackIdentifier internal val paymentElementCallbackIdentifier: String,
     private val savedState: CheckoutControllerSavedState,
     private val checkoutAnalyticsPerformer: CheckoutAnalyticsPerformer,
+    private val checkoutPresenterLifecycle: CheckoutPresenterLifecycle,
 ) {
     /**
      * The latest [Session] data, or `null` until [configure] has completed successfully.
@@ -305,12 +307,13 @@ class CheckoutController @Inject internal constructor(
      * @param activity The activity the payment UI will be presented from.
      */
     fun createPresenter(activity: ComponentActivity): CheckoutPresenter {
+        val presenterLifecycleOwner = checkoutPresenterLifecycle.create(activity)
         val subcomponent = checkoutPresenterSubcomponentFactory.create(
             activityResultCaller = PaymentElementActivityResultCaller(
                 key = "CheckoutController(instance = $paymentElementCallbackIdentifier)",
                 registryOwner = activity,
             ),
-            lifecycleOwner = activity,
+            lifecycleOwner = presenterLifecycleOwner,
             activityResultRegistry = activity.activityResultRegistry,
             statusBarColor = StatusBarCompat.color(activity),
         )
@@ -319,10 +322,12 @@ class CheckoutController @Inject internal constructor(
     }
 
     /**
-     * Releases resources held by this controller and clears its loaded state. Call this when the
-     * controller is no longer needed.
+     * Dismisses payment UI, releases resources held by this controller and its presenters, and
+     * clears its loaded state. Call this when the controller is no longer needed.
      */
     fun destroy() {
+        checkoutPresenterLifecycle.destroy()
+        PaymentElementCallbackReferences.remove(paymentElementCallbackIdentifier)
         viewModelScope.cancel()
         checkoutStateLoader.clear()
         savedState.clear()

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenterInitializer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenterInitializer.kt
@@ -3,9 +3,11 @@ package com.stripe.android.checkout
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.paymentelement.callbacks.PaymentElementCallbackIdentifier
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.embedded.content.EmbeddedSheetLauncher
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
+import com.stripe.android.paymentelement.embedded.sheet.EmbeddedSheetActivity
 import com.stripe.android.paymentsheet.parseAppearance
 import javax.inject.Inject
 
@@ -16,6 +18,7 @@ internal class CheckoutPresenterInitializer @Inject constructor(
     private val sheetLauncher: EmbeddedSheetLauncher,
     private val sheetStateHolder: SheetStateHolder,
     private val stateHolder: CheckoutControllerStateHolder,
+    @PaymentElementCallbackIdentifier private val paymentElementCallbackIdentifier: String,
 ) {
     fun initialize() {
         confirmationHandler.register(activityResultCaller, lifecycleOwner)
@@ -23,10 +26,17 @@ internal class CheckoutPresenterInitializer @Inject constructor(
         sheetStateHolder.sheetLauncher = sheetLauncher
         stateHolder.state?.embeddedConfiguration?.appearance?.parseAppearance()
 
+        (lifecycleOwner as? PresenterLifecycleOwner)?.addControllerDestroyListener {
+            EmbeddedSheetActivity.dismiss(paymentElementCallbackIdentifier)
+            sheetStateHolder.sheetIsOpen = false
+        }
+
         lifecycleOwner.lifecycle.addObserver(
             object : DefaultLifecycleObserver {
                 override fun onDestroy(owner: LifecycleOwner) {
-                    sheetStateHolder.sheetLauncher = null
+                    if (sheetStateHolder.sheetLauncher === sheetLauncher) {
+                        sheetStateHolder.sheetLauncher = null
+                    }
                 }
             }
         )

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenterLifecycle.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPresenterLifecycle.kt
@@ -1,0 +1,81 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.LifecycleRegistry
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+internal class CheckoutPresenterLifecycle @Inject constructor() {
+    private val owners = mutableSetOf<PresenterLifecycleOwner>()
+
+    fun create(activity: LifecycleOwner): PresenterLifecycleOwner {
+        val owner = PresenterLifecycleOwner(
+            activity = activity,
+            onDestroyed = owners::remove,
+        )
+        if (owner.lifecycle.currentState != Lifecycle.State.DESTROYED) {
+            owners.add(owner)
+        }
+        return owner
+    }
+
+    fun destroy() {
+        owners.toList().forEach { it.destroyByController() }
+    }
+}
+
+internal class PresenterLifecycleOwner(
+    private val activity: LifecycleOwner,
+    private val onDestroyed: (PresenterLifecycleOwner) -> Unit,
+) : LifecycleOwner, DefaultLifecycleObserver {
+    private val lifecycleRegistry = LifecycleRegistry(this)
+    private val controllerDestroyListeners = mutableListOf<() -> Unit>()
+
+    override val lifecycle: Lifecycle = lifecycleRegistry
+
+    init {
+        activity.lifecycle.addObserver(this)
+        if (activity.lifecycle.currentState == Lifecycle.State.DESTROYED) {
+            destroy()
+        }
+    }
+
+    fun addControllerDestroyListener(listener: () -> Unit) {
+        controllerDestroyListeners += listener
+    }
+
+    fun destroyByController() {
+        controllerDestroyListeners.forEach { it() }
+        destroy()
+    }
+
+    override fun onCreate(owner: LifecycleOwner) = handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+
+    override fun onStart(owner: LifecycleOwner) = handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+    override fun onResume(owner: LifecycleOwner) = handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+
+    override fun onPause(owner: LifecycleOwner) = handleLifecycleEvent(Lifecycle.Event.ON_PAUSE)
+
+    override fun onStop(owner: LifecycleOwner) = handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+
+    override fun onDestroy(owner: LifecycleOwner) = destroy()
+
+    private fun handleLifecycleEvent(event: Lifecycle.Event) {
+        if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
+            lifecycleRegistry.handleLifecycleEvent(event)
+        }
+    }
+
+    private fun destroy() {
+        if (lifecycleRegistry.currentState == Lifecycle.State.DESTROYED) return
+
+        activity.lifecycle.removeObserver(this)
+        lifecycleRegistry.currentState = Lifecycle.State.DESTROYED
+        controllerDestroyListeners.clear()
+        onDestroyed(this)
+    }
+}

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/sheet/EmbeddedSheetActivity.kt
@@ -12,10 +12,12 @@ import com.stripe.android.paymentsheet.ui.PaymentElementTheme
 import com.stripe.android.paymentsheet.utils.renderEdgeToEdge
 import com.stripe.android.uicore.elements.bottomsheet.rememberStripeBottomSheetState
 import com.stripe.android.uicore.utils.fadeOut
+import java.lang.ref.WeakReference
 
 @OptIn(ExperimentalMaterialApi::class)
 internal class EmbeddedSheetActivity : AppCompatActivity() {
     private var coordinator: EmbeddedSheetActivityCoordinator? = null
+    private var paymentElementCallbackIdentifier: String? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -26,6 +28,8 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
             finish()
             return
         }
+        paymentElementCallbackIdentifier = activityArgs.paymentElementCallbackIdentifier
+        activeActivities[activityArgs.paymentElementCallbackIdentifier] = WeakReference(this)
 
         renderEdgeToEdge()
         val coordinator = EmbeddedSheetActivityCoordinator(
@@ -74,9 +78,20 @@ internal class EmbeddedSheetActivity : AppCompatActivity() {
     override fun onDestroy() {
         super.onDestroy()
         coordinator?.onDestroy()
+        paymentElementCallbackIdentifier?.let { identifier ->
+            if (activeActivities[identifier]?.get() === this) {
+                activeActivities.remove(identifier)
+            }
+        }
     }
 
-    private companion object {
+    companion object {
         const val STATE_ACTIVITY_ARGS = "embedded_sheet_activity_args"
+
+        private val activeActivities = mutableMapOf<String, WeakReference<EmbeddedSheetActivity>>()
+
+        internal fun dismiss(paymentElementCallbackIdentifier: String) {
+            activeActivities.remove(paymentElementCallbackIdentifier)?.get()?.finish()
+        }
     }
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutControllerTest.kt
@@ -396,6 +396,16 @@ internal class CheckoutControllerTest {
     }
 
     @Test
+    fun `destroy removes payment element callbacks`() = runTest {
+        val controller = createController()
+        PaymentElementCallbackReferences[DEFAULT_INTEGRATION_NAME] = PaymentElementCallbacks.Builder().build()
+
+        controller.destroy()
+
+        assertThat(PaymentElementCallbackReferences[DEFAULT_INTEGRATION_NAME]).isNull()
+    }
+
+    @Test
     fun `clearPaymentOption clears payment option state`() = runMutationScenario(
         paymentSelection = PaymentSelection.GooglePay,
         temporarySelection = "card",

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterInitializerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterInitializerTest.kt
@@ -79,6 +79,7 @@ internal class CheckoutPresenterInitializerTest {
                 stateHolder = CheckoutControllerStateFactory.createStateHolder(
                     SavedStateHandle(mapOf(CheckoutControllerStateHolder.STATE_KEY to restoredState))
                 ),
+                paymentElementCallbackIdentifier = "test",
             )
 
             initializer.initialize()
@@ -106,6 +107,7 @@ internal class CheckoutPresenterInitializerTest {
             sheetLauncher = sheetLauncher,
             sheetStateHolder = sheetStateHolder,
             stateHolder = stateHolder,
+            paymentElementCallbackIdentifier = "test",
         )
 
         Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterLifecycleTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutPresenterLifecycleTest.kt
@@ -1,0 +1,76 @@
+package com.stripe.android.checkout
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import app.cash.turbine.Turbine
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.testing.CoroutineTestRule
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+internal class CheckoutPresenterLifecycleTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    @Test
+    fun `presenter lifecycle follows activity lifecycle`() = runTest {
+        val activity = TestLifecycleOwner()
+        val presenter = CheckoutPresenterLifecycle().create(activity)
+
+        activity.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
+        activity.handleLifecycleEvent(Lifecycle.Event.ON_START)
+
+        assertThat(presenter.lifecycle.currentState).isEqualTo(Lifecycle.State.STARTED)
+
+        activity.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+
+        assertThat(presenter.lifecycle.currentState).isEqualTo(Lifecycle.State.DESTROYED)
+    }
+
+    @Test
+    fun `destroy transitions every presenter lifecycle to destroyed`() = runTest {
+        val activity = TestLifecycleOwner(Lifecycle.State.RESUMED)
+        val presenterLifecycle = CheckoutPresenterLifecycle()
+        val firstPresenter = presenterLifecycle.create(activity)
+        val secondPresenter = presenterLifecycle.create(activity)
+
+        presenterLifecycle.destroy()
+
+        assertThat(firstPresenter.lifecycle.currentState).isEqualTo(Lifecycle.State.DESTROYED)
+        assertThat(secondPresenter.lifecycle.currentState).isEqualTo(Lifecycle.State.DESTROYED)
+    }
+
+    @Test
+    fun `destroy invokes controller destroy listener`() = runTest {
+        val presenterLifecycle = CheckoutPresenterLifecycle()
+        val presenter = presenterLifecycle.create(TestLifecycleOwner(Lifecycle.State.RESUMED))
+        val listenerCalls = Turbine<Unit>()
+        presenter.addControllerDestroyListener { listenerCalls.add(Unit) }
+
+        presenterLifecycle.destroy()
+
+        listenerCalls.awaitItem()
+        listenerCalls.ensureAllEventsConsumed()
+    }
+
+    @Test
+    fun `activity destroy removes presenter without invoking controller destroy listener`() = runTest {
+        val activity = TestLifecycleOwner(Lifecycle.State.RESUMED)
+        val presenterLifecycle = CheckoutPresenterLifecycle()
+        val presenter = presenterLifecycle.create(activity)
+        val listenerCalls = Turbine<Unit>()
+        presenter.addControllerDestroyListener { listenerCalls.add(Unit) }
+
+        activity.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)
+        presenterLifecycle.destroy()
+
+        assertThat(presenter.lifecycle.currentState).isEqualTo(Lifecycle.State.DESTROYED)
+        listenerCalls.expectNoEvents()
+        listenerCalls.ensureAllEventsConsumed()
+    }
+}


### PR DESCRIPTION
# Summary

Ensure `CheckoutController.destroy()` shuts down every presenter created by the controller before clearing controller state.

The controller now owns presenter lifecycles, dismisses an active embedded Payment Element sheet, unregisters presenter activity-result launchers, and removes its global callback references during destruction.

# Motivation

Calling `destroy()` while Payment Element UI was active cleared controller state but left the presenter and its activity-result registrations alive. A later activity result could therefore return to a presenter whose backing controller state had already been removed.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Automated validation:
- `./gradlew detekt`
- `./gradlew :paymentsheet:testDebugUnitTest` (6,981 existing tests passed; four newly added lifecycle tests initially exposed a missing Robolectric test runner)
- `./gradlew :paymentsheet:testDebugUnitTest --tests 'com.stripe.android.checkout.CheckoutPresenterLifecycleTest'`
- Focused `CheckoutControllerTest` and `CheckoutPresenterInitializerTest` coverage passed.

No tests were ignored.

# Screenshots

Not applicable; this is lifecycle cleanup with no visual changes.

# Changelog

Not applicable; CheckoutController is a preview, library-group API and this change does not affect the stable public API surface.

Committed and created by Codex.
