### PR TITLE
Add diagnostic context to error analytics

### DIFF
--- a/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeViewModel.kt
+++ b/payments-core/src/main/java/com/stripe/android/challenge/confirmation/IntentConfirmationChallengeViewModel.kt
@@ -103,6 +103,11 @@ internal class IntentConfirmationChallengeViewModel @Inject constructor(
         if (intentId == null || clientSecret == null) {
             errorReporter.report(
                 errorEvent = UnexpectedErrorEvent.INTENT_CONFIRMATION_CHALLENGE_INTENT_PARAMETERS_UNAVAILABLE,
+                additionalNonPiiParams = mapOf(
+                    "is_intent_id_null" to (intentId == null).toString(),
+                    "is_client_secret_null" to (clientSecret == null).toString(),
+                    "intent_type" to args.intent.javaClass.name,
+                ),
             )
             return
         }

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayLauncherActivity.kt
@@ -99,7 +99,12 @@ internal class GooglePayLauncherActivity : AppCompatActivity() {
                     val host = AuthActivityStarterHost.create(this)
                     viewModel.confirmStripeIntent(host, params)
                 } else {
-                    errorReporter.report(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_MISSING_INTENT_DATA)
+                    errorReporter.report(
+                        ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_MISSING_INTENT_DATA,
+                        additionalNonPiiParams = mapOf(
+                            "status_code" to taskResult.status.statusCode.toString(),
+                        ),
+                    )
                     viewModel.updateResult(
                         GooglePayLauncher.Result.Failed(
                             RuntimeException(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/GooglePayPaymentMethodLauncherActivity.kt
@@ -108,7 +108,12 @@ internal class GooglePayPaymentMethodLauncherActivity : AppCompatActivity() {
                 if (result != null) {
                     onGooglePayResult(result)
                 } else {
-                    errorReporter.report(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_MISSING_INTENT_DATA)
+                    errorReporter.report(
+                        ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_MISSING_INTENT_DATA,
+                        additionalNonPiiParams = mapOf(
+                            "status_code" to taskResult.status.statusCode.toString(),
+                        ),
+                    )
                     updateResult(
                         GooglePayPaymentMethodLauncher.Result.Failed(
                             RuntimeException(

--- a/payments-core/src/main/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandler.kt
+++ b/payments-core/src/main/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandler.kt
@@ -11,6 +11,7 @@ import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataError
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdate
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallbackRegistry
+import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateCallbackRegistry.Selection
 import com.stripe.android.googlepaylauncher.GooglePayPaymentDataUpdateResponse
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import kotlinx.coroutines.launch
@@ -23,33 +24,19 @@ internal object GooglePayPaymentDataCallbackHandler {
         errorReporter: ErrorReporter,
         stringResolver: (ResolvableString) -> String
     ) {
-        val selection = GooglePayPaymentDataUpdateCallbackRegistry.get()
-
-        if (request == null) {
-            handleUnexpectedError(
-                event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_REQUEST,
-                googlePayJsonFactory = googlePayJsonFactory,
-                errorReporter = errorReporter,
-                stringResolver = stringResolver,
-                onCompleteListener = onCompleteListener,
-            )
-
-            return
-        } else if (selection == null) {
-            handleUnexpectedError(
-                event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK,
-                googlePayJsonFactory = googlePayJsonFactory,
-                errorReporter = errorReporter,
-                stringResolver = stringResolver,
-                onCompleteListener = onCompleteListener,
-            )
-
-            return
-        }
+        val selection = validateInputs(
+            request = request,
+            selection = GooglePayPaymentDataUpdateCallbackRegistry.get(),
+            onCompleteListener = onCompleteListener,
+            googlePayJsonFactory = googlePayJsonFactory,
+            errorReporter = errorReporter,
+            stringResolver = stringResolver,
+        ) ?: return
+        val paymentDataRequest = requireNotNull(request)
 
         selection.workScope.launch {
             val update = runCatching {
-                GooglePayPaymentDataUpdate.fromIntermediatePaymentData(request)
+                GooglePayPaymentDataUpdate.fromIntermediatePaymentData(paymentDataRequest)
             }.getOrElse { error ->
                 handleUnexpectedError(
                     event = ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE,
@@ -58,6 +45,7 @@ internal object GooglePayPaymentDataCallbackHandler {
                     errorReporter = errorReporter,
                     stringResolver = stringResolver,
                     onCompleteListener = onCompleteListener,
+                    additionalNonPiiParams = failureStageParams("parse_intermediate_payment_data"),
                 )
 
                 return@launch
@@ -80,6 +68,7 @@ internal object GooglePayPaymentDataCallbackHandler {
                     errorReporter = errorReporter,
                     stringResolver = stringResolver,
                     onCompleteListener = onCompleteListener,
+                    additionalNonPiiParams = failureStageParams("serialize_callback_response"),
                 )
 
                 return@launch
@@ -87,6 +76,30 @@ internal object GooglePayPaymentDataCallbackHandler {
 
             onCompleteListener.complete(PaymentDataRequestUpdate.fromJson(json.toString()))
         }
+    }
+
+    private fun validateInputs(
+        request: IntermediatePaymentData?,
+        selection: Selection?,
+        onCompleteListener: OnCompleteListener<PaymentDataRequestUpdate>,
+        googlePayJsonFactory: GooglePayJsonFactory,
+        errorReporter: ErrorReporter,
+        stringResolver: (ResolvableString) -> String,
+    ): Selection? {
+        val event = when {
+            request == null -> ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_REQUEST
+            selection == null -> ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK
+            else -> return selection
+        }
+        handleUnexpectedError(
+            event = event,
+            googlePayJsonFactory = googlePayJsonFactory,
+            errorReporter = errorReporter,
+            stringResolver = stringResolver,
+            onCompleteListener = onCompleteListener,
+            additionalNonPiiParams = inputPresenceParams(request != null, selection != null),
+        )
+        return null
     }
 
     private fun merchantFailureResponse(
@@ -112,10 +125,15 @@ internal object GooglePayPaymentDataCallbackHandler {
         googlePayJsonFactory: GooglePayJsonFactory,
         errorReporter: ErrorReporter,
         stringResolver: (ResolvableString) -> String,
+        additionalNonPiiParams: Map<String, String>,
     ) {
+        val callbackTriggerParams = callbackTrigger?.let {
+            mapOf("callback_trigger" to it.name)
+        }.orEmpty()
         errorReporter.report(
             errorEvent = event,
-            stripeException = throwable?.let { StripeException.create(it) }
+            stripeException = throwable?.let { StripeException.create(it) },
+            additionalNonPiiParams = callbackTriggerParams + additionalNonPiiParams,
         )
 
         onCompleteListener.complete(
@@ -145,5 +163,19 @@ internal object GooglePayPaymentDataCallbackHandler {
             GooglePayPaymentDataUpdate.CallbackTrigger.Offer ->
                 GooglePayPaymentDataError.Intent.Offer
         }
+    }
+
+    private fun inputPresenceParams(
+        hasRequest: Boolean,
+        hasRegisteredCallback: Boolean,
+    ): Map<String, String> {
+        return mapOf(
+            "has_request" to hasRequest.toString(),
+            "has_registered_callback" to hasRegisteredCallback.toString(),
+        )
+    }
+
+    private fun failureStageParams(stage: String): Map<String, String> {
+        return mapOf("failure_stage" to stage)
     }
 }

--- a/payments-core/src/main/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporter.kt
@@ -1,5 +1,6 @@
 package com.stripe.android.hcaptcha.analytics
 
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.networking.AnalyticsRequestExecutor
 import com.stripe.android.core.networking.AnalyticsRequestFactory
 import com.stripe.android.core.utils.DurationProvider
@@ -41,7 +42,11 @@ internal class DefaultCaptchaEventsReporter @Inject constructor(
                 errorReporter.report(ErrorReporter.ExpectedErrorEvent.HCAPTCHA_FAILURE)
             }
             else -> {
-                errorReporter.report(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE)
+                errorReporter.report(
+                    errorEvent = ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE,
+                    stripeException = error?.let(StripeException::create),
+                    additionalNonPiiParams = mapOf("is_error_null" to (error == null).toString()),
+                )
             }
         }
 

--- a/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
+++ b/payments-core/src/main/java/com/stripe/android/payments/core/analytics/ErrorReporter.kt
@@ -102,7 +102,11 @@ interface ErrorReporter : FraudDetectionErrorReporter {
                 "analytics_value" to stripeException.analyticsValue(),
                 "status_code" to statusCode?.toString(),
                 "request_id" to stripeException.requestId,
-                "error_type" to stripeException.stripeError?.type,
+                "error_type" to (
+                    stripeException.stripeError?.type
+                        ?: stripeException.cause?.javaClass?.name
+                        ?: stripeException.javaClass.name
+                ),
                 "error_code" to stripeException.stripeError?.code,
             ).filterNotNullValues()
         }

--- a/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
+++ b/payments-core/src/main/java/com/stripe/android/view/PaymentAuthWebViewActivity.kt
@@ -104,6 +104,9 @@ class PaymentAuthWebViewActivity : AppCompatActivity() {
             )
                 .report(
                     errorEvent = ErrorReporter.UnexpectedErrorEvent.AUTH_WEB_VIEW_BLANK_CLIENT_SECRET,
+                    additionalNonPiiParams = mapOf(
+                        "client_secret_length" to clientSecret.length.toString(),
+                    ),
                 )
             return
         }

--- a/payments-core/src/test/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandlerTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/googlepaylauncher/callback/GooglePayPaymentDataCallbackHandlerTest.kt
@@ -33,8 +33,13 @@ class GooglePayPaymentDataCallbackHandlerTest {
     ) {
         onPaymentDataChanged(null)
 
-        assertThat(errorReporter.awaitCall().errorEvent)
+        val report = errorReporter.awaitCall()
+        assertThat(report.errorEvent)
             .isEqualTo(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_REQUEST)
+        assertThat(report.additionalNonPiiParams).containsExactly(
+            "has_request", "false",
+            "has_registered_callback", "true",
+        )
         assertErrorUpdate(listener.completions.awaitItem())
     }
 
@@ -45,8 +50,13 @@ class GooglePayPaymentDataCallbackHandlerTest {
     ) {
         onPaymentDataChanged(request())
 
-        assertThat(errorReporter.awaitCall().errorEvent)
+        val report = errorReporter.awaitCall()
+        assertThat(report.errorEvent)
             .isEqualTo(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_MISSING_CALLBACK)
+        assertThat(report.additionalNonPiiParams).containsExactly(
+            "has_request", "true",
+            "has_registered_callback", "false",
+        )
         assertErrorUpdate(listener.completions.awaitItem())
     }
 
@@ -93,6 +103,9 @@ class GooglePayPaymentDataCallbackHandlerTest {
         assertThat(report.errorEvent)
             .isEqualTo(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE)
         assertThat(report.stripeException).isNotNull()
+        assertThat(report.additionalNonPiiParams).containsExactly(
+            "failure_stage", "parse_intermediate_payment_data",
+        )
         assertErrorUpdate(listener.completions.awaitItem())
     }
 
@@ -116,6 +129,9 @@ class GooglePayPaymentDataCallbackHandlerTest {
         assertThat(report.errorEvent)
             .isEqualTo(ErrorReporter.UnexpectedErrorEvent.GOOGLE_PAY_DYNAMIC_CALLBACK_PARSING_FAILURE)
         assertThat(report.stripeException).isNotNull()
+        assertThat(report.additionalNonPiiParams).containsExactly(
+            "failure_stage", "serialize_callback_response",
+        )
         assertErrorUpdate(listener.completions.awaitItem())
     }
 

--- a/payments-core/src/test/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/hcaptcha/analytics/DefaultCaptchaEventsReporterTest.kt
@@ -9,6 +9,7 @@ import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.hcaptcha.HCaptchaError
 import com.stripe.hcaptcha.HCaptchaException
+import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -89,9 +90,11 @@ internal class DefaultCaptchaEventsReporterTest {
             assertThat(loggedParams["error_message"]).isEqualTo("test error")
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
 
-            // Verify unexpected error was reported
-            assertThat(fakeErrorReporter.getLoggedErrors())
-                .contains(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
+            val report = fakeErrorReporter.awaitCall()
+            assertThat(report.errorEvent)
+                .isEqualTo(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE)
+            assertThat(report.stripeException?.cause).isInstanceOf(Throwable::class.java)
+            assertThat(report.additionalNonPiiParams).containsExactly("is_error_null", "false")
         }
 
     @Test
@@ -111,9 +114,11 @@ internal class DefaultCaptchaEventsReporterTest {
             assertThat(loggedParams["error_message"]).isNull()
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
 
-            // Verify unexpected error was reported for null error
-            assertThat(fakeErrorReporter.getLoggedErrors())
-                .contains(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
+            val report = fakeErrorReporter.awaitCall()
+            assertThat(report.errorEvent)
+                .isEqualTo(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE)
+            assertThat(report.stripeException).isNull()
+            assertThat(report.additionalNonPiiParams).containsExactly("is_error_null", "true")
         }
 
     @Test
@@ -130,9 +135,11 @@ internal class DefaultCaptchaEventsReporterTest {
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
             assertThat(loggedParams["duration"]).isEqualTo(0f)
 
-            // Verify unexpected error was reported
-            assertThat(fakeErrorReporter.getLoggedErrors())
-                .contains(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE.eventName)
+            val report = fakeErrorReporter.awaitCall()
+            assertThat(report.errorEvent)
+                .isEqualTo(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE)
+            assertThat(report.stripeException?.cause).isInstanceOf(Throwable::class.java)
+            assertThat(report.additionalNonPiiParams).containsExactly("is_error_null", "false")
         }
 
     @Test
@@ -153,9 +160,8 @@ internal class DefaultCaptchaEventsReporterTest {
             assertThat(loggedParams["error_message"]).isEqualTo("Network error")
             assertThat(loggedParams["site_key"]).isEqualTo(SITE_KEY)
 
-            // Verify expected error was reported for HCaptchaException
-            assertThat(fakeErrorReporter.getLoggedErrors())
-                .contains(ErrorReporter.ExpectedErrorEvent.HCAPTCHA_FAILURE.eventName)
+            assertThat(fakeErrorReporter.awaitCall().errorEvent)
+                .isEqualTo(ErrorReporter.ExpectedErrorEvent.HCAPTCHA_FAILURE)
         }
 
     @Test
@@ -226,8 +232,8 @@ internal class DefaultCaptchaEventsReporterTest {
 
     private fun runScenario(
         durationProvider: DurationProvider = DefaultDurationProvider.instance,
-        testBlock: (DefaultCaptchaEventsReporter, FakeAnalyticsRequestExecutor, FakeErrorReporter) -> Unit
-    ) {
+        testBlock: suspend (DefaultCaptchaEventsReporter, FakeAnalyticsRequestExecutor, FakeErrorReporter) -> Unit
+    ) = runTest {
         val analyticsRequestExecutor = FakeAnalyticsRequestExecutor()
         val fakeErrorReporter = FakeErrorReporter()
         val eventsReporter = DefaultCaptchaEventsReporter(
@@ -245,6 +251,7 @@ internal class DefaultCaptchaEventsReporterTest {
         )
 
         testBlock(eventsReporter, analyticsRequestExecutor, fakeErrorReporter)
+        fakeErrorReporter.ensureAllEventsConsumed()
     }
 
     companion object {

--- a/payments-core/src/test/java/com/stripe/android/payments/core/analytics/RealErrorReporterTest.kt
+++ b/payments-core/src/test/java/com/stripe/android/payments/core/analytics/RealErrorReporterTest.kt
@@ -105,6 +105,16 @@ class RealErrorReporterTest {
     }
 
     @Test
+    fun `RealErrorReporter logs the original error type when Stripe error type is unavailable`() {
+        val exception = StripeException.create(TestException())
+
+        realErrorReporter.report(ErrorReporter.UnexpectedErrorEvent.HCAPTCHA_UNEXPECTED_FAILURE, exception)
+
+        val analyticsRequestParams = analyticsRequestExecutor.getExecutedRequests().single().params
+        assertThat(analyticsRequestParams["error_type"]).isEqualTo(TestException::class.java.name)
+    }
+
+    @Test
     fun `RealErrorReporter logs skips exception params when exception is null via analyticsRequestExecutor`() {
         realErrorReporter.report(
             errorEvent = ErrorReporter.ExpectedErrorEvent.GET_SAVED_PAYMENT_METHODS_FAILURE,
@@ -117,4 +127,6 @@ class RealErrorReporterTest {
         assertThat(analyticsRequestParams.get("status_code")).isNull()
         assertThat(analyticsRequestParams.get("request_id")).isNull()
     }
+
+    private class TestException : Exception()
 }

--- a/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
+++ b/payments-ui-core/src/main/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxy.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.text.style.StyleSpan
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
+import com.google.android.gms.common.api.ApiException
 import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.model.AutocompleteSessionToken
 import com.google.android.libraries.places.api.model.PlaceTypes
@@ -132,7 +133,8 @@ internal class DefaultPlacesClientProxy(
         } catch (e: Exception) {
             errorReporter.report(
                 ErrorReporter.ExpectedErrorEvent.PLACES_FIND_AUTOCOMPLETE_ERROR,
-                StripeException.create(e)
+                StripeException.create(e),
+                additionalNonPiiParams = e.googlePlacesErrorParams(),
             )
             Result.failure(
                 Exception("Could not find autocomplete predictions: ${e.message}")
@@ -165,7 +167,11 @@ internal class DefaultPlacesClientProxy(
             )
             Result.success(place.transformGoogleToStripeAddress(locale))
         } catch (e: Exception) {
-            errorReporter.report(ErrorReporter.ExpectedErrorEvent.PLACES_FETCH_PLACE_ERROR, StripeException.create(e))
+            errorReporter.report(
+                ErrorReporter.ExpectedErrorEvent.PLACES_FETCH_PLACE_ERROR,
+                StripeException.create(e),
+                additionalNonPiiParams = e.googlePlacesErrorParams(),
+            )
             Result.failure(
                 Exception("Could not fetch place: ${e.message}")
             )
@@ -187,7 +193,10 @@ internal class UnsupportedPlacesClientProxy(val errorReporter: ErrorReporter) : 
         if (BuildConfig.DEBUG) {
             throw exception
         }
-        errorReporter.report(ErrorReporter.UnexpectedErrorEvent.FIND_AUTOCOMPLETE_PREDICTIONS_WITHOUT_DEPENDENCY)
+        errorReporter.report(
+            ErrorReporter.UnexpectedErrorEvent.FIND_AUTOCOMPLETE_PREDICTIONS_WITHOUT_DEPENDENCY,
+            StripeException.create(exception),
+        )
         return Result.failure(exception)
     }
 
@@ -198,7 +207,18 @@ internal class UnsupportedPlacesClientProxy(val errorReporter: ErrorReporter) : 
         if (BuildConfig.DEBUG) {
             throw exception
         }
-        errorReporter.report(ErrorReporter.UnexpectedErrorEvent.FETCH_PLACE_WITHOUT_DEPENDENCY)
+        errorReporter.report(
+            ErrorReporter.UnexpectedErrorEvent.FETCH_PLACE_WITHOUT_DEPENDENCY,
+            StripeException.create(exception),
+        )
         return Result.failure(exception)
+    }
+}
+
+private fun Exception.googlePlacesErrorParams(): Map<String, String> {
+    return if (this is ApiException) {
+        mapOf("error_code" to statusCode.toString())
+    } else {
+        emptyMap()
     }
 }

--- a/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxyTest.kt
+++ b/payments-ui-core/src/test/java/com/stripe/android/ui/core/elements/autocomplete/PlacesClientProxyTest.kt
@@ -1,6 +1,8 @@
 package com.stripe.android.ui.core.elements.autocomplete
 
 import android.os.Build
+import com.google.android.gms.common.api.ApiException
+import com.google.android.gms.common.api.Status
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.tasks.Task
 import com.google.android.gms.tasks.Tasks
@@ -25,6 +27,7 @@ import com.google.android.libraries.places.api.net.SearchNearbyRequest
 import com.google.android.libraries.places.api.net.SearchNearbyResponse
 import com.google.android.libraries.places.internal.zzmy
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
 import com.stripe.android.uicore.elements.IsPlacesAvailable
@@ -180,6 +183,33 @@ class PlacesClientProxyTest {
         }
 
     @Test
+    fun `findAutocompletePredictions reports Google Places status code`() =
+        runTest(UnconfinedTestDispatcher()) {
+            val errorReporter = FakeErrorReporter()
+            val error = ApiException(Status(GOOGLE_PLACES_ERROR_CODE))
+            val client = createGooglePlacesClient(
+                onFindAutocompletePredictions = { Tasks.forException(error) }
+            )
+            val proxy = DefaultPlacesClientProxy(client, errorReporter)
+
+            val result = proxy.findAutocompletePredictions(
+                query = "some query",
+                country = "US",
+                limit = 3,
+            )
+            runCurrent()
+
+            assertThat(result.exceptionOrNull()).isNotNull()
+            val report = errorReporter.awaitCall()
+            assertThat(report.errorEvent).isEqualTo(ErrorReporter.ExpectedErrorEvent.PLACES_FIND_AUTOCOMPLETE_ERROR)
+            assertThat(report.stripeException?.cause).isSameInstanceAs(error)
+            assertThat(report.additionalNonPiiParams).containsExactly(
+                "error_code", GOOGLE_PLACES_ERROR_CODE.toString(),
+            )
+            errorReporter.ensureAllEventsConsumed()
+        }
+
+    @Test
     fun `getPlacesPoweredByGoogleDrawable returns drawable when places is available`() {
         val drawable = PlacesClientProxy.getPlacesPoweredByGoogleDrawable(
             isSystemDarkTheme = true,
@@ -326,5 +356,9 @@ class PlacesClientProxyTest {
             }
         }
         return client
+    }
+
+    private companion object {
+        const val GOOGLE_PLACES_ERROR_CODE = 9012
     }
 }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutSheetLauncher.kt
@@ -187,7 +187,12 @@ internal class CheckoutSheetLauncher @Inject constructor(
     ) {
         if (configuration == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL,
+                additionalNonPiiParams = mapOf(
+                    "launcher" to "checkout_sheet",
+                    "operation" to "launch_form",
+                    "payment_method_code" to code,
+                ),
             )
             return
         }
@@ -223,7 +228,12 @@ internal class CheckoutSheetLauncher @Inject constructor(
     ) {
         if (configuration == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL,
+                additionalNonPiiParams = mapOf(
+                    "launcher" to "checkout_sheet",
+                    "operation" to "launch_manage",
+                    "selection_type" to (selection?.javaClass?.name ?: "null"),
+                ),
             )
             return
         }
@@ -253,7 +263,12 @@ internal class CheckoutSheetLauncher @Inject constructor(
     ) {
         if (configuration == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL,
+                additionalNonPiiParams = mapOf(
+                    "launcher" to "checkout_sheet",
+                    "operation" to "launch_payment_options",
+                    "selection_type" to (selection?.javaClass?.name ?: "null"),
+                ),
             )
             return
         }
@@ -290,7 +305,11 @@ internal class CheckoutSheetLauncher @Inject constructor(
             val refreshedState = embeddedContentState.value
             if (refreshedState == null) {
                 errorReporter.report(
-                    ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                    ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL,
+                    additionalNonPiiParams = mapOf(
+                        "launcher" to "checkout_sheet",
+                        "operation" to "resume_pending_ready_launch",
+                    ),
                 )
                 return@launch
             }

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddCollectionHandler.kt
@@ -296,7 +296,12 @@ internal class DefaultTapToAddCollectionHandler(
                 errorReporter.report(
                     ErrorReporter
                         .UnexpectedErrorEvent
-                        .TAP_TO_ADD_NO_GENERATED_CARD_AFTER_SUCCESSFUL_INTENT_CONFIRMATION
+                        .TAP_TO_ADD_NO_GENERATED_CARD_AFTER_SUCCESSFUL_INTENT_CONFIRMATION,
+                    additionalNonPiiParams = mapOf(
+                        "intent_status" to (intent.status?.toString() ?: "null"),
+                        "intent_payment_method_types" to intent.paymentMethodTypes.joinToString(","),
+                        "customer_metadata_type" to customerMetadata.javaClass.name,
+                    ),
                 )
 
                 throw IllegalStateException(

--- a/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/common/taptoadd/TapToAddConnectionManager.kt
@@ -322,8 +322,9 @@ internal class DefaultTapToAddConnectionManager(
 
         errorEvent?.let { event ->
             errorReporter.report(
-                event,
-                StripeException.create(error),
+                errorEvent = event,
+                stripeException = StripeException.create(error),
+                additionalNonPiiParams = additionalParams,
             )
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/CustomerSheetViewModel.kt
@@ -739,7 +739,8 @@ internal class CustomerSheetViewModel(
 
                 if (metadata == null) {
                     errorReporter.report(
-                        ErrorReporter.UnexpectedErrorEvent.CUSTOMER_SHEET_METADATA_NULL_ON_CONFIRM
+                        ErrorReporter.UnexpectedErrorEvent.CUSTOMER_SHEET_METADATA_NULL_ON_CONFIRM,
+                        additionalNonPiiParams = missingMetadataParams(currentViewState),
                     )
 
                     _result.value = InternalCustomerSheetResult.Error(
@@ -1277,6 +1278,17 @@ internal class CustomerSheetViewModel(
             is CustomerSheetViewState.UpdatePaymentMethod -> CustomerSheetEventReporter.Screen.EditPaymentMethod
             else -> null
         }
+
+    private fun missingMetadataParams(
+        state: CustomerSheetViewState.AddPaymentMethod,
+    ): Map<String, String> {
+        return mapOf(
+            "payment_method_code" to state.paymentMethodCode,
+            "draft_selection_type" to (state.draftPaymentSelection?.javaClass?.name ?: "null"),
+            "is_processing" to state.isProcessing.toString(),
+            "has_form_values" to (state.formFieldValues != null).toString(),
+        )
+    }
 
     private data class CustomerState(
         val paymentMethods: List<PaymentMethod>,

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionElementsSessionManager.kt
@@ -115,7 +115,12 @@ internal class DefaultCustomerSessionElementsSessionManager @Inject constructor(
             errorReporter.report(
                 ErrorReporter
                     .UnexpectedErrorEvent
-                    .CUSTOMER_SESSION_ON_CUSTOMER_SHEET_ELEMENTS_SESSION_NO_CUSTOMER_FIELD
+                    .CUSTOMER_SESSION_ON_CUSTOMER_SHEET_ELEMENTS_SESSION_NO_CUSTOMER_FIELD,
+                additionalNonPiiParams = mapOf(
+                    "intent_type" to elementsSession.stripeIntent.javaClass.name,
+                    "payment_method_types" to elementsSession.stripeIntent.paymentMethodTypes.joinToString(","),
+                    "sessions_error_type" to (elementsSession.sessionsError?.javaClass?.name ?: "null"),
+                ),
             )
 
             throw IllegalStateException(

--- a/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/customersheet/data/CustomerSessionPaymentMethodDataSource.kt
@@ -54,6 +54,7 @@ internal class CustomerSessionPaymentMethodDataSource @Inject constructor(
     override suspend fun attachPaymentMethod(paymentMethodId: String): CustomerSheetDataResult<PaymentMethod> {
         errorReporter.report(
             errorEvent = ErrorReporter.UnexpectedErrorEvent.CUSTOMER_SHEET_ATTACH_CALLED_WITH_CUSTOMER_SESSION,
+            additionalNonPiiParams = mapOf("operation" to "attach_payment_method"),
         )
 
         return CustomerSheetDataResult.failure(

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -37,7 +37,11 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
         val confirmationArgs = operationCoordinator.tryBeginConfirmation {
             val state = stateHolder.state ?: run {
                 errorReporter.report(
-                    ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
+                    ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM,
+                    additionalNonPiiParams = mapOf(
+                        "wallet_type" to expressButton.toWalletType().code,
+                        "express_button_type" to expressButton.javaClass.name,
+                    ),
                 )
                 return@tryBeginConfirmation null
             }
@@ -46,7 +50,11 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
                 expressButton = expressButton,
             ) ?: run {
                 errorReporter.report(
-                    ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
+                    ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM,
+                    additionalNonPiiParams = mapOf(
+                        "wallet_type" to expressButton.toWalletType().code,
+                        "express_button_type" to expressButton.javaClass.name,
+                    ),
                 )
                 null
             }

--- a/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/account/DefaultLinkAccountManager.kt
@@ -225,7 +225,10 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 }
             }
         } else {
-            errorReporter.report(ErrorReporter.UnexpectedErrorEvent.LINK_ATTACH_CARD_WITH_NULL_ACCOUNT)
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.LINK_ATTACH_CARD_WITH_NULL_ACCOUNT,
+                additionalNonPiiParams = mapOf("operation" to "create_card_payment_details"),
+            )
             Result.failure(
                 IllegalStateException("A non-null Link account is needed to create payment details")
             )
@@ -249,7 +252,10 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 errorReporter.report(ErrorReporter.SuccessEvent.LINK_CREATE_CARD_SUCCESS)
             }
         } ?: run {
-            errorReporter.report(ErrorReporter.UnexpectedErrorEvent.LINK_ATTACH_CARD_WITH_NULL_ACCOUNT)
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.LINK_ATTACH_CARD_WITH_NULL_ACCOUNT,
+                additionalNonPiiParams = mapOf("operation" to "create_payment_details_from_payment_method"),
+            )
             Result.failure(
                 exception = IllegalStateException("A non-null Link account is needed to create payment details")
             )
@@ -285,7 +291,10 @@ internal class DefaultLinkAccountManager @Inject constructor(
                 clientAttributionMetadata = config.clientAttributionMetadata,
             )
         } else {
-            errorReporter.report(ErrorReporter.UnexpectedErrorEvent.LINK_ATTACH_BANK_ACCOUNT_WITH_NULL_ACCOUNT)
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.LINK_ATTACH_BANK_ACCOUNT_WITH_NULL_ACCOUNT,
+                additionalNonPiiParams = mapOf("operation" to "create_bank_account_payment_details"),
+            )
             Result.failure(
                 IllegalStateException("A non-null Link account is needed to create payment details")
             )

--- a/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/analytics/DefaultLinkEventsReporter.kt
@@ -26,7 +26,10 @@ internal class DefaultLinkEventsReporter @Inject constructor(
     override fun onInvalidSessionState(state: LinkEventsReporter.SessionState) {
         val params = mapOf(FIELD_SESSION_STATE to state.analyticsValue)
 
-        errorReporter.report(ErrorReporter.UnexpectedErrorEvent.LINK_INVALID_SESSION_STATE)
+        errorReporter.report(
+            ErrorReporter.UnexpectedErrorEvent.LINK_INVALID_SESSION_STATE,
+            additionalNonPiiParams = params,
+        )
         fireEvent(LinkEvent.SignUpFailureInvalidSessionState, params)
     }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/attestation/AttestationConfirmationDefinition.kt
@@ -98,7 +98,10 @@ internal class AttestationConfirmationDefinition @Inject constructor(
             }
             AttestationActivityResult.NoResult -> {
                 errorReporter.report(
-                    errorEvent = UnexpectedErrorEvent.INTENT_CONFIRMATION_CHALLENGE_INTENT_NO_ATTESTATION_RESULT
+                    errorEvent = UnexpectedErrorEvent.INTENT_CONFIRMATION_CHALLENGE_INTENT_NO_ATTESTATION_RESULT,
+                    additionalNonPiiParams = mapOf(
+                        "confirmation_option_type" to confirmationOption.javaClass.name,
+                    ),
                 )
                 ConfirmationDefinition.Result.NextStep(
                     confirmationOption = confirmationOption.attachToken(null),

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cardart/PaymentOptionCardArtPrefetchConfirmationDefinition.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/confirmation/cardart/PaymentOptionCardArtPrefetchConfirmationDefinition.kt
@@ -2,6 +2,7 @@ package com.stripe.android.paymentelement.confirmation.cardart
 
 import androidx.activity.result.ActivityResultCaller
 import androidx.lifecycle.LifecycleOwner
+import com.stripe.android.core.exception.StripeException
 import com.stripe.android.core.injection.IOContext
 import com.stripe.android.core.strings.resolvableString
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
@@ -38,7 +39,14 @@ internal class PaymentOptionCardArtPrefetchConfirmationDefinition @Inject constr
         confirmationArgs: ConfirmationHandler.Args,
     ): ConfirmationDefinition.Action<Nothing> {
         val error = IllegalStateException("CardArtPrefetchConfirmationDefinition should not be used for confirmation")
-        errorReporter.report(UnexpectedErrorEvent.CARD_ART_PREFETCH_INVOKED_FOR_CONFIRMATION)
+        errorReporter.report(
+            UnexpectedErrorEvent.CARD_ART_PREFETCH_INVOKED_FOR_CONFIRMATION,
+            stripeException = StripeException.create(error),
+            additionalNonPiiParams = mapOf(
+                "operation" to "action",
+                "confirmation_option_type" to confirmationOption.javaClass.name,
+            ),
+        )
         return ConfirmationDefinition.Action.Fail(
             cause = error,
             message = "CardArtPrefetchConfirmationDefinition should not be used for confirmation".resolvableString,
@@ -52,7 +60,13 @@ internal class PaymentOptionCardArtPrefetchConfirmationDefinition @Inject constr
         confirmationOption: ConfirmationHandler.Option,
         confirmationArgs: ConfirmationHandler.Args,
     ) {
-        errorReporter.report(UnexpectedErrorEvent.CARD_ART_PREFETCH_INVOKED_FOR_CONFIRMATION)
+        errorReporter.report(
+            UnexpectedErrorEvent.CARD_ART_PREFETCH_INVOKED_FOR_CONFIRMATION,
+            additionalNonPiiParams = mapOf(
+                "operation" to "launch",
+                "confirmation_option_type" to confirmationOption.javaClass.name,
+            ),
+        )
     }
 
     override fun createLauncher(
@@ -67,7 +81,13 @@ internal class PaymentOptionCardArtPrefetchConfirmationDefinition @Inject constr
         launcherArgs: Nothing,
         result: Nothing,
     ): ConfirmationDefinition.Result {
-        errorReporter.report(UnexpectedErrorEvent.CARD_ART_PREFETCH_INVOKED_FOR_CONFIRMATION)
+        errorReporter.report(
+            UnexpectedErrorEvent.CARD_ART_PREFETCH_INVOKED_FOR_CONFIRMATION,
+            additionalNonPiiParams = mapOf(
+                "operation" to "to_result",
+                "confirmation_option_type" to confirmationOption.javaClass.name,
+            ),
+        )
         return ConfirmationDefinition.Result.NextStep(
             confirmationOption = confirmationOption,
             arguments = confirmationArgs,

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/DefaultEmbeddedSheetLauncher.kt
@@ -171,7 +171,12 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     ) {
         if (configuration == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL,
+                additionalNonPiiParams = mapOf(
+                    "launcher" to "embedded_sheet",
+                    "operation" to "launch_form",
+                    "payment_method_code" to code,
+                ),
             )
             return
         }
@@ -207,7 +212,12 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     ) {
         if (configuration == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL,
+                additionalNonPiiParams = mapOf(
+                    "launcher" to "embedded_sheet",
+                    "operation" to "launch_manage",
+                    "selection_type" to (selection?.javaClass?.name ?: "null"),
+                ),
             )
             return
         }
@@ -237,7 +247,12 @@ internal class DefaultEmbeddedSheetLauncher @Inject constructor(
     ) {
         if (configuration == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_SHEET_LAUNCHER_EMBEDDED_STATE_IS_NULL,
+                additionalNonPiiParams = mapOf(
+                    "launcher" to "embedded_sheet",
+                    "operation" to "launch_payment_options",
+                    "selection_type" to (selection?.javaClass?.name ?: "null"),
+                ),
             )
             return
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentOptionsPresenter.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentelement/embedded/content/EmbeddedPaymentOptionsPresenter.kt
@@ -21,14 +21,22 @@ internal class DefaultEmbeddedPaymentOptionsPresenter @Inject constructor(
         val state = state.value
         if (state == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NOT_CONFIGURED
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NOT_CONFIGURED,
+                additionalNonPiiParams = mapOf(
+                    "has_sheet_launcher" to (sheetStateHolder.sheetLauncher != null).toString(),
+                    "selection_type" to (selectionHolder.selection.value?.javaClass?.name ?: "null"),
+                ),
             )
             return
         }
         val launcher = sheetStateHolder.sheetLauncher
         if (launcher == null) {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NO_LAUNCHER
+                ErrorReporter.UnexpectedErrorEvent.EMBEDDED_PRESENT_PAYMENT_OPTIONS_NO_LAUNCHER,
+                additionalNonPiiParams = mapOf(
+                    "selection_type" to (selectionHolder.selection.value?.javaClass?.name ?: "null"),
+                    "has_customer" to (customerStateHolder.customer.value != null).toString(),
+                ),
             )
             return
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentOptionsViewModel.kt
@@ -266,6 +266,9 @@ internal class PaymentOptionsViewModel @Inject constructor(
                     TapToAddNextStep.Complete -> {
                         errorReporter.report(
                             ErrorReporter.UnexpectedErrorEvent.TAP_TO_ADD_FLOW_CONTROLLER_RECEIVED_COMPLETE_RESULT,
+                            additionalNonPiiParams = mapOf(
+                                "current_screen" to navigationHandler.currentScreen.value.javaClass.name,
+                            ),
                         )
                     }
                     is TapToAddNextStep.Continue -> {

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/PaymentSheetViewModel.kt
@@ -296,6 +296,10 @@ internal class PaymentSheetViewModel @Inject internal constructor(
                     is TapToAddNextStep.Continue -> {
                         errorReporter.report(
                             ErrorReporter.UnexpectedErrorEvent.TAP_TO_ADD_PAYMENT_SHEET_RECEIVED_CONTINUE_RESULT,
+                            additionalNonPiiParams = mapOf(
+                                "current_screen" to navigationHandler.currentScreen.value.javaClass.name,
+                                "payment_method_type" to (result.paymentSelection.paymentMethod.type?.code ?: "null"),
+                            ),
                         )
                     }
                 }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/paymentdatacollection/polling/PollingNextActionHandler.kt
@@ -41,7 +41,13 @@ internal class PollingNextActionHandler : PaymentNextActionHandler<StripeIntent>
         val localPollingAuthenticator = pollingLauncher
         if (localPollingAuthenticator == null) {
             ErrorReporter.createFallbackInstance(host.application)
-                .report(ErrorReporter.UnexpectedErrorEvent.MISSING_POLLING_AUTHENTICATOR)
+                .report(
+                    ErrorReporter.UnexpectedErrorEvent.MISSING_POLLING_AUTHENTICATOR,
+                    additionalNonPiiParams = mapOf(
+                        "intent_type" to actionable.javaClass.name,
+                        "next_action_type" to (actionable.nextActionType?.code ?: "null"),
+                    ),
+                )
         } else {
             localPollingAuthenticator.launch(args, options)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/state/CustomerState.kt
@@ -115,7 +115,13 @@ internal class CreateCustomerState @Inject constructor(
         prefetchedPaymentMethods: PrefetchedPaymentMethods?,
     ): List<PaymentMethod> {
         if (prefetchedPaymentMethods == null) {
-            errorReporter.report(ErrorReporter.UnexpectedErrorEvent.PREFETCHED_PMS_NULL_FOR_EPHEMERAL_KEY)
+            errorReporter.report(
+                ErrorReporter.UnexpectedErrorEvent.PREFETCHED_PMS_NULL_FOR_EPHEMERAL_KEY,
+                additionalNonPiiParams = mapOf(
+                    "supported_payment_method_types" to metadata.supportedSavedPaymentMethodTypes()
+                        .joinToString(",") { it.code },
+                ),
+            )
             return emptyList()
         }
 

--- a/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/paymentsheet/ui/WalletButtonsInteractor.kt
@@ -262,7 +262,11 @@ internal class DefaultWalletButtonsInteractor constructor(
                     }
                 } ?: run {
                     errorReporter.report(
-                        ErrorReporter.UnexpectedErrorEvent.WALLET_BUTTONS_NULL_WALLET_ARGUMENTS_ON_CONFIRM
+                        ErrorReporter.UnexpectedErrorEvent.WALLET_BUTTONS_NULL_WALLET_ARGUMENTS_ON_CONFIRM,
+                        additionalNonPiiParams = mapOf(
+                            "wallet_type" to action.button.walletType.code,
+                            "button_type" to action.button.javaClass.name,
+                        ),
                     )
                 }
             }
@@ -308,7 +312,12 @@ internal class DefaultWalletButtonsInteractor constructor(
             }
         } ?: run {
             errorReporter.report(
-                ErrorReporter.UnexpectedErrorEvent.WALLET_BUTTONS_NULL_CONFIRMATION_ARGS_ON_CONFIRM
+                ErrorReporter.UnexpectedErrorEvent.WALLET_BUTTONS_NULL_CONFIRMATION_ARGS_ON_CONFIRM,
+                additionalNonPiiParams = mapOf(
+                    "wallet_type" to button.walletType.code,
+                    "button_type" to button.javaClass.name,
+                    "selection_type" to (arguments.paymentSelection?.javaClass?.name ?: "null"),
+                ),
             )
         }
     }

--- a/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/common/taptoadd/DefaultTapToAddConnectionManagerTest.kt
@@ -199,7 +199,10 @@ class DefaultTapToAddConnectionManagerTest {
         assertThat(reportCall.errorEvent)
             .isEqualTo(ErrorReporter.UnexpectedErrorEvent.TAP_TO_ADD_DISCOVER_READERS_CANCEL_FAILURE)
         assertThat(reportCall.stripeException?.cause).isInstanceOf(TerminalException::class.java)
-        assertThat(reportCall.additionalNonPiiParams).isEmpty()
+        assertThat(reportCall.additionalNonPiiParams).containsExactly(
+            "terminalErrorCode",
+            TerminalErrorCode.CANCEL_FAILED.toLogString(),
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/customersheet/data/DefaultCustomerSessionElementsSessionManagerTest.kt
@@ -6,6 +6,7 @@ import com.stripe.android.customersheet.utils.FakeCustomerSessionProvider
 import com.stripe.android.isInstanceOf
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadataFixtures.DEFAULT_API_CONFIG
 import com.stripe.android.model.ElementsSession
+import com.stripe.android.model.SetupIntent
 import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.paymentsheet.FakePrefsRepository
 import com.stripe.android.paymentsheet.PaymentSheet
@@ -388,13 +389,20 @@ class DefaultCustomerSessionElementsSessionManagerTest {
             "`customer` field should be available when using `CustomerSession` in elements/session!"
         )
 
-        assertThat(errorReporter.getLoggedErrors()).containsExactly(
-            ErrorReporter.SuccessEvent.CUSTOMER_SHEET_CUSTOMER_SESSION_ELEMENTS_SESSION_LOAD_SUCCESS.eventName,
-            ErrorReporter
-                .UnexpectedErrorEvent
-                .CUSTOMER_SESSION_ON_CUSTOMER_SHEET_ELEMENTS_SESSION_NO_CUSTOMER_FIELD
-                .eventName
+        assertThat(errorReporter.awaitCall().errorEvent).isEqualTo(
+            ErrorReporter.SuccessEvent.CUSTOMER_SHEET_CUSTOMER_SESSION_ELEMENTS_SESSION_LOAD_SUCCESS
         )
+        val unexpectedError = errorReporter.awaitCall()
+        assertThat(unexpectedError.errorEvent).isEqualTo(
+            ErrorReporter.UnexpectedErrorEvent
+                .CUSTOMER_SESSION_ON_CUSTOMER_SHEET_ELEMENTS_SESSION_NO_CUSTOMER_FIELD
+        )
+        assertThat(unexpectedError.additionalNonPiiParams).containsExactly(
+            "intent_type", SetupIntent::class.java.name,
+            "payment_method_types", "card",
+            "sessions_error_type", "null",
+        )
+        errorReporter.ensureAllEventsConsumed()
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -53,7 +53,10 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         assertThat(call.errorEvent)
             .isEqualTo(ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM)
         assertThat(call.stripeException).isNull()
-        assertThat(call.additionalNonPiiParams).isEmpty()
+        assertThat(call.additionalNonPiiParams).containsExactly(
+            "wallet_type", "google_pay",
+            "express_button_type", ExpressButton.GooglePay::class.java.name,
+        )
     }
 
     @Test
@@ -71,7 +74,10 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
         )
         assertThat(call.stripeException).isNull()
-        assertThat(call.additionalNonPiiParams).isEmpty()
+        assertThat(call.additionalNonPiiParams).containsExactly(
+            "wallet_type", "google_pay",
+            "express_button_type", ExpressButton.GooglePay::class.java.name,
+        )
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/paymentsheet/ui/DefaultWalletButtonsInteractorTest.kt
@@ -369,7 +369,10 @@ class DefaultWalletButtonsInteractorTest {
         assertThat(call.errorEvent)
             .isEqualTo(ErrorReporter.UnexpectedErrorEvent.WALLET_BUTTONS_NULL_WALLET_ARGUMENTS_ON_CONFIRM)
         assertThat(call.stripeException).isNull()
-        assertThat(call.additionalNonPiiParams).isEmpty()
+        assertThat(call.additionalNonPiiParams).containsExactly(
+            "wallet_type", "link",
+            "button_type", WalletButtonsInteractor.WalletButton.Link::class.java.name,
+        )
 
         errorReporter.ensureAllEventsConsumed()
     }
@@ -405,7 +408,11 @@ class DefaultWalletButtonsInteractorTest {
         assertThat(call.errorEvent)
             .isEqualTo(ErrorReporter.UnexpectedErrorEvent.WALLET_BUTTONS_NULL_CONFIRMATION_ARGS_ON_CONFIRM)
         assertThat(call.stripeException).isNull()
-        assertThat(call.additionalNonPiiParams).isEmpty()
+        assertThat(call.additionalNonPiiParams).containsExactly(
+            "wallet_type", "link",
+            "button_type", WalletButtonsInteractor.WalletButton.Link::class.java.name,
+            "selection_type", "null",
+        )
 
         errorReporter.ensureAllEventsConsumed()
     }


### PR DESCRIPTION
# Summary
- Attach contextual, PII-free state to every `UnexpectedErrorEvent` report instead of repeating information already present in the event name.
- Preserve underlying exception types and provider error codes so alerts can be segmented by their actual cause.
- Add focused coverage for HCaptcha, Google Pay callbacks, Google Places, CustomerSession, wallet buttons, Tap to Add, and express checkout payloads.

Committed and created by Codex.

# Motivation
Unexpected error alerts can be difficult to investigate because their payloads do not explain the state or failure that produced them. This change reports only controlled values such as exception class names, enum/status codes, null-state flags, operation names, and SDK model types; it does not include customer input, identifiers, URLs, or raw exception messages.

# Testing
- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

`./gradlew :payments-core:testDebugUnitTest :payments-ui-core:testDebugUnitTest :paymentsheet:testDebugUnitTest`

`./gradlew :payments-core:detekt :payments-ui-core:detekt :paymentsheet:detekt`

`./gradlew :payments-core:apiCheck :payments-ui-core:apiCheck :paymentsheet:apiCheck`

`./gradlew :payments-core:lintDebug :payments-ui-core:lintDebug :paymentsheet:lintDebug` (`payments-core` and `payments-ui-core` passed; `paymentsheet` is blocked by the pre-existing `ViewModelConstructorInComposable` error in `AutocompleteScreenTest.kt`.)

<!-- Ignored Tests Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

# Screenshots
| Before  | After |
| ------------- | ------------- |
| N/A — non-UI change | N/A — non-UI change |

# Changelog
No user-facing change.
