### PR TITLE
Confine active Checkout mutation emissions to Main

### DIFF
--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -111,7 +111,7 @@ internal class CheckoutPaymentElementTest {
     }
 
     @Test
-    fun testBillingTaxUpdateRefreshesCheckoutSession() = runAutomaticTaxTest { context, controller ->
+    fun testBillingTaxUpdateRefreshesCheckoutSession() = runAutomaticTaxTest {
         enqueueTaxUpdate(automaticTaxResponse(UPDATED_TOTAL, TAX_STATUS_COMPLETE))
 
         contentPage.clickOnLpm("card")
@@ -122,17 +122,17 @@ internal class CheckoutPaymentElementTest {
         assertThat(controller.session.value?.tax?.status)
             .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
         contentPage.assertHasSelectedLpm("card")
-        context.markTestSucceeded()
+        markTestSucceeded()
     }
 
     @Test
-    fun testBillingTaxUpdateFailureCanRetryFromPaymentOptions() = runAutomaticTaxTest { context, controller ->
+    fun testBillingTaxUpdateFailureCanRetryFromPaymentOptions() = runAutomaticTaxTest {
         enqueueTaxUpdate { response ->
             response.setResponseCode(400)
             response.setBody("""{"error":{"message":"Invalid tax region"}}""")
         }
 
-        context.presentPaymentOptions()
+        presentPaymentOptions()
         verticalModePage.clickNewPaymentMethodButton("card")
         fillOutCardAndBillingDetails()
         formPage.clickPrimaryButtonWithoutWaitingForDismissal()
@@ -149,7 +149,7 @@ internal class CheckoutPaymentElementTest {
         assertThat(controller.session.value?.tax?.status)
             .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
         contentPage.assertHasSelectedLpm("card")
-        context.markTestSucceeded()
+        markTestSucceeded()
     }
 
     @Test
@@ -192,7 +192,7 @@ internal class CheckoutPaymentElementTest {
         runAutomaticTaxTest(
             paymentMethodLayout = paymentMethodLayout,
             checkoutInitResponse = automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_REQUIRES_LOCATION),
-        ) { context, controller ->
+        ) {
             enqueueTaxUpdate(automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_COMPLETE))
             contentPage.clickOnLpm("card")
             fillOutCardAndBillingDetails()
@@ -201,7 +201,7 @@ internal class CheckoutPaymentElementTest {
 
             enqueueTaxUpdate(automaticTaxResponse(UPDATED_TOTAL, TAX_STATUS_COMPLETE))
 
-            context.presentPaymentOptions()
+            presentPaymentOptions()
             preparePaymentOptionsScreen(paymentMethodLayout)
             clickPaymentOptionsPrimaryButton()
 
@@ -209,7 +209,7 @@ internal class CheckoutPaymentElementTest {
             assertThat(controller.session.value?.tax?.status)
                 .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
             contentPage.assertHasSelectedLpm("card")
-            context.markTestSucceeded()
+            markTestSucceeded()
         }
     }
 
@@ -222,8 +222,8 @@ internal class CheckoutPaymentElementTest {
                 INITIAL_TOTAL,
                 TAX_STATUS_REQUIRES_LOCATION,
             ),
-        ) { context, controller ->
-            context.presentPaymentOptions()
+        ) {
+            presentPaymentOptions()
             selectCashApp(paymentMethodLayout)
             formPage.waitUntilVisible()
 
@@ -235,7 +235,7 @@ internal class CheckoutPaymentElementTest {
             assertThat(controller.session.value?.tax?.status)
                 .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
             contentPage.assertHasSelectedLpm("cashapp")
-            context.markTestSucceeded()
+            markTestSucceeded()
         }
     }
 
@@ -249,8 +249,8 @@ internal class CheckoutPaymentElementTest {
                 INITIAL_TOTAL,
                 TAX_STATUS_REQUIRES_LOCATION,
             ),
-        ) { context, controller ->
-            context.presentPaymentOptions()
+        ) {
+            presentPaymentOptions()
             selectCashApp(paymentMethodLayout)
             formPage.waitUntilVisible()
             assertBillingDetailsArePopulated()
@@ -262,7 +262,7 @@ internal class CheckoutPaymentElementTest {
             assertThat(controller.session.value?.tax?.status)
                 .isEqualTo(CheckoutController.Session.Tax.Status.Ready)
             contentPage.assertHasSelectedLpm("cashapp")
-            context.markTestSucceeded()
+            markTestSucceeded()
         }
     }
 
@@ -286,7 +286,7 @@ internal class CheckoutPaymentElementTest {
     }
 
     private fun runAutomaticTaxTest(
-        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+        block: suspend Scenario.() -> Unit,
     ) = runAutomaticTaxTest(
         configuration = checkoutConfiguration(PaymentElement.Configuration.PaymentMethodLayout.Vertical),
         checkoutInitResponse = automaticTaxResponse(INITIAL_TOTAL, TAX_STATUS_REQUIRES_LOCATION),
@@ -296,7 +296,7 @@ internal class CheckoutPaymentElementTest {
     private fun runAutomaticTaxTest(
         paymentMethodLayout: PaymentElement.Configuration.PaymentMethodLayout,
         checkoutInitResponse: (MockResponse) -> Unit,
-        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+        block: suspend Scenario.() -> Unit,
     ) = runAutomaticTaxTest(
         configuration = checkoutConfiguration(paymentMethodLayout),
         checkoutInitResponse = checkoutInitResponse,
@@ -306,21 +306,38 @@ internal class CheckoutPaymentElementTest {
     private fun runAutomaticTaxTest(
         configuration: CheckoutController.Configuration,
         checkoutInitResponse: (MockResponse) -> Unit,
-        block: (CheckoutPaymentElementTestRunnerContext, CheckoutController) -> Unit,
+        block: suspend Scenario.() -> Unit,
     ) {
-        lateinit var controller: CheckoutController
         runCheckoutPaymentElementTest(
             networkRule = networkRule,
             checkoutInitResponse = checkoutInitResponse,
-            setup = {
-                controller = it
-                it.configure(
+            setup = { controller ->
+                controller.configure(
                     clientSecret = DEFAULT_CLIENT_SECRET,
                     configuration = configuration,
                 ).getOrThrow()
             },
-        ) { context ->
-            block(context, controller)
+        ) { runnerContext ->
+            Scenario(runnerContext).block()
+        }
+    }
+
+    private class Scenario(
+        private val runnerContext: CheckoutPaymentElementTestRunnerContext,
+    ) {
+        val controller: CheckoutController
+            get() = runnerContext.controller
+
+        fun presentPaymentOptions() {
+            runnerContext.presentPaymentOptions()
+        }
+
+        fun confirm() {
+            runnerContext.confirm()
+        }
+
+        fun markTestSucceeded() {
+            runnerContext.markTestSucceeded()
         }
     }
 

--- a/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
+++ b/paymentsheet/src/androidTest/java/com/stripe/android/checkout/CheckoutPaymentElementTest.kt
@@ -32,6 +32,7 @@ import com.stripe.android.paymentsheet.utils.TestRules
 import com.stripe.android.paymentsheet.verticalmode.TEST_TAG_PAYMENT_METHOD_VERTICAL_LAYOUT
 import com.stripe.paymentelementtestpages.BillingDetailsPage
 import com.stripe.paymentelementtestpages.VerticalModePage
+import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import org.json.JSONObject
 import org.junit.After
@@ -308,26 +309,31 @@ internal class CheckoutPaymentElementTest {
         checkoutInitResponse: (MockResponse) -> Unit,
         block: suspend Scenario.() -> Unit,
     ) {
+        lateinit var controller: CheckoutController
         runCheckoutPaymentElementTest(
             networkRule = networkRule,
             checkoutInitResponse = checkoutInitResponse,
-            setup = { controller ->
-                controller.configure(
+            setup = { configuredController ->
+                controller = configuredController
+                configuredController.configure(
                     clientSecret = DEFAULT_CLIENT_SECRET,
                     configuration = configuration,
                 ).getOrThrow()
             },
         ) { runnerContext ->
-            Scenario(runnerContext).block()
+            runBlocking {
+                Scenario(
+                    runnerContext = runnerContext,
+                    controller = controller,
+                ).block()
+            }
         }
     }
 
     private class Scenario(
         private val runnerContext: CheckoutPaymentElementTestRunnerContext,
+        val controller: CheckoutController,
     ) {
-        val controller: CheckoutController
-            get() = runnerContext.controller
-
         fun presentPaymentOptions() {
             runnerContext.presentPaymentOptions()
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutConfirmationPerformer.kt
@@ -9,6 +9,7 @@ import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
@@ -23,16 +24,16 @@ internal class CheckoutConfirmationPerformer @Inject constructor(
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) {
     fun confirm() {
-        val state = stateHolder.state ?: return
-        val paymentSelection = state.paymentSelection ?: return
-        val arguments = operationCoordinator.tryBeginConfirmation {
-          confirmationArgs(
-              state = state,
-              paymentSelection = paymentSelection,
-          )
-        } ?: return
-        analyticsPerformer.onPaymentElementConfirmationStarted(paymentSelection)
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.Main.immediate) {
+            val state = stateHolder.state ?: return@launch
+            val paymentSelection = state.paymentSelection ?: return@launch
+            val arguments = operationCoordinator.tryBeginConfirmation {
+                confirmationArgs(
+                    state = state,
+                    paymentSelection = paymentSelection,
+                )
+            } ?: return@launch
+            analyticsPerformer.onPaymentElementConfirmationStarted(paymentSelection)
             try {
                 confirmationHandler.start(arguments)
             } catch (error: CancellationException) {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -43,13 +43,12 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     ): Result<T> {
         var admitted = false
         try {
-            withContext(NonCancellable + Dispatchers.Main.immediate) {
+            withContext(Dispatchers.Main.immediate) {
                 synchronized(admissionLock) {
                     pendingMutations += 1
+                    admitted = true
                     updateIsUpdating()
                 }
-                // Keep admission ownership through cancellation of the UI context handoff.
-                admitted = true
             }
 
             return mutex.withLock {

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -44,7 +44,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     ): Result<T> {
         var admitted = false
         try {
-            withContext(NonCancellable + uiContext) {
+            withContext(uiContext + NonCancellable) {
                 synchronized(admissionLock) {
                     pendingMutations += 1
                     updateIsUpdating()
@@ -58,7 +58,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
             }
         } finally {
             if (admitted) {
-                withContext(NonCancellable + uiContext) {
+                withContext(uiContext + NonCancellable) {
                     synchronized(admissionLock) {
                         pendingMutations -= 1
                         updateIsUpdating()

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -2,12 +2,13 @@
 
 package com.stripe.android.checkout
 
+import androidx.annotation.MainThread
 import com.stripe.android.core.Logger
-import com.stripe.android.core.injection.UIContext
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +18,6 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.coroutines.CoroutineContext
 
 @Singleton
 internal class CheckoutOperationCoordinator @Inject constructor(
@@ -25,7 +25,6 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private val sheetStateHolder: SheetStateHolder,
     private val sessionRefresher: CheckoutSessionRefresher,
     private val logger: Logger,
-    @UIContext private val uiContext: CoroutineContext,
     private val resultCallback: CheckoutController.ResultCallback,
 ) {
     private val admissionLock = Any()
@@ -44,7 +43,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     ): Result<T> {
         var admitted = false
         try {
-            withContext(uiContext + NonCancellable) {
+            withContext(NonCancellable + Dispatchers.Main.immediate) {
                 synchronized(admissionLock) {
                     pendingMutations += 1
                     updateIsUpdating()
@@ -58,7 +57,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
             }
         } finally {
             if (admitted) {
-                withContext(uiContext + NonCancellable) {
+                withContext(NonCancellable + Dispatchers.Main.immediate) {
                     synchronized(admissionLock) {
                         pendingMutations -= 1
                         updateIsUpdating()
@@ -68,6 +67,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
         }
     }
 
+    @MainThread
     fun tryBeginConfirmation(
         arguments: () -> ConfirmationHandler.Args?,
     ): ConfirmationHandler.Args? {
@@ -117,24 +117,28 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private suspend fun completeConfirmation(
         mapResult: suspend (confirmationWasRestored: Boolean) -> CheckoutController.Result?,
     ) {
-        val wasRestored = synchronized(admissionLock) {
-            if (!confirmationInFlight || confirmationCompletionClaimed) {
-                return
-            } else {
-                confirmationCompletionClaimed = true
-                confirmationWasRestored
+        val wasRestored = withContext(Dispatchers.Main.immediate) {
+            synchronized(admissionLock) {
+                if (!confirmationInFlight || confirmationCompletionClaimed) {
+                    return@withContext null
+                } else {
+                    confirmationCompletionClaimed = true
+                    confirmationWasRestored
+                }
             }
-        }
+        } ?: return
 
         try {
             mapResult(wasRestored)?.let(resultCallback::onResult)
         } finally {
-            synchronized(admissionLock) {
-                confirmationInFlight = false
-                confirmationWasRestored = false
-                confirmationCompletionClaimed = false
-                mutex.unlock()
-                updateIsUpdating()
+            withContext(NonCancellable + Dispatchers.Main.immediate) {
+                synchronized(admissionLock) {
+                    confirmationInFlight = false
+                    confirmationWasRestored = false
+                    confirmationCompletionClaimed = false
+                    mutex.unlock()
+                    updateIsUpdating()
+                }
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutOperationCoordinator.kt
@@ -3,17 +3,21 @@
 package com.stripe.android.checkout
 
 import com.stripe.android.core.Logger
+import com.stripe.android.core.injection.UIContext
 import com.stripe.android.paymentelement.confirmation.ConfirmationHandler
 import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResponseKey
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.coroutines.CoroutineContext
 
 @Singleton
 internal class CheckoutOperationCoordinator @Inject constructor(
@@ -21,6 +25,7 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     private val sheetStateHolder: SheetStateHolder,
     private val sessionRefresher: CheckoutSessionRefresher,
     private val logger: Logger,
+    @UIContext private val uiContext: CoroutineContext,
     private val resultCallback: CheckoutController.ResultCallback,
 ) {
     private val admissionLock = Any()
@@ -37,19 +42,28 @@ internal class CheckoutOperationCoordinator @Inject constructor(
     suspend fun <T> runMutation(
         block: suspend () -> Result<T>,
     ): Result<T> {
-        synchronized(admissionLock) {
-            pendingMutations += 1
-            updateIsUpdating()
-        }
+        var admitted = false
+        try {
+            withContext(NonCancellable + uiContext) {
+                synchronized(admissionLock) {
+                    pendingMutations += 1
+                    updateIsUpdating()
+                }
+                // Keep admission ownership through cancellation of the UI context handoff.
+                admitted = true
+            }
 
-        return try {
-            mutex.withLock {
+            return mutex.withLock {
                 block()
             }
         } finally {
-            synchronized(admissionLock) {
-                pendingMutations -= 1
-                updateIsUpdating()
+            if (admitted) {
+                withContext(NonCancellable + uiContext) {
+                    synchronized(admissionLock) {
+                        pendingMutations -= 1
+                        updateIsUpdating()
+                    }
+                }
             }
         }
     }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -3,7 +3,6 @@ package com.stripe.android.checkout
 import android.graphics.Bitmap
 import android.os.Bundle
 import com.stripe.android.common.model.CommonConfiguration
-import com.stripe.android.core.injection.UIContext
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -16,12 +15,12 @@ import com.stripe.android.paymentsheet.parseAppearance
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Provider
-import kotlin.coroutines.CoroutineContext
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutStateLoader @Inject constructor(
@@ -33,7 +32,6 @@ internal class CheckoutStateLoader @Inject constructor(
     private val stateHolder: CheckoutControllerStateHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
-    @UIContext private val uiContext: CoroutineContext,
 ) {
     suspend fun loadInitial(
         configuration: CheckoutController.Configuration.State,
@@ -123,7 +121,7 @@ internal class CheckoutStateLoader @Inject constructor(
             linkEagerPresentationSuppressed = carryForward.linkEagerPresentationSuppressed,
         )
 
-        withContext(uiContext) {
+        withContext(Dispatchers.Main.immediate) {
             stateHolder.state = newState
             customerStateHolder.setCustomerState(loadResults.customer)
         }

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutStateLoader.kt
@@ -3,6 +3,7 @@ package com.stripe.android.checkout
 import android.graphics.Bitmap
 import android.os.Bundle
 import com.stripe.android.common.model.CommonConfiguration
+import com.stripe.android.core.injection.UIContext
 import com.stripe.android.lpmfoundations.paymentmethod.PaymentMethodMetadata
 import com.stripe.android.paymentelement.CheckoutSessionPreview
 import com.stripe.android.paymentelement.EmbeddedPaymentElement
@@ -17,8 +18,10 @@ import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Provider
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(CheckoutSessionPreview::class)
 internal class CheckoutStateLoader @Inject constructor(
@@ -30,6 +33,7 @@ internal class CheckoutStateLoader @Inject constructor(
     private val stateHolder: CheckoutControllerStateHolder,
     private val customerStateHolder: CustomerStateHolder,
     private val internalRowSelectionCallback: Provider<InternalRowSelectionCallback?>,
+    @UIContext private val uiContext: CoroutineContext,
 ) {
     suspend fun loadInitial(
         configuration: CheckoutController.Configuration.State,
@@ -105,7 +109,7 @@ internal class CheckoutStateLoader @Inject constructor(
             formSheetAction = embeddedConfig.formSheetAction,
         )
 
-        stateHolder.state = CheckoutControllerState(
+        val newState = CheckoutControllerState(
             configuration = configuration,
             checkoutSessionResponse = response,
             flagImages = flagImages,
@@ -119,7 +123,10 @@ internal class CheckoutStateLoader @Inject constructor(
             linkEagerPresentationSuppressed = carryForward.linkEagerPresentationSuppressed,
         )
 
-        customerStateHolder.setCustomerState(loadResults.customer)
+        withContext(uiContext) {
+            stateHolder.state = newState
+            customerStateHolder.setCustomerState(loadResults.customer)
+        }
     }
 
     private suspend fun loadPaymentElements(

--- a/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ece/ExpressCheckoutElementConfirmationPerformer.kt
@@ -15,6 +15,7 @@ import com.stripe.android.payments.core.analytics.ErrorReporter
 import com.stripe.android.payments.core.injection.STATUS_BAR_COLOR
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Named
@@ -34,27 +35,26 @@ internal class DefaultExpressCheckoutElementConfirmationPerformer @Inject constr
     @ViewModelScope private val viewModelScope: CoroutineScope,
 ) : ExpressCheckoutElementConfirmationPerformer {
     override fun confirm(expressButton: ExpressButton) {
-        val confirmationArgs = operationCoordinator.tryBeginConfirmation {
-            val state = stateHolder.state ?: run {
-                errorReporter.report(
-                    ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
-                )
-                return@tryBeginConfirmation null
-            }
-            getConfirmationArgs(
-                state = state,
-                expressButton = expressButton,
-            ) ?: run {
-                errorReporter.report(
-                    ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
-                )
-                null
-            }
-        } ?: return
+        viewModelScope.launch(Dispatchers.Main.immediate) {
+            val confirmationArgs = operationCoordinator.tryBeginConfirmation {
+                val state = stateHolder.state ?: run {
+                    errorReporter.report(
+                        ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_STATE_ON_CONFIRM
+                    )
+                    return@tryBeginConfirmation null
+                }
+                getConfirmationArgs(
+                    state = state,
+                    expressButton = expressButton,
+                ) ?: run {
+                    errorReporter.report(
+                        ErrorReporter.UnexpectedErrorEvent.EXPRESS_CHECKOUT_ELEMENT_NULL_CONFIRMATION_ARGS_ON_CONFIRM
+                    )
+                    null
+                }
+            } ?: return@launch
 
-        analyticsPerformer.onExpressCheckoutElementConfirmationStarted(expressButton.toSelection())
-
-        viewModelScope.launch {
+            analyticsPerformer.onExpressCheckoutElementConfirmationStarted(expressButton.toSelection())
             try {
                 confirmationHandler.start(confirmationArgs)
             } catch (error: CancellationException) {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -18,9 +18,16 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -76,6 +83,35 @@ internal class CheckoutConfirmationPerformerTest {
     }
 
     @Test
+    fun `confirm admits only one immediate confirmation`() = runScenario(
+        state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+    ) {
+        withContext(Dispatchers.Main.immediate) {
+            performer.confirm()
+            performer.confirm()
+        }
+
+        confirmationHandler.startTurbine.awaitItem()
+        confirmationHandler.startTurbine.expectNoEvents()
+    }
+
+    @Test
+    fun `confirm from a background context emits updating on Main`() = runScenario(
+        state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
+        mainDispatcherProvider = { StandardTestDispatcher(it) },
+    ) {
+        performer.confirm()
+
+        assertThat(operationCoordinator.isUpdating.value).isFalse()
+        confirmationHandler.startTurbine.expectNoEvents()
+
+        testScheduler.runCurrent()
+
+        assertThat(operationCoordinator.isUpdating.value).isTrue()
+        confirmationHandler.startTurbine.awaitItem()
+    }
+
+    @Test
     fun `confirm records the payment selection for analytics`() = runScenario(
         state = googlePayState(paymentSelection = PaymentSelection.GooglePay),
     ) {
@@ -114,57 +150,69 @@ internal class CheckoutConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         statusBarColor: Int? = null,
+        mainDispatcherProvider: (TestCoroutineScheduler) -> TestDispatcher = {
+            UnconfinedTestDispatcher(it)
+        },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val confirmationHandler = FakeConfirmationHandler()
-        val savedStateHandle = SavedStateHandle()
-        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
-        stateHolder.state = state
-        val sessionRefresher = FakeCheckoutSessionRefresher()
-        val operationCoordinator = CheckoutOperationCoordinator(
-            confirmationHandler = confirmationHandler,
-            sheetStateHolder = SheetStateHolder(savedStateHandle),
-            sessionRefresher = sessionRefresher,
-            logger = Logger.noop(),
-            uiContext = UnconfinedTestDispatcher(testScheduler),
-            resultCallback = {},
-        )
-        val eventReporter = FakeEventReporter()
-        val analyticsPerformer = CheckoutAnalyticsPerformer(
-            confirmationHandler = confirmationHandler,
-            eventReporter = eventReporter,
-            savedStateHandle = savedStateHandle,
-        )
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            analyticsPerformer.reportConfirmationResults()
+        val mainDispatcher = mainDispatcherProvider(testScheduler)
+        Dispatchers.setMain(mainDispatcher)
+        try {
+            val confirmationHandler = FakeConfirmationHandler()
+            val savedStateHandle = SavedStateHandle()
+            val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
+            stateHolder.state = state
+            val sessionRefresher = FakeCheckoutSessionRefresher()
+            val operationCoordinator = CheckoutOperationCoordinator(
+                confirmationHandler = confirmationHandler,
+                sheetStateHolder = SheetStateHolder(savedStateHandle),
+                sessionRefresher = sessionRefresher,
+                logger = Logger.noop(),
+                resultCallback = {},
+            )
+            val eventReporter = FakeEventReporter()
+            val analyticsPerformer = CheckoutAnalyticsPerformer(
+                confirmationHandler = confirmationHandler,
+                eventReporter = eventReporter,
+                savedStateHandle = savedStateHandle,
+            )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                analyticsPerformer.reportConfirmationResults()
+            }
+            val performer = CheckoutConfirmationPerformer(
+                confirmationHandler = confirmationHandler,
+                stateHolder = stateHolder,
+                operationCoordinator = operationCoordinator,
+                analyticsPerformer = analyticsPerformer,
+                commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Test App"),
+                statusBarColor = statusBarColor,
+                viewModelScope = backgroundScope,
+            )
+
+            Scenario(
+                performer = performer,
+                operationCoordinator = operationCoordinator,
+                confirmationHandler = confirmationHandler,
+                eventReporter = eventReporter,
+                stateHolder = stateHolder,
+                testScheduler = testScheduler,
+            ).block()
+
+            confirmationHandler.validate()
+            sessionRefresher.ensureAllEventsConsumed()
+            eventReporter.validate()
+        } finally {
+            Dispatchers.resetMain()
         }
-        val performer = CheckoutConfirmationPerformer(
-            confirmationHandler = confirmationHandler,
-            stateHolder = stateHolder,
-            operationCoordinator = operationCoordinator,
-            analyticsPerformer = analyticsPerformer,
-            commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Test App"),
-            statusBarColor = statusBarColor,
-            viewModelScope = backgroundScope,
-        )
-
-        Scenario(
-            performer = performer,
-            confirmationHandler = confirmationHandler,
-            eventReporter = eventReporter,
-            stateHolder = stateHolder,
-        ).block()
-
-        confirmationHandler.validate()
-        sessionRefresher.ensureAllEventsConsumed()
-        eventReporter.validate()
     }
 
     private class Scenario(
         val performer: CheckoutConfirmationPerformer,
+        val operationCoordinator: CheckoutOperationCoordinator,
         val confirmationHandler: FakeConfirmationHandler,
         val eventReporter: FakeEventReporter,
         val stateHolder: CheckoutControllerStateHolder,
+        val testScheduler: TestCoroutineScheduler,
     )
 
     private companion object {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -126,6 +126,7 @@ internal class CheckoutConfirmationPerformerTest {
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
+            uiContext = UnconfinedTestDispatcher(testScheduler),
             resultCallback = {},
         )
         val eventReporter = FakeEventReporter()

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutConfirmationPerformerTest.kt
@@ -18,16 +18,17 @@ import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.testing.CoroutineTestRule
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.Test
@@ -35,6 +36,9 @@ import kotlin.test.Test
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutConfirmationPerformerTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
 
     @Test
     fun `confirm does nothing when state is not loaded`() = runScenario(state = null) {
@@ -150,60 +154,56 @@ internal class CheckoutConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         statusBarColor: Int? = null,
-        mainDispatcherProvider: (TestCoroutineScheduler) -> TestDispatcher = {
+        mainDispatcherProvider: (TestCoroutineScheduler) -> CoroutineDispatcher = {
             UnconfinedTestDispatcher(it)
         },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val mainDispatcher = mainDispatcherProvider(testScheduler)
         Dispatchers.setMain(mainDispatcher)
-        try {
-            val confirmationHandler = FakeConfirmationHandler()
-            val savedStateHandle = SavedStateHandle()
-            val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
-            stateHolder.state = state
-            val sessionRefresher = FakeCheckoutSessionRefresher()
-            val operationCoordinator = CheckoutOperationCoordinator(
-                confirmationHandler = confirmationHandler,
-                sheetStateHolder = SheetStateHolder(savedStateHandle),
-                sessionRefresher = sessionRefresher,
-                logger = Logger.noop(),
-                resultCallback = {},
-            )
-            val eventReporter = FakeEventReporter()
-            val analyticsPerformer = CheckoutAnalyticsPerformer(
-                confirmationHandler = confirmationHandler,
-                eventReporter = eventReporter,
-                savedStateHandle = savedStateHandle,
-            )
-            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-                analyticsPerformer.reportConfirmationResults()
-            }
-            val performer = CheckoutConfirmationPerformer(
-                confirmationHandler = confirmationHandler,
-                stateHolder = stateHolder,
-                operationCoordinator = operationCoordinator,
-                analyticsPerformer = analyticsPerformer,
-                commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Test App"),
-                statusBarColor = statusBarColor,
-                viewModelScope = backgroundScope,
-            )
-
-            Scenario(
-                performer = performer,
-                operationCoordinator = operationCoordinator,
-                confirmationHandler = confirmationHandler,
-                eventReporter = eventReporter,
-                stateHolder = stateHolder,
-                testScheduler = testScheduler,
-            ).block()
-
-            confirmationHandler.validate()
-            sessionRefresher.ensureAllEventsConsumed()
-            eventReporter.validate()
-        } finally {
-            Dispatchers.resetMain()
+        val confirmationHandler = FakeConfirmationHandler()
+        val savedStateHandle = SavedStateHandle()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
+        stateHolder.state = state
+        val sessionRefresher = FakeCheckoutSessionRefresher()
+        val operationCoordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            sheetStateHolder = SheetStateHolder(savedStateHandle),
+            sessionRefresher = sessionRefresher,
+            logger = Logger.noop(),
+            resultCallback = {},
+        )
+        val eventReporter = FakeEventReporter()
+        val analyticsPerformer = CheckoutAnalyticsPerformer(
+            confirmationHandler = confirmationHandler,
+            eventReporter = eventReporter,
+            savedStateHandle = savedStateHandle,
+        )
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            analyticsPerformer.reportConfirmationResults()
         }
+        val performer = CheckoutConfirmationPerformer(
+            confirmationHandler = confirmationHandler,
+            stateHolder = stateHolder,
+            operationCoordinator = operationCoordinator,
+            analyticsPerformer = analyticsPerformer,
+            commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Test App"),
+            statusBarColor = statusBarColor,
+            viewModelScope = backgroundScope,
+        )
+
+        Scenario(
+            performer = performer,
+            operationCoordinator = operationCoordinator,
+            confirmationHandler = confirmationHandler,
+            eventReporter = eventReporter,
+            stateHolder = stateHolder,
+            testScheduler = testScheduler,
+        ).block()
+
+        confirmationHandler.validate()
+        sessionRefresher.ensureAllEventsConsumed()
+        eventReporter.validate()
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -18,6 +18,7 @@ import com.stripe.android.paymentelement.confirmation.intent.CheckoutSessionResp
 import com.stripe.android.paymentelement.embedded.content.SheetStateHolder
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeLogger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -36,10 +37,10 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
+import org.junit.Rule
 import org.junit.Test
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
@@ -51,6 +52,9 @@ import kotlin.test.assertFailsWith
 
 @Suppress("LargeClass")
 internal class CheckoutOperationCoordinatorTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
 
     @Test
     fun `runMutation returns the block result`() = runScenario {
@@ -906,58 +910,54 @@ internal class CheckoutOperationCoordinatorTest {
         hasReloadedFromProcessDeath: Boolean = false,
         resultCallback: CheckoutController.ResultCallback? = null,
         logger: Logger = Logger.noop(),
-        uiContextProvider: (TestCoroutineScheduler) -> CoroutineContext = {
+        uiContextProvider: (TestCoroutineScheduler) -> CoroutineDispatcher = {
             UnconfinedTestDispatcher(it)
         },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val uiContext = uiContextProvider(testScheduler)
-        Dispatchers.setMain(uiContext[ContinuationInterceptor] as CoroutineDispatcher)
-        try {
-            val confirmationState = MutableStateFlow(initialConfirmationState)
-            val confirmationHandler = FakeConfirmationHandler(
-                hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
-                state = confirmationState,
-            )
-            val sheetStateHolder = SheetStateHolder(SavedStateHandle()).apply {
-                this.sheetIsOpen = sheetIsOpen
-            }
-            val resultTurbine = Turbine<CheckoutController.Result>()
-            val sessionRefresher = FakeCheckoutSessionRefresher()
-            val coordinator = CheckoutOperationCoordinator(
-                confirmationHandler = confirmationHandler,
-                sheetStateHolder = sheetStateHolder,
-                sessionRefresher = sessionRefresher,
-                logger = logger,
-                resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
-            )
-            val observerJob = backgroundScope.launch {
-                coordinator.observeConfirmationResults()
-            }
-            testScheduler.runCurrent()
-
-            Scenario(
-                coordinator = coordinator,
-                uiContext = uiContext,
-                confirmationState = confirmationState,
-                resultTurbine = resultTurbine,
-                refreshCalls = sessionRefresher.calls,
-                sessionRefresher = sessionRefresher,
-                observerJob = observerJob,
-                testScope = this,
-            ).block()
-
-            confirmationHandler.validate()
-            resultTurbine.ensureAllEventsConsumed()
-            sessionRefresher.ensureAllEventsConsumed()
-        } finally {
-            Dispatchers.resetMain()
+        Dispatchers.setMain(uiContext)
+        val confirmationState = MutableStateFlow(initialConfirmationState)
+        val confirmationHandler = FakeConfirmationHandler(
+            hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
+            state = confirmationState,
+        )
+        val sheetStateHolder = SheetStateHolder(SavedStateHandle()).apply {
+            this.sheetIsOpen = sheetIsOpen
         }
+        val resultTurbine = Turbine<CheckoutController.Result>()
+        val sessionRefresher = FakeCheckoutSessionRefresher()
+        val coordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            sheetStateHolder = sheetStateHolder,
+            sessionRefresher = sessionRefresher,
+            logger = logger,
+            resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
+        )
+        val observerJob = backgroundScope.launch {
+            coordinator.observeConfirmationResults()
+        }
+        testScheduler.runCurrent()
+
+        Scenario(
+            coordinator = coordinator,
+            uiContext = uiContext,
+            confirmationState = confirmationState,
+            resultTurbine = resultTurbine,
+            refreshCalls = sessionRefresher.calls,
+            sessionRefresher = sessionRefresher,
+            observerJob = observerJob,
+            testScope = this,
+        ).block()
+
+        confirmationHandler.validate()
+        resultTurbine.ensureAllEventsConsumed()
+        sessionRefresher.ensureAllEventsConsumed()
     }
 
     private class Scenario(
         val coordinator: CheckoutOperationCoordinator,
-        val uiContext: CoroutineContext,
+        val uiContext: CoroutineDispatcher,
         val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
         val resultTurbine: Turbine<CheckoutController.Result>,
         val refreshCalls: Turbine<FakeCheckoutSessionRefresher.Call>,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
@@ -117,8 +118,12 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `runMutation closes the gate before returning on the UI context`() = runScenario {
-        withContext(Dispatchers.Main.immediate) {
+    fun `runMutation closes the gate before returning on the Main dispatcher`() = runScenario(
+        uiContextProvider = { scheduler ->
+            ImmediateMainTestDispatcher(StandardTestDispatcher(scheduler))
+        },
+    ) {
+        withContext(uiContext) {
             val releaseMutation = CompletableDeferred<Unit>()
             val mutation = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
                 coordinator.runMutation {
@@ -131,6 +136,7 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNull()
 
             releaseMutation.complete(Unit)
+            runCurrent()
             mutation.join()
             assertThat(coordinator.isUpdating.value).isFalse()
         }
@@ -311,45 +317,36 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `cancelling the UI context job does not strand mutation cleanup`() {
-        val uiJob = Job()
+    fun `cancelling before queued admission leaves processing unchanged`() = runScenario(
+        uiContextProvider = { scheduler -> StandardTestDispatcher(scheduler) },
+    ) {
+        val callerDispatcher = UnconfinedTestDispatcher(testScheduler)
 
-        runScenario(
-            uiContextProvider = { scheduler ->
-                StandardTestDispatcher(scheduler) + uiJob
-            },
-        ) {
-            val callerDispatcher = UnconfinedTestDispatcher(testScheduler)
+        coordinator.isUpdating.test {
+            assertThat(awaitItem()).isFalse()
 
-            coordinator.isUpdating.test {
-                assertThat(awaitItem()).isFalse()
-
-                val mutation = backgroundScope.async(callerDispatcher) {
-                    coordinator.runMutation<Unit> {
-                        awaitCancellation()
-                    }
+            val mutation = backgroundScope.async(callerDispatcher) {
+                coordinator.runMutation {
+                    Result.success(Unit)
                 }
-                runCurrent()
-
-                assertThat(awaitItem()).isTrue()
-
-                uiJob.cancel()
-                mutation.cancel()
-                runCurrent()
-                mutation.join()
-
-                assertThat(coordinator.isUpdating.value).isFalse()
-                assertThat(awaitItem()).isFalse()
-
-                val laterMutation = backgroundScope.async(callerDispatcher) {
-                    coordinator.runMutation { Result.success(Unit) }
-                }
-                runCurrent()
-
-                assertThat(laterMutation.await().isSuccess).isTrue()
-                assertThat(awaitItem()).isTrue()
-                assertThat(awaitItem()).isFalse()
             }
+
+            assertThat(mutation.isCompleted).isFalse()
+            mutation.cancel()
+            runCurrent()
+            mutation.join()
+
+            expectNoEvents()
+            assertThat(coordinator.isUpdating.value).isFalse()
+
+            val laterMutation = backgroundScope.async(callerDispatcher) {
+                coordinator.runMutation { Result.success(Unit) }
+            }
+            runCurrent()
+
+            assertThat(laterMutation.await().isSuccess).isTrue()
+            assertThat(awaitItem()).isTrue()
+            assertThat(awaitItem()).isFalse()
         }
     }
 
@@ -978,6 +975,35 @@ internal class CheckoutOperationCoordinatorTest {
 
         fun enqueueRefreshAction(action: suspend () -> Unit) {
             sessionRefresher.enqueueRefreshAction(action)
+        }
+    }
+
+    private class ImmediateMainTestDispatcher(
+        private val delegate: CoroutineDispatcher,
+    ) : MainCoroutineDispatcher() {
+        private val immediateDispatcher = object : MainCoroutineDispatcher() {
+            override val immediate: MainCoroutineDispatcher
+                get() = this
+
+            override fun dispatch(context: CoroutineContext, block: Runnable) {
+                delegate.dispatch(context, block)
+            }
+
+            override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+                val currentDispatcher = context[ContinuationInterceptor]
+                return currentDispatcher !== this && currentDispatcher !== this@ImmediateMainTestDispatcher
+            }
+        }
+
+        override val immediate: MainCoroutineDispatcher
+            get() = immediateDispatcher
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            delegate.dispatch(context, block)
+        }
+
+        override fun isDispatchNeeded(context: CoroutineContext): Boolean {
+            return delegate.isDispatchNeeded(context)
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -21,6 +21,7 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFacto
 import com.stripe.android.testing.FakeLogger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -34,7 +35,9 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
 import org.junit.Test
 import java.util.concurrent.CopyOnWriteArrayList
@@ -109,6 +112,26 @@ internal class CheckoutOperationCoordinatorTest {
             }
 
             assertThat(result.isSuccess).isTrue()
+            assertThat(coordinator.isUpdating.value).isFalse()
+        }
+    }
+
+    @Test
+    fun `runMutation closes the gate before returning on the UI context`() = runScenario {
+        withContext(Dispatchers.Main.immediate) {
+            val releaseMutation = CompletableDeferred<Unit>()
+            val mutation = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                coordinator.runMutation {
+                    releaseMutation.await()
+                    Result.success(Unit)
+                }
+            }
+
+            assertThat(coordinator.isUpdating.value).isTrue()
+            assertThat(coordinator.tryBeginConfirmation { CONFIRMATION_PARAMETERS }).isNull()
+
+            releaseMutation.complete(Unit)
+            mutation.join()
             assertThat(coordinator.isUpdating.value).isFalse()
         }
     }
@@ -892,43 +915,47 @@ internal class CheckoutOperationCoordinatorTest {
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val uiContext = uiContextProvider(testScheduler)
-        val confirmationState = MutableStateFlow(initialConfirmationState)
-        val confirmationHandler = FakeConfirmationHandler(
-            hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
-            state = confirmationState,
-        )
-        val sheetStateHolder = SheetStateHolder(SavedStateHandle()).apply {
-            this.sheetIsOpen = sheetIsOpen
-        }
-        val resultTurbine = Turbine<CheckoutController.Result>()
-        val sessionRefresher = FakeCheckoutSessionRefresher()
-        val coordinator = CheckoutOperationCoordinator(
-            confirmationHandler = confirmationHandler,
-            sheetStateHolder = sheetStateHolder,
-            sessionRefresher = sessionRefresher,
-            logger = logger,
-            uiContext = uiContext,
-            resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
-        )
-        val observerJob = backgroundScope.launch {
-            coordinator.observeConfirmationResults()
-        }
-        testScheduler.runCurrent()
+        Dispatchers.setMain(uiContext[ContinuationInterceptor] as CoroutineDispatcher)
+        try {
+            val confirmationState = MutableStateFlow(initialConfirmationState)
+            val confirmationHandler = FakeConfirmationHandler(
+                hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
+                state = confirmationState,
+            )
+            val sheetStateHolder = SheetStateHolder(SavedStateHandle()).apply {
+                this.sheetIsOpen = sheetIsOpen
+            }
+            val resultTurbine = Turbine<CheckoutController.Result>()
+            val sessionRefresher = FakeCheckoutSessionRefresher()
+            val coordinator = CheckoutOperationCoordinator(
+                confirmationHandler = confirmationHandler,
+                sheetStateHolder = sheetStateHolder,
+                sessionRefresher = sessionRefresher,
+                logger = logger,
+                resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
+            )
+            val observerJob = backgroundScope.launch {
+                coordinator.observeConfirmationResults()
+            }
+            testScheduler.runCurrent()
 
-        Scenario(
-            coordinator = coordinator,
-            uiContext = uiContext,
-            confirmationState = confirmationState,
-            resultTurbine = resultTurbine,
-            refreshCalls = sessionRefresher.calls,
-            sessionRefresher = sessionRefresher,
-            observerJob = observerJob,
-            testScope = this,
-        ).block()
+            Scenario(
+                coordinator = coordinator,
+                uiContext = uiContext,
+                confirmationState = confirmationState,
+                resultTurbine = resultTurbine,
+                refreshCalls = sessionRefresher.calls,
+                sessionRefresher = sessionRefresher,
+                observerJob = observerJob,
+                testScope = this,
+            ).block()
 
-        confirmationHandler.validate()
-        resultTurbine.ensureAllEventsConsumed()
-        sessionRefresher.ensureAllEventsConsumed()
+            confirmationHandler.validate()
+            resultTurbine.ensureAllEventsConsumed()
+            sessionRefresher.ensureAllEventsConsumed()
+        } finally {
+            Dispatchers.resetMain()
+        }
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -88,6 +88,9 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(mutationStarted.isCompleted).isTrue()
 
             releaseMutation.complete(Unit)
+            expectNoEvents()
+            assertThat(mutation.isCompleted).isFalse()
+
             runCurrent()
 
             assertThat(mutation.await().isSuccess).isTrue()
@@ -159,7 +162,9 @@ internal class CheckoutOperationCoordinatorTest {
     }
 
     @Test
-    fun `mutations are serialized without isUpdating flickering between them`() = runScenario {
+    fun `mutations are serialized without isUpdating flickering between them`() = runScenario(
+        uiContextProvider = { scheduler -> StandardTestDispatcher(scheduler) },
+    ) {
         val firstStarted = CompletableDeferred<Unit>()
         val releaseFirst = CompletableDeferred<Unit>()
         val secondStarted = CompletableDeferred<Unit>()
@@ -175,6 +180,7 @@ internal class CheckoutOperationCoordinatorTest {
                     Result.success(Unit)
                 }
             }
+            runCurrent()
             firstStarted.await()
             assertThat(awaitItem()).isTrue()
 
@@ -278,6 +284,49 @@ internal class CheckoutOperationCoordinatorTest {
             assertThat(laterMutation.await().getOrThrow()).isEqualTo("later")
             assertThat(awaitItem()).isTrue()
             assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `cancelling the UI context job does not strand mutation cleanup`() {
+        val uiJob = Job()
+
+        runScenario(
+            uiContextProvider = { scheduler ->
+                StandardTestDispatcher(scheduler) + uiJob
+            },
+        ) {
+            val callerDispatcher = UnconfinedTestDispatcher(testScheduler)
+
+            coordinator.isUpdating.test {
+                assertThat(awaitItem()).isFalse()
+
+                val mutation = backgroundScope.async(callerDispatcher) {
+                    coordinator.runMutation<Unit> {
+                        awaitCancellation()
+                    }
+                }
+                runCurrent()
+
+                assertThat(awaitItem()).isTrue()
+
+                uiJob.cancel()
+                mutation.cancel()
+                runCurrent()
+                mutation.join()
+
+                assertThat(coordinator.isUpdating.value).isFalse()
+                assertThat(awaitItem()).isFalse()
+
+                val laterMutation = backgroundScope.async(callerDispatcher) {
+                    coordinator.runMutation { Result.success(Unit) }
+                }
+                runCurrent()
+
+                assertThat(laterMutation.await().isSuccess).isTrue()
+                assertThat(awaitItem()).isTrue()
+                assertThat(awaitItem()).isFalse()
+            }
         }
     }
 

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutOperationCoordinatorTest.kt
@@ -21,19 +21,28 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFacto
 import com.stripe.android.testing.FakeLogger
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
 import org.junit.Test
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
 import kotlin.test.assertFailsWith
 
 @Suppress("LargeClass")
@@ -46,6 +55,59 @@ internal class CheckoutOperationCoordinatorTest {
         }
 
         assertThat(result.getOrThrow()).isEqualTo("result")
+    }
+
+    @Test
+    fun `runMutation emits processing on the UI context and preserves the caller context`() = runScenario(
+        uiContextProvider = { scheduler -> StandardTestDispatcher(scheduler) },
+    ) {
+        val callerName = CoroutineName("mutation-caller")
+        val callerDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val mutationStarted = CompletableDeferred<Unit>()
+        val releaseMutation = CompletableDeferred<Unit>()
+
+        coordinator.isUpdating.test {
+            assertThat(awaitItem()).isFalse()
+
+            val mutation = backgroundScope.async(callerDispatcher + callerName) {
+                coordinator.runMutation {
+                    assertThat(coroutineContext[CoroutineName]).isEqualTo(callerName)
+                    assertThat(coroutineContext[ContinuationInterceptor]).isEqualTo(callerDispatcher)
+                    mutationStarted.complete(Unit)
+                    releaseMutation.await()
+                    Result.success(Unit)
+                }
+            }
+
+            assertThat(mutationStarted.isCompleted).isFalse()
+            assertThat(coordinator.isUpdating.value).isFalse()
+
+            runCurrent()
+
+            assertThat(awaitItem()).isTrue()
+            assertThat(mutationStarted.isCompleted).isTrue()
+
+            releaseMutation.complete(Unit)
+            runCurrent()
+
+            assertThat(mutation.await().isSuccess).isTrue()
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `runMutation is updating inside the block when invoked on the UI context`() = runScenario {
+        withContext(uiContext) {
+            assertThat(coordinator.isUpdating.value).isFalse()
+
+            val result = coordinator.runMutation {
+                assertThat(coordinator.isUpdating.value).isTrue()
+                Result.success(Unit)
+            }
+
+            assertThat(result.isSuccess).isTrue()
+            assertThat(coordinator.isUpdating.value).isFalse()
+        }
     }
 
     @Test
@@ -179,6 +241,42 @@ internal class CheckoutOperationCoordinatorTest {
             releaseFirst.complete(Unit)
             assertThat(first.await().isSuccess).isTrue()
 
+            assertThat(awaitItem()).isFalse()
+        }
+    }
+
+    @Test
+    fun `cancelling an admitted mutation releases processing and allows a later mutation`() = runScenario(
+        uiContextProvider = { scheduler -> StandardTestDispatcher(scheduler) },
+    ) {
+        val callerDispatcher = UnconfinedTestDispatcher(testScheduler)
+
+        coordinator.isUpdating.test {
+            assertThat(awaitItem()).isFalse()
+
+            val mutation = backgroundScope.async(callerDispatcher) {
+                coordinator.runMutation<Unit> {
+                    awaitCancellation()
+                }
+            }
+            runCurrent()
+
+            assertThat(awaitItem()).isTrue()
+            mutation.cancel()
+            runCurrent()
+            mutation.join()
+
+            assertThat(awaitItem()).isFalse()
+
+            val laterMutation = backgroundScope.async(callerDispatcher) {
+                coordinator.runMutation {
+                    Result.success("later")
+                }
+            }
+            runCurrent()
+
+            assertThat(laterMutation.await().getOrThrow()).isEqualTo("later")
+            assertThat(awaitItem()).isTrue()
             assertThat(awaitItem()).isFalse()
         }
     }
@@ -739,8 +837,12 @@ internal class CheckoutOperationCoordinatorTest {
         hasReloadedFromProcessDeath: Boolean = false,
         resultCallback: CheckoutController.ResultCallback? = null,
         logger: Logger = Logger.noop(),
+        uiContextProvider: (TestCoroutineScheduler) -> CoroutineContext = {
+            UnconfinedTestDispatcher(it)
+        },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
+        val uiContext = uiContextProvider(testScheduler)
         val confirmationState = MutableStateFlow(initialConfirmationState)
         val confirmationHandler = FakeConfirmationHandler(
             hasReloadedFromProcessDeath = hasReloadedFromProcessDeath,
@@ -756,6 +858,7 @@ internal class CheckoutOperationCoordinatorTest {
             sheetStateHolder = sheetStateHolder,
             sessionRefresher = sessionRefresher,
             logger = logger,
+            uiContext = uiContext,
             resultCallback = resultCallback ?: CheckoutController.ResultCallback(resultTurbine::add),
         )
         val observerJob = backgroundScope.launch {
@@ -765,6 +868,7 @@ internal class CheckoutOperationCoordinatorTest {
 
         Scenario(
             coordinator = coordinator,
+            uiContext = uiContext,
             confirmationState = confirmationState,
             resultTurbine = resultTurbine,
             refreshCalls = sessionRefresher.calls,
@@ -780,6 +884,7 @@ internal class CheckoutOperationCoordinatorTest {
 
     private class Scenario(
         val coordinator: CheckoutOperationCoordinator,
+        val uiContext: CoroutineContext,
         val confirmationState: MutableStateFlow<ConfirmationHandler.State>,
         val resultTurbine: Turbine<CheckoutController.Result>,
         val refreshCalls: Turbine<FakeCheckoutSessionRefresher.Call>,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -43,10 +43,13 @@ import com.stripe.android.uicore.utils.stateFlowOf
 import com.stripe.android.utils.FakePaymentMethodMessagePromotionsHelper
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -904,98 +907,102 @@ internal class CheckoutSheetLauncherTest {
         promotions: List<PaymentMethodMessagePromotion>? = null,
         block: suspend Scenario.() -> Unit
     ) = runTest {
-        var immediateActionInvoked = false
-        val testScope = this
-        val lifecycleOwner = TestLifecycleOwner()
-        val savedStateHandle = SavedStateHandle()
-        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
-        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
-        val customerStateHolder = DefaultCustomerStateHolder(
-            savedStateHandle = savedStateHandle,
-            selection = selectionHolder.selection,
-            customerMetadata = stateFlowOf(paymentMethodMetadata.customerMetadata),
-            paymentMethodMetadataFlow = stateFlowOf(null),
-        )
-        val sheetStateHolder = SheetStateHolder(savedStateHandle)
-        val errorReporter = FakeErrorReporter()
-        val sessionRefresher = FakeCheckoutSessionRefresher()
-        val logger = FakeLogger()
-        val confirmationHandler = FakeConfirmationHandler()
-        val operationCoordinator = CheckoutOperationCoordinator(
-            confirmationHandler = confirmationHandler,
-            sheetStateHolder = sheetStateHolder,
-            sessionRefresher = sessionRefresher,
-            logger = logger,
-            uiContext = UnconfinedTestDispatcher(testScheduler),
-            resultCallback = CheckoutController.ResultCallback {},
-        )
-        val launcherState = CheckoutSheetLauncherState(savedStateHandle)
-        val embeddedContentState = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(
-            EmbeddedContentHelperStateHolder.State(
-                paymentMethodMetadata = paymentMethodMetadata,
-                embeddedViewDisplaysMandateText = true,
-                configuration = EmbeddedConfigurationFactory.create(),
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            var immediateActionInvoked = false
+            val testScope = this
+            val lifecycleOwner = TestLifecycleOwner()
+            val savedStateHandle = SavedStateHandle()
+            val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
+            val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+            val customerStateHolder = DefaultCustomerStateHolder(
+                savedStateHandle = savedStateHandle,
+                selection = selectionHolder.selection,
+                customerMetadata = stateFlowOf(paymentMethodMetadata.customerMetadata),
+                paymentMethodMetadataFlow = stateFlowOf(null),
             )
-        )
-
-        DummyActivityResultCaller.test {
-            fun createSheetLauncher(
-                owner: TestLifecycleOwner,
-                state: CheckoutSheetLauncherState,
-            ): CheckoutSheetLauncher {
-                return CheckoutSheetLauncher(
-                    activityResultCaller = activityResultCaller,
-                    lifecycleOwner = owner,
-                    selectionHolder = selectionHolder,
-                    customerStateHolder = customerStateHolder,
-                    sheetStateHolder = sheetStateHolder,
-                    errorReporter = errorReporter,
-                    sessionRefresher = sessionRefresher,
-                    operationCoordinator = operationCoordinator,
-                    launcherState = state,
-                    embeddedContentState = embeddedContentState,
-                    logger = logger,
-                    coroutineScope = testScope,
-                    productUsage = setOf("Checkout"),
-                    statusBarColor = null,
-                    paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
-                    rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
-                    paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(promotions),
-                )
-            }
-
-            val sheetLauncher = createSheetLauncher(lifecycleOwner, launcherState)
-            val registerCall = awaitRegisterCall()
-            val launcher = awaitNextRegisteredLauncher()
-
-            assertThat(registerCall).isNotNull()
-            assertThat(registerCall.contract).isInstanceOf<EmbeddedSheetContract>()
-
-            Scenario(
-                selectionHolder = selectionHolder,
-                lifecycleOwner = lifecycleOwner,
-                customerStateHolder = customerStateHolder,
-                dummyActivityResultCallerScenario = this,
-                registerCall = registerCall,
-                launcher = launcher,
-                sheetLauncher = sheetLauncher,
+            val sheetStateHolder = SheetStateHolder(savedStateHandle)
+            val errorReporter = FakeErrorReporter()
+            val sessionRefresher = FakeCheckoutSessionRefresher()
+            val logger = FakeLogger()
+            val confirmationHandler = FakeConfirmationHandler()
+            val operationCoordinator = CheckoutOperationCoordinator(
+                confirmationHandler = confirmationHandler,
                 sheetStateHolder = sheetStateHolder,
-                errorReporter = errorReporter,
-                immediateActionWasInvoked = { immediateActionInvoked },
                 sessionRefresher = sessionRefresher,
                 logger = logger,
-                operationCoordinator = operationCoordinator,
-                launcherState = launcherState,
-                savedStateHandle = savedStateHandle,
-                embeddedContentState = embeddedContentState,
-                coroutineScope = testScope,
-                createSheetLauncher = ::createSheetLauncher,
-                runCurrent = testScheduler::runCurrent,
-            ).block()
-        }
+                resultCallback = CheckoutController.ResultCallback {},
+            )
+            val launcherState = CheckoutSheetLauncherState(savedStateHandle)
+            val embeddedContentState = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(
+                EmbeddedContentHelperStateHolder.State(
+                    paymentMethodMetadata = paymentMethodMetadata,
+                    embeddedViewDisplaysMandateText = true,
+                    configuration = EmbeddedConfigurationFactory.create(),
+                )
+            )
 
-        confirmationHandler.validate()
-        sessionRefresher.ensureAllEventsConsumed()
+            DummyActivityResultCaller.test {
+                fun createSheetLauncher(
+                    owner: TestLifecycleOwner,
+                    state: CheckoutSheetLauncherState,
+                ): CheckoutSheetLauncher {
+                    return CheckoutSheetLauncher(
+                        activityResultCaller = activityResultCaller,
+                        lifecycleOwner = owner,
+                        selectionHolder = selectionHolder,
+                        customerStateHolder = customerStateHolder,
+                        sheetStateHolder = sheetStateHolder,
+                        errorReporter = errorReporter,
+                        sessionRefresher = sessionRefresher,
+                        operationCoordinator = operationCoordinator,
+                        launcherState = state,
+                        embeddedContentState = embeddedContentState,
+                        logger = logger,
+                        coroutineScope = testScope,
+                        productUsage = setOf("Checkout"),
+                        statusBarColor = null,
+                        paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+                        rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
+                        paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(promotions),
+                    )
+                }
+
+                val sheetLauncher = createSheetLauncher(lifecycleOwner, launcherState)
+                val registerCall = awaitRegisterCall()
+                val launcher = awaitNextRegisteredLauncher()
+
+                assertThat(registerCall).isNotNull()
+                assertThat(registerCall.contract).isInstanceOf<EmbeddedSheetContract>()
+
+                Scenario(
+                    selectionHolder = selectionHolder,
+                    lifecycleOwner = lifecycleOwner,
+                    customerStateHolder = customerStateHolder,
+                    dummyActivityResultCallerScenario = this,
+                    registerCall = registerCall,
+                    launcher = launcher,
+                    sheetLauncher = sheetLauncher,
+                    sheetStateHolder = sheetStateHolder,
+                    errorReporter = errorReporter,
+                    immediateActionWasInvoked = { immediateActionInvoked },
+                    sessionRefresher = sessionRefresher,
+                    logger = logger,
+                    operationCoordinator = operationCoordinator,
+                    launcherState = launcherState,
+                    savedStateHandle = savedStateHandle,
+                    embeddedContentState = embeddedContentState,
+                    coroutineScope = testScope,
+                    createSheetLauncher = ::createSheetLauncher,
+                    runCurrent = testScheduler::runCurrent,
+                ).block()
+            }
+
+            confirmationHandler.validate()
+            sessionRefresher.ensureAllEventsConsumed()
+        } finally {
+            Dispatchers.resetMain()
+        }
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -33,6 +33,7 @@ import com.stripe.android.paymentsheet.PaymentSheetFixtures
 import com.stripe.android.paymentsheet.createCustomerState
 import com.stripe.android.paymentsheet.model.PaymentSelection
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
+import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.DummyActivityResultCaller
 import com.stripe.android.testing.DummyActivityResultCaller.RegisterCall
 import com.stripe.android.testing.FakeErrorReporter
@@ -47,7 +48,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.Rule
@@ -62,6 +62,9 @@ import org.robolectric.RobolectricTestRunner
 internal class CheckoutSheetLauncherTest {
 
     private val applicationContext = ApplicationProvider.getApplicationContext<Application>()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
 
     @get:Rule
     val paymentConfigurationTestRule = PaymentConfigurationTestRule(applicationContext)
@@ -908,101 +911,97 @@ internal class CheckoutSheetLauncherTest {
         block: suspend Scenario.() -> Unit
     ) = runTest {
         Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
-        try {
-            var immediateActionInvoked = false
-            val testScope = this
-            val lifecycleOwner = TestLifecycleOwner()
-            val savedStateHandle = SavedStateHandle()
-            val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
-            val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
-            val customerStateHolder = DefaultCustomerStateHolder(
-                savedStateHandle = savedStateHandle,
-                selection = selectionHolder.selection,
-                customerMetadata = stateFlowOf(paymentMethodMetadata.customerMetadata),
-                paymentMethodMetadataFlow = stateFlowOf(null),
+        var immediateActionInvoked = false
+        val testScope = this
+        val lifecycleOwner = TestLifecycleOwner()
+        val savedStateHandle = SavedStateHandle()
+        val selectionHolder = DefaultEmbeddedSelectionHolder(savedStateHandle)
+        val paymentMethodMetadata = PaymentMethodMetadataFactory.create()
+        val customerStateHolder = DefaultCustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = selectionHolder.selection,
+            customerMetadata = stateFlowOf(paymentMethodMetadata.customerMetadata),
+            paymentMethodMetadataFlow = stateFlowOf(null),
+        )
+        val sheetStateHolder = SheetStateHolder(savedStateHandle)
+        val errorReporter = FakeErrorReporter()
+        val sessionRefresher = FakeCheckoutSessionRefresher()
+        val logger = FakeLogger()
+        val confirmationHandler = FakeConfirmationHandler()
+        val operationCoordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            sheetStateHolder = sheetStateHolder,
+            sessionRefresher = sessionRefresher,
+            logger = logger,
+            resultCallback = CheckoutController.ResultCallback {},
+        )
+        val launcherState = CheckoutSheetLauncherState(savedStateHandle)
+        val embeddedContentState = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(
+            EmbeddedContentHelperStateHolder.State(
+                paymentMethodMetadata = paymentMethodMetadata,
+                embeddedViewDisplaysMandateText = true,
+                configuration = EmbeddedConfigurationFactory.create(),
             )
-            val sheetStateHolder = SheetStateHolder(savedStateHandle)
-            val errorReporter = FakeErrorReporter()
-            val sessionRefresher = FakeCheckoutSessionRefresher()
-            val logger = FakeLogger()
-            val confirmationHandler = FakeConfirmationHandler()
-            val operationCoordinator = CheckoutOperationCoordinator(
-                confirmationHandler = confirmationHandler,
-                sheetStateHolder = sheetStateHolder,
-                sessionRefresher = sessionRefresher,
-                logger = logger,
-                resultCallback = CheckoutController.ResultCallback {},
-            )
-            val launcherState = CheckoutSheetLauncherState(savedStateHandle)
-            val embeddedContentState = MutableStateFlow<EmbeddedContentHelperStateHolder.State?>(
-                EmbeddedContentHelperStateHolder.State(
-                    paymentMethodMetadata = paymentMethodMetadata,
-                    embeddedViewDisplaysMandateText = true,
-                    configuration = EmbeddedConfigurationFactory.create(),
-                )
-            )
+        )
 
-            DummyActivityResultCaller.test {
-                fun createSheetLauncher(
-                    owner: TestLifecycleOwner,
-                    state: CheckoutSheetLauncherState,
-                ): CheckoutSheetLauncher {
-                    return CheckoutSheetLauncher(
-                        activityResultCaller = activityResultCaller,
-                        lifecycleOwner = owner,
-                        selectionHolder = selectionHolder,
-                        customerStateHolder = customerStateHolder,
-                        sheetStateHolder = sheetStateHolder,
-                        errorReporter = errorReporter,
-                        sessionRefresher = sessionRefresher,
-                        operationCoordinator = operationCoordinator,
-                        launcherState = state,
-                        embeddedContentState = embeddedContentState,
-                        logger = logger,
-                        coroutineScope = testScope,
-                        productUsage = setOf("Checkout"),
-                        statusBarColor = null,
-                        paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
-                        rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
-                        paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(promotions),
-                    )
-                }
-
-                val sheetLauncher = createSheetLauncher(lifecycleOwner, launcherState)
-                val registerCall = awaitRegisterCall()
-                val launcher = awaitNextRegisteredLauncher()
-
-                assertThat(registerCall).isNotNull()
-                assertThat(registerCall.contract).isInstanceOf<EmbeddedSheetContract>()
-
-                Scenario(
+        DummyActivityResultCaller.test {
+            fun createSheetLauncher(
+                owner: TestLifecycleOwner,
+                state: CheckoutSheetLauncherState,
+            ): CheckoutSheetLauncher {
+                return CheckoutSheetLauncher(
+                    activityResultCaller = activityResultCaller,
+                    lifecycleOwner = owner,
                     selectionHolder = selectionHolder,
-                    lifecycleOwner = lifecycleOwner,
                     customerStateHolder = customerStateHolder,
-                    dummyActivityResultCallerScenario = this,
-                    registerCall = registerCall,
-                    launcher = launcher,
-                    sheetLauncher = sheetLauncher,
                     sheetStateHolder = sheetStateHolder,
                     errorReporter = errorReporter,
-                    immediateActionWasInvoked = { immediateActionInvoked },
                     sessionRefresher = sessionRefresher,
-                    logger = logger,
                     operationCoordinator = operationCoordinator,
-                    launcherState = launcherState,
-                    savedStateHandle = savedStateHandle,
+                    launcherState = state,
                     embeddedContentState = embeddedContentState,
+                    logger = logger,
                     coroutineScope = testScope,
-                    createSheetLauncher = ::createSheetLauncher,
-                    runCurrent = testScheduler::runCurrent,
-                ).block()
+                    productUsage = setOf("Checkout"),
+                    statusBarColor = null,
+                    paymentElementCallbackIdentifier = CALLBACK_IDENTIFIER,
+                    rowSelectionImmediateActionHandler = { immediateActionInvoked = true },
+                    paymentMethodMessagePromotionsHelper = FakePaymentMethodMessagePromotionsHelper(promotions),
+                )
             }
 
-            confirmationHandler.validate()
-            sessionRefresher.ensureAllEventsConsumed()
-        } finally {
-            Dispatchers.resetMain()
+            val sheetLauncher = createSheetLauncher(lifecycleOwner, launcherState)
+            val registerCall = awaitRegisterCall()
+            val launcher = awaitNextRegisteredLauncher()
+
+            assertThat(registerCall).isNotNull()
+            assertThat(registerCall.contract).isInstanceOf<EmbeddedSheetContract>()
+
+            Scenario(
+                selectionHolder = selectionHolder,
+                lifecycleOwner = lifecycleOwner,
+                customerStateHolder = customerStateHolder,
+                dummyActivityResultCallerScenario = this,
+                registerCall = registerCall,
+                launcher = launcher,
+                sheetLauncher = sheetLauncher,
+                sheetStateHolder = sheetStateHolder,
+                errorReporter = errorReporter,
+                immediateActionWasInvoked = { immediateActionInvoked },
+                sessionRefresher = sessionRefresher,
+                logger = logger,
+                operationCoordinator = operationCoordinator,
+                launcherState = launcherState,
+                savedStateHandle = savedStateHandle,
+                embeddedContentState = embeddedContentState,
+                coroutineScope = testScope,
+                createSheetLauncher = ::createSheetLauncher,
+                runCurrent = testScheduler::runCurrent,
+            ).block()
         }
+
+        confirmationHandler.validate()
+        sessionRefresher.ensureAllEventsConsumed()
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutSheetLauncherTest.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
@@ -925,6 +926,7 @@ internal class CheckoutSheetLauncherTest {
             sheetStateHolder = sheetStateHolder,
             sessionRefresher = sessionRefresher,
             logger = logger,
+            uiContext = UnconfinedTestDispatcher(testScheduler),
             resultCallback = CheckoutController.ResultCallback {},
         )
         val launcherState = CheckoutSheetLauncherState(savedStateHandle)

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -43,10 +43,16 @@ import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.time.Duration
@@ -354,6 +360,80 @@ internal class CheckoutStateLoaderTest {
         assertThat(stateHolder.state?.linkEagerPresentationSuppressed).isFalse()
     }
 
+    @Test
+    fun `loadInitial completes payment element loading before queued UI commit`() = runScenario(
+        customer = savedCustomer(),
+        uiContextProvider = { StandardTestDispatcher(it) },
+    ) {
+        val load = backgroundScope.async(UnconfinedTestDispatcher(testScheduler)) {
+            loader.loadInitial(
+                configuration = defaultConfiguration(),
+                checkoutSessionResponse = response(),
+            )
+        }
+
+        assertThat(paymentElementLoader.lastIntegrationConfiguration).isNotNull()
+        assertThat(load.isCompleted).isFalse()
+        assertThat(stateHolder.state).isNull()
+        assertThat(customerStateHolder.customer.value).isNull()
+
+        testScheduler.runCurrent()
+        load.await()
+    }
+
+    @Test
+    fun `advancing the UI dispatcher commits controller and customer state`() = runScenario(
+        customer = savedCustomer(),
+        uiContextProvider = { StandardTestDispatcher(it) },
+    ) {
+        val load = backgroundScope.async(UnconfinedTestDispatcher(testScheduler)) {
+            loader.loadInitial(
+                configuration = defaultConfiguration(),
+                checkoutSessionResponse = response(),
+            )
+        }
+
+        assertThat(stateHolder.state).isNull()
+        assertThat(customerStateHolder.customer.value).isNull()
+
+        testScheduler.runCurrent()
+        load.await()
+
+        assertThat(stateHolder.state?.checkoutSessionResponse?.id)
+            .isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+        assertThat(customerStateHolder.customer.value).isEqualTo(savedCustomer())
+    }
+
+    @Test
+    fun `cancellation before queued UI commit leaves both holders unchanged`() {
+        val existingState = committedState(paymentSelection = PaymentSelection.GooglePay)
+        val existingCustomer = savedCustomer()
+
+        runScenario(
+            uiContextProvider = { StandardTestDispatcher(it) },
+        ) {
+            stateHolder.state = existingState
+            customerStateHolder.setCustomerState(existingCustomer)
+
+            val load = backgroundScope.async(UnconfinedTestDispatcher(testScheduler)) {
+                loader.loadInitial(
+                    configuration = defaultConfiguration(),
+                    checkoutSessionResponse = response(),
+                )
+            }
+
+            assertThat(load.isCompleted).isFalse()
+            assertThat(stateHolder.state).isEqualTo(existingState)
+            assertThat(customerStateHolder.customer.value).isEqualTo(existingCustomer)
+
+            load.cancelAndJoin()
+            testScheduler.runCurrent()
+
+            assertThat(stateHolder.state).isEqualTo(existingState)
+            assertThat(customerStateHolder.customer.value).isEqualTo(existingCustomer)
+        }
+    }
+
     private fun defaultConfiguration() = CheckoutController.Configuration().build()
 
     private fun response(
@@ -413,6 +493,9 @@ internal class CheckoutStateLoaderTest {
         // When null, a RecordingSelectionChooser is used. Pass a factory to exercise the real
         // DefaultEmbeddedSelectionChooser (it needs the shared SavedStateHandle to track state).
         selectionChooser: ((SavedStateHandle) -> EmbeddedSelectionChooser)? = null,
+        uiContextProvider: (TestCoroutineScheduler) -> CoroutineContext = {
+            UnconfinedTestDispatcher(it)
+        },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val application = ApplicationProvider.getApplicationContext<Application>()
@@ -448,6 +531,7 @@ internal class CheckoutStateLoaderTest {
             customer = customer,
             delay = paymentElementLoaderDelay,
         )
+        val uiContext = uiContextProvider(testScheduler)
         val loader = CheckoutStateLoader(
             embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
             commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Example, Inc."),
@@ -457,6 +541,7 @@ internal class CheckoutStateLoaderTest {
             stateHolder = stateHolder,
             customerStateHolder = customerStateHolder,
             internalRowSelectionCallback = { internalRowSelectionCallback },
+            uiContext = uiContext,
         )
 
         Scenario(
@@ -467,6 +552,7 @@ internal class CheckoutStateLoaderTest {
             chooser = recordingChooser,
             imageLoader = imageLoader,
             testScheduler = testScheduler,
+            backgroundScope = backgroundScope,
         ).block()
 
         imageLoader.ensureAllEventsConsumed()
@@ -480,6 +566,7 @@ internal class CheckoutStateLoaderTest {
         val chooser: RecordingSelectionChooser,
         val imageLoader: FakeStripeImageLoader,
         val testScheduler: TestCoroutineScheduler,
+        val backgroundScope: CoroutineScope,
     )
 
     // Records the arguments of the most recent choose() call and returns a preconfigured selection,

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -30,6 +30,7 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponse
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.CustomerState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
+import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeAnalyticsRequestExecutor
 import com.stripe.android.testing.FakeStripeImageLoader
 import com.stripe.android.uicore.FormInsets
@@ -52,13 +53,11 @@ import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
+import org.junit.Rule
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import kotlin.coroutines.ContinuationInterceptor
-import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.time.Duration
@@ -71,6 +70,9 @@ import kotlin.time.Duration.Companion.seconds
 )
 @RunWith(RobolectricTestRunner::class)
 internal class CheckoutStateLoaderTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
 
     @Test
     fun `loadInitial commits only payment element metadata when ECE is not configured`() = runScenario {
@@ -507,73 +509,69 @@ internal class CheckoutStateLoaderTest {
         // When null, a RecordingSelectionChooser is used. Pass a factory to exercise the real
         // DefaultEmbeddedSelectionChooser (it needs the shared SavedStateHandle to track state).
         selectionChooser: ((SavedStateHandle) -> EmbeddedSelectionChooser)? = null,
-        uiContextProvider: (TestCoroutineScheduler) -> CoroutineContext = {
+        uiContextProvider: (TestCoroutineScheduler) -> CoroutineDispatcher = {
             UnconfinedTestDispatcher(it)
         },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val uiContext = uiContextProvider(testScheduler)
-        Dispatchers.setMain(uiContext[ContinuationInterceptor] as CoroutineDispatcher)
-        try {
-            val application = ApplicationProvider.getApplicationContext<Application>()
-            val imageLoader = FakeStripeImageLoader(
-                loadResult = Result.success(Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)),
-            )
-            val flagImageResolver = FlagImageResolver(
-                flagImageRepository = FlagImageRepository(imageLoader = imageLoader, displayDensity = 3f),
-                analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
-                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                    context = application,
-                    publishableKey = "pk_test_123",
-                ),
-            )
-            val savedStateHandle = SavedStateHandle()
-            val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
-            val customerStateHolder = DefaultCustomerStateHolder(
-                savedStateHandle = savedStateHandle,
-                selection = stateHolder.selection,
-                paymentMethodMetadataFlow = stateHolder.stateFlow.mapAsStateFlow {
-                    it?.paymentMethodMetadata
-                },
-                customerMetadata = stateHolder.stateFlow.mapAsStateFlow {
-                    it?.paymentMethodMetadata?.customerMetadata
-                },
-            )
-            val recordingChooser = RecordingSelectionChooser(chosenSelection)
-            val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
-            val paymentElementLoader = FakePaymentElementLoader(
-                paymentSelection = loaderSelection,
-                shouldFail = shouldFail,
-                isGooglePayAvailable = isGooglePayAvailable,
-                customer = customer,
-                delay = paymentElementLoaderDelay,
-            )
-            val loader = CheckoutStateLoader(
-                embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
-                commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Example, Inc."),
-                flagImageResolver = flagImageResolver,
-                paymentElementLoader = paymentElementLoader,
-                selectionChooser = chooser,
-                stateHolder = stateHolder,
-                customerStateHolder = customerStateHolder,
-                internalRowSelectionCallback = { internalRowSelectionCallback },
-            )
+        Dispatchers.setMain(uiContext)
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val imageLoader = FakeStripeImageLoader(
+            loadResult = Result.success(Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)),
+        )
+        val flagImageResolver = FlagImageResolver(
+            flagImageRepository = FlagImageRepository(imageLoader = imageLoader, displayDensity = 3f),
+            analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
+            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                context = application,
+                publishableKey = "pk_test_123",
+            ),
+        )
+        val savedStateHandle = SavedStateHandle()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
+        val customerStateHolder = DefaultCustomerStateHolder(
+            savedStateHandle = savedStateHandle,
+            selection = stateHolder.selection,
+            paymentMethodMetadataFlow = stateHolder.stateFlow.mapAsStateFlow {
+                it?.paymentMethodMetadata
+            },
+            customerMetadata = stateHolder.stateFlow.mapAsStateFlow {
+                it?.paymentMethodMetadata?.customerMetadata
+            },
+        )
+        val recordingChooser = RecordingSelectionChooser(chosenSelection)
+        val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
+        val paymentElementLoader = FakePaymentElementLoader(
+            paymentSelection = loaderSelection,
+            shouldFail = shouldFail,
+            isGooglePayAvailable = isGooglePayAvailable,
+            customer = customer,
+            delay = paymentElementLoaderDelay,
+        )
+        val loader = CheckoutStateLoader(
+            embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
+            commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Example, Inc."),
+            flagImageResolver = flagImageResolver,
+            paymentElementLoader = paymentElementLoader,
+            selectionChooser = chooser,
+            stateHolder = stateHolder,
+            customerStateHolder = customerStateHolder,
+            internalRowSelectionCallback = { internalRowSelectionCallback },
+        )
 
-            Scenario(
-                loader = loader,
-                stateHolder = stateHolder,
-                customerStateHolder = customerStateHolder,
-                paymentElementLoader = paymentElementLoader,
-                chooser = recordingChooser,
-                imageLoader = imageLoader,
-                testScheduler = testScheduler,
-                backgroundScope = backgroundScope,
-            ).block()
+        Scenario(
+            loader = loader,
+            stateHolder = stateHolder,
+            customerStateHolder = customerStateHolder,
+            paymentElementLoader = paymentElementLoader,
+            chooser = recordingChooser,
+            imageLoader = imageLoader,
+            testScheduler = testScheduler,
+            backgroundScope = backgroundScope,
+        ).block()
 
-            imageLoader.ensureAllEventsConsumed()
-        } finally {
-            Dispatchers.resetMain()
-        }
+        imageLoader.ensureAllEventsConsumed()
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -389,7 +389,7 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
-    fun `advancing the UI dispatcher commits controller state before customer state`() = runScenario(
+    fun `advancing the UI dispatcher commits controller and customer state`() = runScenario(
         customer = savedCustomer(),
         uiContextProvider = { StandardTestDispatcher(it) },
     ) {

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -1,12 +1,12 @@
 package com.stripe.android.checkout
 
 import android.app.Application
-import app.cash.turbine.test
 import android.graphics.Bitmap
 import android.os.Bundle
 import androidx.compose.ui.graphics.toArgb
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.stripe.android.checkouttesting.DEFAULT_CHECKOUT_SESSION_ID
 import com.stripe.android.common.model.CommonConfiguration

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -1,6 +1,7 @@
 package com.stripe.android.checkout
 
 import android.app.Application
+import app.cash.turbine.test
 import android.graphics.Bitmap
 import android.os.Bundle
 import androidx.compose.ui.graphics.toArgb
@@ -372,7 +373,8 @@ internal class CheckoutStateLoaderTest {
             )
         }
 
-        assertThat(paymentElementLoader.lastIntegrationConfiguration).isNotNull()
+        assertThat(paymentElementLoader.loadCompletion.isCompleted).isTrue()
+        assertThat(chooser.lastCall).isNotNull()
         assertThat(load.isCompleted).isFalse()
         assertThat(stateHolder.state).isNull()
         assertThat(customerStateHolder.customer.value).isNull()
@@ -382,26 +384,32 @@ internal class CheckoutStateLoaderTest {
     }
 
     @Test
-    fun `advancing the UI dispatcher commits controller and customer state`() = runScenario(
+    fun `advancing the UI dispatcher commits controller state before customer state`() = runScenario(
         customer = savedCustomer(),
         uiContextProvider = { StandardTestDispatcher(it) },
     ) {
-        val load = backgroundScope.async(UnconfinedTestDispatcher(testScheduler)) {
-            loader.loadInitial(
-                configuration = defaultConfiguration(),
-                checkoutSessionResponse = response(),
-            )
+        customerStateHolder.customer.test {
+            assertThat(awaitItem()).isNull()
+
+            val load = backgroundScope.async(UnconfinedTestDispatcher(testScheduler)) {
+                loader.loadInitial(
+                    configuration = defaultConfiguration(),
+                    checkoutSessionResponse = response(),
+                )
+            }
+
+            assertThat(load.isCompleted).isFalse()
+            assertThat(stateHolder.state).isNull()
+            expectNoEvents()
+
+            testScheduler.runCurrent()
+
+            assertThat(awaitItem()).isEqualTo(savedCustomer())
+            assertThat(stateHolder.state?.checkoutSessionResponse?.id)
+                .isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
+            load.await()
+            ensureAllEventsConsumed()
         }
-
-        assertThat(stateHolder.state).isNull()
-        assertThat(customerStateHolder.customer.value).isNull()
-
-        testScheduler.runCurrent()
-        load.await()
-
-        assertThat(stateHolder.state?.checkoutSessionResponse?.id)
-            .isEqualTo(DEFAULT_CHECKOUT_SESSION_ID)
-        assertThat(customerStateHolder.customer.value).isEqualTo(savedCustomer())
     }
 
     @Test

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/CheckoutStateLoaderTest.kt
@@ -44,15 +44,20 @@ import com.stripe.android.utils.FakeIsNfcScanningAvailable
 import com.stripe.android.utils.FakeLinkConfigurationCoordinator
 import com.stripe.android.utils.FakePaymentElementLoader
 import com.stripe.android.utils.NullCardAccountRangeRepositoryFactory
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.coroutines.ContinuationInterceptor
 import kotlin.coroutines.CoroutineContext
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -490,6 +495,7 @@ internal class CheckoutStateLoaderTest {
         ),
     )
 
+    @Suppress("LongMethod")
     private fun runScenario(
         loaderSelection: PaymentSelection? = null,
         chosenSelection: PaymentSelection? = null,
@@ -506,64 +512,68 @@ internal class CheckoutStateLoaderTest {
         },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val application = ApplicationProvider.getApplicationContext<Application>()
-        val imageLoader = FakeStripeImageLoader(
-            loadResult = Result.success(Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)),
-        )
-        val flagImageResolver = FlagImageResolver(
-            flagImageRepository = FlagImageRepository(imageLoader = imageLoader, displayDensity = 3f),
-            analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
-            paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
-                context = application,
-                publishableKey = "pk_test_123",
-            ),
-        )
-        val savedStateHandle = SavedStateHandle()
-        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
-        val customerStateHolder = DefaultCustomerStateHolder(
-            savedStateHandle = savedStateHandle,
-            selection = stateHolder.selection,
-            paymentMethodMetadataFlow = stateHolder.stateFlow.mapAsStateFlow {
-                it?.paymentMethodMetadata
-            },
-            customerMetadata = stateHolder.stateFlow.mapAsStateFlow {
-                it?.paymentMethodMetadata?.customerMetadata
-            },
-        )
-        val recordingChooser = RecordingSelectionChooser(chosenSelection)
-        val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
-        val paymentElementLoader = FakePaymentElementLoader(
-            paymentSelection = loaderSelection,
-            shouldFail = shouldFail,
-            isGooglePayAvailable = isGooglePayAvailable,
-            customer = customer,
-            delay = paymentElementLoaderDelay,
-        )
         val uiContext = uiContextProvider(testScheduler)
-        val loader = CheckoutStateLoader(
-            embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
-            commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Example, Inc."),
-            flagImageResolver = flagImageResolver,
-            paymentElementLoader = paymentElementLoader,
-            selectionChooser = chooser,
-            stateHolder = stateHolder,
-            customerStateHolder = customerStateHolder,
-            internalRowSelectionCallback = { internalRowSelectionCallback },
-            uiContext = uiContext,
-        )
+        Dispatchers.setMain(uiContext[ContinuationInterceptor] as CoroutineDispatcher)
+        try {
+            val application = ApplicationProvider.getApplicationContext<Application>()
+            val imageLoader = FakeStripeImageLoader(
+                loadResult = Result.success(Bitmap.createBitmap(48, 48, Bitmap.Config.ARGB_8888)),
+            )
+            val flagImageResolver = FlagImageResolver(
+                flagImageRepository = FlagImageRepository(imageLoader = imageLoader, displayDensity = 3f),
+                analyticsRequestExecutor = FakeAnalyticsRequestExecutor(),
+                paymentAnalyticsRequestFactory = PaymentAnalyticsRequestFactory(
+                    context = application,
+                    publishableKey = "pk_test_123",
+                ),
+            )
+            val savedStateHandle = SavedStateHandle()
+            val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
+            val customerStateHolder = DefaultCustomerStateHolder(
+                savedStateHandle = savedStateHandle,
+                selection = stateHolder.selection,
+                paymentMethodMetadataFlow = stateHolder.stateFlow.mapAsStateFlow {
+                    it?.paymentMethodMetadata
+                },
+                customerMetadata = stateHolder.stateFlow.mapAsStateFlow {
+                    it?.paymentMethodMetadata?.customerMetadata
+                },
+            )
+            val recordingChooser = RecordingSelectionChooser(chosenSelection)
+            val chooser = selectionChooser?.invoke(savedStateHandle) ?: recordingChooser
+            val paymentElementLoader = FakePaymentElementLoader(
+                paymentSelection = loaderSelection,
+                shouldFail = shouldFail,
+                isGooglePayAvailable = isGooglePayAvailable,
+                customer = customer,
+                delay = paymentElementLoaderDelay,
+            )
+            val loader = CheckoutStateLoader(
+                embeddedConfigurationFactory = CheckoutEmbeddedConfigurationFactory(appName = "Example, Inc."),
+                commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Example, Inc."),
+                flagImageResolver = flagImageResolver,
+                paymentElementLoader = paymentElementLoader,
+                selectionChooser = chooser,
+                stateHolder = stateHolder,
+                customerStateHolder = customerStateHolder,
+                internalRowSelectionCallback = { internalRowSelectionCallback },
+            )
 
-        Scenario(
-            loader = loader,
-            stateHolder = stateHolder,
-            customerStateHolder = customerStateHolder,
-            paymentElementLoader = paymentElementLoader,
-            chooser = recordingChooser,
-            imageLoader = imageLoader,
-            testScheduler = testScheduler,
-            backgroundScope = backgroundScope,
-        ).block()
+            Scenario(
+                loader = loader,
+                stateHolder = stateHolder,
+                customerStateHolder = customerStateHolder,
+                paymentElementLoader = paymentElementLoader,
+                chooser = recordingChooser,
+                imageLoader = imageLoader,
+                testScheduler = testScheduler,
+                backgroundScope = backgroundScope,
+            ).block()
 
-        imageLoader.ensureAllEventsConsumed()
+            imageLoader.ensureAllEventsConsumed()
+        } finally {
+            Dispatchers.resetMain()
+        }
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -30,9 +30,16 @@ import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFacto
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
 import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.withContext
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -201,6 +208,49 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
         }
     }
 
+    @Test
+    fun `confirm admits only one immediate confirmation`() {
+        val state = createState()
+
+        runScenario(
+            state = state,
+            expressButton = createGooglePayExpressButton(
+                paymentMethodMetadata = requireNotNull(state.expressCheckoutElementPaymentMethodMetadata),
+            ),
+        ) {
+            withContext(Dispatchers.Main.immediate) {
+                performer.confirm(expressButton)
+                performer.confirm(expressButton)
+            }
+
+            confirmationHandler.startTurbine.awaitItem()
+            confirmationHandler.startTurbine.expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `confirm from a background context emits updating on Main`() {
+        val state = createState()
+
+        runScenario(
+            state = state,
+            expressButton = createGooglePayExpressButton(
+                paymentMethodMetadata = requireNotNull(state.expressCheckoutElementPaymentMethodMetadata),
+            ),
+            mainDispatcherProvider = { StandardTestDispatcher(it) },
+        ) {
+            performer.confirm(expressButton)
+
+            assertThat(operationCoordinator.isUpdating.value).isFalse()
+            confirmationHandler.startTurbine.expectNoEvents()
+
+            testScheduler.runCurrent()
+
+            assertThat(operationCoordinator.isUpdating.value).isTrue()
+            confirmationHandler.startTurbine.awaitItem()
+        }
+    }
+
     private fun createState(
         allowedShippingCountries: List<String>? = null,
         requiresBillingAddress: Boolean = false,
@@ -233,63 +283,75 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         expressButton: ExpressButton,
+        mainDispatcherProvider: (TestCoroutineScheduler) -> TestDispatcher = {
+            UnconfinedTestDispatcher(it)
+        },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
-        val confirmationHandler = FakeConfirmationHandler()
-        val errorReporter = FakeErrorReporter()
-        val savedStateHandle = SavedStateHandle()
-        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
-        stateHolder.state = state
-        val sessionRefresher = FakeCheckoutSessionRefresher()
-        val operationCoordinator = CheckoutOperationCoordinator(
-            confirmationHandler = confirmationHandler,
-            sheetStateHolder = SheetStateHolder(savedStateHandle),
-            sessionRefresher = sessionRefresher,
-            logger = Logger.noop(),
-            uiContext = UnconfinedTestDispatcher(testScheduler),
-            resultCallback = {},
-        )
-        val paymentSheetEventReporter = FakeEventReporter()
-        val analyticsPerformer = CheckoutAnalyticsPerformer(
-            confirmationHandler = confirmationHandler,
-            eventReporter = paymentSheetEventReporter,
-            savedStateHandle = savedStateHandle,
-        )
-        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            analyticsPerformer.reportConfirmationResults()
+        val mainDispatcher = mainDispatcherProvider(testScheduler)
+        Dispatchers.setMain(mainDispatcher)
+        try {
+            val confirmationHandler = FakeConfirmationHandler()
+            val errorReporter = FakeErrorReporter()
+            val savedStateHandle = SavedStateHandle()
+            val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
+            stateHolder.state = state
+            val sessionRefresher = FakeCheckoutSessionRefresher()
+            val operationCoordinator = CheckoutOperationCoordinator(
+                confirmationHandler = confirmationHandler,
+                sheetStateHolder = SheetStateHolder(savedStateHandle),
+                sessionRefresher = sessionRefresher,
+                logger = Logger.noop(),
+                resultCallback = {},
+            )
+            val paymentSheetEventReporter = FakeEventReporter()
+            val analyticsPerformer = CheckoutAnalyticsPerformer(
+                confirmationHandler = confirmationHandler,
+                eventReporter = paymentSheetEventReporter,
+                savedStateHandle = savedStateHandle,
+            )
+            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+                analyticsPerformer.reportConfirmationResults()
+            }
+            val performer = DefaultExpressCheckoutElementConfirmationPerformer(
+                stateHolder = stateHolder,
+                confirmationHandler = confirmationHandler,
+                operationCoordinator = operationCoordinator,
+                analyticsPerformer = analyticsPerformer,
+                commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Test App"),
+                errorReporter = errorReporter,
+                statusBarColor = null,
+                viewModelScope = backgroundScope,
+            )
+
+            Scenario(
+                performer = performer,
+                operationCoordinator = operationCoordinator,
+                confirmationHandler = confirmationHandler,
+                errorReporter = errorReporter,
+                paymentSheetEventReporter = paymentSheetEventReporter,
+                stateHolder = stateHolder,
+                expressButton = expressButton,
+                testScheduler = testScheduler,
+            ).block()
+
+            confirmationHandler.validate()
+            sessionRefresher.ensureAllEventsConsumed()
+            errorReporter.ensureAllEventsConsumed()
+            paymentSheetEventReporter.validate()
+        } finally {
+            Dispatchers.resetMain()
         }
-        val performer = DefaultExpressCheckoutElementConfirmationPerformer(
-            stateHolder = stateHolder,
-            confirmationHandler = confirmationHandler,
-            operationCoordinator = operationCoordinator,
-            analyticsPerformer = analyticsPerformer,
-            commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Test App"),
-            errorReporter = errorReporter,
-            statusBarColor = null,
-            viewModelScope = backgroundScope,
-        )
-
-        Scenario(
-            performer = performer,
-            confirmationHandler = confirmationHandler,
-            errorReporter = errorReporter,
-            paymentSheetEventReporter = paymentSheetEventReporter,
-            stateHolder = stateHolder,
-            expressButton = expressButton,
-        ).block()
-
-        confirmationHandler.validate()
-        sessionRefresher.ensureAllEventsConsumed()
-        errorReporter.ensureAllEventsConsumed()
-        paymentSheetEventReporter.validate()
     }
 
     private class Scenario(
         val performer: DefaultExpressCheckoutElementConfirmationPerformer,
+        val operationCoordinator: CheckoutOperationCoordinator,
         val confirmationHandler: FakeConfirmationHandler,
         val errorReporter: FakeErrorReporter,
         val paymentSheetEventReporter: FakeEventReporter,
         val stateHolder: CheckoutControllerStateHolder,
         val expressButton: ExpressButton,
+        val testScheduler: TestCoroutineScheduler,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -246,6 +246,7 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
             sheetStateHolder = SheetStateHolder(savedStateHandle),
             sessionRefresher = sessionRefresher,
             logger = Logger.noop(),
+            uiContext = UnconfinedTestDispatcher(testScheduler),
             resultCallback = {},
         )
         val paymentSheetEventReporter = FakeEventReporter()

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ece/DefaultExpressCheckoutElementConfirmationPerformerTest.kt
@@ -29,17 +29,18 @@ import com.stripe.android.paymentsheet.analytics.FakeEventReporter
 import com.stripe.android.paymentsheet.repositories.CheckoutSessionResponseFactory
 import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.utils.LinkTestUtils
+import com.stripe.android.testing.CoroutineTestRule
 import com.stripe.android.testing.FakeErrorReporter
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import kotlinx.coroutines.withContext
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -47,6 +48,9 @@ import org.robolectric.RobolectricTestRunner
 @OptIn(CheckoutSessionPreview::class)
 @RunWith(RobolectricTestRunner::class)
 internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
 
     @Test
     fun `confirm reports unexpected error when state is not loaded`() = runScenario(
@@ -283,65 +287,61 @@ internal class DefaultExpressCheckoutElementConfirmationPerformerTest {
     private fun runScenario(
         state: CheckoutControllerState?,
         expressButton: ExpressButton,
-        mainDispatcherProvider: (TestCoroutineScheduler) -> TestDispatcher = {
+        mainDispatcherProvider: (TestCoroutineScheduler) -> CoroutineDispatcher = {
             UnconfinedTestDispatcher(it)
         },
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val mainDispatcher = mainDispatcherProvider(testScheduler)
         Dispatchers.setMain(mainDispatcher)
-        try {
-            val confirmationHandler = FakeConfirmationHandler()
-            val errorReporter = FakeErrorReporter()
-            val savedStateHandle = SavedStateHandle()
-            val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
-            stateHolder.state = state
-            val sessionRefresher = FakeCheckoutSessionRefresher()
-            val operationCoordinator = CheckoutOperationCoordinator(
-                confirmationHandler = confirmationHandler,
-                sheetStateHolder = SheetStateHolder(savedStateHandle),
-                sessionRefresher = sessionRefresher,
-                logger = Logger.noop(),
-                resultCallback = {},
-            )
-            val paymentSheetEventReporter = FakeEventReporter()
-            val analyticsPerformer = CheckoutAnalyticsPerformer(
-                confirmationHandler = confirmationHandler,
-                eventReporter = paymentSheetEventReporter,
-                savedStateHandle = savedStateHandle,
-            )
-            backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-                analyticsPerformer.reportConfirmationResults()
-            }
-            val performer = DefaultExpressCheckoutElementConfirmationPerformer(
-                stateHolder = stateHolder,
-                confirmationHandler = confirmationHandler,
-                operationCoordinator = operationCoordinator,
-                analyticsPerformer = analyticsPerformer,
-                commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Test App"),
-                errorReporter = errorReporter,
-                statusBarColor = null,
-                viewModelScope = backgroundScope,
-            )
-
-            Scenario(
-                performer = performer,
-                operationCoordinator = operationCoordinator,
-                confirmationHandler = confirmationHandler,
-                errorReporter = errorReporter,
-                paymentSheetEventReporter = paymentSheetEventReporter,
-                stateHolder = stateHolder,
-                expressButton = expressButton,
-                testScheduler = testScheduler,
-            ).block()
-
-            confirmationHandler.validate()
-            sessionRefresher.ensureAllEventsConsumed()
-            errorReporter.ensureAllEventsConsumed()
-            paymentSheetEventReporter.validate()
-        } finally {
-            Dispatchers.resetMain()
+        val confirmationHandler = FakeConfirmationHandler()
+        val errorReporter = FakeErrorReporter()
+        val savedStateHandle = SavedStateHandle()
+        val stateHolder = CheckoutControllerStateFactory.createStateHolder(savedStateHandle)
+        stateHolder.state = state
+        val sessionRefresher = FakeCheckoutSessionRefresher()
+        val operationCoordinator = CheckoutOperationCoordinator(
+            confirmationHandler = confirmationHandler,
+            sheetStateHolder = SheetStateHolder(savedStateHandle),
+            sessionRefresher = sessionRefresher,
+            logger = Logger.noop(),
+            resultCallback = {},
+        )
+        val paymentSheetEventReporter = FakeEventReporter()
+        val analyticsPerformer = CheckoutAnalyticsPerformer(
+            confirmationHandler = confirmationHandler,
+            eventReporter = paymentSheetEventReporter,
+            savedStateHandle = savedStateHandle,
+        )
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            analyticsPerformer.reportConfirmationResults()
         }
+        val performer = DefaultExpressCheckoutElementConfirmationPerformer(
+            stateHolder = stateHolder,
+            confirmationHandler = confirmationHandler,
+            operationCoordinator = operationCoordinator,
+            analyticsPerformer = analyticsPerformer,
+            commonConfigurationFactory = CheckoutCommonConfigurationFactory(appName = "Test App"),
+            errorReporter = errorReporter,
+            statusBarColor = null,
+            viewModelScope = backgroundScope,
+        )
+
+        Scenario(
+            performer = performer,
+            operationCoordinator = operationCoordinator,
+            confirmationHandler = confirmationHandler,
+            errorReporter = errorReporter,
+            paymentSheetEventReporter = paymentSheetEventReporter,
+            stateHolder = stateHolder,
+            expressButton = expressButton,
+            testScheduler = testScheduler,
+        ).block()
+
+        confirmationHandler.validate()
+        sessionRefresher.ensureAllEventsConsumed()
+        errorReporter.ensureAllEventsConsumed()
+        paymentSheetEventReporter.validate()
     }
 
     private class Scenario(

--- a/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/utils/FakePaymentElementLoader.kt
@@ -19,6 +19,7 @@ import com.stripe.android.paymentsheet.state.LinkState
 import com.stripe.android.paymentsheet.state.PaymentElementLoader
 import com.stripe.android.paymentsheet.state.PaymentSheetLoadingException
 import com.stripe.android.ui.core.cbc.CardBrandChoiceEligibility
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.delay
 import kotlin.time.Duration
 
@@ -41,6 +42,8 @@ internal class FakePaymentElementLoader(
 
     var lastIntegrationConfiguration: PaymentElementLoader.Configuration? = null
         private set
+
+    val loadCompletion = CompletableDeferred<Unit>()
 
     fun updateStripeIntent(intent: StripeIntent) {
         this.stripeIntent = intent
@@ -96,7 +99,7 @@ internal class FakePaymentElementLoader(
     ): Result<PaymentElementLoader.State> {
         lastIntegrationConfiguration = integrationConfiguration
         delay(delay)
-        return if (shouldFail) {
+        val result: Result<PaymentElementLoader.State> = if (shouldFail) {
             Result.failure(IllegalStateException("oh no"))
         } else {
             val configuration = integrationConfiguration.commonConfiguration
@@ -119,5 +122,7 @@ internal class FakePaymentElementLoader(
                 )
             )
         }
+        loadCompletion.complete(Unit)
+        return result
     }
 }


### PR DESCRIPTION
# Summary

Make active Checkout mutation and state emissions safe for Compose-observed UI state. This is pre-work for the saved-method Automatic Tax stack.

# Motivation

Checkout mutation and confirmation entry points can be called from a context that is not Main. Observable processing state, Checkout state, and customer state commits need a Main emission boundary while network and repository work retain the caller context.

# What changed

- Active mutation admission and cleanup publish `isUpdating` through `Dispatchers.Main.immediate`; cleanup remains protected from cancellation.
- Checkout and Express Checkout confirmation entry points perform admission in the existing ViewModel scope on `Dispatchers.Main.immediate`.
- Checkout controller and customer state loader commits run through `Dispatchers.Main.immediate`.
- Mutation bodies, loading work, and repository or network calls retain their caller context.
- Public caller APIs and the Compose reader contract are unchanged.

# Coverage

- Coordinator tests cover caller-context preservation, inline Main.immediate admission, serialization, pre-admission cancellation, admitted cancellation, and gate reuse.
- Confirmation performer tests cover background confirmation admission and duplicate suppression for Checkout and Express Checkout.
- State loader tests cover queued UI commits and cancellation before a queued commit.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

- Focused Paymentsheet unit tests passed for `CheckoutOperationCoordinatorTest`, `CheckoutStateLoaderTest`, `CheckoutConfirmationPerformerTest`, and `DefaultExpressCheckoutElementConfirmationPerformerTest`.
- The pre-push `:paymentsheet:apiCheck` and `:paymentsheet:detekt` checks passed.
- `git diff --check` passed.
- Fresh CI is pending for this head.

## Stack

```mermaid
graph LR
  A["#14525"] --> B["Pre-work: Main emissions"]
  B --> C["#14340"]
  C --> D["#14430"]
```

# Screenshots

| Before | After |
| ------------- | ------------- |
| N/A | N/A |

# Changelog

None. This is internal Checkout preview behavior and does not change the public API.

Committed and created by Claude.
