### PR TITLE
Gate Checkout ShippingAddressElement on configuration

### DIFF
--- a/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
+++ b/paymentsheet/src/main/java/com/stripe/android/elements/ShippingAddressElement.kt
@@ -104,7 +104,8 @@ class ShippingAddressElement internal constructor(
     }
 
     fun present() {
-        if (stateHolder.state == null) {
+        val state = stateHolder.state
+        if (state == null || state.configuration.shippingAddressElementConfiguration == null) {
             errorReporter.report(
                 ErrorReporter.ExpectedErrorEvent.CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED
             )

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -39,6 +39,10 @@ internal class ShippingAddressElementTest {
     @get:Rule
     val coroutineTestRule = CoroutineTestRule()
 
+    private val configuredCheckoutConfiguration = CheckoutController.Configuration()
+        .shippingAddressElement(ShippingAddressElement.Configuration())
+        .build()
+
     @Test
     fun `present before checkout configuration reports and does not launch`() = runScenario(configured = false) {
         shippingAddressElement.present()
@@ -57,7 +61,29 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `present launches a blank address form with hosted autocomplete`() = runScenario {
+    fun `present without shipping address element configuration reports and does not launch`() =
+        runScenario(
+            configuration = CheckoutController.Configuration().build(),
+        ) {
+            shippingAddressElement.present()
+
+            val call = errorReporter.awaitCall()
+            assertThat(call.errorEvent).isEqualTo(
+                ErrorReporter.ExpectedErrorEvent.CHECKOUT_SHIPPING_ADDRESS_ELEMENT_PRESENT_NOT_CONFIGURED
+            )
+            assertThat(call.errorEvent.eventName).isEqualTo(
+                "checkout.shipping_address_element.present.not_configured"
+            )
+            assertThat(call.stripeException).isNull()
+            assertThat(call.additionalNonPiiParams).isEmpty()
+            activityLauncher.launchCalls.expectNoEvents()
+            paymentConfiguration.getCalls.expectNoEvents()
+        }
+
+    @Test
+    fun `present launches a blank address form with hosted autocomplete`() = runScenario(
+        configuration = configuredCheckoutConfiguration,
+    ) {
         shippingAddressElement.present()
 
         val launch = activityLauncher.launchCalls.awaitItem()
@@ -80,7 +106,9 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `present suppresses duplicate presentations`() = runScenario {
+    fun `present suppresses duplicate presentations`() = runScenario(
+        configuration = configuredCheckoutConfiguration,
+    ) {
         shippingAddressElement.present()
         shippingAddressElement.present()
 
@@ -90,7 +118,9 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `recreated element suppresses presentation while original is active`() = runScenario {
+    fun `recreated element suppresses presentation while original is active`() = runScenario(
+        configuration = configuredCheckoutConfiguration,
+    ) {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
@@ -104,7 +134,9 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `present resolves the latest payment configuration`() = runScenario {
+    fun `present resolves the latest payment configuration`() = runScenario(
+        configuration = configuredCheckoutConfiguration,
+    ) {
         shippingAddressElement.present()
 
         val firstLaunch = activityLauncher.launchCalls.awaitItem()
@@ -122,7 +154,9 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `successful result clears presentation and commits complete address`() = runScenario {
+    fun `successful result clears presentation and commits complete address`() = runScenario(
+        configuration = configuredCheckoutConfiguration,
+    ) {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
 
@@ -168,6 +202,7 @@ internal class ShippingAddressElementTest {
 
         runScenario(
             configured = true,
+            configuration = configuredCheckoutConfiguration,
             commitShippingAddress = FakeCommitShippingAddress(commitResult),
         ) {
             shippingAddressElement.present()
@@ -204,7 +239,9 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `canceled result clears presentation without committing`() = runScenario {
+    fun `canceled result clears presentation without committing`() = runScenario(
+        configuration = configuredCheckoutConfiguration,
+    ) {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
@@ -216,7 +253,9 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `malformed successful result clears presentation without committing`() = runScenario {
+    fun `malformed successful result clears presentation without committing`() = runScenario(
+        configuration = configuredCheckoutConfiguration,
+    ) {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
@@ -238,7 +277,9 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `recreated element result clears presentation after host destruction`() = runScenario {
+    fun `recreated element result clears presentation after host destruction`() = runScenario(
+        configuration = configuredCheckoutConfiguration,
+    ) {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
@@ -269,9 +310,11 @@ internal class ShippingAddressElementTest {
 
     private fun runScenario(
         configured: Boolean = true,
+        configuration: CheckoutController.Configuration.State = configuredCheckoutConfiguration,
         block: suspend Scenario.() -> Unit,
     ) = runScenario(
         configured = configured,
+        configuration = configuration,
         commitShippingAddress = FakeCommitShippingAddress(
             CompletableDeferred(Result.success(Unit)),
         ),
@@ -280,6 +323,7 @@ internal class ShippingAddressElementTest {
 
     private fun runScenario(
         configured: Boolean,
+        configuration: CheckoutController.Configuration.State,
         commitShippingAddress: FakeCommitShippingAddress,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
@@ -288,7 +332,9 @@ internal class ShippingAddressElementTest {
             savedStateHandle = savedStateHandle,
         )
         if (configured) {
-            stateHolder.state = CheckoutControllerStateFactory.create()
+            stateHolder.state = CheckoutControllerStateFactory.create(
+                configuration = configuration,
+            )
         }
         val shippingAddressElementStateHolder = ShippingAddressElementStateHolder(savedStateHandle)
         val paymentConfiguration = RecordingProvider(

--- a/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
+++ b/paymentsheet/src/test/java/com/stripe/android/elements/ShippingAddressElementTest.kt
@@ -81,9 +81,7 @@ internal class ShippingAddressElementTest {
         }
 
     @Test
-    fun `present launches a blank address form with hosted autocomplete`() = runScenario(
-        configuration = configuredCheckoutConfiguration,
-    ) {
+    fun `present launches a blank address form with hosted autocomplete`() = runScenario {
         shippingAddressElement.present()
 
         val launch = activityLauncher.launchCalls.awaitItem()
@@ -106,9 +104,7 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `present suppresses duplicate presentations`() = runScenario(
-        configuration = configuredCheckoutConfiguration,
-    ) {
+    fun `present suppresses duplicate presentations`() = runScenario {
         shippingAddressElement.present()
         shippingAddressElement.present()
 
@@ -118,9 +114,7 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `recreated element suppresses presentation while original is active`() = runScenario(
-        configuration = configuredCheckoutConfiguration,
-    ) {
+    fun `recreated element suppresses presentation while original is active`() = runScenario {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
@@ -134,9 +128,7 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `present resolves the latest payment configuration`() = runScenario(
-        configuration = configuredCheckoutConfiguration,
-    ) {
+    fun `present resolves the latest payment configuration`() = runScenario {
         shippingAddressElement.present()
 
         val firstLaunch = activityLauncher.launchCalls.awaitItem()
@@ -154,9 +146,7 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `successful result clears presentation and commits complete address`() = runScenario(
-        configuration = configuredCheckoutConfiguration,
-    ) {
+    fun `successful result clears presentation and commits complete address`() = runScenario {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
 
@@ -201,8 +191,6 @@ internal class ShippingAddressElementTest {
         val commitResult = CompletableDeferred<Result<Unit>>()
 
         runScenario(
-            configured = true,
-            configuration = configuredCheckoutConfiguration,
             commitShippingAddress = FakeCommitShippingAddress(commitResult),
         ) {
             shippingAddressElement.present()
@@ -239,9 +227,7 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `canceled result clears presentation without committing`() = runScenario(
-        configuration = configuredCheckoutConfiguration,
-    ) {
+    fun `canceled result clears presentation without committing`() = runScenario {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
@@ -253,9 +239,7 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `malformed successful result clears presentation without committing`() = runScenario(
-        configuration = configuredCheckoutConfiguration,
-    ) {
+    fun `malformed successful result clears presentation without committing`() = runScenario {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
@@ -277,9 +261,7 @@ internal class ShippingAddressElementTest {
     }
 
     @Test
-    fun `recreated element result clears presentation after host destruction`() = runScenario(
-        configuration = configuredCheckoutConfiguration,
-    ) {
+    fun `recreated element result clears presentation after host destruction`() = runScenario {
         shippingAddressElement.present()
         activityLauncher.launchCalls.awaitItem()
         assertThat(paymentConfiguration.getCalls.awaitItem()).isEqualTo(Unit)
@@ -311,20 +293,9 @@ internal class ShippingAddressElementTest {
     private fun runScenario(
         configured: Boolean = true,
         configuration: CheckoutController.Configuration.State = configuredCheckoutConfiguration,
-        block: suspend Scenario.() -> Unit,
-    ) = runScenario(
-        configured = configured,
-        configuration = configuration,
-        commitShippingAddress = FakeCommitShippingAddress(
+        commitShippingAddress: FakeCommitShippingAddress = FakeCommitShippingAddress(
             CompletableDeferred(Result.success(Unit)),
         ),
-        block = block,
-    )
-
-    private fun runScenario(
-        configured: Boolean,
-        configuration: CheckoutController.Configuration.State,
-        commitShippingAddress: FakeCommitShippingAddress,
         block: suspend Scenario.() -> Unit,
     ) = runTest {
         val savedStateHandle = SavedStateHandle()


### PR DESCRIPTION
# Summary

Gate Checkout `ShippingAddressElement` presentation on its optional element configuration.

## What changed

When Checkout is not configured, or when its `shippingAddressElementConfiguration` is absent, `ShippingAddressElement.present()` now reports the existing not-configured error and returns before launching the address form.

## What stays the same

Configured SAE presentation, duplicate-presentation suppression, activity-result handling, and address commits are unchanged. There are no public API changes. Payment Element, Currency Selector Element, Express Checkout Element, and unrelated lifecycle behavior are out of scope.

## Coverage

- Preserved the existing pre-configuration no-launch test.
- Added configured-Checkout/no-SAE-configuration coverage for the existing error and no-launch behavior.
- Made the default `runScenario` fixture explicitly configure SAE for positive presentation scenarios.
- Added the no-SAE-configuration case as an explicit test-local special case.

# Motivation

The Checkout Elements API decision makes element configurations optional: providing an element configuration opts the integration into that element. The Android SAE path was the remaining gap because a configured Checkout could launch SAE even when its optional configuration was absent.

# Testing

- [x] Added tests
- [x] Modified tests
- [ ] Manually verified

Local verification:

- `git diff --check` passed.
- The normal path-aware pre-push hook passed `:paymentsheet:detekt` and `:paymentsheet:apiCheck`.
- CI is pending.

# Screenshots

Not applicable. This change prevents an unconfigured element from launching and does not change rendered UI.

# Changelog

No changelog entry is required for this private-preview correctness fix.

# Notes

The Payment Element non-null-default inconsistency is recorded as a separate follow-up and is intentionally not changed here.

Committed and created by Codex.
