### PR TITLE
Move PaymentConfiguration initialization to Onramp

### DIFF
--- a/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
+++ b/crypto-onramp/src/main/java/com/stripe/android/crypto/onramp/OnrampInteractor.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.Parcelable
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.SavedStateHandle
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.R
 import com.stripe.android.core.utils.flatMapCatching
 import com.stripe.android.crypto.onramp.CheckoutState.Status
@@ -134,8 +135,10 @@ internal class OnrampInteractor @Inject constructor(
             )
         }
 
-        // We are *not* calling `PaymentConfiguration.init()` here because we're relying on
-        // `LinkController.configure()` to do it.
+        PaymentConfiguration.init(
+            context = application.applicationContext,
+            publishableKey = configurationState.publishableKey,
+        )
         val linkResult = linkController.configure(
             LinkController.Configuration(
                 merchantDisplayName = configurationState.merchantDisplayName,

--- a/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
+++ b/crypto-onramp/src/test/java/com/stripe/android/crypto/onramp/OnrampInteractorTest.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
+import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.StripeError
 import com.stripe.android.core.exception.APIException
 import com.stripe.android.core.exception.InvalidRequestException
@@ -129,11 +130,16 @@ class OnrampInteractorTest {
 
     @Test
     fun testConfigureIsSuccessful() = runTest {
+        val application = RuntimeEnvironment.getApplication()
+        PaymentConfiguration.init(application, "pk_before_configure", "acct_before_configure")
         whenever(linkController.configure(any())).thenReturn(Result.success(Unit))
 
         val result = interactor.configure(createConfigurationState())
 
         assert(result is OnrampConfigurationResult.Completed)
+        val paymentConfiguration = PaymentConfiguration.getInstance(application)
+        assertThat(paymentConfiguration.publishableKey).isEqualTo("pk_test_12345")
+        assertThat(paymentConfiguration.stripeAccountId).isNull()
     }
 
     @Test
@@ -797,6 +803,7 @@ class OnrampInteractorTest {
     @Test
     fun uncategorizedExceptionFallsBackToSafeUserMessage() = runTest {
         val application = mock<Application> {
+            on { applicationContext } doReturn RuntimeEnvironment.getApplication()
             on { packageName } doReturn "com.example.app"
             on { getString(any()) } doReturn "Something went wrong. Please try again later."
         }
@@ -847,6 +854,7 @@ class OnrampInteractorTest {
     @Test
     fun appAttestationExceptionUsesSingleLocalizedFallbackUserMessage() = runTest {
         val application = mock<Application> {
+            on { applicationContext } doReturn RuntimeEnvironment.getApplication()
             on { packageName } doReturn "com.example.app"
             on { getString(any()) } doReturn
                 "This app couldn't be verified due to an attestation error. Please try again later or contact the developer if the issue persists."
@@ -1976,6 +1984,7 @@ class OnrampInteractorTest {
         val runtimeApplication = RuntimeEnvironment.getApplication()
 
         return mock {
+            on { applicationContext } doReturn runtimeApplication
             on { packageName } doReturn runtimeApplication.packageName
             on { getString(R.string.stripe_onramp_default_api_error_user_message) } doReturn
                 defaultApiErrorUserMessage

--- a/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/link/LinkControllerInteractor.kt
@@ -7,7 +7,6 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.RestrictTo
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.SavedStateHandle
-import com.stripe.android.PaymentConfiguration
 import com.stripe.android.core.Logger
 import com.stripe.android.core.injection.ViewModelScope
 import com.stripe.android.core.strings.ResolvableString
@@ -185,11 +184,6 @@ internal class LinkControllerInteractor @Inject constructor(
         val config = configuration.build()
         this.configuration = config
         updateState { State() }
-        PaymentConfiguration.init(
-            context = application,
-            publishableKey = config.publishableKey,
-            stripeAccountId = config.stripeAccountId,
-        )
         return linkConfigurationLoader.load(config)
             .flatMapCatching { linkMetadata ->
                 val component = linkComponentFactoryProvider.get()

--- a/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/link/LinkControllerInteractorTest.kt
@@ -149,8 +149,9 @@ class LinkControllerInteractorTest {
     }
 
     @Test
-    fun `configure() sets new configuration and loads it`() = runTest {
+    fun `configure() loads configuration without updating PaymentConfiguration`() = runTest {
         val interactor = createInteractor()
+        PaymentConfiguration.init(application, "pk_original", "acct_original")
 
         val loadedConfiguration = LinkTestUtils.createLinkConfiguration()
         linkConfigurationLoader.linkConfigurationResult = Result.success(
@@ -169,8 +170,8 @@ class LinkControllerInteractorTest {
         assertThat(interactor.configure(controllerConfig).isSuccess).isTrue()
         assertThat(linkComponent.configuration).isEqualTo(loadedConfiguration)
         val paymentConfiguration = PaymentConfiguration.getInstance(application)
-        assertThat(paymentConfiguration.publishableKey).isEqualTo("pk_123")
-        assertThat(paymentConfiguration.stripeAccountId).isEqualTo("acct_123")
+        assertThat(paymentConfiguration.publishableKey).isEqualTo("pk_original")
+        assertThat(paymentConfiguration.stripeAccountId).isEqualTo("acct_original")
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Stop LinkController from initializing process-global PaymentConfiguration when it is configured.
- Make OnrampInteractor explicitly initialize PaymentConfiguration with its publishable key before configuring Link.
- Verify Link leaves existing global configuration unchanged and Onramp installs its own compatibility configuration.

## Motivation

- MPE is being migrated to accept ApiConfiguration (with publishable key/stripe account ID) from public APIs, removing the reliance on PaymentConfiguration.
- The goal is two allow two separate SDKs work in the same app, so we cannot initialize PaymentConfiguration from paymentsheet flows, which includes LinkController flows


## Testing

- [ ] Added tests
- [X] Modified tests
- [ ] Manually verified

## Screenshots

N/A

## Changelog

N/A

Committed and created by Codex.