### PR TITLE
Animate inline address predictions

### DIFF
--- a/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InlineAddressPredictionsUI.kt
+++ b/stripe-ui-core/src/main/java/com/stripe/android/uicore/elements/InlineAddressPredictionsUI.kt
@@ -1,6 +1,15 @@
 package com.stripe.android.uicore.elements
 
 import androidx.annotation.RestrictTo
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -37,23 +46,39 @@ fun InlineAddressPredictionsUI(
     onClear: () -> Unit,
     onEnterManually: (() -> Unit)?,
 ) {
-    if (!shouldShowPredictionsDropdown(state)) {
-        return
-    }
-
-    Card(
-        elevation = 4.dp,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 4.dp),
-    ) {
-        InlineAddressPredictionsContent(
-            state = state,
-            attributionDrawable = attributionDrawable,
-            onPredictionSelected = onPredictionSelected,
-            onClear = onClear,
-            onEnterManually = onEnterManually,
-        )
+    AnimatedContent(
+        modifier = Modifier.fillMaxWidth(),
+        targetState = state,
+        contentKey = { shouldShowPredictionsDropdown(it) },
+        transitionSpec = {
+            if (shouldShowPredictionsDropdown(targetState)) {
+                (fadeIn() + expandVertically(expandFrom = Alignment.Top)) togetherWith
+                    ExitTransition.None using null
+            } else {
+                EnterTransition.None togetherWith
+                    (fadeOut() + shrinkVertically(shrinkTowards = Alignment.Top)) using null
+            }
+        },
+        label = "InlineAddressPredictions",
+    ) { animatedState ->
+        if (shouldShowPredictionsDropdown(animatedState)) {
+            Card(
+                elevation = 4.dp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
+            ) {
+                Box(modifier = Modifier.fillMaxWidth().animateContentSize()) {
+                    InlineAddressPredictionsContent(
+                        state = animatedState,
+                        attributionDrawable = attributionDrawable,
+                        onPredictionSelected = onPredictionSelected,
+                        onClear = onClear,
+                        onEnterManually = onEnterManually,
+                    )
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->

This pull request adds some animations to Address Element's inline autocomplete sheet.

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

💅 

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [ ] Added tests
- [ ] Modified tests
- [x] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screen recordings

### Before

https://github.com/user-attachments/assets/c1038e92-9fc5-4101-985e-239921e7def7

### After

https://github.com/user-attachments/assets/ad8faee9-74a0-43bb-b7ab-3adc2a1c4266

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A