### PR TITLE
Add phone to checkout billing details

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutController.kt
@@ -901,6 +901,10 @@ class CheckoutController @Inject internal constructor(
                  * The customer's full name.
                  */
                 val name: String?,
+                /**
+                 * The customer's phone number.
+                 */
+                val phone: String?,
             ) {
                 /**
                  * A billing address.

--- a/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/checkout/CheckoutPaymentOptionDisplayDataFactory.kt
@@ -94,5 +94,6 @@ private fun PaymentMethod.BillingDetails.toCheckoutBillingDetails(): PaymentOpti
         },
         email = email,
         name = name,
+        phone = phone,
     )
 }

--- a/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/checkout/DefaultCheckoutPaymentOptionFactoryTest.kt
@@ -91,6 +91,7 @@ internal class DefaultCheckoutPaymentOptionFactoryTest {
         val billingDetails = requireNotNull(option?.billingDetails)
         assertThat(billingDetails.name).isEqualTo("Jenny Rosen")
         assertThat(billingDetails.email).isEqualTo("jenny.rosen@example.com")
+        assertThat(billingDetails.phone).isEqualTo("123-456-7890")
         assertThat(billingDetails.address?.line1).isEqualTo("1234 Main Street")
         assertThat(billingDetails.address?.city).isEqualTo("San Francisco")
         assertThat(billingDetails.address?.state).isEqualTo("CA")


### PR DESCRIPTION
# Summary
Expose the customer's phone number in `CheckoutController.Session.PaymentOptionDisplayData.BillingDetails` and populate it from the selected payment method.

# Motivation
Checkout integrations need access to all collected billing contact details when rendering or processing the selected payment option. Phone was available on the underlying payment method but omitted from the Checkout display model.

# Testing
- [ ] Added tests
- [x] Modified tests
- [ ] Manually verified

Ran:
- `./gradlew :paymentsheet:testDebugUnitTest --tests com.stripe.android.checkout.DefaultCheckoutPaymentOptionFactoryTest`
- `./gradlew detekt`

No tests were ignored.

# Screenshots
Not applicable; this changes model data and has no visual UI changes.

# Changelog
Not applicable; this is an internal preview Checkout API change.

Committed and created by Codex.
