### PR TITLE
Refactor Checkout tax test scenario

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -111,7 +111,7 @@ internal class CheckoutPaymentElementTest {
     }
 
     @Test
-    fun testBillingTaxUpdateRefreshesCheckoutSession() = runAutomaticTaxTest { context, controller ->
+    fun testBillingTaxUpdateRefreshesCheckoutSession() = runAutomaticTaxTest {
         enqueueTaxUpdate(automaticTaxResponse(UPDATED_TOTAL, TAX_STATUS_COMPLETE))
 
         contentPage.clickOnLpm("card")
@@ -122,17 +122,17 @@ internal class CheckoutPaymentElementTest {
         assertThat(controller.session.value?.tax?.status)
             .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
         contentPage.assertHasSelectedLpm("card")
-        context.markTestSucceeded()
+        markTestSucceeded()
     }
 
     @Test
-    fun testBillingTaxUpdateFailureCanRetryFromPaymentOptions() = runAutomaticTaxTest { context, controller ->
+    fun testBillingTaxUpdateFailureCanRetryFromPaymentOptions() = runAutomaticTaxTest {
         enqueueTaxUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error":{"message":"Invalid tax region"}}""")
         }
 
-        context.presentPaymentOptions()
+        presentPaymentOptions()
         verticalModePage.clickNewPaymentMethodButton("card")
         fillOutCardAndBillingDetails()
         formPage.clickPrimaryButtonWithoutWaitingForDismissal()
@@ -149,7 +149,7 @@ internal class CheckoutPaymentElementTest {
         assertThat(controller.session.value?.tax?.status)
             .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
         contentPage.assertHasSelectedLpm("card")
-        context.markTestSucceeded()
+        markTestSucceeded()
     }
 
     @Test
@@ -192,7 +192,7 @@ internal class CheckoutPaymentElementTest {
         runAutomaticTaxTest(
             paymentMethodLayout = paymentMethodLayout,
             checkoutInitResponse = automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_REQUIRES_LOCATION),
-        ) { context, controller ->
+        ) {
             enqueueTaxUpdate(automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_COMPLETE))
             contentPage.clickOnLpm("card")
             fillOutCardAndBillingDetails()
@@ -201,7 +201,7 @@ internal class CheckoutPaymentElementTest {
 
             enqueueTaxUpdate(automaticTaxResponse(UPDATED_TOTAL, TAX_STATUS_COMPLETE))
 
-            context.presentPaymentOptions()
+            presentPaymentOptions()
             preparePaymentOptionsScreen(paymentMethodLayout)
             clickPaymentOptionsPrimaryButton()
 
@@ -209,7 +209,7 @@ internal class CheckoutPaymentElementTest {
             assertThat(controller.session.value?.tax?.status)
                 .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
             contentPage.assertHasSelectedLpm("card")
-            context.markTestSucceeded()
+            markTestSucceeded()
         }
     }
 
@@ -222,8 +222,8 @@ internal class CheckoutPaymentElementTest {
                 INITIAL_TOTAL,
                 TAX_STATUS_REQUIRES_LOCATION,
             ),
-        ) { context, controller ->
-            context.presentPaymentOptions()
+        ) {
+            presentPaymentOptions()
             selectCashApp(paymentMethodLayout)
             formPage.waitUntilVisible()
 
@@ -235,7 +235,7 @@ internal class CheckoutPaymentElementTest {
             assertThat(controller.session.value?.tax?.status)
                 .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
             contentPage.assertHasSelectedLpm("cashapp")
-            context.markTestSucceeded()
+            markTestSucceeded()
         }
     }
 
@@ -249,8 +249,8 @@ internal class CheckoutPaymentElementTest {
                 INITIAL_TOTAL,
                 TAX_STATUS_REQUIRES_LOCATION,
             ),
-        ) { context, controller ->
-            context.presentPaymentOptions()
+        ) {
+            presentPaymentOptions()
             selectCashApp(paymentMethodLayout)
             formPage.waitUntilVisible()
             assertBillingDetailsArePopulated()
@@ -262,7 +262,7 @@ internal class CheckoutPaymentElementTest {
             assertThat(controller.session.value?.tax?.status)
                 .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
             contentPage.assertHasSelectedLpm("cashapp")
-            context.markTestSucceeded()
+            markTestSucceeded()
         }
     }
 
@@ -286,7 +286,7 @@ internal class CheckoutPaymentElementTest {
     }
 
     private fun runAutomaticTaxTest(
-        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+        block: suspend Scenario.() -> Unit,
     ) = runAutomaticTaxTest(
         configuration = checkoutConfiguration(PaymentElement.Configuration.PaymentMethodLayout.Vertical),
         checkoutInitResponse = automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_REQUIRES_LOCATION),
@@ -296,7 +296,7 @@ internal class CheckoutPaymentElementTest {
     private fun runAutomaticTaxTest(
         paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
         checkoutInitResponse: (MockResponse) -> Unit,
-        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+        block: suspend Scenario.() -> Unit,
     ) = runAutomaticTaxTest(
         configuration = checkoutConfiguration(paymentMethodLayout),
         checkoutInitResponse = checkoutInitResponse,
@@ -306,21 +306,38 @@ internal class CheckoutPaymentElementTest {
     private fun runAutomaticTaxTest(
         configuration: CheckoutController.Configuration,
         checkoutInitResponse: (MockResponse) -> Unit,
-        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+        block: suspend Scenario.() -> Unit,
     ) {
-        lateinit var controller: CheckoutController
         runCheckoutPaymentElementTest(
             networkRule = networkRule,
             checkoutInitResponse = checkoutInitResponse,
-            setup = {
-                controller = it
-                it.configure(
+            setup = { controller ->
+                controller.configure(
                     clientSecret = DEFAULT_CLIENT_SECRET,
                     configuration = configuration,
                 ).getOrThrow()
             },
-        ) { context ->
-            block(context, controller)
+        ) { runnerContext ->
+            Scenario(runnerContext).block()
+        }
+    }
+
+    private class Scenario(
+        private val runnerContext: CheckoutPaymentElementTestRunnerContext,
+    ) {
+        val controller: CheckoutController
+            get() = runnerContext.controller
+
+        fun presentPaymentOptions() {
+            runnerContext.presentPaymentOptions()
+        }
+
+        fun confirm() {
+            runnerContext.confirm()
+        }
+
+        fun markTestSucceeded() {
+            runnerContext.markTestSucceeded()
         }
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT
 import com.stripe.paymentelementtestpages.BillingDetailsPage
 import com.stripe.paymentelementtestpages.VerticalModePage
+import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import org.json.JSONObject
 import org.junit.After
@@ -308,26 +309,31 @@ internal class CheckoutPaymentElementTest {
         checkoutInitResponse: (MockResponse) -> Unit,
         block: suspend Scenario.() -> Unit,
     ) {
+        lateinit var controller: CheckoutController
         runCheckoutPaymentElementTest(
             networkRule = networkRule,
             checkoutInitResponse = checkoutInitResponse,
-            setup = { controller ->
-                controller.configure(
+            setup = { configuredController ->
+                controller = configuredController
+                configuredController.configure(
                     clientSecret = DEFAULT_CLIENT_SECRET,
                     configuration = configuration,
                 ).getOrThrow()
             },
         ) { runnerContext ->
-            Scenario(runnerContext).block()
+            runBlocking {
+                Scenario(
+                    runnerContext = runnerContext,
+                    controller = controller,
+                ).block()
+            }
         }
     }
 
     private class Scenario(
         private val runnerContext: CheckoutPaymentElementTestRunnerContext,
+        val controller: CheckoutController,
     ) {
-        val controller: CheckoutController
-            get() = runnerContext.controller
-
         fun presentPaymentOptions() {
             runnerContext.presentPaymentOptions()
         }


### PR DESCRIPTION
# Summary

Refactor the Checkout Automatic Tax Android tests around a private receiver-style `Scenario`.

The scenario owns the runner context and exposes only the controller, payment-options presentation, confirmation, and explicit success-completion actions needed by these cases. The generic Checkout test runner and non-Automatic-Tax callers remain unchanged.

# Motivation

Automatic Tax tests currently pass the generic runner context and controller through every lambda. The receiver scenario keeps that setup boundary local to the suite without changing production behavior, requests, timing, or assertions.

# Testing

- [x] Modified tests
- [ ] Manually verified

The repository pre-push checks for `:paymentsheet:apiCheck` and `:paymentsheet:detekt` passed.

# Screenshots

N/A. Test-only refactor.

Committed and created by Codex.
