### PR TITLE
Support permissioned Link financial connections

### DIFF
--- a/financial-connections-core/src/main/java/com/stripe/android/financialconnections/ConfigurationInternal.kt
+++ b/financial-connections-core/src/main/java/com/stripe/android/financialconnections/ConfigurationInternal.kt
@@ -13,7 +13,8 @@ import java.io.Serializable
 data class FinancialConnectionsSheetConfiguration(
     val financialConnectionsSessionClientSecret: String,
     val publishableKey: String,
-    val stripeAccountId: String? = null
+    val stripeAccountId: String? = null,
+    val hasRequestedDataPermissions: Boolean,
 ) : Parcelable
 
 /**

--- a/financial-connections-core/src/main/java/com/stripe/android/financialconnections/ConfigurationInternal.kt
+++ b/financial-connections-core/src/main/java/com/stripe/android/financialconnections/ConfigurationInternal.kt
@@ -4,6 +4,7 @@ import android.os.Parcelable
 import androidx.annotation.RestrictTo
 import com.stripe.android.core.model.StripeModel
 import com.stripe.android.model.IncentiveEligibilitySession
+import com.stripe.android.model.LinkBrand
 import com.stripe.android.model.LinkMode
 import kotlinx.parcelize.Parcelize
 import java.io.Serializable
@@ -15,6 +16,18 @@ data class FinancialConnectionsSheetConfiguration(
     val publishableKey: String,
     val stripeAccountId: String? = null,
     val hasRequestedDataPermissions: Boolean,
+    val existingConsumer: FinancialConnectionsConsumer?,
+) : Parcelable
+
+@Parcelize
+@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+data class FinancialConnectionsConsumer(
+    val emailAddress: String,
+    val phoneNumber: String,
+    val clientSecret: String,
+    val publishableKey: String?,
+    val isVerified: Boolean,
+    val linkBrand: LinkBrand?,
 ) : Parcelable
 
 /**

--- a/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/TextFixtures.kt
+++ b/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/TextFixtures.kt
@@ -11,6 +11,7 @@ internal object TextFixtures {
     val configuration = FinancialConnectionsSheetConfiguration(
         financialConnectionsSessionClientSecret = "client_secret_123",
         publishableKey = "pk_test_123",
+        hasRequestedDataPermissions = false,
     )
 
     val syncResponse = SynchronizeSessionResponse(

--- a/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/TextFixtures.kt
+++ b/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/TextFixtures.kt
@@ -12,6 +12,7 @@ internal object TextFixtures {
         financialConnectionsSessionClientSecret = "client_secret_123",
         publishableKey = "pk_test_123",
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
 
     val syncResponse = SynchronizeSessionResponse(

--- a/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/repository/FinancialConnectionsLiteRepositoryTest.kt
+++ b/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/repository/FinancialConnectionsLiteRepositoryTest.kt
@@ -20,6 +20,7 @@ internal class FinancialConnectionsLiteRepositoryTest {
             publishableKey = "pk_merchant",
             stripeAccountId = "acct_merchant",
             hasRequestedDataPermissions = true,
+            existingConsumer = null,
         )
 
         val options = with(repository) { configuration.apiRequestOptions() }

--- a/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/repository/FinancialConnectionsLiteRepositoryTest.kt
+++ b/financial-connections-lite/src/test/java/com/stripe/android/financialconnections/lite/repository/FinancialConnectionsLiteRepositoryTest.kt
@@ -1,0 +1,30 @@
+package com.stripe.android.financialconnections.lite.repository
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
+import com.stripe.android.financialconnections.lite.network.FinancialConnectionsLiteRequestExecutor
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+internal class FinancialConnectionsLiteRepositoryTest {
+
+    @Test
+    fun `permissioned sessions use supplied merchant credentials`() {
+        val repository = FinancialConnectionsLiteRepositoryImpl(
+            requestExecutor = mock<FinancialConnectionsLiteRequestExecutor>(),
+            apiRequestFactory = mock<ApiRequest.Factory>(),
+        )
+        val configuration = FinancialConnectionsSheetConfiguration(
+            financialConnectionsSessionClientSecret = "fcsess_secret",
+            publishableKey = "pk_merchant",
+            stripeAccountId = "acct_merchant",
+            hasRequestedDataPermissions = true,
+        )
+
+        val options = with(repository) { configuration.apiRequestOptions() }
+
+        assertThat(options.apiKey).isEqualTo("pk_merchant")
+        assertThat(options.stripeAccount).isEqualTo("acct_merchant")
+    }
+}

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -56,7 +56,8 @@ class FinancialConnectionsSheet internal constructor(
         return FinancialConnectionsSheetConfiguration(
             financialConnectionsSessionClientSecret = financialConnectionsSessionClientSecret,
             publishableKey = publishableKey,
-            stripeAccountId = stripeAccountId
+            stripeAccountId = stripeAccountId,
+            hasRequestedDataPermissions = false,
         )
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/FinancialConnectionsSheet.kt
@@ -58,6 +58,7 @@ class FinancialConnectionsSheet internal constructor(
             publishableKey = publishableKey,
             stripeAccountId = stripeAccountId,
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         )
     }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSession.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSession.kt
@@ -2,12 +2,14 @@ package com.stripe.android.financialconnections.domain
 
 import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
 import com.stripe.android.financialconnections.model.FinancialConnectionsSession
+import com.stripe.android.financialconnections.repository.AttachedPaymentAccountRepository
 import com.stripe.android.financialconnections.repository.FinancialConnectionsRepository
 import javax.inject.Inject
 
 internal class CompleteFinancialConnectionsSession @Inject constructor(
     private val repository: FinancialConnectionsRepository,
     private val fetchPaginatedAccountsForSession: FetchPaginatedAccountsForSession,
+    private val attachedPaymentAccountRepository: AttachedPaymentAccountRepository,
     private val configuration: FinancialConnectionsSheetConfiguration
 ) {
 
@@ -25,6 +27,7 @@ internal class CompleteFinancialConnectionsSession @Inject constructor(
         return Result(
             session = fullSession,
             status = computeSessionCompletionStatus(fullSession, earlyTerminationCause, closeAuthFlowError),
+            generatedPaymentDetailIds = attachedPaymentAccountRepository.get()?.generatedPaymentDetailIds.orEmpty(),
         )
     }
 
@@ -39,6 +42,7 @@ internal class CompleteFinancialConnectionsSession @Inject constructor(
     data class Result(
         val session: FinancialConnectionsSession,
         val status: String,
+        val generatedPaymentDetailIds: List<String>,
     )
 }
 

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccount.kt
@@ -42,8 +42,11 @@ internal class PollAttachPaymentAccount @Inject constructor(
                     paymentAccount = params,
                     // null, if account should not be saved to Link user.
                     consumerSessionClientSecret = consumerSessionProvider.provideConsumerSession()?.clientSecret,
-                ).also {
-                    attachedPaymentAccountRepository.set(params)
+                ).also { response ->
+                    attachedPaymentAccountRepository.set(
+                        paymentAccount = params,
+                        generatedPaymentDetailIds = response.generatedPaymentDetailIds,
+                    )
                 }
             } catch (e: StripeException) {
                 throw e.toDomainException(

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/model/LinkAccountSessionPaymentAccount.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/model/LinkAccountSessionPaymentAccount.kt
@@ -14,6 +14,8 @@ internal data class LinkAccountSessionPaymentAccount(
     val microdepositVerificationMethod: MicrodepositVerificationMethod = UNKNOWN,
     @SerialName(value = "networking_successful")
     val networkingSuccessful: Boolean? = null,
+    @SerialName(value = "generated_payment_detail_ids")
+    val generatedPaymentDetailIds: List<String> = emptyList(),
     @SerialName(value = "next_pane")
     val nextPane: FinancialConnectionsSessionManifest.Pane? = null
 ) {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModel.kt
@@ -356,7 +356,22 @@ internal class FinancialConnectionsSheetNativeViewModel @Inject constructor(
                         )
                     }
 
-                    session.hasAValidAccount() -> {
+                    state.configuration.hasRequestedDataPermissions &&
+                        completionResult.generatedPaymentDetailIds.isEmpty() -> {
+                        finishWithResult(
+                            Failed(
+                                error = UnclassifiedError(
+                                    name = "PermissionedLinkAccountSessionCompletionError",
+                                    message = "Permissioned Link Account Session completed " +
+                                        "without generated payment details.",
+                                )
+                            )
+                        )
+                    }
+
+                    session.hasAValidAccount() ||
+                        state.configuration.hasRequestedDataPermissions &&
+                        completionResult.generatedPaymentDetailIds.isNotEmpty() -> {
                         if (state.flowType == FinancialConnectionsSheetFlowType.ForInstantDebits) {
                             handleInstantDebitsCompletion(session)
                         } else {

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/AttachedPaymentAccountRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/AttachedPaymentAccountRepository.kt
@@ -19,13 +19,22 @@ internal class AttachedPaymentAccountRepository @Inject constructor(
     savedStateHandle = savedStateHandle,
 ) {
 
-    fun set(paymentAccount: PaymentAccountParams) {
+    fun set(
+        paymentAccount: PaymentAccountParams,
+        generatedPaymentDetailIds: List<String>,
+    ) {
         logger.debug("payment account set to $paymentAccount")
-        set(State(paymentAccount))
+        set(
+            State(
+                attachedPaymentAccount = paymentAccount,
+                generatedPaymentDetailIds = generatedPaymentDetailIds,
+            )
+        )
     }
 
     @Parcelize
     data class State(
-        val attachedPaymentAccount: PaymentAccountParams? = null
+        val attachedPaymentAccount: PaymentAccountParams?,
+        val generatedPaymentDetailIds: List<String>,
     ) : Parcelable
 }

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/ConsumerSessionRepository.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/ConsumerSessionRepository.kt
@@ -1,27 +1,18 @@
 package com.stripe.android.financialconnections.repository
 
-import android.os.Parcelable
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.financialconnections.FinancialConnectionsConsumer
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSession.VerificationSession.SessionState.Verified
 import com.stripe.android.model.ConsumerSession.VerificationSession.SessionType.SignUp
-import com.stripe.android.model.LinkBrand
 import getRedactedPhoneNumber
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 
 internal const val KeyConsumerSession = "ConsumerSession"
 
-@Parcelize
-internal data class CachedConsumerSession(
-    val emailAddress: String,
-    val phoneNumber: String,
-    val clientSecret: String,
-    val publishableKey: String?,
-    val isVerified: Boolean,
-    val linkBrand: LinkBrand?,
-) : Parcelable
+internal typealias CachedConsumerSession = FinancialConnectionsConsumer
 
 internal fun interface ConsumerSessionProvider {
     fun provideConsumerSession(): CachedConsumerSession?
@@ -42,7 +33,14 @@ internal interface ConsumerSessionRepository : ConsumerSessionProvider {
 
 internal class RealConsumerSessionRepository @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
+    configuration: FinancialConnectionsSheetConfiguration,
 ) : ConsumerSessionRepository {
+
+    init {
+        if (savedStateHandle.contains(KeyConsumerSession).not()) {
+            savedStateHandle[KeyConsumerSession] = configuration.existingConsumer
+        }
+    }
 
     override val consumerSessionFlow: StateFlow<CachedConsumerSession?> =
         savedStateHandle.getStateFlow(key = KeyConsumerSession, initialValue = null)

--- a/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/api/ProvideApiRequestOptions.kt
+++ b/financial-connections/src/main/java/com/stripe/android/financialconnections/repository/api/ProvideApiRequestOptions.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.financialconnections.repository.api
 
 import com.stripe.android.core.networking.ApiRequest
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
 import com.stripe.android.financialconnections.domain.IsLinkWithStripe
 import com.stripe.android.financialconnections.repository.ConsumerSessionProvider
 import javax.inject.Inject
@@ -13,6 +14,7 @@ internal class RealProvideApiRequestOptions @Inject constructor(
     private val consumerSessionProvider: ConsumerSessionProvider,
     private val isLinkWithStripe: IsLinkWithStripe,
     private val apiRequestOptions: ApiRequest.Options,
+    private val configuration: FinancialConnectionsSheetConfiguration,
 ) : ProvideApiRequestOptions {
 
     override fun invoke(
@@ -26,6 +28,8 @@ internal class RealProvideApiRequestOptions @Inject constructor(
     }
 
     private fun consumerApiRequestOptions(): ApiRequest.Options? {
+        if (configuration.hasRequestedDataPermissions) return null
+
         val session = consumerSessionProvider.provideConsumerSession()?.takeIf { it.isVerified }
         val consumerPublishableKey = session?.publishableKey?.takeIf { isLinkWithStripe() }
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetForDataContractTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetForDataContractTest.kt
@@ -25,7 +25,8 @@ class FinancialConnectionsSheetForDataContractTest {
     fun `validate() valid args`() {
         val configuration = FinancialConnectionsSheetConfiguration(
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+            hasRequestedDataPermissions = false,
         )
         val args = FinancialConnectionsSheetActivityArgs.ForData(configuration)
         args.validate()
@@ -35,7 +36,8 @@ class FinancialConnectionsSheetForDataContractTest {
     fun `validate() missing session client secret`() {
         val configuration = FinancialConnectionsSheetConfiguration(
             " ",
-            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+            hasRequestedDataPermissions = false,
         )
         val args = FinancialConnectionsSheetActivityArgs.ForData(configuration)
         assertFailsWith<InvalidParameterException>(
@@ -49,7 +51,8 @@ class FinancialConnectionsSheetForDataContractTest {
     fun `validate() missing publishable key`() {
         val configuration = FinancialConnectionsSheetConfiguration(
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-            " "
+            " ",
+            hasRequestedDataPermissions = false,
         )
         val args = FinancialConnectionsSheetActivityArgs.ForData(configuration)
         assertFailsWith<InvalidParameterException>(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetForDataContractTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetForDataContractTest.kt
@@ -27,6 +27,7 @@ class FinancialConnectionsSheetForDataContractTest {
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
             ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         )
         val args = FinancialConnectionsSheetActivityArgs.ForData(configuration)
         args.validate()
@@ -38,6 +39,7 @@ class FinancialConnectionsSheetForDataContractTest {
             " ",
             ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         )
         val args = FinancialConnectionsSheetActivityArgs.ForData(configuration)
         assertFailsWith<InvalidParameterException>(
@@ -53,6 +55,7 @@ class FinancialConnectionsSheetForDataContractTest {
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
             " ",
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         )
         val args = FinancialConnectionsSheetActivityArgs.ForData(configuration)
         assertFailsWith<InvalidParameterException>(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetTest.kt
@@ -20,7 +20,8 @@ class FinancialConnectionsSheetTest {
         verify(financialConnectionsSheetLauncher).present(
             FinancialConnectionsSheetConfiguration(
                 ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+                hasRequestedDataPermissions = false,
             )
         )
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetTest.kt
@@ -22,6 +22,7 @@ class FinancialConnectionsSheetTest {
                 ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
                 ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
                 hasRequestedDataPermissions = false,
+                existingConsumer = null,
             )
         )
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -68,7 +68,8 @@ class FinancialConnectionsSheetViewModelTest {
     private val eventReporter = mock<FinancialConnectionsEventReporter>()
     private val configuration = FinancialConnectionsSheetConfiguration(
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        hasRequestedDataPermissions = false,
     )
 
     private val syncResponse = syncResponse()

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/FinancialConnectionsSheetViewModelTest.kt
@@ -70,6 +70,7 @@ class FinancialConnectionsSheetViewModelTest {
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
 
     private val syncResponse = syncResponse()

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSessionTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSessionTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.financialconnections.domain
 
+import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.core.Logger
 import com.stripe.android.core.exception.APIConnectionException
 import com.stripe.android.financialconnections.ApiKeyFixtures
 import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
@@ -8,7 +10,9 @@ import com.stripe.android.financialconnections.domain.NativeAuthFlowCoordinator.
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccount
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccountFixtures
 import com.stripe.android.financialconnections.model.FinancialConnectionsAccountList
+import com.stripe.android.financialconnections.model.PaymentAccountParams
 import com.stripe.android.financialconnections.networking.FakeFinancialConnectionsRepository
+import com.stripe.android.financialconnections.repository.AttachedPaymentAccountRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -64,10 +68,25 @@ internal class CompleteFinancialConnectionsSessionTest {
         assertThat(result.status).isEqualTo("custom_manual_entry")
     }
 
+    @Test
+    fun `Returns generated payment detail IDs from attached payment account state`() = runTest {
+        val completeSession = buildCompleteSessionUseCase(
+            generatedPaymentDetailIds = listOf("csmrpd_1", "csmrpd_2"),
+        )
+
+        val result = completeSession(
+            earlyTerminationCause = null,
+            closeAuthFlowError = null,
+        )
+
+        assertThat(result.generatedPaymentDetailIds).containsExactly("csmrpd_1", "csmrpd_2").inOrder()
+    }
+
     private fun buildCompleteSessionUseCase(
         accounts: List<FinancialConnectionsAccount> = listOf(
             FinancialConnectionsAccountFixtures.CHECKING_ACCOUNT,
         ),
+        generatedPaymentDetailIds: List<String> = emptyList(),
     ): CompleteFinancialConnectionsSession {
         val session = ApiKeyFixtures.financialConnectionsSessionNoAccounts().copy(
             accountsNew = FinancialConnectionsAccountList(
@@ -85,12 +104,24 @@ internal class CompleteFinancialConnectionsSessionTest {
 
         val configuration = FinancialConnectionsSheetConfiguration(
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+            hasRequestedDataPermissions = false,
         )
+        val attachedPaymentAccountRepository = AttachedPaymentAccountRepository(
+            savedStateHandle = SavedStateHandle(),
+            logger = Logger.noop(),
+        )
+        if (generatedPaymentDetailIds.isNotEmpty()) {
+            attachedPaymentAccountRepository.set(
+                paymentAccount = PaymentAccountParams.LinkedAccount("la_123"),
+                generatedPaymentDetailIds = generatedPaymentDetailIds,
+            )
+        }
 
         return CompleteFinancialConnectionsSession(
             repository = repository,
             fetchPaginatedAccountsForSession = fetchPaginatedAccountsForSession,
+            attachedPaymentAccountRepository = attachedPaymentAccountRepository,
             configuration = configuration,
         )
     }

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSessionTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CompleteFinancialConnectionsSessionTest.kt
@@ -106,6 +106,7 @@ internal class CompleteFinancialConnectionsSessionTest {
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
             ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         )
         val attachedPaymentAccountRepository = AttachedPaymentAccountRepository(
             savedStateHandle = SavedStateHandle(),

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CurrentLinkBrandTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CurrentLinkBrandTest.kt
@@ -23,6 +23,7 @@ internal class CurrentLinkBrandTest {
         configuration = FinancialConnectionsSheetConfiguration(
             financialConnectionsSessionClientSecret = ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
             publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+            hasRequestedDataPermissions = false,
         ),
         reducedBranding = false,
         testMode = false,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CurrentLinkBrandTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/CurrentLinkBrandTest.kt
@@ -24,6 +24,7 @@ internal class CurrentLinkBrandTest {
             financialConnectionsSessionClientSecret = ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
             publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         ),
         reducedBranding = false,
         testMode = false,
@@ -38,7 +39,10 @@ internal class CurrentLinkBrandTest {
     )
 
     private val manifestRepository = FakeFinancialConnectionsManifestRepository()
-    private val consumerSessionRepository = RealConsumerSessionRepository(SavedStateHandle())
+    private val consumerSessionRepository = RealConsumerSessionRepository(
+        savedStateHandle = SavedStateHandle(),
+        configuration = initialState.configuration,
+    )
 
     @Test
     fun `falls back to initial state linkBrand`() {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccountTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccountTest.kt
@@ -31,7 +31,8 @@ internal class PollAttachPaymentAccountTest {
     private val attachedPaymentAccountRepository = mock(AttachedPaymentAccountRepository::class.java)
     private val configuration = FinancialConnectionsSheetConfiguration(
         financialConnectionsSessionClientSecret = "client_secret",
-        publishableKey = "publishable_key"
+        publishableKey = "publishable_key",
+        hasRequestedDataPermissions = false,
     )
 
     private val pollAttachPaymentAccount = PollAttachPaymentAccount(
@@ -52,6 +53,7 @@ internal class PollAttachPaymentAccountTest {
         val paymentAccount = LinkAccountSessionPaymentAccount(
             id = "acct_123",
             microdepositVerificationMethod = DESCRIPTOR_CODE,
+            generatedPaymentDetailIds = listOf("csmrpd_123"),
         )
 
         whenever(
@@ -66,7 +68,10 @@ internal class PollAttachPaymentAccountTest {
         val result = pollAttachPaymentAccount(sync, null, params)
 
         assertThat(result).isEqualTo(paymentAccount)
-        verify(attachedPaymentAccountRepository).set(params)
+        verify(attachedPaymentAccountRepository).set(
+            paymentAccount = params,
+            generatedPaymentDetailIds = listOf("csmrpd_123"),
+        )
     }
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccountTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAttachPaymentAccountTest.kt
@@ -33,6 +33,7 @@ internal class PollAttachPaymentAccountTest {
         financialConnectionsSessionClientSecret = "client_secret",
         publishableKey = "publishable_key",
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
 
     private val pollAttachPaymentAccount = PollAttachPaymentAccount(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccountsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccountsTest.kt
@@ -35,7 +35,8 @@ internal class PollAuthorizationSessionAccountsTest {
     private val repository: FinancialConnectionsAccountsRepository = mock()
     private val configuration = FinancialConnectionsSheetConfiguration(
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        hasRequestedDataPermissions = false,
     )
     private val pollAuthorizationSessionAccounts =
         PollAuthorizationSessionAccounts(repository, configuration)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccountsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionAccountsTest.kt
@@ -37,6 +37,7 @@ internal class PollAuthorizationSessionAccountsTest {
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
     private val pollAuthorizationSessionAccounts =
         PollAuthorizationSessionAccounts(repository, configuration)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResultsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResultsTest.kt
@@ -19,7 +19,8 @@ internal class PollAuthorizationSessionOAuthResultsTest {
         repository = repository,
         configuration = FinancialConnectionsSheetConfiguration(
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+            ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+            hasRequestedDataPermissions = false,
         )
     )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResultsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PollAuthorizationSessionOAuthResultsTest.kt
@@ -21,6 +21,7 @@ internal class PollAuthorizationSessionOAuthResultsTest {
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
             ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         )
     )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PostAuthorizationSessionTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PostAuthorizationSessionTest.kt
@@ -27,6 +27,7 @@ internal class PostAuthorizationSessionTest {
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
             ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         ),
         APPLICATION_ID
     )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PostAuthorizationSessionTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/PostAuthorizationSessionTest.kt
@@ -26,6 +26,7 @@ internal class PostAuthorizationSessionTest {
         configuration = FinancialConnectionsSheetConfiguration(
             ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
             ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+            hasRequestedDataPermissions = false,
         ),
         APPLICATION_ID
     )

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
@@ -277,6 +277,7 @@ internal class SaveAccountToLinkTest {
                 ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
                 ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
                 hasRequestedDataPermissions = false,
+                existingConsumer = null,
             ),
             successContentRepository = successRepository,
             repository = repository,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SaveAccountToLinkTest.kt
@@ -202,7 +202,8 @@ internal class SaveAccountToLinkTest {
                     attachedPaymentAccount = PaymentAccountParams.BankAccount(
                         accountNumber = "acct_123",
                         routingNumber = "110000000",
-                    )
+                    ),
+                    generatedPaymentDetailIds = emptyList(),
                 )
             )
 
@@ -241,7 +242,8 @@ internal class SaveAccountToLinkTest {
                 attachedPaymentAccount = PaymentAccountParams.BankAccount(
                     accountNumber = "acct_123",
                     routingNumber = "110000000",
-                )
+                ),
+                generatedPaymentDetailIds = emptyList(),
             )
         )
 
@@ -273,7 +275,8 @@ internal class SaveAccountToLinkTest {
             locale = Locale.getDefault(),
             configuration = FinancialConnectionsSheetConfiguration(
                 ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+                ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+                hasRequestedDataPermissions = false,
             ),
             successContentRepository = successRepository,
             repository = repository,

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccountsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccountsTest.kt
@@ -24,6 +24,7 @@ class SelectNetworkedAccountsTest {
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
     private val successContentRepository: SuccessContentRepository =
         mock(SuccessContentRepository::class.java)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccountsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/domain/SelectNetworkedAccountsTest.kt
@@ -22,7 +22,8 @@ class SelectNetworkedAccountsTest {
 
     private val configuration = FinancialConnectionsSheetConfiguration(
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        hasRequestedDataPermissions = false,
     )
     private val successContentRepository: SuccessContentRepository =
         mock(SuccessContentRepository::class.java)

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
@@ -65,7 +65,8 @@ internal class InstitutionPickerViewModelTest {
     private val nativeAuthFlowCoordinator = NativeAuthFlowCoordinator()
     private val defaultConfiguration = FinancialConnectionsSheetConfiguration(
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        hasRequestedDataPermissions = false,
     )
 
     private fun buildViewModel(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/institutionpicker/InstitutionPickerViewModelTest.kt
@@ -67,6 +67,7 @@ internal class InstitutionPickerViewModelTest {
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
 
     private fun buildViewModel(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/features/networkingsavetolinkverification/NetworkingSaveToLinkVerificationViewModelTest.kt
@@ -138,7 +138,8 @@ class NetworkingSaveToLinkVerificationViewModelTest {
                     attachedPaymentAccount = PaymentAccountParams.BankAccount(
                         routingNumber = "123456789",
                         accountNumber = "123456789"
-                    )
+                    ),
+                    generatedPaymentDetailIds = emptyList(),
                 )
             )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncherTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncherTest.kt
@@ -16,7 +16,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class FinancialConnectionsSheetForDataLauncherTest {
 
-    private val configuration = FinancialConnectionsSheetConfiguration("", "")
+    private val configuration = FinancialConnectionsSheetConfiguration("", "", hasRequestedDataPermissions = false)
 
     @Test
     fun `create and present should return expected ConnectionsSheetResult#Completed`() {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncherTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForDataLauncherTest.kt
@@ -16,7 +16,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class FinancialConnectionsSheetForDataLauncherTest {
 
-    private val configuration = FinancialConnectionsSheetConfiguration("", "", hasRequestedDataPermissions = false)
+    private val configuration = FinancialConnectionsSheetConfiguration(
+        "",
+        "",
+        hasRequestedDataPermissions = false,
+        existingConsumer = null,
+    )
 
     @Test
     fun `create and present should return expected ConnectionsSheetResult#Completed`() {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncherTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncherTest.kt
@@ -14,7 +14,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class FinancialConnectionsSheetForInstantDebitsLauncherTest {
 
-    private val configuration = FinancialConnectionsSheetConfiguration("", "")
+    private val configuration = FinancialConnectionsSheetConfiguration("", "", hasRequestedDataPermissions = false)
     private val encodedPaymentMethod = "{\"id\": \"pm_123\"}"
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncherTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForInstantDebitsLauncherTest.kt
@@ -14,7 +14,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class FinancialConnectionsSheetForInstantDebitsLauncherTest {
 
-    private val configuration = FinancialConnectionsSheetConfiguration("", "", hasRequestedDataPermissions = false)
+    private val configuration = FinancialConnectionsSheetConfiguration(
+        "",
+        "",
+        hasRequestedDataPermissions = false,
+        existingConsumer = null,
+    )
     private val encodedPaymentMethod = "{\"id\": \"pm_123\"}"
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncherTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncherTest.kt
@@ -17,7 +17,12 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class FinancialConnectionsSheetForTokenLauncherTest {
 
-    private val configuration = FinancialConnectionsSheetConfiguration("", "", hasRequestedDataPermissions = false)
+    private val configuration = FinancialConnectionsSheetConfiguration(
+        "",
+        "",
+        hasRequestedDataPermissions = false,
+        existingConsumer = null,
+    )
 
     @Test
     fun `create and present should return expected ConnectionsSheetForTokenResult#Completed`() {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncherTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/launcher/FinancialConnectionsSheetForTokenLauncherTest.kt
@@ -17,7 +17,7 @@ import org.robolectric.RobolectricTestRunner
 @RunWith(RobolectricTestRunner::class)
 class FinancialConnectionsSheetForTokenLauncherTest {
 
-    private val configuration = FinancialConnectionsSheetConfiguration("", "")
+    private val configuration = FinancialConnectionsSheetConfiguration("", "", hasRequestedDataPermissions = false)
 
     @Test
     fun `create and present should return expected ConnectionsSheetForTokenResult#Completed`() {

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/model/LinkAccountSessionPaymentAccountTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/model/LinkAccountSessionPaymentAccountTest.kt
@@ -1,0 +1,28 @@
+package com.stripe.android.financialconnections.model
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+
+internal class LinkAccountSessionPaymentAccountTest {
+
+    @Test
+    fun `decodes generated payment detail IDs`() {
+        val response = Json.decodeFromString(
+            LinkAccountSessionPaymentAccount.serializer(),
+            """{"id":"la_123","generated_payment_detail_ids":["csmrpd_1","csmrpd_2"]}""",
+        )
+
+        assertThat(response.generatedPaymentDetailIds).containsExactly("csmrpd_1", "csmrpd_2").inOrder()
+    }
+
+    @Test
+    fun `missing generated payment detail IDs decodes as empty`() {
+        val response = Json.decodeFromString(
+            LinkAccountSessionPaymentAccount.serializer(),
+            """{"id":"la_123"}""",
+        )
+
+        assertThat(response.generatedPaymentDetailIds).isEmpty()
+    }
+}

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeStateTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeStateTest.kt
@@ -12,7 +12,8 @@ internal class FinancialConnectionsSheetNativeStateTest {
 
     private val configuration = FinancialConnectionsSheetConfiguration(
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        hasRequestedDataPermissions = false,
     )
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeStateTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeStateTest.kt
@@ -14,6 +14,7 @@ internal class FinancialConnectionsSheetNativeStateTest {
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
@@ -72,7 +72,8 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
     private val applicationId = "com.sample.applicationid"
     private val configuration = FinancialConnectionsSheetConfiguration(
         financialConnectionsSessionClientSecret = ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-        publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        hasRequestedDataPermissions = false,
     )
     private val encodedPaymentMethod = "{\"id\": \"pm_123\"}"
 
@@ -98,6 +99,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
                 CompleteFinancialConnectionsSession.Result(
                     session = sessionWithCustomManualEntry,
                     status = "canceled",
+                    generatedPaymentDetailIds = emptyList(),
                 )
             )
 
@@ -120,6 +122,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             CompleteFinancialConnectionsSession.Result(
                 session = sessionWithAccounts,
                 status = "completed",
+                generatedPaymentDetailIds = emptyList(),
             )
         )
 
@@ -142,12 +145,57 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
     }
 
     @Test
+    fun `permissioned session completes when generated payment details are present`() = runTest {
+        whenever(completeFinancialConnectionsSession(anyOrNull(), anyOrNull())).thenReturn(
+            CompleteFinancialConnectionsSession.Result(
+                session = financialConnectionsSessionNoAccounts(),
+                status = "completed",
+                generatedPaymentDetailIds = listOf("csmrpd_123"),
+            )
+        )
+        val initialState = stateWithLinkBrand(LinkBrand.Link).copy(
+            configuration = configuration.copy(hasRequestedDataPermissions = true),
+        )
+        val viewModel = createViewModel(initialState = initialState)
+
+        nativeAuthFlowCoordinator().emit(Complete(null))
+
+        withState(viewModel) {
+            assertThat((it.viewEffect as? Finish)?.result).isInstanceOf(Completed::class.java)
+        }
+    }
+
+    @Test
+    fun `permissioned session fails when generated payment details are missing`() = runTest {
+        whenever(completeFinancialConnectionsSession(anyOrNull(), anyOrNull())).thenReturn(
+            CompleteFinancialConnectionsSession.Result(
+                session = financialConnectionsSessionWithNoMoreAccounts,
+                status = "completed",
+                generatedPaymentDetailIds = emptyList(),
+            )
+        )
+        val initialState = stateWithLinkBrand(LinkBrand.Link).copy(
+            configuration = configuration.copy(hasRequestedDataPermissions = true),
+        )
+        val viewModel = createViewModel(initialState = initialState)
+
+        nativeAuthFlowCoordinator().emit(Complete(null))
+
+        withState(viewModel) {
+            val result = (it.viewEffect as? Finish)?.result
+            assertThat(result).isInstanceOf(Failed::class.java)
+            assertThat((result as Failed).error).isInstanceOf(UnclassifiedError::class.java)
+        }
+    }
+
+    @Test
     fun `onCloseClick - when closing, no accounts, no errors, finish with cancel`() = runTest {
         val sessionWithNoAccounts = financialConnectionsSessionNoAccounts()
         whenever(completeFinancialConnectionsSession(anyOrNull(), anyOrNull())).thenReturn(
             CompleteFinancialConnectionsSession.Result(
                 session = sessionWithNoAccounts,
                 status = "canceled",
+                generatedPaymentDetailIds = emptyList(),
             )
         )
 
@@ -182,6 +230,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             CompleteFinancialConnectionsSession.Result(
                 session = sessionWithNoAccounts,
                 status = "custom_manual_entry",
+                generatedPaymentDetailIds = emptyList(),
             )
         )
 
@@ -310,6 +359,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             CompleteFinancialConnectionsSession.Result(
                 session = session,
                 status = "completed",
+                generatedPaymentDetailIds = emptyList(),
             )
         )
 
@@ -369,6 +419,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             CompleteFinancialConnectionsSession.Result(
                 session = session,
                 status = "completed",
+                generatedPaymentDetailIds = emptyList(),
             )
         )
 
@@ -425,6 +476,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             CompleteFinancialConnectionsSession.Result(
                 session = session,
                 status = "completed",
+                generatedPaymentDetailIds = emptyList(),
             )
         )
 
@@ -473,6 +525,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
             CompleteFinancialConnectionsSession.Result(
                 session = session,
                 status = "completed",
+                generatedPaymentDetailIds = emptyList(),
             )
         )
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/presentation/FinancialConnectionsSheetNativeViewModelTest.kt
@@ -74,6 +74,7 @@ internal class FinancialConnectionsSheetNativeViewModelTest {
         financialConnectionsSessionClientSecret = ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
         publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
     private val encodedPaymentMethod = "{\"id\": \"pm_123\"}"
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepositoryImplTest.kt
@@ -30,6 +30,7 @@ internal class FinancialConnectionsAccountsRepositoryImplTest {
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
         ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
     private val authSessionId = "AuthSessionId"
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsAccountsRepositoryImplTest.kt
@@ -28,7 +28,8 @@ internal class FinancialConnectionsAccountsRepositoryImplTest {
     private val apiRequestFactory = mock<ApiRequest.Factory>()
     private val configuration = FinancialConnectionsSheetConfiguration(
         ApiKeyFixtures.DEFAULT_FINANCIAL_CONNECTIONS_SESSION_SECRET,
-        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY
+        ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        hasRequestedDataPermissions = false,
     )
     private val authSessionId = "AuthSessionId"
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/FinancialConnectionsConsumerSessionRepositoryImplTest.kt
@@ -11,6 +11,7 @@ import com.stripe.android.financialconnections.ApiKeyFixtures.consumerSession
 import com.stripe.android.financialconnections.ApiKeyFixtures.consumerSessionSignup
 import com.stripe.android.financialconnections.ApiKeyFixtures.verifiedConsumerSession
 import com.stripe.android.financialconnections.ElementsSessionContext
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
 import com.stripe.android.financialconnections.repository.api.FinancialConnectionsConsumersApiService
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.ConsumerSession.VerificationSession.SessionState
@@ -47,7 +48,15 @@ class FinancialConnectionsConsumerSessionRepositoryImplTest {
     )
     private val logger: Logger = mock()
     private val locale: Locale = Locale.getDefault()
-    private val consumerSessionRepository = RealConsumerSessionRepository(SavedStateHandle())
+    private val consumerSessionRepository = RealConsumerSessionRepository(
+        savedStateHandle = SavedStateHandle(),
+        configuration = FinancialConnectionsSheetConfiguration(
+            financialConnectionsSessionClientSecret = "fcsess_secret",
+            publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+            hasRequestedDataPermissions = false,
+            existingConsumer = null,
+        ),
+    )
     private val fraudDetectionDataRepository = mock<FraudDetectionDataRepository>()
 
     private fun buildRepository(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/RealConsumerSessionRepositoryTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/RealConsumerSessionRepositoryTest.kt
@@ -2,6 +2,8 @@ package com.stripe.android.financialconnections.repository
 
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.financialconnections.FinancialConnectionsConsumer
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.LinkBrand
 import org.junit.Test
@@ -15,7 +17,7 @@ class RealConsumerSessionRepositoryTest {
             isVerified = true,
         )
 
-        val store = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
+        val store = createStore()
         store.storeNewConsumerSession(session, "pk_123")
 
         val cachedSession = store.provideConsumerSession()
@@ -38,7 +40,7 @@ class RealConsumerSessionRepositoryTest {
             isVerified = false,
         )
 
-        val store = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
+        val store = createStore()
         store.storeNewConsumerSession(session, "pk_123")
 
         val cachedSession = store.provideConsumerSession()
@@ -56,7 +58,7 @@ class RealConsumerSessionRepositoryTest {
 
     @Test
     fun `Keeps existing publishable key when storing updated consumer session`() {
-        val store = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
+        val store = createStore()
 
         val session1 = makeConsumerSession(
             clientSecret = "abc_123",
@@ -86,7 +88,7 @@ class RealConsumerSessionRepositoryTest {
 
     @Test
     fun `Overrides existing publishable key when storing new consumer session`() {
-        val store = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
+        val store = createStore()
 
         val session1 = makeConsumerSession(
             clientSecret = "abc_123",
@@ -122,7 +124,7 @@ class RealConsumerSessionRepositoryTest {
             linkBrand = LinkBrand.Onelink,
         )
 
-        val store = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
+        val store = createStore()
         store.storeNewConsumerSession(session, "pk_123")
 
         val cachedSession = store.provideConsumerSession()
@@ -131,13 +133,13 @@ class RealConsumerSessionRepositoryTest {
 
     @Test
     fun `consumerSessionFlow emits null initially`() {
-        val store = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
+        val store = createStore()
         assertThat(store.consumerSessionFlow.value).isNull()
     }
 
     @Test
     fun `consumerSessionFlow emits updated session when stored`() {
-        val store = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
+        val store = createStore()
 
         val session = makeConsumerSession(
             clientSecret = "abc_123",
@@ -152,7 +154,7 @@ class RealConsumerSessionRepositoryTest {
 
     @Test
     fun `updateConsumerSession updates linkBrand from new session`() {
-        val store = RealConsumerSessionRepository(savedStateHandle = SavedStateHandle())
+        val store = createStore()
 
         val session1 = makeConsumerSession(
             clientSecret = "abc_123",
@@ -170,6 +172,38 @@ class RealConsumerSessionRepositoryTest {
 
         val cachedSession = store.provideConsumerSession()
         assertThat(cachedSession?.linkBrand).isEqualTo(LinkBrand.Onelink)
+    }
+
+    @Test
+    fun `Seeds existing consumer from configuration`() {
+        val existingConsumer = FinancialConnectionsConsumer(
+            emailAddress = "email@email.com",
+            phoneNumber = "(•••) •••-1234",
+            clientSecret = "consumer_secret",
+            publishableKey = "pk_consumer",
+            isVerified = true,
+            linkBrand = LinkBrand.Link,
+        )
+
+        val store = createStore(existingConsumer = existingConsumer)
+
+        assertThat(store.provideConsumerSession()).isEqualTo(existingConsumer)
+        assertThat(store.consumerSessionFlow.value).isEqualTo(existingConsumer)
+    }
+
+    private fun createStore(
+        savedStateHandle: SavedStateHandle = SavedStateHandle(),
+        existingConsumer: FinancialConnectionsConsumer? = null,
+    ): RealConsumerSessionRepository {
+        return RealConsumerSessionRepository(
+            savedStateHandle = savedStateHandle,
+            configuration = FinancialConnectionsSheetConfiguration(
+                financialConnectionsSessionClientSecret = "fcsess_secret",
+                publishableKey = "pk_merchant",
+                hasRequestedDataPermissions = existingConsumer != null,
+                existingConsumer = existingConsumer,
+            ),
+        )
     }
 
     private fun makeConsumerSession(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/api/RealProvideApiRequestOptionsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/api/RealProvideApiRequestOptionsTest.kt
@@ -19,6 +19,7 @@ class RealProvideApiRequestOptionsTest {
         publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         stripeAccountId = "acct_123",
         hasRequestedDataPermissions = false,
+        existingConsumer = null,
     )
 
     @Test

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/api/RealProvideApiRequestOptionsTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/repository/api/RealProvideApiRequestOptionsTest.kt
@@ -3,6 +3,7 @@ package com.stripe.android.financialconnections.repository.api
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.core.networking.ApiRequest
 import com.stripe.android.financialconnections.ApiKeyFixtures
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
 import com.stripe.android.financialconnections.repository.CachedConsumerSession
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -12,6 +13,12 @@ class RealProvideApiRequestOptionsTest {
     private val merchantApiRequestOptions = ApiRequest.Options(
         apiKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
         stripeAccount = "acct_123",
+    )
+    private val configuration = FinancialConnectionsSheetConfiguration(
+        financialConnectionsSessionClientSecret = "fcsess_secret",
+        publishableKey = ApiKeyFixtures.DEFAULT_PUBLISHABLE_KEY,
+        stripeAccountId = "acct_123",
+        hasRequestedDataPermissions = false,
     )
 
     @Test
@@ -25,6 +32,7 @@ class RealProvideApiRequestOptionsTest {
             consumerSessionProvider = { cachedConsumerSession },
             isLinkWithStripe = { true },
             apiRequestOptions = merchantApiRequestOptions,
+            configuration = configuration,
         )
 
         val apiOptions = provideApiRequestOptions(useConsumerPublishableKey = true)
@@ -44,6 +52,7 @@ class RealProvideApiRequestOptionsTest {
             consumerSessionProvider = { cachedConsumerSession },
             isLinkWithStripe = { false },
             apiRequestOptions = merchantApiRequestOptions,
+            configuration = configuration,
         )
 
         val consumerApiOptions = provideApiRequestOptions(useConsumerPublishableKey = true)
@@ -61,6 +70,7 @@ class RealProvideApiRequestOptionsTest {
             consumerSessionProvider = { cachedConsumerSession },
             isLinkWithStripe = { true },
             apiRequestOptions = merchantApiRequestOptions,
+            configuration = configuration,
         )
 
         val consumerApiOptions = provideApiRequestOptions(useConsumerPublishableKey = true)
@@ -78,6 +88,7 @@ class RealProvideApiRequestOptionsTest {
             consumerSessionProvider = { cachedConsumerSession },
             isLinkWithStripe = { true },
             apiRequestOptions = merchantApiRequestOptions,
+            configuration = configuration,
         )
 
         val consumerApiOptions = provideApiRequestOptions(useConsumerPublishableKey = true)
@@ -95,10 +106,29 @@ class RealProvideApiRequestOptionsTest {
             consumerSessionProvider = { cachedConsumerSession },
             isLinkWithStripe = { true },
             apiRequestOptions = merchantApiRequestOptions,
+            configuration = configuration,
         )
 
         val consumerApiOptions = provideApiRequestOptions(useConsumerPublishableKey = false)
         assertThat(consumerApiOptions).isEqualTo(merchantApiRequestOptions)
+    }
+
+    @Test
+    fun `Provides merchant API options for permissioned Link sessions`() = runTest {
+        val cachedConsumerSession = makeCachedConsumerSession(
+            isVerified = true,
+            publishableKey = "pk_consumer",
+        )
+        val provideApiRequestOptions = RealProvideApiRequestOptions(
+            consumerSessionProvider = { cachedConsumerSession },
+            isLinkWithStripe = { true },
+            apiRequestOptions = merchantApiRequestOptions,
+            configuration = configuration.copy(hasRequestedDataPermissions = true),
+        )
+
+        val apiOptions = provideApiRequestOptions(useConsumerPublishableKey = true)
+
+        assertThat(apiOptions).isEqualTo(merchantApiRequestOptions)
     }
 
     private fun makeCachedConsumerSession(

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/HostedAuthUrlBuilderTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/HostedAuthUrlBuilderTest.kt
@@ -14,6 +14,7 @@ internal class HostedAuthUrlBuilderTest {
             publishableKey = "pk_merchant",
             stripeAccountId = "acct_merchant",
             hasRequestedDataPermissions = false,
+            existingConsumer = null,
         )
         val hostedAuthUrl = "https://connect.stripe.com/hosted_auth"
 

--- a/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/HostedAuthUrlBuilderTest.kt
+++ b/financial-connections/src/test/java/com/stripe/android/financialconnections/utils/HostedAuthUrlBuilderTest.kt
@@ -1,0 +1,36 @@
+package com.stripe.android.financialconnections.utils
+
+import com.google.common.truth.Truth.assertThat
+import com.stripe.android.financialconnections.FinancialConnectionsSheetConfiguration
+import com.stripe.android.financialconnections.launcher.FinancialConnectionsSheetActivityArgs
+import org.junit.Test
+
+internal class HostedAuthUrlBuilderTest {
+
+    @Test
+    fun `permissioned sessions do not change the hosted auth URL`() {
+        val configuration = FinancialConnectionsSheetConfiguration(
+            financialConnectionsSessionClientSecret = "fcsess_secret",
+            publishableKey = "pk_merchant",
+            stripeAccountId = "acct_merchant",
+            hasRequestedDataPermissions = false,
+        )
+        val hostedAuthUrl = "https://connect.stripe.com/hosted_auth"
+
+        val standardUrl = HostedAuthUrlBuilder.create(
+            args = FinancialConnectionsSheetActivityArgs.ForData(configuration),
+            hostedAuthUrl = hostedAuthUrl,
+        )
+        val permissionedUrl = HostedAuthUrlBuilder.create(
+            args = FinancialConnectionsSheetActivityArgs.ForData(
+                configuration.copy(hasRequestedDataPermissions = true)
+            ),
+            hostedAuthUrl = hostedAuthUrl,
+        )
+
+        assertThat(permissionedUrl).isEqualTo(standardUrl)
+        assertThat(permissionedUrl).doesNotContain("consumer_session_client_secret")
+        assertThat(permissionedUrl).doesNotContain("consumer_publishable_key")
+        assertThat(permissionedUrl).doesNotContain("consumer_email")
+    }
+}

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -65,6 +65,7 @@ class CollectBankAccountActivity : AppCompatActivity() {
                 publishableKey = publishableKey,
                 stripeAccountId = stripeAccountId,
                 hasRequestedDataPermissions = false,
+                existingConsumer = null,
             ),
             elementsSessionContext = elementsSessionContext
         )

--- a/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/bankaccount/ui/CollectBankAccountActivity.kt
@@ -64,6 +64,7 @@ class CollectBankAccountActivity : AppCompatActivity() {
                 financialConnectionsSessionClientSecret = financialConnectionsSessionSecret,
                 publishableKey = publishableKey,
                 stripeAccountId = stripeAccountId,
+                hasRequestedDataPermissions = false,
             ),
             elementsSessionContext = elementsSessionContext
         )

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/BuildFinancialConnectionsLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/BuildFinancialConnectionsLauncherTest.kt
@@ -36,6 +36,7 @@ class BuildFinancialConnectionsLauncherTest {
                 financialConnectionsSessionClientSecret = "test_secret",
                 publishableKey = "test_key",
                 hasRequestedDataPermissions = false,
+                existingConsumer = null,
             ),
             elementsSessionContext = null
         )
@@ -69,6 +70,7 @@ class BuildFinancialConnectionsLauncherTest {
                 financialConnectionsSessionClientSecret = "test_secret",
                 publishableKey = "test_key",
                 hasRequestedDataPermissions = false,
+                existingConsumer = null,
             ),
             elementsSessionContext = null
         )
@@ -102,6 +104,7 @@ class BuildFinancialConnectionsLauncherTest {
                 financialConnectionsSessionClientSecret = "test_secret",
                 publishableKey = "test_key",
                 hasRequestedDataPermissions = false,
+                existingConsumer = null,
             ),
             elementsSessionContext = null
         )
@@ -135,6 +138,7 @@ class BuildFinancialConnectionsLauncherTest {
                 financialConnectionsSessionClientSecret = "test_secret",
                 publishableKey = "test_key",
                 hasRequestedDataPermissions = false,
+                existingConsumer = null,
             ),
             elementsSessionContext = null
         )

--- a/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/BuildFinancialConnectionsLauncherTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/bankaccount/domain/BuildFinancialConnectionsLauncherTest.kt
@@ -34,7 +34,8 @@ class BuildFinancialConnectionsLauncherTest {
         val testArgs = FinancialConnectionsSheetActivityArgs.ForData(
             configuration = FinancialConnectionsSheetConfiguration(
                 financialConnectionsSessionClientSecret = "test_secret",
-                publishableKey = "test_key"
+                publishableKey = "test_key",
+                hasRequestedDataPermissions = false,
             ),
             elementsSessionContext = null
         )
@@ -66,7 +67,8 @@ class BuildFinancialConnectionsLauncherTest {
         val testArgs = FinancialConnectionsSheetActivityArgs.ForData(
             configuration = FinancialConnectionsSheetConfiguration(
                 financialConnectionsSessionClientSecret = "test_secret",
-                publishableKey = "test_key"
+                publishableKey = "test_key",
+                hasRequestedDataPermissions = false,
             ),
             elementsSessionContext = null
         )
@@ -98,7 +100,8 @@ class BuildFinancialConnectionsLauncherTest {
         val testArgs = FinancialConnectionsSheetActivityArgs.ForInstantDebits(
             configuration = FinancialConnectionsSheetConfiguration(
                 financialConnectionsSessionClientSecret = "test_secret",
-                publishableKey = "test_key"
+                publishableKey = "test_key",
+                hasRequestedDataPermissions = false,
             ),
             elementsSessionContext = null
         )
@@ -130,7 +133,8 @@ class BuildFinancialConnectionsLauncherTest {
         val testArgs = FinancialConnectionsSheetActivityArgs.ForInstantDebits(
             configuration = FinancialConnectionsSheetConfiguration(
                 financialConnectionsSessionClientSecret = "test_secret",
-                publishableKey = "test_key"
+                publishableKey = "test_key",
+                hasRequestedDataPermissions = false,
             ),
             elementsSessionContext = null
         )

--- a/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/model/LinkAccount.kt
@@ -2,6 +2,7 @@ package com.stripe.android.link.model
 
 import android.os.Parcelable
 import com.stripe.android.core.utils.FeatureFlags
+import com.stripe.android.financialconnections.FinancialConnectionsConsumer
 import com.stripe.android.model.ConsumerSession
 import com.stripe.android.model.DisplayablePaymentDetails
 import com.stripe.android.model.LinkBrand
@@ -68,6 +69,17 @@ internal data class LinkAccount(
 
     val consentPresentation: ConsentPresentation?
         get() = linkAuthIntentInfo?.consentPresentation
+
+    internal fun toFinancialConnectionsConsumer(): FinancialConnectionsConsumer {
+        return FinancialConnectionsConsumer(
+            emailAddress = email,
+            phoneNumber = redactedPhoneNumber,
+            clientSecret = clientSecret,
+            publishableKey = consumerPublishableKey,
+            isVerified = isVerified,
+            linkBrand = consumerLinkBrand,
+        )
+    }
 
     @IgnoredOnParcel
     val accountStatus = when {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -143,7 +143,11 @@ internal class WalletViewModel(
         }
 
         viewModelScope.launch {
-            loadPaymentDetails(selectedItemId = linkLaunchMode.selectedItemId)
+            loadPaymentDetails(
+                selectedItemId = linkLaunchMode.selectedItemId,
+                isAfterAdding = false,
+                selectNewBankAccount = false,
+            )
         }
 
         viewModelScope.launch {
@@ -201,15 +205,30 @@ internal class WalletViewModel(
 
     private suspend fun loadPaymentDetails(
         selectedItemId: String?,
-        isAfterAdding: Boolean = false
+        isAfterAdding: Boolean,
+        selectNewBankAccount: Boolean,
     ) {
+        val existingPaymentDetailIds = uiState.value.paymentDetailsList.mapTo(mutableSetOf()) { it.id }
         linkAccountManager.listPaymentDetails(
             paymentMethodTypes = stripeIntent.supportedPaymentMethodTypes(linkAccount.supportedPaymentDetailsTypes)
         ).fold(
             onSuccess = { response ->
+                val generatedBankAccountId = response.paymentDetails
+                    .filterIsInstance<ConsumerPaymentDetails.BankAccount>()
+                    .firstOrNull { it.id !in existingPaymentDetailIds }
+                    ?.id
+                if (selectNewBankAccount && generatedBankAccountId == null) {
+                    onAddBankAccountError(
+                        error = IllegalStateException(
+                            "Permissioned Link Account Session completed without generated payment details."
+                        ),
+                        loggerMessage = "Failed to load generated bank account",
+                    )
+                    return@fold
+                }
                 _uiState.update {
                     it.copy(
-                        selectedItemId = selectedItemId,
+                        selectedItemId = if (selectNewBankAccount) generatedBankAccountId else selectedItemId,
                         userSetIsExpanded = if (isAfterAdding) false else it.userSetIsExpanded,
                         errorMessage = if (isAfterAdding) null else it.errorMessage,
                         addBankAccountState = if (isAfterAdding) AddBankAccountState.Idle else it.addBankAccountState,
@@ -391,7 +410,11 @@ internal class WalletViewModel(
         viewModelScope.launch {
             linkAccountManager.deletePaymentDetails(item.id).fold(
                 onSuccess = {
-                    loadPaymentDetails(selectedItemId = uiState.value.selectedItem?.id)
+                    loadPaymentDetails(
+                        selectedItemId = uiState.value.selectedItem?.id,
+                        isAfterAdding = false,
+                        selectNewBankAccount = false,
+                    )
                 },
                 onFailure = { error ->
                     updateErrorMessageAndStopProcessing(
@@ -478,9 +501,18 @@ internal class WalletViewModel(
         viewModelScope.launch {
             linkAccountManager.createLinkAccountSession()
                 .mapCatching { session ->
+                    val hasRequestedDataPermissions = configuration.financialConnectionsPermissions
+                        ?.isNotEmpty() == true
                     FinancialConnectionsSheetConfiguration(
                         financialConnectionsSessionClientSecret = session.clientSecret,
-                        publishableKey = linkAccount.consumerPublishableKey!!,
+                        publishableKey = if (hasRequestedDataPermissions) {
+                            requireNotNull(configuration.merchantPublishableKey)
+                        } else {
+                            requireNotNull(linkAccount.consumerPublishableKey)
+                        },
+                        stripeAccountId = configuration.merchantStripeAccountId
+                            .takeIf { hasRequestedDataPermissions },
+                        hasRequestedDataPermissions = hasRequestedDataPermissions,
                     )
                 }
                 .fold(
@@ -517,13 +549,28 @@ internal class WalletViewModel(
         viewModelScope.launch {
             when (result) {
                 is FinancialConnectionsSheetResult.Completed -> {
-                    val accountId = result.financialConnectionsSession.accounts.data.firstOrNull()?.id
-                    if (accountId != null) {
+                    val hasRequestedDataPermissions = configuration.financialConnectionsPermissions
+                        ?.isNotEmpty() == true
+                    if (hasRequestedDataPermissions) {
+                        loadPaymentDetails(
+                            selectedItemId = null,
+                            isAfterAdding = true,
+                            selectNewBankAccount = true,
+                        )
+                    } else {
+                        val accountId = result.financialConnectionsSession.accounts.data.firstOrNull()?.id
+                        if (accountId == null) {
+                            _uiState.update {
+                                it.copy(addBankAccountState = AddBankAccountState.Idle)
+                            }
+                            return@launch
+                        }
                         linkAccountManager.createBankAccountPaymentDetails(accountId)
                             .mapCatching { paymentDetails ->
                                 loadPaymentDetails(
                                     selectedItemId = paymentDetails.id,
-                                    isAfterAdding = true
+                                    isAfterAdding = true,
+                                    selectNewBankAccount = false,
                                 )
                             }
                             .onFailure {
@@ -532,10 +579,6 @@ internal class WalletViewModel(
                                     loggerMessage = "Failed to create/load bank account"
                                 )
                             }
-                    } else {
-                        _uiState.update {
-                            it.copy(addBankAccountState = AddBankAccountState.Idle)
-                        }
                     }
                 }
                 FinancialConnectionsSheetResult.Canceled -> {

--- a/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/ui/wallet/WalletViewModel.kt
@@ -513,6 +513,7 @@ internal class WalletViewModel(
                         stripeAccountId = configuration.merchantStripeAccountId
                             .takeIf { hasRequestedDataPermissions },
                         hasRequestedDataPermissions = hasRequestedDataPermissions,
+                        existingConsumer = linkAccount.toFinancialConnectionsConsumer(),
                     )
                 }
                 .fold(

--- a/paymentsheet/src/test/java/com/stripe/android/link/model/LinkAccountTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/model/LinkAccountTest.kt
@@ -109,6 +109,26 @@ class LinkAccountTest {
         assertThat(linkAccount.consumerLinkBrand).isNull()
     }
 
+    @Test
+    fun `toFinancialConnectionsConsumer includes existing consumer details`() {
+        val linkAccount = LinkAccount(
+            consumerSession = makeConsumerSession(
+                linkBrand = LinkBrand.Link,
+                isVerified = true,
+            ),
+            consumerPublishableKey = "pk_consumer",
+        )
+
+        val consumer = linkAccount.toFinancialConnectionsConsumer()
+
+        assertThat(consumer.emailAddress).isEqualTo("test@example.com")
+        assertThat(consumer.phoneNumber).isEqualTo("(•••) ••• ••07")
+        assertThat(consumer.clientSecret).isEqualTo("consumer_session_007")
+        assertThat(consumer.publishableKey).isEqualTo("pk_consumer")
+        assertThat(consumer.isVerified).isTrue()
+        assertThat(consumer.linkBrand).isEqualTo(LinkBrand.Link)
+    }
+
     private fun makeConsumerSession(
         linkBrand: LinkBrand? = null,
         isVerified: Boolean = false,

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -206,6 +206,7 @@ class WalletViewModelTest {
                 val expectedConfig = FinancialConnectionsSheetConfiguration(
                     financialConnectionsSessionClientSecret = TestFactory.LINK_ACCOUNT_SESSION.clientSecret,
                     publishableKey = linkAccount.consumerPublishableKey!!,
+                    hasRequestedDataPermissions = false,
                 )
                 assertThat(addBankAccountState).isEqualTo(AddBankAccountState.Processing(expectedConfig))
             }
@@ -225,6 +226,50 @@ class WalletViewModelTest {
             }
         }
     }
+
+    @Test
+    fun `permissioned bank account flow uses merchant credentials and reloads generated payment details`() =
+        runTest(dispatcher) {
+            val generatedBankAccount = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT.copy(id = "csmrpd_generated")
+            val configuration = TestFactory.LINK_CONFIGURATION.copy(
+                financialConnectionsPermissions = listOf("balances"),
+                merchantPublishableKey = "pk_merchant",
+                merchantStripeAccountId = "acct_merchant",
+            )
+            testAddBankAccount(configuration = configuration) { vm, linkAccountManager ->
+                skipItems(1)
+
+                vm.onAddPaymentMethodOptionClicked(AddPaymentMethodOption.Bank(FinancialConnectionsAvailability.Full))
+                awaitItem()
+                awaitItem().run {
+                    val sheetConfiguration =
+                        (addBankAccountState as AddBankAccountState.Processing).configToPresent
+                    assertThat(sheetConfiguration).isEqualTo(
+                        FinancialConnectionsSheetConfiguration(
+                            financialConnectionsSessionClientSecret = TestFactory.LINK_ACCOUNT_SESSION.clientSecret,
+                            publishableKey = "pk_merchant",
+                            stripeAccountId = "acct_merchant",
+                            hasRequestedDataPermissions = true,
+                        )
+                    )
+                }
+
+                linkAccountManager.nextListPaymentDetailsResult = Result.success(
+                    ConsumerPaymentDetails(
+                        paymentDetails = TestFactory.CONSUMER_PAYMENT_DETAILS.paymentDetails + generatedBankAccount
+                    )
+                )
+                vm.onFinancialConnectionsResult(
+                    FinancialConnectionsSheetResult.Completed(mockFinancialConnectionsSession())
+                )
+
+                awaitItem().run {
+                    assertThat(selectedItemId).isEqualTo(generatedBankAccount.id)
+                    assertThat(addBankAccountState).isEqualTo(AddBankAccountState.Idle)
+                }
+                assertThat(linkAccountManager.createBankAccountPaymentDetailsCalls).isEmpty()
+            }
+        }
 
     @Test
     fun `viewmodel should handle link account session request error when adding bank account`() = runTest(dispatcher) {
@@ -1256,12 +1301,14 @@ class WalletViewModelTest {
 
     private suspend fun testAddBankAccount(
         linkAccount: LinkAccount = TestFactory.LINK_ACCOUNT_WITH_PK,
+        configuration: LinkConfiguration = TestFactory.LINK_CONFIGURATION,
         validate: suspend TurbineTestContext<WalletUiState>.(WalletViewModel, WalletLinkAccountManager) -> Unit,
     ) {
         val linkAccountManager = WalletLinkAccountManager()
         val vm = createViewModel(
             linkAccount = linkAccount,
             linkAccountManager = linkAccountManager,
+            configuration = configuration,
         )
         vm.onExpandedChanged(true)
 
@@ -1289,12 +1336,25 @@ class WalletViewModelTest {
 
 private open class WalletLinkAccountManager : FakeLinkAccountManager() {
     val listPaymentDetailsCalls = arrayListOf<Set<String>>()
+    val createBankAccountPaymentDetailsCalls = arrayListOf<String>()
     val updatePaymentDetailsCalls = arrayListOf<ConsumerPaymentDetailsUpdateParams>()
     val deletePaymentDetailsCalls = arrayListOf<String>()
+    var nextListPaymentDetailsResult: Result<ConsumerPaymentDetails>? = null
 
     override suspend fun listPaymentDetails(paymentMethodTypes: Set<String>): Result<ConsumerPaymentDetails> {
         listPaymentDetailsCalls.add(paymentMethodTypes)
+        nextListPaymentDetailsResult?.let {
+            listPaymentDetailsResult = it
+            nextListPaymentDetailsResult = null
+        }
         return super.listPaymentDetails(paymentMethodTypes)
+    }
+
+    override suspend fun createBankAccountPaymentDetails(
+        bankAccountId: String
+    ): Result<ConsumerPaymentDetails.PaymentDetails> {
+        createBankAccountPaymentDetailsCalls.add(bankAccountId)
+        return super.createBankAccountPaymentDetails(bankAccountId)
     }
 
     override suspend fun updatePaymentDetails(

--- a/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/ui/wallet/WalletViewModelTest.kt
@@ -207,6 +207,7 @@ class WalletViewModelTest {
                     financialConnectionsSessionClientSecret = TestFactory.LINK_ACCOUNT_SESSION.clientSecret,
                     publishableKey = linkAccount.consumerPublishableKey!!,
                     hasRequestedDataPermissions = false,
+                    existingConsumer = linkAccount.toFinancialConnectionsConsumer(),
                 )
                 assertThat(addBankAccountState).isEqualTo(AddBankAccountState.Processing(expectedConfig))
             }
@@ -231,12 +232,16 @@ class WalletViewModelTest {
     fun `permissioned bank account flow uses merchant credentials and reloads generated payment details`() =
         runTest(dispatcher) {
             val generatedBankAccount = CONSUMER_PAYMENT_DETAILS_BANK_ACCOUNT.copy(id = "csmrpd_generated")
+            val linkAccount = TestFactory.LINK_ACCOUNT_WITH_PK
             val configuration = TestFactory.LINK_CONFIGURATION.copy(
                 financialConnectionsPermissions = listOf("balances"),
                 merchantPublishableKey = "pk_merchant",
                 merchantStripeAccountId = "acct_merchant",
             )
-            testAddBankAccount(configuration = configuration) { vm, linkAccountManager ->
+            testAddBankAccount(
+                linkAccount = linkAccount,
+                configuration = configuration,
+            ) { vm, linkAccountManager ->
                 skipItems(1)
 
                 vm.onAddPaymentMethodOptionClicked(AddPaymentMethodOption.Bank(FinancialConnectionsAvailability.Full))
@@ -250,6 +255,7 @@ class WalletViewModelTest {
                             publishableKey = "pk_merchant",
                             stripeAccountId = "acct_merchant",
                             hasRequestedDataPermissions = true,
+                            existingConsumer = linkAccount.toFinancialConnectionsConsumer(),
                         )
                     )
                 }


### PR DESCRIPTION
Committed-By-Agent: codex

# Summary

Uses merchant credentials for permissioned Financial Connections flows and selects the generated Link bank account on completion, while preserving existing non-permissioned behavior

# Motivation

IBP+FC support!

# Testing
<!-- How was the code tested? Be as specific as possible. -->
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| *before screenshot*  | *after screenshot* |

# Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
